### PR TITLE
[spark] Upgrade spark version to 3.3.2 of spark-common

### DIFF
--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <name>Paimon : Spark : Common</name>
 
     <properties>
-        <spark.version>3.2.2</spark.version>
+        <spark.version>3.3.2</spark.version>
     </properties>
 
     <dependencies>

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
@@ -40,8 +40,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -185,5 +187,18 @@ public abstract class SparkReadTestBase {
                 String.format(
                         "INSERT INTO paimon.default.%s VALUES %s",
                         tableName, StringUtils.join(values, ",")));
+    }
+
+    // return of 'SHOW CREATE TABLE' excluding TBLPROPERTIES
+    protected String showCreateString(String table, String... fieldSpec) {
+        return String.format(
+                "CREATE TABLE %s (%s)\n",
+                table,
+                Arrays.stream(fieldSpec).map(s -> "\n  " + s).collect(Collectors.joining(",")));
+    }
+
+    // default schema
+    protected String defaultShowCreateString(String table) {
+        return showCreateString(table, "a INT NOT NULL", "b BIGINT", "c STRING");
     }
 }


### PR DESCRIPTION
### Purpose

To upgrade spark-common version.

### Tests

Original tests under spark-common.
Main fixing the return of `SHOW CREATE TABLE`
1. Column name doesn't escaped with '`' any more.
2. There is a blank space after `TABLEPROPERTIES`

When fixing tests, I made some changes:
1.  the `SparkReadTestBase` has set the catalog and namespace, so I remove the useless namespace in test SQLs;
2. most `SHOW CREATE TABLE` tests don't care about `TABLEPROPERTIES` so I remove them, and I add `SparkReadITCase#testShowCreateTable` to cover the case (USING, PARTITIONED, COMMENT, TBLPROPERTIES).

### API and Format 

No changes.

### Documentation

No.