### PR TITLE
[FLINK-31190] Supports Spark call procedure command on Table Store

### DIFF
--- a/flink-table-store-spark/flink-table-store-spark-common/pom.xml
+++ b/flink-table-store-spark/flink-table-store-spark-common/pom.xml
@@ -35,6 +35,8 @@ under the License.
 
     <properties>
         <spark.version>3.2.2</spark.version>
+        <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
+        <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -60,6 +62,33 @@ under the License.
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>${scala-maven-plugin.version}</version>
+                    <configuration>
+                        <args>
+                            <arg>-nobootcp</arg>
+                            <arg>-target:jvm-${target.java.version}</arg>
+                        </args>
+                        <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -80,6 +109,44 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${antlr4-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <visitor>true</visitor>
+                    <listener>true</listener>
+                    <sourceDirectory>src/main/antlr</sourceDirectory>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/TableStoreSqlExtensions.g4
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/TableStoreSqlExtensions.g4
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is an adaptation of Presto's and Spark's grammar files.
+ */
+
+grammar TableStoreSqlExtensions;
+
+@lexer::members {
+  /**
+   * Verify whether current token is a valid decimal token (which contains dot).
+   * Returns true if the character that follows the token is not a digit or letter or underscore.
+   *
+   * For example:
+   * For char stream "2.3", "2." is not a valid decimal token, because it is followed by digit '3'.
+   * For char stream "2.3_", "2.3" is not a valid decimal token, because it is followed by '_'.
+   * For char stream "2.3W", "2.3" is not a valid decimal token, because it is followed by 'W'.
+   * For char stream "12.0D 34.E2+0.12 "  12.0D is a valid decimal token because it is followed
+   * by a space. 34.E2 is a valid decimal token because it is followed by symbol '+'
+   * which is not a digit or letter or underscore.
+   */
+  public boolean isValidDecimal() {
+    int nextChar = _input.LA(1);
+    if (nextChar >= 'A' && nextChar <= 'Z' || nextChar >= '0' && nextChar <= '9' ||
+      nextChar == '_') {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * This method will be called when we see '/*' and try to match it as a bracketed comment.
+   * If the next character is '+', it should be parsed as hint later, and we cannot match
+   * it as a bracketed comment.
+   *
+   * Returns true if the next character is '+'.
+   */
+  public boolean isHint() {
+    int nextChar = _input.LA(1);
+    if (nextChar == '+') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+singleStatement
+    : statement ';'* EOF
+    ;
+
+statement
+    : CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'                  #call
+    ;
+
+callArgument
+    : expression                    #positionalArgument
+    | identifier '=>' expression    #namedArgument
+    ;
+
+expression
+    : constant
+    | stringMap
+    ;
+
+constant
+    : number                          #numericLiteral
+    | booleanValue                    #booleanLiteral
+    | STRING+                         #stringLiteral
+    | identifier STRING               #typeConstructor
+    ;
+
+stringMap
+    : MAP '(' constant (',' constant)* ')'
+    ;
+
+booleanValue
+    : TRUE | FALSE
+    ;
+
+number
+    : MINUS? EXPONENT_VALUE           #exponentLiteral
+    | MINUS? DECIMAL_VALUE            #decimalLiteral
+    | MINUS? INTEGER_VALUE            #integerLiteral
+    | MINUS? BIGINT_LITERAL           #bigIntLiteral
+    | MINUS? SMALLINT_LITERAL         #smallIntLiteral
+    | MINUS? TINYINT_LITERAL          #tinyIntLiteral
+    | MINUS? DOUBLE_LITERAL           #doubleLiteral
+    | MINUS? FLOAT_LITERAL            #floatLiteral
+    | MINUS? BIGDECIMAL_LITERAL       #bigDecimalLiteral
+    ;
+
+multipartIdentifier
+    : parts+=identifier ('.' parts+=identifier)*
+    ;
+
+identifier
+    : IDENTIFIER              #unquotedIdentifier
+    | quotedIdentifier        #quotedIdentifierAlternative
+    | nonReserved             #unquotedIdentifier
+    ;
+
+quotedIdentifier
+    : BACKQUOTED_IDENTIFIER
+    ;
+
+nonReserved
+    : CALL
+    | TRUE | FALSE
+    | MAP
+    ;
+
+CALL: 'CALL';
+
+TRUE: 'TRUE';
+FALSE: 'FALSE';
+
+MAP: 'MAP';
+
+PLUS: '+';
+MINUS: '-';
+
+STRING
+    : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
+    | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
+    ;
+
+BIGINT_LITERAL
+    : DIGIT+ 'L'
+    ;
+
+SMALLINT_LITERAL
+    : DIGIT+ 'S'
+    ;
+
+TINYINT_LITERAL
+    : DIGIT+ 'Y'
+    ;
+
+INTEGER_VALUE
+    : DIGIT+
+    ;
+
+EXPONENT_VALUE
+    : DIGIT+ EXPONENT
+    | DECIMAL_DIGITS EXPONENT {isValidDecimal()}?
+    ;
+
+DECIMAL_VALUE
+    : DECIMAL_DIGITS {isValidDecimal()}?
+    ;
+
+FLOAT_LITERAL
+    : DIGIT+ EXPONENT? 'F'
+    | DECIMAL_DIGITS EXPONENT? 'F' {isValidDecimal()}?
+    ;
+
+DOUBLE_LITERAL
+    : DIGIT+ EXPONENT? 'D'
+    | DECIMAL_DIGITS EXPONENT? 'D' {isValidDecimal()}?
+    ;
+
+BIGDECIMAL_LITERAL
+    : DIGIT+ EXPONENT? 'BD'
+    | DECIMAL_DIGITS EXPONENT? 'BD' {isValidDecimal()}?
+    ;
+
+IDENTIFIER
+    : (LETTER | DIGIT | '_')+
+    ;
+
+BACKQUOTED_IDENTIFIER
+    : '`' ( ~'`' | '``' )* '`'
+    ;
+
+fragment DECIMAL_DIGITS
+    : DIGIT+ '.' DIGIT*
+    | '.' DIGIT+
+    ;
+
+fragment EXPONENT
+    : 'E' [+-]? DIGIT+
+    ;
+
+fragment DIGIT
+    : [0-9]
+    ;
+
+fragment LETTER
+    : [A-Z]
+    ;
+
+SIMPLE_COMMENT
+    : '--' ('\\\n' | ~[\r\n])* '\r'? '\n'? -> channel(HIDDEN)
+    ;
+
+BRACKETED_COMMENT
+    : '/*' {!isHint()}? (BRACKETED_COMMENT|.)*? '*/' -> channel(HIDDEN)
+    ;
+
+WS
+    : [ \r\n\t]+ -> channel(HIDDEN)
+    ;
+
+// Catch-all for anything we can't recognize.
+// We use this to be able to ignore and recover all the text
+// when splitting statements with DelimiterLexer
+UNRECOGNIZED
+    : .
+    ;

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/flink/table/store/spark/SparkProcedures.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/flink/table/store/spark/SparkProcedures.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.spark;
+
+import org.apache.spark.sql.connector.procedure.Procedure;
+import org.apache.spark.sql.connector.procedure.ProcedureBuilder;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** The {@link Procedure}s including all the stored procedures of Spark. */
+public class SparkProcedures {
+
+    private static final Map<String, Supplier<ProcedureBuilder>> BUILDERS = initProcedureBuilders();
+
+    private SparkProcedures() {}
+
+    public static ProcedureBuilder newBuilder(String name) {
+        // procedure resolution is case insensitive to match the existing Spark behavior for
+        // functions
+        Supplier<ProcedureBuilder> builderSupplier = BUILDERS.get(name.toLowerCase(Locale.ROOT));
+        return builderSupplier != null ? builderSupplier.get() : null;
+    }
+
+    private static Map<String, Supplier<ProcedureBuilder>> initProcedureBuilders() {
+        return Collections.emptyMap();
+    }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/catalyst/analysis/NoSuchProcedureException.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/catalyst/analysis/NoSuchProcedureException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis;
+
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+import scala.Option;
+
+/**
+ * Thrown by a catalog when a stored procedure cannot be found. The analyzer will rethrow the
+ * exception as an {@link AnalysisException} with the correct position information.
+ */
+public class NoSuchProcedureException extends AnalysisException {
+
+    public NoSuchProcedureException(Identifier ident) {
+        super(
+                "Procedure " + ident + " not found",
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                new String[0]);
+    }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.apache.spark.sql.connector.procedure.Procedure;
+
+/**
+ * A {@link CatalogPlugin catalog} interface for working with stored procedures.
+ *
+ * <p>Implementations should implement this interface if they expose stored procedures that can be
+ * called via CALL statements.
+ */
+public interface ProcedureCatalog extends CatalogPlugin {
+
+    /**
+     * Loads a {@link Procedure stored procedure} by {@link Identifier identifier}.
+     *
+     * @param identifier A stored procedure identifier.
+     * @return The procedure's metadata of given identifier.
+     * @throws NoSuchProcedureException Thrown, if there is no matching procedure stored.
+     */
+    Procedure loadProcedure(Identifier identifier) throws NoSuchProcedureException;
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/Procedure.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/Procedure.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.procedure;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+
+/** An interface representing a stored procedure available for execution. */
+public interface Procedure {
+
+    /** Returns the input parameters of this procedure. */
+    ProcedureParameter[] parameters();
+
+    /** Returns the type of rows produced by this procedure. */
+    StructType outputType();
+
+    /**
+     * Executes this procedure.
+     *
+     * <p>Spark will align the provided arguments according to the input parameters defined in
+     * {@link #parameters()} either by position or by name before execution.
+     *
+     * <p>Implementations may provide a summary of execution by returning one or many rows as a
+     * result. The schema of output rows must match the defined output type in {@link
+     * #outputType()}.
+     *
+     * @param args Input arguments.
+     * @return The result of executing this procedure with the given arguments.
+     */
+    InternalRow[] call(InternalRow args);
+
+    /** Returns the description of this procedure. */
+    default String description() {
+        return this.getClass().toString();
+    }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureBuilder.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.procedure;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+/** A builder of {@link Procedure} that builds a stored procedure available for execution. */
+public interface ProcedureBuilder {
+
+    /**
+     * Returns a {@link ProcedureBuilder procedure builder} via given table catalog.
+     *
+     * @param tableCatalog The table catalog.
+     * @return The procedure builder with given catalog.
+     */
+    ProcedureBuilder withTableCatalog(TableCatalog tableCatalog);
+
+    /**
+     * Builds a {@link Procedure stored procedure} via given {@link Identifier identifier}.
+     *
+     * @return The stored procedure of given identifier.
+     */
+    Procedure build();
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureParameter.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureParameter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.procedure;
+
+import org.apache.spark.sql.types.DataType;
+
+/** An input parameter of a {@link Procedure stored procedure}. */
+public interface ProcedureParameter {
+
+    /**
+     * Creates a required input parameter.
+     *
+     * @param name The name of the parameter.
+     * @param dataType The type of the parameter.
+     * @return The constructed stored procedure parameter.
+     */
+    static ProcedureParameter required(String name, DataType dataType) {
+        return new ProcedureParameterImpl(name, dataType, true);
+    }
+
+    /**
+     * Creates an optional input parameter.
+     *
+     * @param name The name of the parameter.
+     * @param dataType The type of the parameter.
+     * @return The constructed optional stored procedure parameter.
+     */
+    static ProcedureParameter optional(String name, DataType dataType) {
+        return new ProcedureParameterImpl(name, dataType, false);
+    }
+
+    /** Returns the name of this parameter. */
+    String name();
+
+    /** Returns the type of this parameter. */
+    DataType dataType();
+
+    /** Returns true if this parameter is required. */
+    boolean required();
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureParameterImpl.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/java/org/apache/spark/sql/connector/procedure/ProcedureParameterImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.procedure;
+
+import org.apache.spark.sql.types.DataType;
+
+import java.util.Objects;
+
+/** An implementation of {@link ProcedureParameter}. */
+public class ProcedureParameterImpl implements ProcedureParameter {
+
+    private final String name;
+    private final DataType dataType;
+    private final boolean required;
+
+    public ProcedureParameterImpl(String name, DataType dataType, boolean required) {
+        this.name = name;
+        this.dataType = dataType;
+        this.required = required;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public DataType dataType() {
+        return dataType;
+    }
+
+    @Override
+    public boolean required() {
+        return required;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        ProcedureParameterImpl that = (ProcedureParameterImpl) other;
+        return required == that.required
+                && Objects.equals(name, that.name)
+                && Objects.equals(dataType, that.dataType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, dataType, required);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "ProcedureParameter(name='%s', type=%s, required=%b)", name, dataType, required);
+    }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/flink/table/store/spark/extensions/TableStoreSparkSessionExtensions.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/flink/table/store/spark/extensions/TableStoreSparkSessionExtensions.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.spark.extensions
+
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.analysis.{ProcedureArgumentCoercion, ResolveProcedures}
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreSparkSqlExtensionsParser
+
+/**
+ * Spark session extension of table store extends the syntax and adds the rules.
+ */
+class TableStoreSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+    // parser extensions
+    extensions.injectParser { case (_, parser) => new TableStoreSparkSqlExtensionsParser(parser) }
+
+    // analyzer extensions
+    extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
+    extensions.injectResolutionRule { _ => ProcedureArgumentCoercion }
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.catalyst.plans.logical.{Call, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+
+object ProcedureArgumentCoercion extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case c @ Call(procedure, args) if c.resolved =>
+      val params = procedure.parameters
+
+      val newArgs = args.zipWithIndex.map { case (arg, index) =>
+        val param = params(index)
+        val paramType = param.dataType
+        val argType = arg.dataType
+
+        if (paramType != argType && !Cast.canUpCast(argType, paramType)) {
+          throw new AnalysisException(
+            s"Wrong arg type for ${param.name}: cannot cast $argType to $paramType")
+        }
+
+        if (paramType != argType) {
+          Cast(arg, paramType)
+        } else {
+          arg
+        }
+      }
+
+      if (newArgs != args) {
+        c.copy(args = newArgs)
+      } else {
+        c
+      }
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.logical.{Call, CallArgument, CallStatement, LogicalPlan, NamedArgument, PositionalArgument}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{CatalogManager, ProcedureCatalog}
+import org.apache.spark.sql.connector.catalog.CatalogPlugin
+import org.apache.spark.sql.connector.catalog.LookupCatalog
+import org.apache.spark.sql.connector.procedure.ProcedureParameter
+
+import java.util.Locale
+
+case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with LookupCatalog {
+
+  protected lazy val catalogManager: CatalogManager = spark.sessionState.catalogManager
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case CallStatement(CatalogAndIdentifier(catalog, ident), args) =>
+      val procedure = catalog.asProcedureCatalog.loadProcedure(ident)
+
+      val params = procedure.parameters
+      val normalizedParams = normalizeParams(params)
+      validateParams(normalizedParams)
+
+      val normalizedArgs = normalizeArgs(args)
+      Call(procedure, args = buildArgExprs(normalizedParams, normalizedArgs).toSeq)
+  }
+
+  private def validateParams(params: Seq[ProcedureParameter]): Unit = {
+    // should not be any duplicate param names
+    val duplicateParamNames = params.groupBy(_.name).collect {
+      case (name, matchingParams) if matchingParams.length > 1 => name
+    }
+
+    if (duplicateParamNames.nonEmpty) {
+      throw new AnalysisException(s"Duplicate parameter names: ${duplicateParamNames.mkString("[", ",", "]")}")
+    }
+
+    // optional params should be at the end
+    params.sliding(2).foreach {
+      case Seq(previousParam, currentParam) if !previousParam.required && currentParam.required =>
+        throw new AnalysisException(
+          s"Optional parameters must be after required ones but $currentParam is after $previousParam")
+      case _ =>
+    }
+  }
+
+  private def buildArgExprs(
+      params: Seq[ProcedureParameter],
+      args: Seq[CallArgument]): Seq[Expression] = {
+
+    // build a map of declared parameter names to their positions
+    val nameToPositionMap = params.map(_.name).zipWithIndex.toMap
+
+    // build a map of parameter names to args
+    val nameToArgMap = buildNameToArgMap(params, args, nameToPositionMap)
+
+    // verify all required parameters are provided
+    val missingParamNames = params.filter(_.required).collect {
+      case param if !nameToArgMap.contains(param.name) => param.name
+    }
+
+    if (missingParamNames.nonEmpty) {
+      throw new AnalysisException(s"Missing required parameters: ${missingParamNames.mkString("[", ",", "]")}")
+    }
+
+    val argExprs = new Array[Expression](params.size)
+
+    nameToArgMap.foreach { case (name, arg) =>
+      val position = nameToPositionMap(name)
+      argExprs(position) = arg.expr
+    }
+
+    // assign nulls to optional params that were not set
+    params.foreach {
+      case p if !p.required && !nameToArgMap.contains(p.name) =>
+        val position = nameToPositionMap(p.name)
+        argExprs(position) = Literal.create(null, p.dataType)
+      case _ =>
+    }
+
+    argExprs
+  }
+
+  private def buildNameToArgMap(
+      params: Seq[ProcedureParameter],
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+
+    val containsNamedArg = args.exists(_.isInstanceOf[NamedArgument])
+    val containsPositionalArg = args.exists(_.isInstanceOf[PositionalArgument])
+
+    if (containsNamedArg && containsPositionalArg) {
+      throw new AnalysisException("Named and positional arguments cannot be mixed")
+    }
+
+    if (containsNamedArg) {
+      buildNameToArgMapUsingNames(args, nameToPositionMap)
+    } else {
+      buildNameToArgMapUsingPositions(args, params)
+    }
+  }
+
+  private def buildNameToArgMapUsingNames(
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+
+    val namedArgs = args.asInstanceOf[Seq[NamedArgument]]
+
+    val validationErrors = namedArgs.groupBy(_.name).collect {
+      case (name, matchingArgs) if matchingArgs.size > 1 => s"Duplicate procedure argument: $name"
+      case (name, _) if !nameToPositionMap.contains(name) => s"Unknown argument: $name"
+    }
+
+    if (validationErrors.nonEmpty) {
+      throw new AnalysisException(s"Could not build name to arg map: ${validationErrors.mkString(", ")}")
+    }
+
+    namedArgs.map(arg => arg.name -> arg).toMap
+  }
+
+  private def buildNameToArgMapUsingPositions(
+      args: Seq[CallArgument],
+      params: Seq[ProcedureParameter]): Map[String, CallArgument] = {
+
+    if (args.size > params.size) {
+      throw new AnalysisException("Too many arguments for procedure")
+    }
+
+    args.zipWithIndex.map { case (arg, position) =>
+      val param = params(position)
+      param.name -> arg
+    }.toMap
+  }
+
+  private def normalizeParams(params: Seq[ProcedureParameter]): Seq[ProcedureParameter] = {
+    params.map {
+      case param if param.required =>
+        val normalizedName = param.name.toLowerCase(Locale.ROOT)
+        ProcedureParameter.required(normalizedName, param.dataType)
+      case param =>
+        val normalizedName = param.name.toLowerCase(Locale.ROOT)
+        ProcedureParameter.optional(normalizedName, param.dataType)
+    }
+  }
+
+  private def normalizeArgs(args: Seq[CallArgument]): Seq[CallArgument] = {
+    args.map {
+      case a @ NamedArgument(name, _) => a.copy(name = name.toLowerCase(Locale.ROOT))
+      case other => other
+    }
+  }
+
+  implicit class CatalogHelper(plugin: CatalogPlugin) {
+    def asProcedureCatalog: ProcedureCatalog = plugin match {
+      case procedureCatalog: ProcedureCatalog =>
+        procedureCatalog
+      case _ =>
+        throw new AnalysisException(s"Cannot use catalog ${plugin.name}: not a ProcedureCatalog")
+    }
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TableStoreSparkSqlExtensionsParser.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TableStoreSparkSqlExtensionsParser.scala
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime.misc.ParseCancellationException
+import org.antlr.v4.runtime.tree.TerminalNodeImpl
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreSqlExtensionsParser.{NonReservedContext, QuotedIdentifierContext}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.internal.VariableSubstitution
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.StructType
+
+import java.util.Locale
+
+/**
+ * The implementation of [[ParserInterface]] that parsers the table store sql extension.
+ *
+ * @param delegate The extension parser.
+ */
+class TableStoreSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+
+  private lazy val substitutor = new VariableSubstitution()
+  private lazy val astBuilder = new TableStoreSqlExtensionsAstBuilder(delegate)
+
+  /**
+   * Parse a string to a LogicalPlan.
+   */
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
+    if (isTableStoreCommand(sqlTextAfterSubstitution)) {
+      parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }.asInstanceOf[LogicalPlan]
+    } else {
+      delegate.parsePlan(sqlText)
+    }
+  }
+
+  /**
+   * Parse a string to an Expression.
+   */
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  /**
+   * Parse a string to a TableIdentifier.
+   */
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  /**
+   * Parse a string to a FunctionIdentifier.
+   */
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  /**
+   * Creates StructType for a given SQL string, which is a comma separated list of field
+   * definitions which will preserve the correct Hive metadata.
+   */
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  /**
+   * Parse a string to a DataType.
+   */
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+
+  /**
+   * Parse a string to a multi-part identifier.
+   */
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  private def isTableStoreCommand(sqlText: String): Boolean = {
+    val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
+        // Strip simple SQL comments that terminate a line, e.g. comments starting with `--`
+        .replaceAll("--.*?\\n", " ")
+        // Strip newlines.
+        .replaceAll("\\s+", " ")
+        // Strip comments of the form  /* ... */. This must come after stripping newlines so that
+        // comments that span multiple lines are caught.
+        .replaceAll("/\\*.*?\\*/", " ")
+        .trim()
+    normalized.startsWith("call")
+  }
+
+  protected def parse[T](command: String)(toResult: TableStoreSqlExtensionsParser => T): T = {
+    val lexer = new TableStoreSqlExtensionsLexer(new UpperCaseCharStream(CharStreams.fromString(command)))
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(TableStoreParseErrorListener)
+
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser = new TableStoreSqlExtensionsParser(tokenStream)
+    parser.addParseListener(TableStoreSqlExtensionsPostProcessor)
+    parser.removeErrorListeners()
+    parser.addErrorListener(TableStoreParseErrorListener)
+
+    try {
+      try {
+        // first, try parsing with potentially faster SLL mode
+        parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
+        toResult(parser)
+      }
+      catch {
+        case _: ParseCancellationException =>
+          // if we fail, parse with LL mode
+          tokenStream.seek(0) // rewind input stream
+          parser.reset()
+
+          // Try Again.
+          parser.getInterpreter.setPredictionMode(PredictionMode.LL)
+          toResult(parser)
+      }
+    }
+    catch {
+      case e: TableStoreParseException if e.command.isDefined =>
+        throw e
+      case e: TableStoreParseException =>
+        throw e.withCommand(command)
+      case e: AnalysisException =>
+        val position = Origin(e.line, e.startPosition)
+        throw new TableStoreParseException(Option(command), e.message, position, position)
+    }
+  }
+}
+
+/* Copied from Apache Spark's to avoid dependency on Spark Internals */
+class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
+  override def consume(): Unit = wrapped.consume
+  override def getSourceName(): String = wrapped.getSourceName
+  override def index(): Int = wrapped.index
+  override def mark(): Int = wrapped.mark
+  override def release(marker: Int): Unit = wrapped.release(marker)
+  override def seek(where: Int): Unit = wrapped.seek(where)
+  override def size(): Int = wrapped.size
+
+  override def getText(interval: Interval): String = wrapped.getText(interval)
+
+  // scalastyle:off
+  override def LA(i: Int): Int = {
+    val la = wrapped.LA(i)
+    if (la == 0 || la == IntStream.EOF) la
+    else Character.toUpperCase(la)
+  }
+  // scalastyle:on
+}
+
+/**
+ * The post-processor validates & cleans-up the parse tree during the parse process.
+ */
+case object TableStoreSqlExtensionsPostProcessor extends TableStoreSqlExtensionsBaseListener {
+
+  /** Remove the back ticks from an Identifier. */
+  override def exitQuotedIdentifier(ctx: QuotedIdentifierContext): Unit = {
+    replaceTokenByIdentifier(ctx, 1) { token =>
+      // Remove the double back ticks in the string.
+      token.setText(token.getText.replace("``", "`"))
+      token
+    }
+  }
+
+  /** Treat non-reserved keywords as Identifiers. */
+  override def exitNonReserved(ctx: NonReservedContext): Unit = {
+    replaceTokenByIdentifier(ctx, 0)(identity)
+  }
+
+  private def replaceTokenByIdentifier(
+      ctx: ParserRuleContext,
+      stripMargins: Int)(
+      f: CommonToken => CommonToken = identity): Unit = {
+    val parent = ctx.getParent
+    parent.removeLastChild()
+    val token = ctx.getChild(0).getPayload.asInstanceOf[Token]
+    val newToken = new CommonToken(
+      new org.antlr.v4.runtime.misc.Pair(token.getTokenSource, token.getInputStream),
+      TableStoreSqlExtensionsParser.IDENTIFIER,
+      token.getChannel,
+      token.getStartIndex + stripMargins,
+      token.getStopIndex - stripMargins)
+    parent.addChild(new TerminalNodeImpl(f(newToken)))
+  }
+}
+
+/* Partially copied from Apache Spark's Parser to avoid dependency on Spark Internals */
+case object TableStoreParseErrorListener extends BaseErrorListener {
+  override def syntaxError(
+      recognizer: Recognizer[_, _],
+      offendingSymbol: scala.Any,
+      line: Int,
+      charPositionInLine: Int,
+      msg: String,
+      e: RecognitionException): Unit = {
+    val (start, stop) = offendingSymbol match {
+      case token: CommonToken =>
+        val start = Origin(Some(line), Some(token.getCharPositionInLine))
+        val length = token.getStopIndex - token.getStartIndex + 1
+        val stop = Origin(Some(line), Some(token.getCharPositionInLine + length))
+        (start, stop)
+      case _ =>
+        val start = Origin(Some(line), Some(charPositionInLine))
+        (start, start)
+    }
+    throw new TableStoreParseException(None, msg, start, stop)
+  }
+}
+
+/**
+ * Copied from Apache Spark
+ * A [[ParseException]] is an [[AnalysisException]] that is thrown during the parse process. It
+ * contains fields and an extended error message that make reporting and diagnosing errors easier.
+ */
+class TableStoreParseException(
+    val command: Option[String],
+    message: String,
+    val start: Origin,
+    val stop: Origin) extends AnalysisException(message, start.line, start.startPosition) {
+
+  def this(message: String, ctx: ParserRuleContext) = {
+    this(Option(TableStoreParserUtils.command(ctx)),
+      message,
+      TableStoreParserUtils.position(ctx.getStart),
+      TableStoreParserUtils.position(ctx.getStop))
+  }
+
+  override def getMessage: String = {
+    val builder = new StringBuilder
+    builder ++= "\n" ++= message
+    start match {
+      case Origin(Some(l), Some(p)) =>
+        builder ++= s"(line $l, pos $p)\n"
+        command.foreach { cmd =>
+          val (above, below) = cmd.split("\n").splitAt(l)
+          builder ++= "\n== SQL ==\n"
+          above.foreach(builder ++= _ += '\n')
+          builder ++= (0 until p).map(_ => "-").mkString("") ++= "^^^\n"
+          below.foreach(builder ++= _ += '\n')
+        }
+      case _ =>
+        command.foreach { cmd =>
+          builder ++= "\n== SQL ==\n" ++= cmd
+        }
+    }
+    builder.toString
+  }
+
+  def withCommand(cmd: String): TableStoreParseException = {
+    new TableStoreParseException(Option(cmd), message, start, stop)
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TableStoreSqlExtensionsAstBuilder.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TableStoreSqlExtensionsAstBuilder.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime.tree.ParseTree
+import org.antlr.v4.runtime.tree.TerminalNode
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreParserUtils.withOrigin
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreSqlExtensionsParser._
+import org.apache.spark.sql.catalyst.plans.logical.{CallArgument, CallStatement, LogicalPlan, NamedArgument, PositionalArgument}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.trees.Origin
+
+import scala.collection.JavaConverters._
+
+/**
+ * This class provides an table store implementation of [[TableStoreSqlExtensionsBaseVisitor]],
+ * which can be extended to create a visitor which only needs to handle a subset
+ * of the available methods.
+ *
+ * @param delegate The extension parser.
+ */
+class TableStoreSqlExtensionsAstBuilder(delegate: ParserInterface) extends TableStoreSqlExtensionsBaseVisitor[AnyRef] {
+
+  override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
+    visit(ctx.statement).asInstanceOf[LogicalPlan]
+  }
+
+  /**
+   * Create a [[CallStatement]] for a stored procedure call.
+   */
+  override def visitCall(ctx: CallContext): CallStatement = withOrigin(ctx) {
+    val name = toSeq(ctx.multipartIdentifier.parts).map(_.getText)
+    val args = toSeq(ctx.callArgument).map(typedVisit[CallArgument])
+    CallStatement(name, args)
+  }
+
+  /**
+   * Create a positional argument in a stored procedure call.
+   */
+  override def visitPositionalArgument(ctx: PositionalArgumentContext): CallArgument = withOrigin(ctx) {
+    val expr = typedVisit[Expression](ctx.expression)
+    PositionalArgument(expr)
+  }
+
+  /**
+   * Create a named argument in a stored procedure call.
+   */
+  override def visitNamedArgument(ctx: NamedArgumentContext): CallArgument = withOrigin(ctx) {
+    val name = ctx.identifier.getText
+    val expr = typedVisit[Expression](ctx.expression)
+    NamedArgument(name, expr)
+  }
+
+  override def visitExpression(ctx: ExpressionContext): Expression = {
+    // reconstruct the SQL string and parse it using the main Spark parser
+    // while we can avoid the logic to build Spark expressions, we still have to parse them
+    // we cannot call ctx.getText directly since it will not render spaces correctly
+    // that's why we need to recurse down the tree in reconstructSqlString
+    val sqlString = reconstructSqlString(ctx)
+    delegate.parseExpression(sqlString)
+  }
+
+  /**
+   * Return a multi-part identifier as Seq[String].
+   */
+  override def visitMultipartIdentifier(ctx: MultipartIdentifierContext): Seq[String] = withOrigin(ctx) {
+    ctx.parts.asScala.map(_.getText)
+  }
+
+  private def toBuffer[T](list: java.util.List[T]) = list.asScala
+
+  private def toSeq[T](list: java.util.List[T]) = toBuffer(list).toSeq
+
+  private def reconstructSqlString(ctx: ParserRuleContext): String = {
+    toBuffer(ctx.children).map {
+      case c: ParserRuleContext => reconstructSqlString(c)
+      case t: TerminalNode => t.getText
+    }.mkString(" ")
+  }
+
+  private def typedVisit[T](ctx: ParseTree): T = {
+    ctx.accept(this).asInstanceOf[T]
+  }
+}
+
+/* Partially copied from Apache Spark's Parser to avoid dependency on Spark Internals */
+object TableStoreParserUtils {
+
+  private[sql] def withOrigin[T](ctx: ParserRuleContext)(f: => T): T = {
+    val current = CurrentOrigin.get
+    CurrentOrigin.set(position(ctx.getStart))
+    try {
+      f
+    } finally {
+      CurrentOrigin.set(current)
+    }
+  }
+
+  private[sql] def position(token: Token): Origin = {
+    val opt = Option(token)
+    Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
+  }
+
+  /** Get the command which created the token. */
+  private[sql] def command(ctx: ParserRuleContext): String = {
+    val stream = ctx.getStart.getInputStream
+    stream.getText(Interval.of(0, stream.size() - 1))
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.connector.procedure.Procedure
+
+/**
+ * A CALL comand, as procedures resolved from SQL.
+ */
+case class Call(procedure: Procedure, args: Seq[Expression]) extends LeafCommand {
+
+  override lazy val output: Seq[Attribute] = procedure.outputType.toAttributes
+
+  override def simpleString(maxFields: Int): String = {
+    s"Call${truncatedString(output.toSeq, "[", ", ", "]", maxFields)} ${procedure.description}"
+  }
+}

--- a/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CallStatement.scala
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CallStatement.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * A CALL statement, as parsed from SQL.
+ */
+case class CallStatement(name: Seq[String], args: Seq[CallArgument]) extends LeafParsedStatement
+
+/**
+ * An argument in a CALL statement.
+ */
+sealed trait CallArgument {
+
+  def expr: Expression
+}
+
+/**
+ * An argument in a CALL statement identified by name.
+ */
+case class NamedArgument(name: String, expr: Expression) extends CallArgument
+
+/**
+ * An argument in a CALL statement identified by position.
+ */
+case class PositionalArgument(expr: Expression) extends CallArgument

--- a/flink-table-store-spark/flink-table-store-spark-common/src/test/java/org/apache/flink/table/store/spark/CallStatementParserTest.java
+++ b/flink-table-store-spark/flink-table-store-spark-common/src/test/java/org/apache/flink/table/store/spark/CallStatementParserTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.spark;
+
+import org.apache.flink.table.store.spark.extensions.TableStoreSparkSessionExtensions;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.Literal;
+import org.apache.spark.sql.catalyst.expressions.Literal$;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreParseException;
+import org.apache.spark.sql.catalyst.parser.extensions.TableStoreSparkSqlExtensionsParser;
+import org.apache.spark.sql.catalyst.plans.logical.CallArgument;
+import org.apache.spark.sql.catalyst.plans.logical.CallStatement;
+import org.apache.spark.sql.catalyst.plans.logical.NamedArgument;
+import org.apache.spark.sql.catalyst.plans.logical.PositionalArgument;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.rules.TemporaryFolder;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import scala.collection.JavaConverters;
+
+/** Test for {@link TableStoreSparkSqlExtensionsParser} of {@link CallStatement}. */
+public class CallStatementParserTest {
+
+    @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+    private static SparkSession spark = null;
+    private static ParserInterface parser = null;
+
+    @BeforeClass
+    public static void startSpark() {
+        CallStatementParserTest.spark =
+                SparkSession.builder()
+                        .master("local[2]")
+                        .config(
+                                "spark.sql.extensions",
+                                TableStoreSparkSessionExtensions.class.getName())
+                        .config("spark.extra.prop", "value")
+                        .getOrCreate();
+        CallStatementParserTest.parser = spark.sessionState().sqlParser();
+    }
+
+    @AfterClass
+    public static void stopSpark() {
+        SparkSession currentSpark = CallStatementParserTest.spark;
+        CallStatementParserTest.spark = null;
+        CallStatementParserTest.parser = null;
+        currentSpark.stop();
+    }
+
+    @Test
+    public void testCallWithPositionalArgs() throws ParseException {
+        CallStatement call =
+                (CallStatement)
+                        parser.parsePlan("CALL c.n.func(1, '2', 3L, true, 1.0D, 9.0e1, 900e-1BD)");
+        Assert.assertEquals(
+                Arrays.asList("c", "n", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+        Assert.assertEquals(7, call.args().size());
+
+        checkArg(call, 0, 1, DataTypes.IntegerType);
+        checkArg(call, 1, "2", DataTypes.StringType);
+        checkArg(call, 2, 3L, DataTypes.LongType);
+        checkArg(call, 3, true, DataTypes.BooleanType);
+        checkArg(call, 4, 1.0D, DataTypes.DoubleType);
+        checkArg(call, 5, 9.0e1, DataTypes.DoubleType);
+        checkArg(call, 6, new BigDecimal("900e-1"), DataTypes.createDecimalType(3, 1));
+    }
+
+    @Test
+    public void testCallWithNamedArgs() throws ParseException {
+        CallStatement call =
+                (CallStatement)
+                        parser.parsePlan("CALL cat.system.func(c1 => 1, c2 => '2', c3 => true)");
+        Assert.assertEquals(
+                Arrays.asList("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+        Assert.assertEquals(3, call.args().size());
+
+        checkArg(call, 0, "c1", 1, DataTypes.IntegerType);
+        checkArg(call, 1, "c2", "2", DataTypes.StringType);
+        checkArg(call, 2, "c3", true, DataTypes.BooleanType);
+    }
+
+    @Test
+    public void testCallWithMixedArgs() throws ParseException {
+        CallStatement call = (CallStatement) parser.parsePlan("CALL cat.system.func(c1 => 1, '2')");
+        Assert.assertEquals(
+                Arrays.asList("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+        Assert.assertEquals(2, call.args().size());
+
+        checkArg(call, 0, "c1", 1, DataTypes.IntegerType);
+        checkArg(call, 1, "2", DataTypes.StringType);
+    }
+
+    @Test
+    public void testCallWithTimestampArg() throws ParseException {
+        CallStatement call =
+                (CallStatement)
+                        parser.parsePlan(
+                                "CALL cat.system.func(TIMESTAMP '2017-02-03T10:37:30.00Z')");
+        Assert.assertEquals(
+                Arrays.asList("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+        Assert.assertEquals(1, call.args().size());
+
+        checkArg(
+                call,
+                0,
+                Timestamp.from(Instant.parse("2017-02-03T10:37:30.00Z")),
+                DataTypes.TimestampType);
+    }
+
+    @Test
+    public void testCallWithVarSubstitution() throws ParseException {
+        CallStatement call =
+                (CallStatement) parser.parsePlan("CALL cat.system.func('${spark.extra.prop}')");
+        Assert.assertEquals(
+                Arrays.asList("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+        Assert.assertEquals(1, call.args().size());
+
+        checkArg(call, 0, "value", DataTypes.StringType);
+    }
+
+    @Test
+    public void testCallParseError() {
+        Assertions.assertThrows(
+                TableStoreParseException.class,
+                () -> parser.parsePlan("CALL cat.system radish kebab"),
+                "missing '(' at 'radish'");
+    }
+
+    @Test
+    public void testCallStripsComments() throws ParseException {
+        List<String> callStatementsWithComments =
+                Arrays.asList(
+                        "/* bracketed comment */  CALL cat.system.func('${spark.extra.prop}')",
+                        "/**/  CALL cat.system.func('${spark.extra.prop}')",
+                        "-- single line comment \n CALL cat.system.func('${spark.extra.prop}')",
+                        "-- multiple \n-- single line \n-- comments \n CALL cat.system.func('${spark.extra.prop}')",
+                        "/* select * from multiline_comment \n where x like '%sql%'; */ CALL cat.system.func('${spark.extra.prop}')",
+                        "/* {\"app\": \"dbt\", \"dbt_version\": \"1.0.1\", \"profile_name\": \"profile1\", \"target_name\": \"dev\", "
+                                + "\"node_id\": \"model.profile1.stg_users\"} \n*/ CALL cat.system.func('${spark.extra.prop}')",
+                        "/* Some multi-line comment \n"
+                                + "*/ CALL /* inline comment */ cat.system.func('${spark.extra.prop}') -- ending comment",
+                        "CALL -- a line ending comment\n"
+                                + "cat.system.func('${spark.extra.prop}')");
+        for (String sqlText : callStatementsWithComments) {
+            CallStatement call = (CallStatement) parser.parsePlan(sqlText);
+            Assert.assertEquals(
+                    Arrays.asList("cat", "system", "func"),
+                    JavaConverters.seqAsJavaList(call.name()));
+
+            Assert.assertEquals(1, call.args().size());
+
+            checkArg(call, 0, "value", DataTypes.StringType);
+        }
+    }
+
+    private void checkArg(
+            CallStatement call, int index, Object expectedValue, DataType expectedType) {
+        checkArg(call, index, null, expectedValue, expectedType);
+    }
+
+    private void checkArg(
+            CallStatement call,
+            int index,
+            String expectedName,
+            Object expectedValue,
+            DataType expectedType) {
+
+        if (expectedName != null) {
+            NamedArgument arg = checkCast(call.args().apply(index), NamedArgument.class);
+            Assert.assertEquals(expectedName, arg.name());
+        } else {
+            CallArgument arg = call.args().apply(index);
+            checkCast(arg, PositionalArgument.class);
+        }
+
+        Expression expectedExpr = toSparkLiteral(expectedValue, expectedType);
+        Expression actualExpr = call.args().apply(index).expr();
+        Assert.assertEquals("Arg types must match", expectedExpr.dataType(), actualExpr.dataType());
+        Assert.assertEquals("Arg must match", expectedExpr, actualExpr);
+    }
+
+    private Literal toSparkLiteral(Object value, DataType dataType) {
+        return Literal$.MODULE$.create(value, dataType);
+    }
+
+    private <T> T checkCast(Object value, Class<T> expectedClass) {
+        Assert.assertTrue(
+                "Expected instance of " + expectedClass.getName(), expectedClass.isInstance(value));
+        return expectedClass.cast(value);
+    }
+}


### PR DESCRIPTION
At present Hudi and Iceberg supports the Spark call procedure command to execute the table service action etc. Flink Table Store could also support Spark call procedure command to run compaction etc.

**The brief change log**
- Introduces `TableStoreSparkSessionExtensions` to extends the syntax and adds the rules of `SparkSessionExtensions`, including the CALL statement.