### PR TITLE
[FLINK-31465] Fix shortcode errors in docs.

### DIFF
--- a/docs/content/docs/concepts/append-only-table.md
+++ b/docs/content/docs/concepts/append-only-table.md
@@ -105,3 +105,5 @@ CREATE TABLE MyTable (
 ```
 
 {{< /tab >}}
+
+{{< /tabs >}}

--- a/docs/content/docs/how-to/creating-tables.md
+++ b/docs/content/docs/how-to/creating-tables.md
@@ -259,6 +259,7 @@ CREATE TABLE MyTableLike LIKE MyTable;
 
 {{< /tab >}}
 
+{{< /tabs >}}
 
 ### Table Properties
 

--- a/docs/content/docs/how-to/writing-tables.md
+++ b/docs/content/docs/how-to/writing-tables.md
@@ -446,3 +446,6 @@ For more information of 'merge-into', see
     /path/to/flink-table-store-flink-**-{{< version >}}.jar \
     merge-into --help
 ```
+{{< /tab >}}
+
+{{< /tabs >}}


### PR DESCRIPTION
Fix the following shortcode errors in docs:

- append-only-table.md
- creating-tables.md
- writing-tables.md