### PR TITLE
[FLINK-31430] Support migrating states between different instances of TableWriteImpl and AbstractFileStoreWrite

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyCompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyCompactManager.java
@@ -116,6 +116,11 @@ public class AppendOnlyCompactManager extends CompactFutureManager {
         toCompact.add(file);
     }
 
+    @Override
+    public List<DataFileMeta> allFiles() {
+        return toCompact;
+    }
+
     /** Finish current task, and update result files to {@link #toCompact}. */
     @Override
     public Optional<CompactResult> getCompactionResult(boolean blocking)

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.compact;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -32,6 +33,8 @@ public interface CompactManager extends Closeable {
 
     /** Add a new file. */
     void addNewFile(DataFileMeta file);
+
+    List<DataFileMeta> allFiles();
 
     /**
      * Trigger a new compaction task.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/NoopCompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/NoopCompactManager.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.utils.Preconditions;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -38,6 +40,11 @@ public class NoopCompactManager implements CompactManager {
 
     @Override
     public void addNewFile(DataFileMeta file) {}
+
+    @Override
+    public List<DataFileMeta> allFiles() {
+        return Collections.emptyList();
+    }
 
     @Override
     public void triggerCompaction(boolean fullCompaction) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
@@ -80,6 +80,11 @@ public class MergeTreeCompactManager extends CompactFutureManager {
     }
 
     @Override
+    public List<DataFileMeta> allFiles() {
+        return levels.allFiles();
+    }
+
+    @Override
     public void triggerCompaction(boolean fullCompaction) {
         Optional<CompactUnit> optionalUnit;
         List<LevelSortedRun> runs = levels.levelSortedRuns();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.compact.NoopCompactManager;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.io.DataFilePathFactory;
 import org.apache.flink.table.store.file.io.RowDataRollingFileWriter;
+import org.apache.flink.table.store.file.utils.CommitIncrement;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -37,6 +38,8 @@ import org.apache.flink.table.store.reader.RecordReaderIterator;
 import org.apache.flink.table.store.table.source.DataSplit;
 import org.apache.flink.table.store.types.RowType;
 import org.apache.flink.table.store.utils.LongCounter;
+
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -89,6 +92,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoredFiles,
+            @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor) {
         // let writer and compact manager hold the same reference
         // and make restore files mutable to update
@@ -115,7 +119,8 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
                 getMaxSequenceNumber(restored),
                 compactManager,
                 commitForceCompact,
-                factory);
+                factory,
+                restoreIncrement);
     }
 
     private AppendOnlyCompactManager.CompactRewriter compactRewriter(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -85,28 +85,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
     }
 
     @Override
-    public WriterContainer<InternalRow> createWriterContainer(
-            BinaryRow partition, int bucket, ExecutorService compactExecutor) {
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        RecordWriter<InternalRow> writer =
-                createWriter(
-                        partition,
-                        bucket,
-                        scanExistingFileMetas(latestSnapshotId, partition, bucket),
-                        compactExecutor);
-        return new WriterContainer<>(writer, latestSnapshotId);
-    }
-
-    @Override
-    public WriterContainer<InternalRow> createEmptyWriterContainer(
-            BinaryRow partition, int bucket, ExecutorService compactExecutor) {
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        RecordWriter<InternalRow> writer =
-                createWriter(partition, bucket, Collections.emptyList(), compactExecutor);
-        return new WriterContainer<>(writer, latestSnapshotId);
-    }
-
-    private RecordWriter<InternalRow> createWriter(
+    protected RecordWriter<InternalRow> createWriter(
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoredFiles,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactRewri
 import org.apache.flink.table.store.file.mergetree.compact.UniversalCompaction;
 import org.apache.flink.table.store.file.schema.KeyValueFieldsExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.utils.CommitIncrement;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.format.FileFormatDiscover;
@@ -52,6 +53,8 @@ import org.apache.flink.table.store.types.RowType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.util.Comparator;
 import java.util.List;
@@ -121,6 +124,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoreFiles,
+            @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(
@@ -156,7 +160,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 mfFactory.create(),
                 writerFactory,
                 options.commitForceCompact(),
-                options.changelogProducer());
+                options.changelogProducer(),
+                restoreIncrement);
     }
 
     private boolean bufferSpillable() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -44,7 +44,6 @@ import org.apache.flink.table.store.file.mergetree.compact.UniversalCompaction;
 import org.apache.flink.table.store.file.schema.KeyValueFieldsExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
-import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.format.FileFormatDiscover;
 import org.apache.flink.table.store.fs.FileIO;
@@ -54,7 +53,6 @@ import org.apache.flink.table.store.types.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -119,28 +117,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     }
 
     @Override
-    public WriterContainer<KeyValue> createWriterContainer(
-            BinaryRow partition, int bucket, ExecutorService compactExecutor) {
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        RecordWriter<KeyValue> writer =
-                createMergeTreeWriter(
-                        partition,
-                        bucket,
-                        scanExistingFileMetas(latestSnapshotId, partition, bucket),
-                        compactExecutor);
-        return new WriterContainer<>(writer, latestSnapshotId);
-    }
-
-    @Override
-    public WriterContainer<KeyValue> createEmptyWriterContainer(
-            BinaryRow partition, int bucket, ExecutorService compactExecutor) {
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        RecordWriter<KeyValue> writer =
-                createMergeTreeWriter(partition, bucket, Collections.emptyList(), compactExecutor);
-        return new WriterContainer<>(writer, latestSnapshotId);
-    }
-
-    private MergeTreeWriter createMergeTreeWriter(
+    protected MergeTreeWriter createWriter(
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoreFiles,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Recoverable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Recoverable.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+/**
+ * Operations implementing this interface can extract and recover their states between different
+ * instances.
+ *
+ * @param <S> type of state
+ */
+public interface Recoverable<S> {
+
+    /**
+     * Extract state of the current operation instance. After calling this method, the operation
+     * instance must be closed and should no longer be used.
+     */
+    S extractStateAndClose() throws Exception;
+
+    /**
+     * Recover state of a previous operation instance into the current operation instance. This
+     * method must be called right after the current instance is constructed.
+     */
+    void recoverFromState(S state);
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/CommitIncrement.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/CommitIncrement.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.store.file.io.CompactIncrement;
+import org.apache.flink.table.store.file.io.NewFilesIncrement;
+
+/** Changes to commit. */
+public class CommitIncrement {
+
+    private final NewFilesIncrement newFilesIncrement;
+    private final CompactIncrement compactIncrement;
+
+    public CommitIncrement(NewFilesIncrement newFilesIncrement, CompactIncrement compactIncrement) {
+        this.newFilesIncrement = newFilesIncrement;
+        this.compactIncrement = compactIncrement;
+    }
+
+    public NewFilesIncrement newFilesIncrement() {
+        return newFilesIncrement;
+    }
+
+    public CompactIncrement compactIncrement() {
+        return compactIncrement;
+    }
+
+    @Override
+    public String toString() {
+        return newFilesIncrement.toString() + "\n" + compactIncrement;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.table.store.file.io.DataFileMeta;
-import org.apache.flink.table.store.file.operation.Recoverable;
 
 import java.util.List;
 
@@ -30,7 +29,7 @@ import java.util.List;
  *
  * @param <T> type of record to write.
  */
-public interface RecordWriter<T> extends Recoverable<CommitIncrement> {
+public interface RecordWriter<T> {
 
     /** Add a key-value element to the writer. */
     void write(T record) throws Exception;
@@ -50,8 +49,8 @@ public interface RecordWriter<T> extends Recoverable<CommitIncrement> {
      */
     void addNewFiles(List<DataFileMeta> files);
 
-    /** Get all files maintained by this writer. */
-    List<DataFileMeta> allFiles();
+    /** Get all data files maintained by this writer. */
+    List<DataFileMeta> dataFiles();
 
     /**
      * Prepare for a commit.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.table.store.file.utils;
 
-import org.apache.flink.table.store.file.io.CompactIncrement;
 import org.apache.flink.table.store.file.io.DataFileMeta;
-import org.apache.flink.table.store.file.io.NewFilesIncrement;
+import org.apache.flink.table.store.file.operation.Recoverable;
 
 import java.util.List;
 
@@ -31,7 +30,7 @@ import java.util.List;
  *
  * @param <T> type of record to write.
  */
-public interface RecordWriter<T> {
+public interface RecordWriter<T> extends Recoverable<CommitIncrement> {
 
     /** Add a key-value element to the writer. */
     void write(T record) throws Exception;
@@ -51,6 +50,9 @@ public interface RecordWriter<T> {
      */
     void addNewFiles(List<DataFileMeta> files);
 
+    /** Get all files maintained by this writer. */
+    List<DataFileMeta> allFiles();
+
     /**
      * Prepare for a commit.
      *
@@ -67,12 +69,4 @@ public interface RecordWriter<T> {
 
     /** Close this writer, the call will delete newly generated but not committed files. */
     void close() throws Exception;
-
-    /** Changes to commit. */
-    interface CommitIncrement {
-
-        NewFilesIncrement newFilesIncrement();
-
-        CompactIncrement compactIncrement();
-    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/Restorable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/Restorable.java
@@ -16,25 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.operation;
+package org.apache.flink.table.store.file.utils;
 
 /**
- * Operations implementing this interface can extract and recover their states between different
+ * Operations implementing this interface can checkpoint and restore their states between different
  * instances.
  *
  * @param <S> type of state
  */
-public interface Recoverable<S> {
+public interface Restorable<S> {
 
-    /**
-     * Extract state of the current operation instance. After calling this method, the operation
-     * instance must be closed and should no longer be used.
-     */
-    S extractStateAndClose() throws Exception;
+    /** Extract state of the current operation instance. */
+    S checkpoint();
 
-    /**
-     * Recover state of a previous operation instance into the current operation instance. This
-     * method must be called right after the current instance is constructed.
-     */
-    void recoverFromState(S state);
+    /** Restore state of a previous operation instance into the current operation instance. */
+    void restore(S state);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -22,7 +22,9 @@ import org.apache.flink.table.store.data.BinaryRow;
 import org.apache.flink.table.store.data.InternalRow;
 import org.apache.flink.table.store.file.disk.IOManager;
 import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.operation.AbstractFileStoreWrite;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
+import org.apache.flink.table.store.file.operation.Recoverable;
 
 import java.util.List;
 
@@ -33,9 +35,10 @@ import static org.apache.flink.table.store.utils.Preconditions.checkState;
  *
  * @param <T> type of record to write into {@link org.apache.flink.table.store.file.FileStore}.
  */
-public class TableWriteImpl<T> implements InnerTableWrite {
+public class TableWriteImpl<T>
+        implements InnerTableWrite, Recoverable<List<AbstractFileStoreWrite.State>> {
 
-    private final FileStoreWrite<T> write;
+    private final AbstractFileStoreWrite<T> write;
     private final SinkRecordConverter recordConverter;
     private final RecordExtractor<T> recordExtractor;
 
@@ -45,7 +48,7 @@ public class TableWriteImpl<T> implements InnerTableWrite {
             FileStoreWrite<T> write,
             SinkRecordConverter recordConverter,
             RecordExtractor<T> recordExtractor) {
-        this.write = write;
+        this.write = (AbstractFileStoreWrite<T>) write;
         this.recordConverter = recordConverter;
         this.recordExtractor = recordExtractor;
     }
@@ -119,6 +122,16 @@ public class TableWriteImpl<T> implements InnerTableWrite {
     @Override
     public void close() throws Exception {
         write.close();
+    }
+
+    @Override
+    public List<AbstractFileStoreWrite.State> extractStateAndClose() throws Exception {
+        return write.extractStateAndClose();
+    }
+
+    @Override
+    public void recoverFromState(List<AbstractFileStoreWrite.State> state) {
+        write.recoverFromState(state);
     }
 
     /** Extractor to extract {@link T} from the {@link SinkRecord}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.store.file.disk.IOManager;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.operation.AbstractFileStoreWrite;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
-import org.apache.flink.table.store.file.operation.Recoverable;
+import org.apache.flink.table.store.file.utils.Restorable;
 
 import java.util.List;
 
@@ -36,7 +36,7 @@ import static org.apache.flink.table.store.utils.Preconditions.checkState;
  * @param <T> type of record to write into {@link org.apache.flink.table.store.file.FileStore}.
  */
 public class TableWriteImpl<T>
-        implements InnerTableWrite, Recoverable<List<AbstractFileStoreWrite.State>> {
+        implements InnerTableWrite, Restorable<List<AbstractFileStoreWrite.State>> {
 
     private final AbstractFileStoreWrite<T> write;
     private final SinkRecordConverter recordConverter;
@@ -125,13 +125,13 @@ public class TableWriteImpl<T>
     }
 
     @Override
-    public List<AbstractFileStoreWrite.State> extractStateAndClose() throws Exception {
-        return write.extractStateAndClose();
+    public List<AbstractFileStoreWrite.State> checkpoint() {
+        return write.checkpoint();
     }
 
     @Override
-    public void recoverFromState(List<AbstractFileStoreWrite.State> state) {
-        write.recoverFromState(state);
+    public void restore(List<AbstractFileStoreWrite.State> state) {
+        write.restore(state);
     }
 
     /** Extractor to extract {@link T} from the {@link SinkRecord}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/StreamTableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/StreamTableScan.java
@@ -19,8 +19,7 @@
 package org.apache.flink.table.store.table.source;
 
 import org.apache.flink.table.store.annotation.Experimental;
-
-import javax.annotation.Nullable;
+import org.apache.flink.table.store.file.utils.Restorable;
 
 /**
  * {@link TableScan} for streaming, supports {@link #checkpoint} and {@link #restore}.
@@ -28,12 +27,4 @@ import javax.annotation.Nullable;
  * @since 0.4.0
  */
 @Experimental
-public interface StreamTableScan extends TableScan {
-
-    /** Checkpoint this stream table scan, return next snapshot id. */
-    @Nullable
-    Long checkpoint();
-
-    /** Restore this stream table scan, read incremental from {@code nextSnapshotId}. */
-    void restore(@Nullable Long nextSnapshotId);
-}
+public interface StreamTableScan extends TableScan, Restorable<Long> {}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/append/AppendOnlyWriterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/append/AppendOnlyWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.data.InternalRow;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.io.DataFilePathFactory;
 import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
+import org.apache.flink.table.store.file.utils.CommitIncrement;
 import org.apache.flink.table.store.file.utils.ExecutorThreadFactory;
 import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.format.FieldStats;
@@ -87,7 +88,7 @@ public class AppendOnlyWriterTest {
 
         for (int i = 0; i < 3; i++) {
             writer.sync();
-            RecordWriter.CommitIncrement inc = writer.prepareCommit(true);
+            CommitIncrement inc = writer.prepareCommit(true);
 
             assertThat(inc.newFilesIncrement().isEmpty()).isTrue();
             assertThat(inc.compactIncrement().isEmpty()).isTrue();
@@ -98,7 +99,7 @@ public class AppendOnlyWriterTest {
     public void testSingleWrite() throws Exception {
         RecordWriter<InternalRow> writer = createEmptyWriter(1024 * 1024L);
         writer.write(row(1, "AAA", PART));
-        RecordWriter.CommitIncrement increment = writer.prepareCommit(true);
+        CommitIncrement increment = writer.prepareCommit(true);
         writer.close();
 
         assertThat(increment.newFilesIncrement().newFiles().size()).isEqualTo(1);
@@ -140,7 +141,7 @@ public class AppendOnlyWriterTest {
             }
 
             writer.sync();
-            RecordWriter.CommitIncrement inc = writer.prepareCommit(true);
+            CommitIncrement inc = writer.prepareCommit(true);
             if (txn > 0 && txn % 3 == 0) {
                 assertThat(inc.compactIncrement().compactBefore()).hasSize(4);
                 assertThat(inc.compactIncrement().compactAfter()).hasSize(1);
@@ -199,7 +200,7 @@ public class AppendOnlyWriterTest {
         }
 
         writer.sync();
-        RecordWriter.CommitIncrement firstInc = writer.prepareCommit(true);
+        CommitIncrement firstInc = writer.prepareCommit(true);
         assertThat(firstInc.compactIncrement().compactBefore()).isEqualTo(Collections.emptyList());
         assertThat(firstInc.compactIncrement().compactAfter()).isEqualTo(Collections.emptyList());
 
@@ -241,7 +242,7 @@ public class AppendOnlyWriterTest {
         assertThat(toCompact).containsExactlyElementsOf(firstInc.newFilesIncrement().newFiles());
         writer.write(row(id, String.format("%03d", id), PART));
         writer.sync();
-        RecordWriter.CommitIncrement secInc = writer.prepareCommit(true);
+        CommitIncrement secInc = writer.prepareCommit(true);
 
         // check compact before and after
         List<DataFileMeta> compactBefore = secInc.compactIncrement().compactBefore();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/append/AppendOnlyWriterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/append/AppendOnlyWriterTest.java
@@ -329,7 +329,8 @@ public class AppendOnlyWriterTest {
                                                         generateCompactAfter(compactBefore)),
                                 pathFactory),
                         forceCompact,
-                        pathFactory),
+                        pathFactory,
+                        null),
                 toCompact);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileFormatSuffixTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileFormatSuffixTest.java
@@ -79,7 +79,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                                 null,
                                 dataFilePathFactory), // not used
                         false,
-                        dataFilePathFactory);
+                        dataFilePathFactory,
+                        null);
         appendOnlyWriter.write(
                 GenericRow.of(1, BinaryString.fromString("aaa"), BinaryString.fromString("1")));
         CommitIncrement increment = appendOnlyWriter.prepareCommit(true);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileFormatSuffixTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileFormatSuffixTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.io.DataFilePathFactory;
 import org.apache.flink.table.store.file.io.KeyValueFileReadWriteTest;
 import org.apache.flink.table.store.file.io.KeyValueFileWriterFactory;
-import org.apache.flink.table.store.file.utils.RecordWriter;
+import org.apache.flink.table.store.file.utils.CommitIncrement;
 import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.fs.Path;
 import org.apache.flink.table.store.fs.local.LocalFileIO;
@@ -82,7 +82,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         dataFilePathFactory);
         appendOnlyWriter.write(
                 GenericRow.of(1, BinaryString.fromString("aaa"), BinaryString.fromString("1")));
-        RecordWriter.CommitIncrement increment = appendOnlyWriter.prepareCommit(true);
+        CommitIncrement increment = appendOnlyWriter.prepareCommit(true);
         appendOnlyWriter.close();
 
         DataFileMeta meta = increment.newFilesIncrement().newFiles().get(0);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -328,7 +328,8 @@ public class MergeTreeTest {
                         DeduplicateMergeFunction.factory().create(),
                         writerFactory,
                         options.commitForceCompact(),
-                        ChangelogProducer.NONE);
+                        ChangelogProducer.NONE,
+                        null);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
         return writer;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.store.file.mergetree.compact.UniversalCompaction;
 import org.apache.flink.table.store.file.schema.KeyValueFieldsExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.utils.CommitIncrement;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.format.FileFormat;
@@ -254,7 +255,7 @@ public class MergeTreeTest {
             }
             writeAll(records);
             expected.addAll(records);
-            RecordWriter.CommitIncrement increment = writer.prepareCommit(true);
+            CommitIncrement increment = writer.prepareCommit(true);
             mergeCompacted(newFileNames, compactedFiles, increment);
         }
         writer.close();
@@ -285,7 +286,7 @@ public class MergeTreeTest {
                 writer.sync();
             }
 
-            RecordWriter.CommitIncrement increment = writer.prepareCommit(true);
+            CommitIncrement increment = writer.prepareCommit(true);
             newFiles.addAll(increment.newFilesIncrement().newFiles());
             mergeCompacted(newFileNames, compactedFiles, increment);
         }
@@ -354,7 +355,7 @@ public class MergeTreeTest {
     private void mergeCompacted(
             Set<String> newFileNames,
             List<DataFileMeta> compactedFiles,
-            RecordWriter.CommitIncrement increment) {
+            CommitIncrement increment) {
         increment.newFilesIncrement().newFiles().stream()
                 .map(DataFileMeta::fileName)
                 .forEach(newFileNames::add);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/TableWriteTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/TableWriteTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.sink;
+
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.data.GenericRow;
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.file.operation.AbstractFileStoreWrite;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.SchemaUtils;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.utils.TraceableFileIO;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.options.MemorySize;
+import org.apache.flink.table.store.options.Options;
+import org.apache.flink.table.store.reader.RecordReaderIterator;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.source.TableScan;
+import org.apache.flink.table.store.types.DataType;
+import org.apache.flink.table.store.types.DataTypes;
+import org.apache.flink.table.store.types.RowType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableWriteImpl}. */
+public class TableWriteTest {
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
+                    new String[] {"pt", "k", "v"});
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private Path tablePath;
+    private String commitUser;
+
+    @BeforeEach
+    public void before() {
+        tablePath = new Path(TraceableFileIO.SCHEME + "://" + tempDir.toString());
+        commitUser = UUID.randomUUID().toString();
+    }
+
+    @AfterEach
+    public void after() {
+        // assert all connections are closed
+        Predicate<Path> pathPredicate = path -> path.toString().contains(tempDir.toString());
+        assertThat(TraceableFileIO.openInputStreams(pathPredicate)).isEmpty();
+        assertThat(TraceableFileIO.openOutputStreams(pathPredicate)).isEmpty();
+    }
+
+    @Test
+    public void testExtractAndRecoverState() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int commitCount = random.nextInt(10) + 1;
+        int extractCount = random.nextInt(10) + 1;
+        int numRecords = 1000;
+        int numPartitions = 2;
+        int numKeys = 100;
+
+        Map<Integer, List<Event>> events = new HashMap<>();
+        for (int i = 0; i < commitCount; i++) {
+            int prepareTime = random.nextInt(numRecords);
+            int commitTime = random.nextInt(prepareTime, numRecords);
+            events.computeIfAbsent(prepareTime, k -> new ArrayList<>()).add(Event.PREPARE_COMMIT);
+            events.computeIfAbsent(commitTime, k -> new ArrayList<>()).add(Event.COMMIT);
+        }
+        for (int i = 0; i < extractCount; i++) {
+            int extractTime = random.nextInt(numRecords);
+            List<Event> eventList = events.computeIfAbsent(extractTime, k -> new ArrayList<>());
+            eventList.add(random.nextInt(eventList.size() + 1), Event.EXTRACT_STATE);
+        }
+
+        FileStoreTable table = createFileStoreTable();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        Map<String, Long> expected = new HashMap<>();
+        List<List<CommitMessage>> commitList = new ArrayList<>();
+        int commitId = 0;
+        for (int i = 0; i < numRecords; i++) {
+            if (events.containsKey(i)) {
+                List<Event> eventList = events.get(i);
+                for (Event event : eventList) {
+                    switch (event) {
+                        case PREPARE_COMMIT:
+                            List<CommitMessage> messages =
+                                    write.prepareCommit(false, commitList.size());
+                            commitList.add(messages);
+                            break;
+                        case COMMIT:
+                            commit.commit(commitId, commitList.get(commitId));
+                            commitId++;
+                            break;
+                        case EXTRACT_STATE:
+                            List<AbstractFileStoreWrite.State> state = write.extractStateAndClose();
+                            write = table.newWrite(commitUser);
+                            write.recoverFromState(state);
+                            break;
+                    }
+                }
+            }
+
+            int partition = random.nextInt(numPartitions);
+            int key = random.nextInt(numKeys);
+            long value = random.nextLong();
+            write.write(GenericRow.of(partition, key, value));
+            expected.put(partition + "|" + key, value);
+        }
+
+        assertThat(commitId).isEqualTo(commitCount);
+        List<CommitMessage> messages = write.prepareCommit(false, commitCount);
+        commit.commit(commitCount, messages);
+        write.close();
+        commit.close();
+
+        Map<String, Long> actual = new HashMap<>();
+        TableScan.Plan plan = table.newScan().plan();
+        try (RecordReaderIterator<InternalRow> it =
+                new RecordReaderIterator<>(table.newRead().createReader(plan))) {
+            while (it.hasNext()) {
+                InternalRow row = it.next();
+                actual.put(row.getInt(0) + "|" + row.getInt(1), row.getLong(2));
+            }
+        }
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private enum Event {
+        PREPARE_COMMIT,
+        COMMIT,
+        EXTRACT_STATE
+    }
+
+    private FileStoreTable createFileStoreTable() throws Exception {
+        Options conf = new Options();
+        conf.set(CoreOptions.BUCKET, 2);
+        conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
+        conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
+
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), tablePath),
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Collections.singletonList("pt"),
+                                Arrays.asList("pt", "k"),
+                                conf.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/TableWriteTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/TableWriteTest.java
@@ -127,9 +127,10 @@ public class TableWriteTest {
                             commitId++;
                             break;
                         case EXTRACT_STATE:
-                            List<AbstractFileStoreWrite.State> state = write.extractStateAndClose();
+                            List<AbstractFileStoreWrite.State> state = write.checkpoint();
+                            write.close();
                             write = table.newWrite(commitUser);
-                            write.recoverFromState(state);
+                            write.restore(state);
                             break;
                     }
                 }

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -89,7 +89,7 @@ public class FileStoreSourceReaderTest {
         return new FileStoreSourceReader<>(
                 RecordsFunction.forIterate(),
                 context,
-                new TestChangelogDataReadWrite(tempDir.toString(), null).createReadWithKey(),
+                new TestChangelogDataReadWrite(tempDir.toString()).createReadWithKey(),
                 null);
     }
 

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
@@ -38,8 +38,6 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -50,8 +48,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,20 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Test for {@link FileStoreSourceSplitReader}. */
 public class FileStoreSourceSplitReaderTest {
 
-    private static ExecutorService service;
-
     @TempDir java.nio.file.Path tempDir;
-
-    @BeforeAll
-    public static void before() {
-        service = Executors.newSingleThreadExecutor();
-    }
-
-    @AfterAll
-    public static void after() {
-        service.shutdownNow();
-        service = null;
-    }
 
     @BeforeEach
     public void beforeEach() throws Exception {
@@ -126,7 +109,7 @@ public class FileStoreSourceSplitReaderTest {
     }
 
     private void innerTestOnce(boolean valueCountMode, int skip) throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(
                         valueCountMode ? rw.createReadWithValueCount() : rw.createReadWithKey(),
@@ -170,7 +153,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testPrimaryKeyWithDelete() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
 
@@ -213,7 +196,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testMultipleBatchInSplit() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
 
@@ -250,7 +233,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testRestore() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
 
@@ -277,7 +260,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testRestoreMultipleBatchInSplit() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
 
@@ -309,7 +292,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testMultipleSplits() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
 
@@ -348,7 +331,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testNoSplit() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), null);
         assertThatThrownBy(reader::fetch).hasMessageContaining("no split remaining");
@@ -357,7 +340,7 @@ public class FileStoreSourceSplitReaderTest {
 
     @Test
     public void testLimit() throws Exception {
-        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader<RecordAndPosition<RowData>> reader =
                 createReader(rw.createReadWithKey(), 2L);
 


### PR DESCRIPTION
Currently `Table` and `TableWrite` in Flink Table Store have a fixed schema. However to consume schema changes, Flink Table Store CDC sinks should have the ability to change its schema during a streaming job.

This require us to pause and store the states of a `TableWrite`, then create a `TableWrite` with newer schema and recover the states in the new `TableWrite`.