### PR TITLE
Introduce Presto Reader for table store

### DIFF
--- a/flink-table-store-presto/flink-table-store-presto-0.270/pom.xml
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>flink-table-store-presto</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>0.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-table-store-presto-0.270</artifactId>
+    <name>Flink Table Store : Presto : 0.270</name>
+
+    <properties>
+        <presto.version>0.270</presto.version>
+        <hadoop.apache2.version>2.7.4-9</hadoop.apache2.version>
+        <slf4j.version>1.7.25</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-store-presto-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+            <version>${hadoop.apache2.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.flink:flink-table-store-presto-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoConnector.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoConnector.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link Connector}. */
+public class PrestoConnector implements Connector {
+
+    private final PrestoTransactionManager transactionManager;
+    private final PrestoSplitManager prestoSplitManager;
+    private final PrestoPageSourceProvider prestoPageSourceProvider;
+    private final PrestoMetadataFactory prestoMetadataFactory;
+
+    public PrestoConnector(
+            PrestoTransactionManager transactionManager,
+            PrestoSplitManager prestoSplitManager,
+            PrestoPageSourceProvider prestoPageSourceProvider,
+            PrestoMetadataFactory prestoMetadataFactory) {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.prestoSplitManager = requireNonNull(prestoSplitManager, "prestoSplitManager is null");
+        this.prestoPageSourceProvider =
+                requireNonNull(prestoPageSourceProvider, "prestoPageSourceProvider is null");
+        this.prestoMetadataFactory =
+                requireNonNull(prestoMetadataFactory, "prestoMetadataFactory is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(
+            IsolationLevel isolationLevel, boolean readOnly) {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        ConnectorTransactionHandle transaction = new PrestoTransactionHandle();
+        try (ThreadContextClassLoader ignored =
+                new ThreadContextClassLoader(getClass().getClassLoader())) {
+            transactionManager.put(transaction, prestoMetadataFactory.create());
+        }
+        return transaction;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle) {
+        ConnectorMetadata metadata = transactionManager.get(transactionHandle);
+        return new ClassLoaderSafeConnectorMetadata(metadata, getClass().getClassLoader());
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager() {
+        return prestoSplitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider() {
+        return prestoPageSourceProvider;
+    }
+
+    @Override
+    public void commit(ConnectorTransactionHandle transaction) {
+        transactionManager.remove(transaction);
+    }
+
+    @Override
+    public void rollback(ConnectorTransactionHandle transaction) {
+        transactionManager.remove(transaction);
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoConnectorFactory.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoConnectorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.options.Options;
+
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link ConnectorFactory}. */
+public class PrestoConnectorFactory implements ConnectorFactory {
+
+    @Override
+    public String getName() {
+        return "paimon";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver() {
+        return new PrestoHandleResolver();
+    }
+
+    @Override
+    public Connector create(
+            String catalogName, Map<String, String> config, ConnectorContext context) {
+        requireNonNull(config, "config is null");
+        return new PrestoConnector(
+                new PrestoTransactionManager(),
+                new PrestoSplitManager(),
+                new PrestoPageSourceProvider(),
+                new PrestoMetadataFactory(Options.fromMap(config), context.getTypeManager())) {};
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoPlugin.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/main/java/org/apache/flink/table/store/presto/PrestoPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+
+import java.util.Collections;
+
+/** Presto {@link Plugin}. */
+public class PrestoPlugin implements Plugin {
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories() {
+        return Collections.singletonList(new PrestoConnectorFactory());
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.store.presto.PrestoPlugin

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/test/java/org/apache/flink/table/store/presto/SimpleTableTestHelper.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/test/java/org/apache/flink/table/store/presto/SimpleTableTestHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.sink.InnerTableCommit;
+import org.apache.flink.table.store.table.sink.InnerTableWrite;
+import org.apache.flink.table.store.types.RowType;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/** A simple table test helper to write and commit. */
+public class SimpleTableTestHelper {
+
+    private final InnerTableWrite writer;
+    private final InnerTableCommit commit;
+
+    public SimpleTableTestHelper(Path path, RowType rowType) throws Exception {
+        new SchemaManager(LocalFileIO.create(), path)
+                .createTable(
+                        new Schema(
+                                rowType.getFields(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                new HashMap<>(),
+                                ""));
+        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
+        String user = "user";
+        this.writer = table.newWrite(user);
+        this.commit = table.newCommit(user);
+    }
+
+    public void write(InternalRow row) throws Exception {
+        writer.write(row);
+    }
+
+    public void commit() throws Exception {
+        commit.commit(0, writer.prepareCommit(true, 0));
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/test/java/org/apache/flink/table/store/presto/TestPrestoITCase.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/test/java/org/apache/flink/table/store/presto/TestPrestoITCase.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.data.GenericMap;
+import org.apache.flink.table.store.data.GenericRow;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.sink.InnerTableCommit;
+import org.apache.flink.table.store.table.sink.InnerTableWrite;
+import org.apache.flink.table.store.types.BigIntType;
+import org.apache.flink.table.store.types.CharType;
+import org.apache.flink.table.store.types.DataField;
+import org.apache.flink.table.store.types.IntType;
+import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.RowKind;
+import org.apache.flink.table.store.types.RowType;
+import org.apache.flink.table.store.types.VarCharType;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.apache.flink.table.store.data.BinaryString.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for presto connector. */
+public class TestPrestoITCase {
+
+    private static final String CATALOG = "paimon";
+    private static final String DB = "default";
+
+    protected QueryRunner createQueryRunner() throws Exception {
+        String warehouse =
+                Files.createTempDirectory(UUID.randomUUID().toString()).toUri().toString();
+
+        Path tablePath1 = new Path(warehouse, DB + ".db/t1");
+        SimpleTableTestHelper testHelper1 = createTestHelper(tablePath1);
+        testHelper1.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper1.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper1.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper1.write(
+                GenericRow.ofKind(RowKind.DELETE, 3, 4L, fromString("2"), fromString("2")));
+        testHelper1.commit();
+
+        Path tablePath2 = new Path(warehouse, "default.db/t2");
+        SimpleTableTestHelper testHelper2 = createTestHelper(tablePath2);
+        testHelper2.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper2.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper2.commit();
+        testHelper2.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper2.write(GenericRow.of(7, 8L, fromString("4"), fromString("4")));
+        testHelper2.commit();
+
+        {
+            Path tablePath3 = new Path(warehouse, "default.db/t3");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "pt", new VarCharType()),
+                                    new DataField(1, "a", new IntType()),
+                                    new DataField(2, "b", new BigIntType()),
+                                    new DataField(3, "c", new BigIntType()),
+                                    new DataField(4, "d", new IntType())));
+            new SchemaManager(LocalFileIO.create(), tablePath3)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.singletonList("pt"),
+                                    Collections.emptyList(),
+                                    new HashMap<>(),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath3);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(GenericRow.of(fromString("1"), 1, 1L, 1L, 1));
+            writer.write(GenericRow.of(fromString("1"), 1, 2L, 2L, 2));
+            writer.write(GenericRow.of(fromString("2"), 3, 3L, 3L, 3));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        {
+            Path tablePath4 = new Path(warehouse, "default.db/t4");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "i", new IntType()),
+                                    new DataField(
+                                            1,
+                                            "map",
+                                            new MapType(
+                                                    new VarCharType(VarCharType.MAX_LENGTH),
+                                                    new VarCharType(VarCharType.MAX_LENGTH)))));
+            new SchemaManager(LocalFileIO.create(), tablePath4)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.singletonList("i"),
+                                    new HashMap<>(),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            1,
+                            new GenericMap(
+                                    new HashMap<Object, Object>() {
+                                        {
+                                            put(fromString("1"), fromString("2"));
+                                        }
+                                    })));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner =
+                    DistributedQueryRunner.builder(
+                                    testSessionBuilder().setCatalog(CATALOG).setSchema(DB).build())
+                            .build();
+            queryRunner.installPlugin(new PrestoPlugin());
+            Map<String, String> options = new HashMap<>();
+            options.put("warehouse", warehouse);
+            queryRunner.createCatalog(CATALOG, CATALOG, options);
+            return queryRunner;
+        } catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    private static SimpleTableTestHelper createTestHelper(Path tablePath) throws Exception {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new IntType()),
+                                new DataField(1, "b", new BigIntType()),
+                                // test field name has upper case
+                                new DataField(2, "aCa", new VarCharType()),
+                                new DataField(3, "d", new CharType(1))));
+        return new SimpleTableTestHelper(tablePath, rowType);
+    }
+
+    @Test
+    public void testComplexTypes() throws Exception {
+        assertThat(sql("SELECT * FROM paimon.default.t4")).isEqualTo("[[1, {1=2}]]");
+    }
+
+    @Test
+    public void testSystemTable() throws Exception {
+        assertThat(
+                        sql(
+                                "SELECT snapshot_id,schema_id,commit_user,commit_identifier,commit_kind FROM \"t1$snapshots\""))
+                .isEqualTo("[[1, 0, user, 0, APPEND]]");
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        assertThat(sql("SELECT * FROM paimon.default.t1"))
+                .isEqualTo("[[1, 2, 1, 1], [5, 6, 3, 3]]");
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t1")).isEqualTo("[[1, 1], [5, 3]]");
+        assertThat(sql("SELECT SUM(b) FROM paimon.default.t1")).isEqualTo("[[8]]");
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t2 WHERE a < 4"))
+                .isEqualTo("[[1, 1], [3, 2]]");
+    }
+
+    @Test
+    public void testGroupByWithCast() throws Exception {
+        assertThat(
+                        sql(
+                                "SELECT pt, a, SUM(b), SUM(d) FROM paimon.default.t3 GROUP BY pt, a ORDER BY pt, a"))
+                .isEqualTo("[[1, 1, 3, 3], [2, 3, 3, 3]]");
+    }
+
+    private String sql(String sql) throws Exception {
+        MaterializedResult result = createQueryRunner().execute(sql);
+        return result.getMaterializedRows().toString();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.270/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-presto/flink-table-store-presto-0.270/src/test/resources/log4j2-test.properties
@@ -1,0 +1,38 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n
+
+logger.kafka.name = kafka
+logger.kafka.level = OFF
+logger.kafka2.name = state.change
+logger.kafka2.level = OFF
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = OFF
+logger.I0Itec.name = org.I0Itec
+logger.I0Itec.level = OFF

--- a/flink-table-store-presto/flink-table-store-presto-0.273/pom.xml
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>flink-table-store-presto</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>0.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-table-store-presto-0.273</artifactId>
+    <name>Flink Table Store : Presto : 0.273</name>
+
+    <properties>
+        <presto.version>0.273</presto.version>
+        <hadoop.apache2.version>2.7.4-9</hadoop.apache2.version>
+        <slf4j.version>1.7.25</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-store-presto-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+            <version>${hadoop.apache2.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.flink:flink-table-store-presto-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoConnector.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoConnector.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.EmptyConnectorCommitHandle;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link Connector}. */
+public class PrestoConnector implements Connector {
+
+    private final PrestoTransactionManager transactionManager;
+    private final PrestoSplitManager prestoSplitManager;
+    private final PrestoPageSourceProvider prestoPageSourceProvider;
+    private final PrestoMetadataFactory prestoMetadataFactory;
+
+    public PrestoConnector(
+            PrestoTransactionManager transactionManager,
+            PrestoSplitManager prestoSplitManager,
+            PrestoPageSourceProvider prestoPageSourceProvider,
+            PrestoMetadataFactory prestoMetadataFactory) {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.prestoSplitManager = requireNonNull(prestoSplitManager, "prestoSplitManager is null");
+        this.prestoPageSourceProvider =
+                requireNonNull(prestoPageSourceProvider, "prestoPageSourceProvider is null");
+        this.prestoMetadataFactory =
+                requireNonNull(prestoMetadataFactory, "prestoMetadataFactory is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(
+            IsolationLevel isolationLevel, boolean readOnly) {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        ConnectorTransactionHandle transaction = new PrestoTransactionHandle();
+        try (ThreadContextClassLoader ignored =
+                new ThreadContextClassLoader(getClass().getClassLoader())) {
+            transactionManager.put(transaction, prestoMetadataFactory.create());
+        }
+        return transaction;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle) {
+        ConnectorMetadata metadata = transactionManager.get(transactionHandle);
+        return new ClassLoaderSafeConnectorMetadata(metadata, getClass().getClassLoader());
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager() {
+        return prestoSplitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider() {
+        return prestoPageSourceProvider;
+    }
+
+    @Override
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction) {
+        transactionManager.remove(transaction);
+        return EmptyConnectorCommitHandle.INSTANCE;
+    }
+
+    @Override
+    public void rollback(ConnectorTransactionHandle transaction) {
+        transactionManager.remove(transaction);
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoConnectorFactory.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoConnectorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.options.Options;
+
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link ConnectorFactory}. */
+public class PrestoConnectorFactory implements ConnectorFactory {
+
+    @Override
+    public String getName() {
+        return "paimon";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver() {
+        return new PrestoHandleResolver();
+    }
+
+    @Override
+    public Connector create(
+            String catalogName, Map<String, String> config, ConnectorContext context) {
+        requireNonNull(config, "config is null");
+        return new PrestoConnector(
+                new PrestoTransactionManager(),
+                new PrestoSplitManager(),
+                new PrestoPageSourceProvider(),
+                new PrestoMetadataFactory(Options.fromMap(config), context.getTypeManager())) {};
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoPlugin.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/main/java/org/apache/flink/table/store/presto/PrestoPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+
+import java.util.Collections;
+
+/** Presto {@link Plugin}. */
+public class PrestoPlugin implements Plugin {
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories() {
+        return Collections.singletonList(new PrestoConnectorFactory());
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.store.presto.PrestoPlugin

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/test/java/org/apache/flink/table/store/presto/SimpleTableTestHelper.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/test/java/org/apache/flink/table/store/presto/SimpleTableTestHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.sink.InnerTableCommit;
+import org.apache.flink.table.store.table.sink.InnerTableWrite;
+import org.apache.flink.table.store.types.RowType;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/** A simple table test helper to write and commit. */
+public class SimpleTableTestHelper {
+
+    private final InnerTableWrite writer;
+    private final InnerTableCommit commit;
+
+    public SimpleTableTestHelper(Path path, RowType rowType) throws Exception {
+        new SchemaManager(LocalFileIO.create(), path)
+                .createTable(
+                        new Schema(
+                                rowType.getFields(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                new HashMap<>(),
+                                ""));
+        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
+        String user = "user";
+        this.writer = table.newWrite(user);
+        this.commit = table.newCommit(user);
+    }
+
+    public void write(InternalRow row) throws Exception {
+        writer.write(row);
+    }
+
+    public void commit() throws Exception {
+        commit.commit(0, writer.prepareCommit(true, 0));
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/test/java/org/apache/flink/table/store/presto/TestPrestoITCase.java
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/test/java/org/apache/flink/table/store/presto/TestPrestoITCase.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.data.GenericMap;
+import org.apache.flink.table.store.data.GenericRow;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.sink.InnerTableCommit;
+import org.apache.flink.table.store.table.sink.InnerTableWrite;
+import org.apache.flink.table.store.types.BigIntType;
+import org.apache.flink.table.store.types.CharType;
+import org.apache.flink.table.store.types.DataField;
+import org.apache.flink.table.store.types.IntType;
+import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.RowKind;
+import org.apache.flink.table.store.types.RowType;
+import org.apache.flink.table.store.types.VarCharType;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.apache.flink.table.store.data.BinaryString.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for presto connector. */
+public class TestPrestoITCase {
+
+    private static final String CATALOG = "paimon";
+    private static final String DB = "default";
+
+    protected QueryRunner createQueryRunner() throws Exception {
+        String warehouse =
+                Files.createTempDirectory(UUID.randomUUID().toString()).toUri().toString();
+
+        Path tablePath1 = new Path(warehouse, DB + ".db/t1");
+        SimpleTableTestHelper testHelper1 = createTestHelper(tablePath1);
+        testHelper1.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper1.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper1.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper1.write(
+                GenericRow.ofKind(RowKind.DELETE, 3, 4L, fromString("2"), fromString("2")));
+        testHelper1.commit();
+
+        Path tablePath2 = new Path(warehouse, "default.db/t2");
+        SimpleTableTestHelper testHelper2 = createTestHelper(tablePath2);
+        testHelper2.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper2.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper2.commit();
+        testHelper2.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper2.write(GenericRow.of(7, 8L, fromString("4"), fromString("4")));
+        testHelper2.commit();
+
+        {
+            Path tablePath3 = new Path(warehouse, "default.db/t3");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "pt", new VarCharType()),
+                                    new DataField(1, "a", new IntType()),
+                                    new DataField(2, "b", new BigIntType()),
+                                    new DataField(3, "c", new BigIntType()),
+                                    new DataField(4, "d", new IntType())));
+            new SchemaManager(LocalFileIO.create(), tablePath3)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.singletonList("pt"),
+                                    Collections.emptyList(),
+                                    new HashMap<>(),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath3);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(GenericRow.of(fromString("1"), 1, 1L, 1L, 1));
+            writer.write(GenericRow.of(fromString("1"), 1, 2L, 2L, 2));
+            writer.write(GenericRow.of(fromString("2"), 3, 3L, 3L, 3));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        {
+            Path tablePath4 = new Path(warehouse, "default.db/t4");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "i", new IntType()),
+                                    new DataField(
+                                            1,
+                                            "map",
+                                            new MapType(
+                                                    new VarCharType(VarCharType.MAX_LENGTH),
+                                                    new VarCharType(VarCharType.MAX_LENGTH)))));
+            new SchemaManager(LocalFileIO.create(), tablePath4)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.singletonList("i"),
+                                    new HashMap<>(),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            1,
+                            new GenericMap(
+                                    new HashMap<Object, Object>() {
+                                        {
+                                            put(fromString("1"), fromString("2"));
+                                        }
+                                    })));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner =
+                    DistributedQueryRunner.builder(
+                                    testSessionBuilder().setCatalog(CATALOG).setSchema(DB).build())
+                            .build();
+            queryRunner.installPlugin(new PrestoPlugin());
+            Map<String, String> options = new HashMap<>();
+            options.put("warehouse", warehouse);
+            queryRunner.createCatalog(CATALOG, CATALOG, options);
+            return queryRunner;
+        } catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    private static SimpleTableTestHelper createTestHelper(Path tablePath) throws Exception {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new IntType()),
+                                new DataField(1, "b", new BigIntType()),
+                                // test field name has upper case
+                                new DataField(2, "aCa", new VarCharType()),
+                                new DataField(3, "d", new CharType(1))));
+        return new SimpleTableTestHelper(tablePath, rowType);
+    }
+
+    @Test
+    public void testComplexTypes() throws Exception {
+        assertThat(sql("SELECT * FROM paimon.default.t4")).isEqualTo("[[1, {1=2}]]");
+    }
+
+    @Test
+    public void testSystemTable() throws Exception {
+        assertThat(
+                        sql(
+                                "SELECT snapshot_id,schema_id,commit_user,commit_identifier,commit_kind FROM \"t1$snapshots\""))
+                .isEqualTo("[[1, 0, user, 0, APPEND]]");
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        assertThat(sql("SELECT * FROM paimon.default.t1"))
+                .isEqualTo("[[1, 2, 1, 1], [5, 6, 3, 3]]");
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t1")).isEqualTo("[[1, 1], [5, 3]]");
+        assertThat(sql("SELECT SUM(b) FROM paimon.default.t1")).isEqualTo("[[8]]");
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t2 WHERE a < 4"))
+                .isEqualTo("[[1, 1], [3, 2]]");
+    }
+
+    @Test
+    public void testGroupByWithCast() throws Exception {
+        assertThat(
+                        sql(
+                                "SELECT pt, a, SUM(b), SUM(d) FROM paimon.default.t3 GROUP BY pt, a ORDER BY pt, a"))
+                .isEqualTo("[[1, 1, 3, 3], [2, 3, 3, 3]]");
+    }
+
+    private String sql(String sql) throws Exception {
+        MaterializedResult result = createQueryRunner().execute(sql);
+        return result.getMaterializedRows().toString();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-0.273/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-presto/flink-table-store-presto-0.273/src/test/resources/log4j2-test.properties
@@ -1,0 +1,38 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n
+
+logger.kafka.name = kafka
+logger.kafka.level = OFF
+logger.kafka2.name = state.change
+logger.kafka2.level = OFF
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = OFF
+logger.I0Itec.name = org.I0Itec
+logger.I0Itec.level = OFF

--- a/flink-table-store-presto/flink-table-store-presto-common/pom.xml
+++ b/flink-table-store-presto/flink-table-store-presto-common/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>flink-table-store-presto</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>0.4-SNAPSHOT</version>
+    </parent>
+
+    <packaging>jar</packaging>
+
+    <artifactId>flink-table-store-presto-common</artifactId>
+    <name>Flink Table Store : Presto : Common</name>
+
+    <properties>
+        <presto.version>0.273</presto.version>
+        <slf4j.version>1.7.25</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+            <version>${presto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.flink:flink-table-store-shade</include>
+                                    <include>org.slf4j:slf4j-api</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/ClassLoaderUtils.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/ClassLoaderUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import java.util.function.Supplier;
+
+/** Utils for {@link ClassLoader}. */
+public class ClassLoaderUtils {
+
+    public static <T> T runWithContextClassLoader(Supplier<T> supplier, ClassLoader classLoader) {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            return supplier.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/EncodingUtils.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/EncodingUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.utils.InstantiationUtil;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/** Utils for encoding. */
+public class EncodingUtils {
+
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+
+    public static <T> String encodeObjectToString(T t) {
+        try {
+            byte[] bytes = InstantiationUtil.serializeObject(t);
+            return new String(BASE64_ENCODER.encode(bytes), UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T decodeStringToObject(String encodedStr) {
+        final byte[] bytes = BASE64_DECODER.decode(encodedStr.getBytes(UTF_8));
+        try {
+            return InstantiationUtil.deserializeObject(bytes, EncodingUtils.class.getClassLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/FieldNameUtils.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/FieldNameUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.types.DataField;
+import org.apache.flink.table.store.types.RowType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Utils for fieldName. */
+public class FieldNameUtils {
+
+    public static List<String> fieldNames(RowType rowType) {
+        return rowType.getFields().stream()
+                .map(DataField::name)
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoColumnHandle.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoColumnHandle.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.store.types.DataType;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link ColumnHandle}. */
+public class PrestoColumnHandle implements ColumnHandle {
+
+    private final String columnName;
+    private final String typeString;
+    private final Type prestoType;
+
+    @JsonCreator
+    public PrestoColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("typeString") String typeString,
+            @JsonProperty("prestoType") Type prestoType) {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.typeString = requireNonNull(typeString, "typeString is null");
+        this.prestoType = requireNonNull(prestoType, "columnType is null");
+    }
+
+    public static PrestoColumnHandle create(
+            String columnName, DataType columnType, TypeManager typeManager) {
+        return new PrestoColumnHandle(
+                columnName,
+                JsonSerdeUtil.toJson(columnType),
+                PrestoTypeUtils.toPrestoType(columnType, typeManager));
+    }
+
+    @JsonProperty
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @JsonProperty
+    public String getTypeString() {
+        return typeString;
+    }
+
+    public DataType logicalType() {
+        return JsonSerdeUtil.fromJson(typeString, DataType.class);
+    }
+
+    @JsonProperty
+    public Type getPrestoType() {
+        return prestoType;
+    }
+
+    public ColumnMetadata getColumnMetadata() {
+        return new ColumnMetadata(columnName, prestoType);
+    }
+
+    @Override
+    public int hashCode() {
+        return columnName.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        PrestoColumnHandle other = (PrestoColumnHandle) obj;
+        return columnName.equals(other.columnName);
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "columnName='"
+                + columnName
+                + '\''
+                + ", typeString='"
+                + typeString
+                + '\''
+                + ", prestoType="
+                + prestoType
+                + '}';
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoFilterConverter.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoFilterConverter.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.types.RowType;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Preconditions;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.Decimals;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.TimeType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+import io.airlift.slice.Slice;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** Presto filter to Paimon predicate. */
+public class PrestoFilterConverter {
+
+    private final RowType rowType;
+    private final PredicateBuilder builder;
+
+    public PrestoFilterConverter(RowType rowType) {
+        this.rowType = rowType;
+        this.builder = new PredicateBuilder(rowType);
+    }
+
+    public Optional<Predicate> convert(TupleDomain<PrestoColumnHandle> tupleDomain) {
+        if (tupleDomain.isAll()) {
+            return Optional.empty();
+        }
+
+        if (!tupleDomain.getDomains().isPresent()) {
+            return Optional.empty();
+        }
+
+        Map<PrestoColumnHandle, Domain> domainMap = tupleDomain.getDomains().get();
+        List<Predicate> conjuncts = new ArrayList<>();
+        for (Map.Entry<PrestoColumnHandle, Domain> entry : domainMap.entrySet()) {
+            PrestoColumnHandle columnHandle = entry.getKey();
+            Domain domain = entry.getValue();
+            int index = rowType.getFieldNames().indexOf(columnHandle.getColumnName());
+            if (index != -1) {
+                try {
+                    conjuncts.add(toPredicate(index, columnHandle.getPrestoType(), domain));
+                } catch (UnsupportedOperationException ignored) {
+                }
+            }
+        }
+
+        if (conjuncts.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(builder.and());
+    }
+
+    private Predicate toPredicate(int columnIndex, Type type, Domain domain) {
+        if (domain.isAll()) {
+            // TODO alwaysTrue
+            throw new UnsupportedOperationException();
+        }
+        if (domain.getValues().isNone()) {
+            if (domain.isNullAllowed()) {
+                return builder.isNull((columnIndex));
+            }
+            // TODO alwaysFalse
+            throw new UnsupportedOperationException();
+        }
+
+        if (domain.getValues().isAll()) {
+            if (domain.isNullAllowed()) {
+                // TODO alwaysTrue
+                throw new UnsupportedOperationException();
+            }
+            return builder.isNotNull((columnIndex));
+        }
+
+        // TODO support structural types
+        if (type instanceof ArrayType
+                || type instanceof MapType
+                || type instanceof com.facebook.presto.common.type.RowType) {
+            // Fail fast. Ignoring expression could lead to data loss in case of deletions.
+            throw new UnsupportedOperationException();
+        }
+
+        if (type.isOrderable()) {
+            List<Range> orderedRanges = domain.getValues().getRanges().getOrderedRanges();
+            List<Object> values = new ArrayList<>();
+            List<Predicate> predicates = new ArrayList<>();
+            for (Range range : orderedRanges) {
+                if (range.isSingleValue()) {
+                    values.add(getLiteralValue(type, range.getLowBoundedValue()));
+                } else {
+                    predicates.add(toPredicate(columnIndex, range));
+                }
+            }
+
+            if (!values.isEmpty()) {
+                predicates.add(builder.in(columnIndex, values));
+            }
+
+            if (domain.isNullAllowed()) {
+                predicates.add(builder.isNull(columnIndex));
+            }
+            return PredicateBuilder.or(predicates);
+        }
+
+        throw new UnsupportedOperationException();
+    }
+
+    private Predicate toPredicate(int columnIndex, Range range) {
+        Type type = range.getType();
+
+        if (range.isSingleValue()) {
+            Object value = getLiteralValue(type, range.getSingleValue());
+            return builder.equal(columnIndex, value);
+        }
+
+        List<Predicate> conjuncts = new ArrayList<>(2);
+        if (!range.isLowUnbounded()) {
+            Object low = getLiteralValue(type, range.getLowBoundedValue());
+            Predicate lowBound;
+            if (range.isLowInclusive()) {
+                lowBound = builder.greaterOrEqual(columnIndex, low);
+            } else {
+                lowBound = builder.greaterThan(columnIndex, low);
+            }
+            conjuncts.add(lowBound);
+        }
+
+        if (!range.isHighUnbounded()) {
+            Object high = getLiteralValue(type, range.getHighBoundedValue());
+            Predicate highBound;
+            if (range.isHighInclusive()) {
+                highBound = builder.lessOrEqual(columnIndex, high);
+            } else {
+                highBound = builder.lessThan(columnIndex, high);
+            }
+            conjuncts.add(highBound);
+        }
+
+        return PredicateBuilder.and(conjuncts);
+    }
+
+    private Object getLiteralValue(Type type, Object prestoNativeValue) {
+        Objects.requireNonNull(prestoNativeValue, "prestoNativeValue is null");
+
+        if (type instanceof BooleanType) {
+            return prestoNativeValue;
+        }
+
+        if (type instanceof IntegerType) {
+            return Math.toIntExact((long) prestoNativeValue);
+        }
+
+        if (type instanceof BigintType) {
+            return prestoNativeValue;
+        }
+
+        if (type instanceof RealType) {
+            return Float.intBitsToFloat(Math.toIntExact((long) prestoNativeValue));
+        }
+
+        if (type instanceof DoubleType) {
+            return prestoNativeValue;
+        }
+
+        if (type instanceof DateType) {
+            return Math.toIntExact(((Long) prestoNativeValue));
+        }
+
+        if (type instanceof TimestampType || type instanceof TimeType) {
+            return TimeUnit.MILLISECONDS.toMicros((Long) prestoNativeValue);
+        }
+
+        if (type instanceof VarcharType) {
+            return ((Slice) prestoNativeValue).toStringUtf8();
+        }
+
+        if (type instanceof VarbinaryType) {
+            return ((Slice) prestoNativeValue).getBytes();
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            Object value =
+                    Objects.requireNonNull(
+                            prestoNativeValue, "The prestoNativeValue must be non-null");
+            if (Decimals.isShortDecimal(decimalType)) {
+                Preconditions.checkArgument(
+                        value instanceof Long,
+                        "A short decimal should be represented by a Long value but was %s",
+                        value.getClass().getName());
+                return BigDecimal.valueOf((long) value).movePointLeft(decimalType.getScale());
+            }
+            Preconditions.checkArgument(
+                    value instanceof Slice,
+                    "A long decimal should be represented by a Slice value but was %s",
+                    value.getClass().getName());
+            return new BigDecimal(
+                    Decimals.decodeUnscaledValue((Slice) value), decimalType.getScale());
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoHandleResolver.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoHandleResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+/** Presto {@link ConnectorHandleResolver}. */
+public class PrestoHandleResolver implements ConnectorHandleResolver {
+
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass() {
+        return PrestoTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass() {
+        return PrestoTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass() {
+        return PrestoColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass() {
+        return PrestoSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass() {
+        return PrestoTransactionHandle.class;
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoMetadata.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoMetadata.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.catalog.CatalogContext;
+import org.apache.flink.table.store.file.catalog.Catalog;
+import org.apache.flink.table.store.file.catalog.CatalogFactory;
+import org.apache.flink.table.store.file.catalog.Identifier;
+import org.apache.flink.table.store.options.Options;
+import org.apache.flink.table.store.utils.InstantiationUtil;
+import org.apache.flink.table.store.utils.StringUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.flink.table.store.utils.Preconditions.checkArgument;
+
+/** Presto {@link ConnectorMetadata}. */
+public class PrestoMetadata implements ConnectorMetadata {
+
+    private final Catalog catalog;
+    private final TypeManager typeManager;
+
+    public PrestoMetadata(Options catalogOptions, TypeManager typeManager) {
+        this.catalog = CatalogFactory.createCatalog(CatalogContext.create(catalogOptions));
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session) {
+        return listSchemaNames();
+    }
+
+    private List<String> listSchemaNames() {
+        return catalog.listDatabases();
+    }
+
+    @Override
+    public boolean schemaExists(ConnectorSession session, String schemaName) {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(schemaName),
+                "schemaName cannot be null or empty");
+        return catalog.databaseExists(schemaName);
+    }
+
+    @Override
+    public void createSchema(
+            ConnectorSession session, String schemaName, Map<String, Object> properties) {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(schemaName),
+                "schemaName cannot be null or empty");
+        try {
+            catalog.createDatabase(schemaName, true);
+        } catch (Catalog.DatabaseAlreadyExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName) {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(schemaName),
+                "schemaName cannot be null or empty");
+        try {
+            catalog.dropDatabase(schemaName, true, true);
+        } catch (Catalog.DatabaseNotExistException | Catalog.DatabaseNotEmptyException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public PrestoTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName) {
+        return getTableHandle(tableName);
+    }
+
+    public PrestoTableHandle getTableHandle(SchemaTableName tableName) {
+        Identifier tablePath = new Identifier(tableName.getSchemaName(), tableName.getTableName());
+        byte[] serializedTable;
+        try {
+            serializedTable = InstantiationUtil.serializeObject(catalog.getTable(tablePath));
+        } catch (Catalog.TableNotExistException e) {
+            return null;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new PrestoTableHandle(
+                tableName.getSchemaName(), tableName.getTableName(), serializedTable);
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns) {
+        PrestoTableHandle handle = (PrestoTableHandle) table;
+        ConnectorTableLayout layout =
+                new ConnectorTableLayout(
+                        new PrestoTableLayoutHandle(handle, constraint.getSummary()));
+        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(
+            ConnectorSession session, ConnectorTableLayoutHandle handle) {
+        return new ConnectorTableLayout(handle);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(
+            ConnectorSession session, ConnectorTableHandle table) {
+        return ((PrestoTableHandle) table).tableMetadata(typeManager);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(
+            ConnectorSession session, ConnectorTableHandle tableHandle) {
+        PrestoTableHandle table = (PrestoTableHandle) tableHandle;
+        Map<String, ColumnHandle> handleMap = new HashMap<>();
+        for (ColumnMetadata column : table.columnMetadatas(typeManager)) {
+            handleMap.put(column.getName(), table.columnHandle(column.getName(), typeManager));
+        }
+        return handleMap;
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(
+            ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle) {
+        return ((PrestoColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName) {
+        List<SchemaTableName> tables = new ArrayList<>();
+        schemaName
+                .map(Collections::singletonList)
+                .orElseGet(catalog::listDatabases)
+                .forEach(schema -> tables.addAll(listTables(schema)));
+        return tables;
+    }
+
+    private List<SchemaTableName> listTables(String schema) {
+        try {
+            return catalog.listTables(schema).stream()
+                    .map(table -> new SchemaTableName(schema, table))
+                    .collect(toList());
+        } catch (Catalog.DatabaseNotExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void renameTable(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            SchemaTableName newTableName) {
+        PrestoTableHandle oldTableHandle = (PrestoTableHandle) tableHandle;
+        try {
+            catalog.renameTable(
+                    new Identifier(oldTableHandle.getSchemaName(), oldTableHandle.getTableName()),
+                    new Identifier(newTableName.getSchemaName(), newTableName.getTableName()),
+                    true);
+        } catch (Catalog.TableNotExistException | Catalog.TableAlreadyExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle) {
+        PrestoTableHandle prestoTableHandle = (PrestoTableHandle) tableHandle;
+        try {
+            catalog.dropTable(
+                    new Identifier(
+                            prestoTableHandle.getSchemaName(), prestoTableHandle.getTableName()),
+                    true);
+        } catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(
+            ConnectorSession session, SchemaTablePrefix prefix) {
+        requireNonNull(prefix, "prefix is null");
+        List<SchemaTableName> tableNames;
+        if (prefix.getTableName() != null) {
+            tableNames = Collections.singletonList(prefix.toSchemaTableName());
+        } else {
+            tableNames = listTables(session, Optional.of(prefix.getSchemaName()));
+        }
+
+        return tableNames.stream()
+                .collect(
+                        toMap(
+                                Function.identity(),
+                                table ->
+                                        getTableHandle(session, table)
+                                                .columnMetadatas(typeManager)));
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoMetadataFactory.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoMetadataFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.options.Options;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+
+/** Presto MetadataFactory. */
+public class PrestoMetadataFactory {
+
+    private final Options catalogOptions;
+    private final TypeManager typeManager;
+
+    public PrestoMetadataFactory(Options catalogOptions, TypeManager typeManager) {
+        this.catalogOptions = catalogOptions;
+        this.typeManager = typeManager;
+    }
+
+    public ConnectorMetadata create() {
+        return new PrestoMetadata(catalogOptions, typeManager);
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoPageSource.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoPageSource.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.data.BinaryString;
+import org.apache.flink.table.store.data.Decimal;
+import org.apache.flink.table.store.data.InternalArray;
+import org.apache.flink.table.store.data.InternalMap;
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.data.Timestamp;
+import org.apache.flink.table.store.reader.RecordReader;
+import org.apache.flink.table.store.types.DataType;
+import org.apache.flink.table.store.types.DataTypeChecks;
+import org.apache.flink.table.store.utils.RowDataUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Verify;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.Decimals;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.Decimals.encodeShortScaledValue;
+import static com.facebook.presto.common.type.Decimals.isLongDecimal;
+import static com.facebook.presto.common.type.Decimals.isShortDecimal;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.String.format;
+
+/** Presto {@link ConnectorPageSource}. */
+public class PrestoPageSource implements ConnectorPageSource {
+
+    private final RecordReader<InternalRow> reader;
+    private final PageBuilder pageBuilder;
+    private final List<Type> columnTypes;
+    private final List<DataType> logicalTypes;
+
+    private boolean isFinished = false;
+
+    public PrestoPageSource(RecordReader<InternalRow> reader, List<ColumnHandle> projectedColumns) {
+        this.reader = reader;
+        this.columnTypes = new ArrayList<>();
+        this.logicalTypes = new ArrayList<>();
+        for (ColumnHandle handle : projectedColumns) {
+            PrestoColumnHandle prestoColumnHandle = (PrestoColumnHandle) handle;
+            columnTypes.add(prestoColumnHandle.getPrestoType());
+            logicalTypes.add(prestoColumnHandle.logicalType());
+        }
+
+        this.pageBuilder = new PageBuilder(columnTypes);
+    }
+
+    @Override
+    public long getCompletedBytes() {
+        return 0;
+    }
+
+    @Override
+    public long getCompletedPositions() {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos() {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return isFinished;
+    }
+
+    @Override
+    public Page getNextPage() {
+        try {
+            return nextPage();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public long getSystemMemoryUsage() {
+        return 0;
+    }
+
+    private Page nextPage() throws IOException {
+        RecordReader.RecordIterator<InternalRow> batch = reader.readBatch();
+        if (batch == null) {
+            isFinished = true;
+            return null;
+        }
+        InternalRow row;
+        while ((row = batch.next()) != null) {
+            pageBuilder.declarePosition();
+            for (int i = 0; i < columnTypes.size(); i++) {
+                BlockBuilder output = pageBuilder.getBlockBuilder(i);
+                appendTo(
+                        columnTypes.get(i),
+                        logicalTypes.get(i),
+                        RowDataUtils.get(row, i, logicalTypes.get(i)),
+                        output);
+            }
+        }
+        batch.releaseBatch();
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return page;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.reader.close();
+    }
+
+    private void appendTo(Type type, DataType logicalType, Object value, BlockBuilder output) {
+        if (value == null) {
+            output.appendNull();
+            return;
+        }
+
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            type.writeBoolean(output, (Boolean) value);
+        } else if (javaType == long.class) {
+            if (type.equals(BIGINT)) {
+                type.writeLong(output, ((Number) value).longValue());
+            } else if (type.equals(INTEGER)) {
+                type.writeLong(output, ((Number) value).intValue());
+            } else if (type instanceof DecimalType) {
+                Verify.verify(isShortDecimal(type), "The type should be short decimal");
+                DecimalType decimalType = (DecimalType) type;
+                BigDecimal decimal = ((Decimal) value).toBigDecimal();
+                type.writeLong(output, encodeShortScaledValue(decimal, decimalType.getScale()));
+            } else if (type.equals(DATE)) {
+                type.writeLong(output, (int) value);
+            } else if (type.equals(TIMESTAMP)) {
+                type.writeLong(output, ((Timestamp) value).getMillisecond() * 1_000);
+            } else if (type.equals(TIME)) {
+                type.writeLong(output, (int) value * 1_000);
+            } else {
+                throw new PrestoException(
+                        GENERIC_INTERNAL_ERROR,
+                        format("Unhandled type for %s: %s", javaType.getSimpleName(), type));
+            }
+        } else if (javaType == double.class) {
+            type.writeDouble(output, ((Number) value).doubleValue());
+        } else if (type instanceof DecimalType) {
+            writeObject(output, type, value);
+        } else if (javaType == Slice.class) {
+            writeSlice(output, type, value);
+        } else if (javaType == Block.class) {
+            writeBlock(output, type, logicalType, value);
+        } else {
+            throw new PrestoException(
+                    GENERIC_INTERNAL_ERROR,
+                    format("Unhandled type for %s: %s", javaType.getSimpleName(), type));
+        }
+    }
+
+    private static void writeSlice(BlockBuilder output, Type type, Object value) {
+        if (type instanceof VarcharType || type instanceof CharType) {
+            type.writeSlice(output, wrappedBuffer(((BinaryString) value).toBytes()));
+        } else if (type instanceof VarbinaryType) {
+            type.writeSlice(output, wrappedBuffer((byte[]) value));
+        } else {
+            throw new PrestoException(
+                    GENERIC_INTERNAL_ERROR, "Unhandled type for Slice: " + type.getTypeSignature());
+        }
+    }
+
+    private static void writeObject(BlockBuilder output, Type type, Object value) {
+        if (type instanceof DecimalType) {
+            Verify.verify(isLongDecimal(type), "The type should be long decimal");
+            DecimalType decimalType = (DecimalType) type;
+            BigDecimal decimal = ((Decimal) value).toBigDecimal();
+            type.writeObject(output, Decimals.encodeScaledValue(decimal, decimalType.getScale()));
+        } else {
+            throw new PrestoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Unhandled type for Object: " + type.getTypeSignature());
+        }
+    }
+
+    private void writeBlock(BlockBuilder output, Type type, DataType logicalType, Object value) {
+        if (type instanceof ArrayType) {
+            BlockBuilder builder = output.beginBlockEntry();
+
+            InternalArray arrayData = (InternalArray) value;
+            DataType elementType = DataTypeChecks.getNestedTypes(logicalType).get(0);
+            for (int i = 0; i < arrayData.size(); i++) {
+                appendTo(
+                        type.getTypeParameters().get(0),
+                        elementType,
+                        RowDataUtils.get(arrayData, i, elementType),
+                        builder);
+            }
+
+            output.closeEntry();
+            return;
+        }
+        if (type instanceof RowType) {
+            InternalRow rowData = (InternalRow) value;
+            BlockBuilder builder = output.beginBlockEntry();
+            for (int index = 0; index < type.getTypeParameters().size(); index++) {
+                Type fieldType = type.getTypeParameters().get(index);
+                DataType fieldLogicalType =
+                        ((org.apache.flink.table.store.types.RowType) logicalType).getTypeAt(index);
+                appendTo(
+                        fieldType,
+                        fieldLogicalType,
+                        RowDataUtils.get(rowData, index, fieldLogicalType),
+                        builder);
+            }
+            output.closeEntry();
+            return;
+        }
+        if (type instanceof MapType) {
+            InternalMap mapData = (InternalMap) value;
+            InternalArray keyArray = mapData.keyArray();
+            InternalArray valueArray = mapData.valueArray();
+            DataType keyType =
+                    ((org.apache.flink.table.store.types.MapType) logicalType).getKeyType();
+            DataType valueType =
+                    ((org.apache.flink.table.store.types.MapType) logicalType).getValueType();
+            BlockBuilder builder = output.beginBlockEntry();
+            for (int i = 0; i < keyArray.size(); i++) {
+                appendTo(
+                        type.getTypeParameters().get(0),
+                        keyType,
+                        RowDataUtils.get(keyArray, i, keyType),
+                        builder);
+                appendTo(
+                        type.getTypeParameters().get(1),
+                        valueType,
+                        RowDataUtils.get(valueArray, i, valueType),
+                        builder);
+            }
+            output.closeEntry();
+            return;
+        }
+        throw new PrestoException(
+                GENERIC_INTERNAL_ERROR, "Unhandled type for Block: " + type.getTypeSignature());
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoPageSourceProvider.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoPageSourceProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.table.Table;
+import org.apache.flink.table.store.table.source.ReadBuilder;
+import org.apache.flink.table.store.types.RowType;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.presto.ClassLoaderUtils.runWithContextClassLoader;
+
+/** Presto {@link ConnectorPageSourceProvider}. */
+public class PrestoPageSourceProvider implements ConnectorPageSourceProvider {
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableLayoutHandle layout,
+            List<ColumnHandle> columns,
+            SplitContext splitContext) {
+        return runWithContextClassLoader(
+                () ->
+                        createPageSource(
+                                ((PrestoTableLayoutHandle) layout).getTableHandle(),
+                                (PrestoSplit) split,
+                                columns),
+                PrestoPageSourceProvider.class.getClassLoader());
+    }
+
+    private ConnectorPageSource createPageSource(
+            PrestoTableHandle tableHandle, PrestoSplit split, List<ColumnHandle> columns) {
+        Table table = tableHandle.table();
+        ReadBuilder read = table.newReadBuilder();
+        RowType rowType = table.rowType();
+        List<String> fieldNames = FieldNameUtils.fieldNames(rowType);
+        List<String> projectedFields =
+                columns.stream()
+                        .map(PrestoColumnHandle.class::cast)
+                        .map(PrestoColumnHandle::getColumnName)
+                        .collect(Collectors.toList());
+        if (!fieldNames.equals(projectedFields)) {
+            int[] projected = projectedFields.stream().mapToInt(fieldNames::indexOf).toArray();
+            read.withProjection(projected);
+        }
+
+        new PrestoFilterConverter(rowType)
+                .convert(tableHandle.getFilter())
+                .ifPresent(read::withFilter);
+
+        try {
+            return new PrestoPageSource(read.newRead().createReader(split.decodeSplit()), columns);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplit.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplit.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.table.source.Split;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+
+/** Trino {@link ConnectorSplit}. */
+public class PrestoSplit implements ConnectorSplit {
+
+    private final String splitSerialized;
+
+    @JsonCreator
+    public PrestoSplit(@JsonProperty("splitSerialized") String splitSerialized) {
+        this.splitSerialized = splitSerialized;
+    }
+
+    public static PrestoSplit fromSplit(Split split) {
+        return new PrestoSplit(EncodingUtils.encodeObjectToString(split));
+    }
+
+    public Split decodeSplit() {
+        return EncodingUtils.decodeStringToObject(splitSerialized);
+    }
+
+    @JsonProperty
+    public String getSplitSerialized() {
+        return splitSerialized;
+    }
+
+    @Override
+    public NodeSelectionStrategy getNodeSelectionStrategy() {
+        return NO_PREFERENCE;
+    }
+
+    @Override
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Object getInfo() {
+        return Collections.emptyMap();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplitManager.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplitManager.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.table.Table;
+import org.apache.flink.table.store.table.source.ReadBuilder;
+import org.apache.flink.table.store.table.source.Split;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Presto {@link ConnectorSplitManager}. */
+public class PrestoSplitManager implements ConnectorSplitManager {
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext) {
+
+        PrestoTableHandle tableHandle = ((PrestoTableLayoutHandle) layout).getTableHandle();
+        Table table = tableHandle.table();
+        ReadBuilder readBuilder = table.newReadBuilder();
+        new PrestoFilterConverter(table.rowType())
+                .convert(tableHandle.getFilter())
+                .ifPresent(readBuilder::withFilter);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        return new PrestoSplitSource(
+                splits.stream().map(PrestoSplit::fromSplit).collect(Collectors.toList()));
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplitSource.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoSplitSource.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+/** Presto {@link ConnectorSplitSource}. */
+public class PrestoSplitSource implements ConnectorSplitSource {
+
+    private final Queue<PrestoSplit> splits;
+
+    public PrestoSplitSource(List<PrestoSplit> splits) {
+        this.splits = new LinkedList<>(splits);
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(
+            ConnectorPartitionHandle partitionHandle, int maxSize) {
+        List<ConnectorSplit> batch = new ArrayList<>();
+        for (int i = 0; i < maxSize; i++) {
+            PrestoSplit split = splits.poll();
+            if (split == null) {
+                break;
+            }
+            batch.add(split);
+        }
+        return CompletableFuture.completedFuture(new ConnectorSplitBatch(batch, isFinished()));
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isFinished() {
+        return splits.isEmpty();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTableHandle.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTableHandle.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.table.Table;
+import org.apache.flink.table.store.utils.InstantiationUtil;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Presto {@link ConnectorTableHandle}. */
+public class PrestoTableHandle implements ConnectorTableHandle {
+
+    private final String schemaName;
+    private final String tableName;
+    private final byte[] serializedTable;
+    private final TupleDomain<PrestoColumnHandle> filter;
+    private final Optional<List<ColumnHandle>> projectedColumns;
+
+    private Table lazyTable;
+
+    public PrestoTableHandle(String schemaName, String tableName, byte[] serializedTable) {
+        this(schemaName, tableName, serializedTable, TupleDomain.all(), Optional.empty());
+    }
+
+    @JsonCreator
+    public PrestoTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("serializedTable") byte[] serializedTable,
+            @JsonProperty("filter") TupleDomain<PrestoColumnHandle> filter,
+            @JsonProperty("projection") Optional<List<ColumnHandle>> projectedColumns) {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.serializedTable = serializedTable;
+        this.filter = filter;
+        this.projectedColumns = projectedColumns;
+    }
+
+    @JsonProperty
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName() {
+        return tableName;
+    }
+
+    @JsonProperty
+    public byte[] getSerializedTable() {
+        return serializedTable;
+    }
+
+    @JsonProperty
+    public TupleDomain<PrestoColumnHandle> getFilter() {
+        return filter;
+    }
+
+    @JsonProperty
+    public Optional<List<ColumnHandle>> getProjectedColumns() {
+        return projectedColumns;
+    }
+
+    public PrestoTableHandle copy(TupleDomain<PrestoColumnHandle> filter) {
+        return new PrestoTableHandle(
+                schemaName, tableName, serializedTable, filter, projectedColumns);
+    }
+
+    public PrestoTableHandle copy(Optional<List<ColumnHandle>> projectedColumns) {
+        return new PrestoTableHandle(
+                schemaName, tableName, serializedTable, filter, projectedColumns);
+    }
+
+    public Table table() {
+        if (lazyTable == null) {
+            try {
+                lazyTable =
+                        InstantiationUtil.deserializeObject(
+                                serializedTable, this.getClass().getClassLoader());
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return lazyTable;
+    }
+
+    public ConnectorTableMetadata tableMetadata(TypeManager typeManager) {
+        return new ConnectorTableMetadata(
+                new SchemaTableName(schemaName, tableName),
+                columnMetadatas(typeManager),
+                Collections.emptyMap());
+    }
+
+    public List<ColumnMetadata> columnMetadatas(TypeManager typeManager) {
+        return table().rowType().getFields().stream()
+                .map(
+                        column ->
+                                ColumnMetadata.builder()
+                                        .setName(column.name())
+                                        .setType(
+                                                PrestoTypeUtils.toPrestoType(
+                                                        column.type(), typeManager))
+                                        .setNullable(column.type().isNullable())
+                                        .setComment(Optional.ofNullable(column.description()))
+                                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public PrestoColumnHandle columnHandle(String field, TypeManager typeManager) {
+        List<String> fieldNames = FieldNameUtils.fieldNames(table().rowType());
+        int index = fieldNames.indexOf(field);
+        if (index == -1) {
+            throw new RuntimeException(
+                    String.format("Cannot find field %s in schema %s", field, fieldNames));
+        }
+        return PrestoColumnHandle.create(field, table().rowType().getTypeAt(index), typeManager);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PrestoTableHandle that = (PrestoTableHandle) o;
+        return Arrays.equals(serializedTable, that.serializedTable)
+                && Objects.equals(schemaName, that.schemaName)
+                && Objects.equals(tableName, that.tableName)
+                && Objects.equals(filter, that.filter)
+                && Objects.equals(projectedColumns, that.projectedColumns);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                schemaName, tableName, filter, projectedColumns, Arrays.hashCode(serializedTable));
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTableLayoutHandle.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTableLayoutHandle.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.MoreObjects;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/** Presto {@link ConnectorTableLayoutHandle}. */
+public class PrestoTableLayoutHandle implements ConnectorTableLayoutHandle {
+
+    private final PrestoTableHandle tableHandle;
+    private final TupleDomain<ColumnHandle> constraintSummary;
+
+    @JsonCreator
+    public PrestoTableLayoutHandle(
+            @JsonProperty("tableHandle") PrestoTableHandle tableHandle,
+            @JsonProperty("constraintSummary") TupleDomain<ColumnHandle> constraintSummary) {
+        this.tableHandle = Objects.requireNonNull(tableHandle, "table is null");
+        this.constraintSummary = constraintSummary;
+    }
+
+    @JsonProperty
+    public PrestoTableHandle getTableHandle() {
+        return tableHandle;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraintSummary() {
+        return constraintSummary;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        PrestoTableLayoutHandle other = (PrestoTableLayoutHandle) obj;
+        return Objects.equals(tableHandle, other.tableHandle)
+                && Objects.equals(constraintSummary, other.constraintSummary);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableHandle, constraintSummary);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("tableHandle", tableHandle)
+                .add("constraintSummary", constraintSummary)
+                .toString();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTransactionHandle.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTransactionHandle.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+/** Presto {@link ConnectorTransactionHandle}. */
+public class PrestoTransactionHandle implements ConnectorTransactionHandle {
+
+    private final UUID uuid;
+
+    public PrestoTransactionHandle() {
+        this(UUID.randomUUID());
+    }
+
+    public PrestoTransactionHandle(@JsonProperty("uuid") UUID uuid) {
+        this.uuid = requireNonNull(uuid, "uuid is null");
+    }
+
+    @JsonProperty
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        PrestoTransactionHandle other = (PrestoTransactionHandle) obj;
+        return Objects.equals(uuid, other.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+    @Override
+    public String toString() {
+        return uuid.toString();
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTransactionManager.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTransactionManager.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Preconditions;
+
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Presto TransactionManager. */
+public class PrestoTransactionManager {
+
+    private final Map<ConnectorTransactionHandle, ConnectorMetadata> transactions =
+            new ConcurrentHashMap<>();
+
+    public ConnectorMetadata get(ConnectorTransactionHandle transaction) {
+        ConnectorMetadata metadata = transactions.get(transaction);
+        Preconditions.checkArgument(metadata != null, "no such transaction: %s", transaction);
+        return metadata;
+    }
+
+    public ConnectorMetadata remove(ConnectorTransactionHandle transaction) {
+        ConnectorMetadata metadata = transactions.remove(transaction);
+        Preconditions.checkArgument(metadata != null, "no such transaction: %s", transaction);
+        return metadata;
+    }
+
+    public void put(ConnectorTransactionHandle transaction, ConnectorMetadata metadata) {
+        ConnectorMetadata existing = transactions.putIfAbsent(transaction, metadata);
+        Preconditions.checkState(existing == null, "transaction already exists: %s", existing);
+    }
+}

--- a/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTypeUtils.java
+++ b/flink-table-store-presto/flink-table-store-presto-common/src/main/java/org/apache/flink/table/store/presto/PrestoTypeUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.presto;
+
+import org.apache.flink.table.store.types.ArrayType;
+import org.apache.flink.table.store.types.BigIntType;
+import org.apache.flink.table.store.types.BinaryType;
+import org.apache.flink.table.store.types.BooleanType;
+import org.apache.flink.table.store.types.CharType;
+import org.apache.flink.table.store.types.DataType;
+import org.apache.flink.table.store.types.DateType;
+import org.apache.flink.table.store.types.DecimalType;
+import org.apache.flink.table.store.types.DoubleType;
+import org.apache.flink.table.store.types.FloatType;
+import org.apache.flink.table.store.types.IntType;
+import org.apache.flink.table.store.types.LocalZonedTimestampType;
+import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
+import org.apache.flink.table.store.types.SmallIntType;
+import org.apache.flink.table.store.types.TimeType;
+import org.apache.flink.table.store.types.TimestampType;
+import org.apache.flink.table.store.types.TinyIntType;
+import org.apache.flink.table.store.types.VarBinaryType;
+import org.apache.flink.table.store.types.VarCharType;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+/** Presto type from Paimon Type. */
+public class PrestoTypeUtils {
+
+    private PrestoTypeUtils() {}
+
+    public static Type toPrestoType(DataType paimonType, TypeManager typeManager) {
+        if (paimonType instanceof CharType) {
+            return com.facebook.presto.common.type.CharType.createCharType(
+                    Math.min(
+                            com.facebook.presto.common.type.CharType.MAX_LENGTH,
+                            ((CharType) paimonType).getLength()));
+        } else if (paimonType instanceof VarCharType) {
+            return VarcharType.createUnboundedVarcharType();
+        } else if (paimonType instanceof BooleanType) {
+            return com.facebook.presto.common.type.BooleanType.BOOLEAN;
+        } else if (paimonType instanceof BinaryType) {
+            return VarbinaryType.VARBINARY;
+        } else if (paimonType instanceof VarBinaryType) {
+            return VarbinaryType.VARBINARY;
+        } else if (paimonType instanceof DecimalType) {
+            return com.facebook.presto.common.type.DecimalType.createDecimalType(
+                    ((DecimalType) paimonType).getPrecision(),
+                    ((DecimalType) paimonType).getScale());
+        } else if (paimonType instanceof TinyIntType) {
+            return TinyintType.TINYINT;
+        } else if (paimonType instanceof SmallIntType) {
+            return SmallintType.SMALLINT;
+        } else if (paimonType instanceof IntType) {
+            return IntegerType.INTEGER;
+        } else if (paimonType instanceof BigIntType) {
+            return BigintType.BIGINT;
+        } else if (paimonType instanceof FloatType) {
+            return RealType.REAL;
+        } else if (paimonType instanceof DoubleType) {
+            return com.facebook.presto.common.type.DoubleType.DOUBLE;
+        } else if (paimonType instanceof DateType) {
+            return com.facebook.presto.common.type.DateType.DATE;
+        } else if (paimonType instanceof TimeType) {
+            return com.facebook.presto.common.type.TimeType.TIME;
+        } else if (paimonType instanceof TimestampType) {
+            return com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+        } else if (paimonType instanceof LocalZonedTimestampType) {
+            return TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+        } else if (paimonType instanceof ArrayType) {
+            DataType elementType = ((ArrayType) paimonType).getElementType();
+            return new com.facebook.presto.common.type.ArrayType(
+                    Objects.requireNonNull(toPrestoType(elementType, typeManager)));
+        } else if (paimonType instanceof MultisetType) {
+            return null;
+        } else if (paimonType instanceof MapType) {
+            MapType paimonMapType = (MapType) paimonType;
+            TypeSignature keyType =
+                    Objects.requireNonNull(toPrestoType(paimonMapType.getKeyType(), typeManager))
+                            .getTypeSignature();
+            TypeSignature valueType =
+                    Objects.requireNonNull(toPrestoType(paimonMapType.getValueType(), typeManager))
+                            .getTypeSignature();
+            return typeManager.getParameterizedType(
+                    StandardTypes.MAP,
+                    ImmutableList.of(
+                            TypeSignatureParameter.of(keyType),
+                            TypeSignatureParameter.of(valueType)));
+        } else {
+            throw new UnsupportedOperationException(
+                    format("Cannot convert from Paimon type '%s' to Presto type", paimonType));
+        }
+    }
+}

--- a/flink-table-store-presto/pom.xml
+++ b/flink-table-store-presto/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <modules>
+        <module>flink-table-store-presto-common</module>
+        <module>flink-table-store-presto-0.273</module>
+        <module>flink-table-store-presto-0.270</module>
+    </modules>
+
+    <parent>
+        <artifactId>flink-table-store-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>0.4-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+
+    <artifactId>flink-table-store-presto</artifactId>
+    <name>Flink Table Store : Presto</name>
+
+    <dependencies>
+        <!-- Flink All dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-store-shade</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Test -->
+        <!--<dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-store-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>-->
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@ under the License.
         <module>flink-table-store-hive</module>
         <module>flink-table-store-spark</module>
         <module>flink-table-store-test-utils</module>
+        <module>flink-table-store-presto</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Add Presto Reader for table store:
1. The Presto server of version 0.273 and above corresponds to flink-table-store-presto-0.273
2. The Presto server version below 0.273 corresponds to flink-table-store-presto-0.270