### PR TITLE
[FLINK-31461] Supports schema historical version expiring

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
@@ -128,6 +128,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.snapshotTimeRetain().toMillis(),
                 pathFactory(),
                 snapshotManager(),
+                schemaManager,
                 manifestFileFactory(),
                 manifestListFactory());
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -48,6 +48,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -425,6 +426,31 @@ public class SchemaManager implements Serializable {
      */
     public void deleteSchema(long schemaId) {
         fileIO.deleteQuietly(toSchemaPath(schemaId));
+    }
+
+    /**
+     * Delete schema with id less than given schema id.
+     *
+     * @param schemaId the given schema id
+     */
+    public void expireSchema(long schemaId) {
+        List<Long> ids = this.listAllIds();
+        if (ids.size() <= 1) {
+            return;
+        }
+
+        Collections.sort(ids);
+        if (ids.get(ids.size() - 1) < schemaId) {
+            return;
+        }
+
+        for (Long id : ids) {
+            if (id < schemaId) {
+                deleteSchema(id);
+            } else {
+                return;
+            }
+        }
     }
 
     public static void checkAlterTableOption(String key) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -92,6 +92,7 @@ public class TestFileStore extends KeyValueFileStore {
     private long commitIdentifier;
 
     private TestFileStore(
+            long schemaId,
             String root,
             CoreOptions options,
             RowType partitionType,
@@ -102,7 +103,7 @@ public class TestFileStore extends KeyValueFileStore {
         super(
                 FileIOFinder.find(new Path(root)),
                 new SchemaManager(FileIOFinder.find(new Path(root)), options.path()),
-                0L,
+                schemaId,
                 options,
                 partitionType,
                 keyType,
@@ -132,6 +133,7 @@ public class TestFileStore extends KeyValueFileStore {
                 millisRetained,
                 pathFactory(),
                 snapshotManager(),
+                schemaManager,
                 manifestFileFactory(),
                 manifestListFactory());
     }
@@ -504,6 +506,7 @@ public class TestFileStore extends KeyValueFileStore {
         private final MergeFunctionFactory<KeyValue> mfFactory;
 
         private CoreOptions.ChangelogProducer changelogProducer;
+        private long schemaId = 0L;
 
         public Builder(
                 String format,
@@ -531,6 +534,11 @@ public class TestFileStore extends KeyValueFileStore {
             return this;
         }
 
+        public Builder schemaId(long schemaId) {
+            this.schemaId = schemaId;
+            return this;
+        }
+
         public TestFileStore build() {
             Options conf = new Options();
 
@@ -550,6 +558,7 @@ public class TestFileStore extends KeyValueFileStore {
             conf.set(CoreOptions.CHANGELOG_PRODUCER, changelogProducer);
 
             return new TestFileStore(
+                    schemaId,
                     root,
                     new CoreOptions(conf),
                     partitionType,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/CleanedFileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/CleanedFileStoreExpireTest.java
@@ -157,6 +157,8 @@ public class CleanedFileStoreExpireTest extends FileStoreExpireTestBase {
     public void testExpireWithNumber() throws Exception {
         FileStoreExpire expire = store.newExpire(1, 3, Long.MAX_VALUE);
 
+        assertThat(schemaManager.listAllIds())
+                .containsExactlyInAnyOrder(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
         for (int i = 1; i <= 3; i++) {
@@ -173,6 +175,7 @@ public class CleanedFileStoreExpireTest extends FileStoreExpireTestBase {
                 }
             }
         }
+        assertThat(schemaManager.listAllIds()).containsExactlyInAnyOrder(10L);
 
         // validate earliest hint file
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
@@ -337,6 +337,6 @@ public class SchemaManagerTest {
         assertThat(manager.listAllIds()).containsExactlyInAnyOrder(5L, 6L, 7L, 8L, 9L, 10L);
 
         manager.expireSchema(10);
-        assertThat(manager.listAllIds()).containsExactlyInAnyOrder(5L, 6L, 7L, 8L, 9L, 10L);
+        assertThat(manager.listAllIds()).containsExactlyInAnyOrder(10L);
     }
 }


### PR DESCRIPTION
This PR aims to delete versions for schema which are no longer referenced by snapshots after expiring snapshots. The main changes are as follows
1. Added `expireSchema` in `SchemaManager`
2. Added expiring schema in `FileStoreExpireImpl.expire`

The main tests are as follows
1. Added test in `SchemaManagerTest.testExpireSchema` to expire schema by given schema id
2. Added test in `CleanedFileStoreExpireTest.testExpireWithNumber` to expire schema after snapshots are expired