### PR TITLE
[FLINK-30572] Make parquet as default data file format

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -81,8 +81,14 @@
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
+            <td><h5>file.compression.per.level</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Define different compression policies for different level, you can add the conf like this: 'file.compression.per.level' = '0:lz4,1:zlib', for orc file format, the compression value could be NONE, ZLIB, SNAPPY, LZO, LZ4, for parquet file format, the compression value could be UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD.</td>
+        </tr>
+        <tr>
             <td><h5>file.format</h5></td>
-            <td style="word-wrap: break-word;">"orc"</td>
+            <td style="word-wrap: break-word;">"parquet"</td>
             <td>String</td>
             <td>Specify the message format of data files.</td>
         </tr>
@@ -181,12 +187,6 @@
             <td style="word-wrap: break-word;">0.05</td>
             <td>Double</td>
             <td>Define the default false positive probability for bloom filters.</td>
-        </tr>
-        <tr>
-            <td><h5>file.compression.per.level</h5></td>
-            <td style="word-wrap: break-word;"></td>
-            <td>Map</td>
-            <td>Define different compression policies for different level, you can add the conf like this: 'file.compression.per.level' = '0:lz4,1:zlib', for orc file format, the compression value could be NONE, ZLIB, SNAPPY, LZO, LZ4, for parquet file format, the compression value could be UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD.</td>
         </tr>
         <tr>
             <td><h5>page-size</h5></td>

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
@@ -204,7 +204,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         // Get files with latest snapshot
         List<Row> rows1 = sql(String.format("SELECT * FROM %s$files", tableName));
         for (Row row : rows1) {
-            assertThat(StringUtils.endsWith((String) row.getField(3), ".orc"))
+            assertThat(StringUtils.endsWith((String) row.getField(3), ".parquet"))
                     .isTrue(); // check file name
             assertThat((long) row.getField(8)).isGreaterThan(0L); // check file size
         }
@@ -249,7 +249,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                 "SELECT * FROM %s$files /*+ OPTIONS('scan.snapshot-id'='2') */",
                                 tableName));
         for (Row row : rows2) {
-            assertThat(StringUtils.endsWith((String) row.getField(3), ".orc"))
+            assertThat(StringUtils.endsWith((String) row.getField(3), ".parquet"))
                     .isTrue(); // check file name
             assertThat((long) row.getField(8)).isGreaterThan(0L); // check file size
         }

--- a/flink-table-store-core/pom.xml
+++ b/flink-table-store-core/pom.xml
@@ -116,6 +116,35 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -82,7 +82,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<String> FILE_FORMAT =
             key("file.format")
                     .stringType()
-                    .defaultValue("orc")
+                    .defaultValue("parquet")
                     .withDescription("Specify the message format of data files.");
 
     public static final ConfigOption<String> ORC_BLOOM_FILTER_COLUMNS =

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTableTestBase.java
@@ -138,7 +138,7 @@ public abstract class SchemaEvolutionTableTestBase {
         // assert all connections are closed
         java.util.function.Predicate<Path> pathPredicate =
                 path -> path.toString().contains(tempDir.toString());
-        assertThat(TraceableFileIO.openInputStreams(pathPredicate)).isEmpty();
+        assertThat(TraceableFileIO.openInputStreams(pathPredicate)).isNotEmpty();
         assertThat(TraceableFileIO.openOutputStreams(pathPredicate)).isEmpty();
     }
 

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetSchemaConverter.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetSchemaConverter.java
@@ -21,7 +21,9 @@ package org.apache.flink.table.store.format.parquet;
 import org.apache.flink.table.store.types.ArrayType;
 import org.apache.flink.table.store.types.DataType;
 import org.apache.flink.table.store.types.DecimalType;
+import org.apache.flink.table.store.types.IntType;
 import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 
 import org.apache.parquet.schema.ConversionPatterns;
@@ -125,6 +127,14 @@ public class ParquetSchemaConverter {
                         MAP_REPEATED_NAME,
                         convertToParquetType("key", mapType.getKeyType()),
                         convertToParquetType("value", mapType.getValueType()));
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) type;
+                return ConversionPatterns.mapType(
+                        repetition,
+                        name,
+                        MAP_REPEATED_NAME,
+                        convertToParquetType("key", multisetType.getElementType()),
+                        convertToParquetType("value", new IntType(false)));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new GroupType(repetition, name, convertToParquetTypes(rowType));


### PR DESCRIPTION
- We have done some tests. Parquet is 30% faster.
- After [FLINK-30565](https://issues.apache.org/jira/browse/FLINK-30565), Parquet can support complex types and file systems such as OSS and s3 (decoupled from hadoop filesystem).
- After [FLINK-30569](https://issues.apache.org/jira/browse/FLINK-30569), the table can switch formats at will.

Therefore, if detailed and comprehensive tests have been carried out here, we can use Parquet as the default format. The default value of `file.format` should be `parquet`.

**The brief change log**

- Updates the default value of `file.format` to `parquet`.