### PR TITLE
[spark] Extract SparkInputPartitionReader from paimon spark connector

### DIFF
--- a/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartition.java
+++ b/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartition.java
@@ -54,31 +54,7 @@ public class SparkInputPartition
         }
         RecordReaderIterator<InternalRow> iterator = new RecordReaderIterator<>(recordReader);
         SparkInternalRow row = new SparkInternalRow(readBuilder.readType());
-        return new InputPartitionReader<org.apache.spark.sql.catalyst.InternalRow>() {
-
-            @Override
-            public boolean next() {
-                if (iterator.hasNext()) {
-                    row.replace(iterator.next());
-                    return true;
-                }
-                return false;
-            }
-
-            @Override
-            public org.apache.spark.sql.catalyst.InternalRow get() {
-                return row;
-            }
-
-            @Override
-            public void close() throws IOException {
-                try {
-                    iterator.close();
-                } catch (Exception e) {
-                    throw new IOException(e);
-                }
-            }
-        };
+        return new SparkInputPartitionReader(iterator, row);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
+++ b/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark;
+
+import org.apache.paimon.reader.RecordReaderIterator;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.sources.v2.reader.InputPartition;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+
+import java.io.IOException;
+
+/** A spark 2 {@link InputPartitionReader} for paimon, created by {@link InputPartition} */
+public class SparkInputPartitionReader implements InputPartitionReader<InternalRow> {
+
+    private final RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator;
+
+    private final SparkInternalRow row;
+
+    public SparkInputPartitionReader(
+            RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator,
+            SparkInternalRow row) {
+        this.iterator = iterator;
+        this.row = row;
+    }
+
+    @Override
+    public boolean next() {
+        if (iterator.hasNext()) {
+            row.replace(iterator.next());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public InternalRow get() {
+        return row;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            iterator.close();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
+++ b/paimon-spark/paimon-spark-2/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
 
 import java.io.IOException;
 
-/** A spark 2 {@link InputPartitionReader} for paimon, created by {@link InputPartition} */
+/** A spark 2 {@link InputPartitionReader} for paimon, created by {@link InputPartition}. */
 public class SparkInputPartitionReader implements InputPartitionReader<InternalRow> {
 
     private final RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 
 import java.io.IOException;
 
-/** A spark 3 {@link PartitionReader} for paimon, created by {@link PartitionReaderFactory} */
+/** A spark 3 {@link PartitionReader} for paimon, created by {@link PartitionReaderFactory}. */
 public class SparkInputPartitionReader implements PartitionReader<InternalRow> {
 
     private final RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartitionReader.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark;
+
+import org.apache.paimon.reader.RecordReaderIterator;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+
+import java.io.IOException;
+
+/** A spark 3 {@link PartitionReader} for paimon, created by {@link PartitionReaderFactory} */
+public class SparkInputPartitionReader implements PartitionReader<InternalRow> {
+
+    private final RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator;
+
+    private final SparkInternalRow row;
+
+    public SparkInputPartitionReader(
+            RecordReaderIterator<org.apache.paimon.data.InternalRow> iterator,
+            SparkInternalRow row) {
+        this.iterator = iterator;
+        this.row = row;
+    }
+
+    @Override
+    public boolean next() {
+        if (iterator.hasNext()) {
+            row.replace(iterator.next());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public InternalRow get() {
+        return row;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            iterator.close();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkReaderFactory.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkReaderFactory.java
@@ -51,30 +51,6 @@ public class SparkReaderFactory implements PartitionReaderFactory {
         }
         RecordReaderIterator<InternalRow> iterator = new RecordReaderIterator<>(reader);
         SparkInternalRow row = new SparkInternalRow(readBuilder.readType());
-        return new PartitionReader<org.apache.spark.sql.catalyst.InternalRow>() {
-
-            @Override
-            public boolean next() {
-                if (iterator.hasNext()) {
-                    row.replace(iterator.next());
-                    return true;
-                }
-                return false;
-            }
-
-            @Override
-            public org.apache.spark.sql.catalyst.InternalRow get() {
-                return row;
-            }
-
-            @Override
-            public void close() throws IOException {
-                try {
-                    iterator.close();
-                } catch (Exception e) {
-                    throw new IOException(e);
-                }
-            }
-        };
+        return new SparkInputPartitionReader(iterator, row);
     }
 }


### PR DESCRIPTION
Extract SparkInputPartitionReader from paimon spark connector

### Purpose

Optimize code structure

### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
