### PR TITLE
[FLINK-31432] Introduce a special StoreWriteOperator to deal with schema changes

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/cdc/Record.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/cdc/Record.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.cdc;
+
+import org.apache.flink.table.store.types.RowKind;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/** A data change message from the CDC source. */
+public class Record implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RowKind kind;
+    private final Map<String, String> fields;
+
+    public Record(RowKind kind, Map<String, String> fields) {
+        this.kind = kind;
+        this.fields = fields;
+    }
+
+    public RowKind kind() {
+        return kind;
+    }
+
+    public Map<String, String> fields() {
+        return fields;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Record)) {
+            return false;
+        }
+
+        Record that = (Record) o;
+        return Objects.equals(kind, that.kind) && Objects.equals(fields, that.fields);
+    }
+}

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperator.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.store.connector.cdc;
 
-import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.store.cdc.Record;
-import org.apache.flink.table.store.connector.FlinkRowWrapper;
 import org.apache.flink.table.store.connector.sink.AbstractStoreWriteOperator;
 import org.apache.flink.table.store.connector.sink.StoreSinkWrite;
+import org.apache.flink.table.store.data.GenericRow;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.options.ConfigOption;
 import org.apache.flink.table.store.options.ConfigOptions;
@@ -78,17 +77,17 @@ public class SchemaAwareStoreWriteOperator extends AbstractStoreWriteOperator<Re
         }
 
         TableSchema schema = table.schema();
-        GenericRowData rowData = new GenericRowData(schema.fields().size());
+        GenericRow row = new GenericRow(schema.fields().size());
         for (Map.Entry<String, String> field : fields.entrySet()) {
             String key = field.getKey();
             String value = field.getValue();
             int idx = schema.fieldNames().indexOf(key);
             DataType type = schema.fields().get(idx).type();
-            rowData.setField(idx, TypeUtils.castFromString(value, type));
+            row.setField(idx, TypeUtils.castFromString(value, type));
         }
 
         try {
-            return write.write(new FlinkRowWrapper(rowData));
+            return write.write(row);
         } catch (Exception e) {
             throw new IOException(e);
         }

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.cdc;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.store.cdc.Record;
+import org.apache.flink.table.store.connector.FlinkRowWrapper;
+import org.apache.flink.table.store.connector.sink.AbstractStoreWriteOperator;
+import org.apache.flink.table.store.connector.sink.StoreSinkWrite;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.options.ConfigOption;
+import org.apache.flink.table.store.options.ConfigOptions;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.LogSinkFunction;
+import org.apache.flink.table.store.table.sink.SinkRecord;
+import org.apache.flink.table.store.types.DataType;
+import org.apache.flink.table.store.utils.TypeUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * An {@link AbstractStoreWriteOperator} which is aware of schema changes.
+ *
+ * <p>When the input {@link Record} contains a field name not in the current {@link TableSchema}, it
+ * periodically queries the latest schema, until the latest schema contains that field name.
+ */
+public class SchemaAwareStoreWriteOperator extends AbstractStoreWriteOperator<Record> {
+
+    static final ConfigOption<Duration> SCHEMA_UPDATE_WAIT_TIME =
+            ConfigOptions.key("cdc.schema-update-wait-time")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(500));
+
+    private final long schemaUpdateWaitMillis;
+
+    public SchemaAwareStoreWriteOperator(
+            FileStoreTable table,
+            @Nullable LogSinkFunction logSinkFunction,
+            StoreSinkWrite.Provider storeSinkWriteProvider) {
+        super(table, logSinkFunction, storeSinkWriteProvider);
+        schemaUpdateWaitMillis =
+                table.options().toConfiguration().get(SCHEMA_UPDATE_WAIT_TIME).toMillis();
+    }
+
+    @Override
+    protected SinkRecord processRecord(Record record) throws Exception {
+        Map<String, String> fields = record.fields();
+
+        if (!schemaMatched(fields)) {
+            while (true) {
+                table = table.copyWithLatestSchema();
+                if (schemaMatched(fields)) {
+                    break;
+                }
+                Thread.sleep(schemaUpdateWaitMillis);
+            }
+            write.replace(commitUser -> table.newWrite(commitUser));
+        }
+
+        TableSchema schema = table.schema();
+        GenericRowData rowData = new GenericRowData(schema.fields().size());
+        for (Map.Entry<String, String> field : fields.entrySet()) {
+            String key = field.getKey();
+            String value = field.getValue();
+            int idx = schema.fieldNames().indexOf(key);
+            DataType type = schema.fields().get(idx).type();
+            rowData.setField(idx, TypeUtils.castFromString(value, type));
+        }
+
+        try {
+            return write.write(new FlinkRowWrapper(rowData));
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    private boolean schemaMatched(Map<String, String> fields) {
+        TableSchema currentSchema = table.schema();
+        return currentSchema.fieldNames().containsAll(fields.keySet());
+    }
+}

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/AbstractStoreWriteOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/AbstractStoreWriteOperator.java
@@ -32,8 +32,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.store.connector.FlinkRowWrapper;
 import org.apache.flink.table.store.log.LogWriteCallback;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.LogSinkFunction;
@@ -45,17 +43,17 @@ import java.io.IOException;
 import java.util.List;
 
 /** A {@link PrepareCommitOperator} to write records. */
-public class StoreWriteOperator extends PrepareCommitOperator {
+public abstract class AbstractStoreWriteOperator<T> extends PrepareCommitOperator<T> {
 
     private static final long serialVersionUID = 2L;
 
-    protected final FileStoreTable table;
+    protected FileStoreTable table;
 
     @Nullable private final LogSinkFunction logSinkFunction;
 
     private final StoreSinkWrite.Provider storeSinkWriteProvider;
 
-    private transient StoreSinkWrite write;
+    protected transient StoreSinkWrite write;
 
     private transient SimpleContext sinkContext;
 
@@ -64,7 +62,7 @@ public class StoreWriteOperator extends PrepareCommitOperator {
 
     @Nullable private transient LogWriteCallback logCallback;
 
-    public StoreWriteOperator(
+    public AbstractStoreWriteOperator(
             FileStoreTable table,
             @Nullable LogSinkFunction logSinkFunction,
             StoreSinkWrite.Provider storeSinkWriteProvider) {
@@ -119,15 +117,10 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     }
 
     @Override
-    public void processElement(StreamRecord<RowData> element) throws Exception {
+    public void processElement(StreamRecord<T> element) throws Exception {
         sinkContext.timestamp = element.hasTimestamp() ? element.getTimestamp() : null;
 
-        SinkRecord record;
-        try {
-            record = write.write(new FlinkRowWrapper(element.getValue()));
-        } catch (Exception e) {
-            throw new IOException(e);
-        }
+        SinkRecord record = processRecord(element.getValue());
 
         if (logSinkFunction != null) {
             // write to log store, need to preserve original pk (which includes partition fields)
@@ -135,6 +128,8 @@ public class StoreWriteOperator extends PrepareCommitOperator {
             logSinkFunction.invoke(logRecord, sinkContext);
         }
     }
+
+    protected abstract SinkRecord processRecord(T record) throws Exception;
 
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/FileStoreSink.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/FileStoreSink.java
@@ -54,7 +54,7 @@ public class FileStoreSink extends FlinkSink {
     @Override
     protected OneInputStreamOperator<RowData, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, boolean isStreaming) {
-        return new StoreWriteOperator(table, logSinkFunction, writeProvider);
+        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider);
     }
 
     @Override

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreSinkWrite.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreSinkWrite.java
@@ -59,6 +59,7 @@ public class FullChangelogStoreSinkWrite extends StoreSinkWriteImpl {
 
     private static final Logger LOG = LoggerFactory.getLogger(FullChangelogStoreSinkWrite.class);
 
+    private final SnapshotManager snapshotManager;
     private final long fullCompactionThresholdMs;
 
     private final Set<Tuple2<BinaryRow, Integer>> currentWrittenBuckets;
@@ -81,6 +82,7 @@ public class FullChangelogStoreSinkWrite extends StoreSinkWriteImpl {
             throws Exception {
         super(table, context, initialCommitUser, ioManager, isOverwrite);
 
+        this.snapshotManager = table.snapshotManager();
         this.fullCompactionThresholdMs = fullCompactionThresholdMs;
 
         currentWrittenBuckets = new HashSet<>();
@@ -198,7 +200,6 @@ public class FullChangelogStoreSinkWrite extends StoreSinkWriteImpl {
     }
 
     private void checkSuccessfulFullCompaction() {
-        SnapshotManager snapshotManager = table.snapshotManager();
         Long latestId = snapshotManager.latestSnapshotId();
         if (latestId == null) {
             return;

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
@@ -23,23 +23,19 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.table.data.RowData;
 
 import java.io.IOException;
 import java.util.List;
 
 /** Prepare commit operator to emit {@link Committable}s. */
-public abstract class PrepareCommitOperator extends AbstractStreamOperator<Committable>
-        implements OneInputStreamOperator<RowData, Committable>, BoundedOneInput {
+public abstract class PrepareCommitOperator<T> extends AbstractStreamOperator<Committable>
+        implements OneInputStreamOperator<T, Committable>, BoundedOneInput {
 
     private boolean endOfInput = false;
 
     public PrepareCommitOperator() {
         setChainingStrategy(ChainingStrategy.ALWAYS);
     }
-
-    @Override
-    public void processElement(StreamRecord<RowData> element) throws Exception {}
 
     @Override
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/RowDataStoreWriteOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/RowDataStoreWriteOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.connector.FlinkRowWrapper;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.LogSinkFunction;
+import org.apache.flink.table.store.table.sink.SinkRecord;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * An {@link AbstractStoreWriteOperator} which accepts Flink's {@link RowData}. The schema of its
+ * writer never changes.
+ */
+public class RowDataStoreWriteOperator extends AbstractStoreWriteOperator<RowData> {
+
+    public RowDataStoreWriteOperator(
+            FileStoreTable table,
+            @Nullable LogSinkFunction logSinkFunction,
+            StoreSinkWrite.Provider storeSinkWriteProvider) {
+        super(table, logSinkFunction, storeSinkWriteProvider);
+    }
+
+    @Override
+    protected SinkRecord processRecord(RowData record) throws Exception {
+        try {
+            return write.write(new FlinkRowWrapper(record));
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -41,7 +41,7 @@ import java.util.List;
  * org.apache.flink.table.store.connector.source.CompactorSourceBuilder}. The records will contain
  * partition keys in the first few columns, and bucket number in the last column.
  */
-public class StoreCompactOperator extends PrepareCommitOperator {
+public class StoreCompactOperator extends PrepareCommitOperator<RowData> {
 
     private final FileStoreTable table;
     private final StoreSinkWrite.Provider storeSinkWriteProvider;

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
@@ -26,13 +26,15 @@ import org.apache.flink.table.store.data.InternalRow;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
+import org.apache.flink.table.store.table.sink.TableWriteImpl;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.function.Function;
 
-/** Helper class of {@link StoreWriteOperator} for different types of table store sinks. */
-interface StoreSinkWrite {
+/** Helper class of {@link AbstractStoreWriteOperator} for different types of table store sinks. */
+public interface StoreSinkWrite {
 
     SinkRecord write(InternalRow rowData) throws Exception;
 
@@ -48,6 +50,9 @@ interface StoreSinkWrite {
 
     void close() throws Exception;
 
+    void replace(Function<String, TableWriteImpl<?>> newWriteProvider) throws Exception;
+
+    /** Provider of {@link StoreSinkWrite}. */
     @FunctionalInterface
     interface Provider extends Serializable {
 

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperatorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperatorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.cdc;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.JavaSerializer;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.store.cdc.Record;
+import org.apache.flink.table.store.connector.sink.Committable;
+import org.apache.flink.table.store.connector.sink.CommittableTypeInfo;
+import org.apache.flink.table.store.connector.sink.StoreSinkWriteImpl;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaChange;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.SchemaUtils;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.utils.TraceableFileIO;
+import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.options.Options;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.types.DataType;
+import org.apache.flink.table.store.types.DataTypes;
+import org.apache.flink.table.store.types.RowKind;
+import org.apache.flink.table.store.types.RowType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SchemaAwareStoreWriteOperator}. */
+public class SchemaAwareStoreWriteOperatorTest {
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
+                    new String[] {"pt", "k", "v"});
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private Path tablePath;
+    private String commitUser;
+
+    @BeforeEach
+    public void before() {
+        tablePath = new Path(TraceableFileIO.SCHEME + "://" + tempDir.toString());
+        commitUser = UUID.randomUUID().toString();
+    }
+
+    @AfterEach
+    public void after() {
+        // assert all connections are closed
+        Predicate<Path> pathPredicate = path -> path.toString().contains(tempDir.toString());
+        assertThat(TraceableFileIO.openInputStreams(pathPredicate)).isEmpty();
+        assertThat(TraceableFileIO.openOutputStreams(pathPredicate)).isEmpty();
+    }
+
+    @Test
+    @Timeout(30000)
+    public void testProcessRecord() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+        OneInputStreamOperatorTestHarness<Record, Committable> harness = createTestHarness(table);
+        harness.open();
+
+        BlockingQueue<Record> toProcess = new LinkedBlockingQueue<>();
+        BlockingQueue<Record> processed = new LinkedBlockingQueue<>();
+        AtomicBoolean running = new AtomicBoolean(true);
+        Runnable r =
+                () -> {
+                    long timestamp = 0;
+                    try {
+                        while (running.get()) {
+                            if (toProcess.isEmpty()) {
+                                Thread.sleep(10);
+                                continue;
+                            }
+
+                            Record record = toProcess.poll();
+                            harness.processElement(record, ++timestamp);
+                            processed.offer(record);
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+        Thread t = new Thread(r);
+        t.start();
+
+        // check that records with compatible schema can be processed immediately
+
+        Map<String, String> fields = new HashMap<>();
+        fields.put("pt", "0");
+        fields.put("k", "1");
+        fields.put("v", "10");
+        Record expected = new Record(RowKind.INSERT, fields);
+        toProcess.offer(expected);
+        Record actual = processed.take();
+        assertThat(actual).isEqualTo(expected);
+
+        fields = new HashMap<>();
+        fields.put("pt", "0");
+        fields.put("k", "2");
+        expected = new Record(RowKind.INSERT, fields);
+        toProcess.offer(expected);
+        actual = processed.take();
+        assertThat(actual).isEqualTo(expected);
+
+        // check that records with new fields should be processed after schema is updated
+
+        fields = new HashMap<>();
+        fields.put("pt", "0");
+        fields.put("k", "3");
+        fields.put("v", "30");
+        fields.put("v2", "300");
+        expected = new Record(RowKind.INSERT, fields);
+        toProcess.offer(expected);
+        actual = processed.poll(1, TimeUnit.SECONDS);
+        assertThat(actual).isNull();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(SchemaChange.addColumn("v2", DataTypes.INT()));
+        actual = processed.take();
+        assertThat(actual).isEqualTo(expected);
+
+        running.set(false);
+        t.join();
+        harness.close();
+    }
+
+    private OneInputStreamOperatorTestHarness<Record, Committable> createTestHarness(
+            FileStoreTable table) throws Exception {
+        SchemaAwareStoreWriteOperator operator =
+                new SchemaAwareStoreWriteOperator(
+                        table,
+                        null,
+                        (t, context, ioManager) ->
+                                new StoreSinkWriteImpl(t, context, commitUser, ioManager, false));
+        TypeSerializer<Record> inputSerializer = new JavaSerializer<>();
+        TypeSerializer<Committable> outputSerializer =
+                new CommittableTypeInfo().createSerializer(new ExecutionConfig());
+        OneInputStreamOperatorTestHarness<Record, Committable> harness =
+                new OneInputStreamOperatorTestHarness<>(operator, inputSerializer);
+        harness.setup(outputSerializer);
+        return harness;
+    }
+
+    private FileStoreTable createFileStoreTable() throws Exception {
+        Options conf = new Options();
+        conf.set(SchemaAwareStoreWriteOperator.SCHEMA_UPDATE_WAIT_TIME, Duration.ofMillis(10));
+
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), tablePath),
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Collections.singletonList("pt"),
+                                Arrays.asList("pt", "k"),
+                                conf.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+    }
+}

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperatorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/cdc/SchemaAwareStoreWriteOperatorTest.java
@@ -67,7 +67,7 @@ public class SchemaAwareStoreWriteOperatorTest {
 
     private static final RowType ROW_TYPE =
             RowType.of(
-                    new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
+                    new DataType[] {DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()},
                     new String[] {"pt", "k", "v"});
 
     @TempDir java.nio.file.Path tempDir;

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreShuffleBucketTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreShuffleBucketTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.store.fs.local.LocalFileIO;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.FileStoreTableFactory;
 import org.apache.flink.table.store.table.sink.SinkRecord;
+import org.apache.flink.table.store.table.sink.TableWriteImpl;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import static org.apache.flink.table.store.connector.LogicalTypeConversion.toLogicalType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -159,5 +161,9 @@ public class FileStoreShuffleBucketTest extends CatalogITCaseBase {
 
         @Override
         public void close() throws Exception {}
+
+        @Override
+        public void replace(Function<String, TableWriteImpl<?>> newWriteProvider)
+                throws Exception {}
     }
 }


### PR DESCRIPTION
Currently `StoreWriteOperator` is not able to deal with schema changes. We need to introduce a special `StoreWriteOperator` to deal with schema changes.