### PR TITLE
[flink] Limit should not rely on assign all splits in StaticFileStoreSplitEnumerator

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
@@ -39,8 +39,21 @@ public final class FileStoreSourceReader<T>
             SourceReaderContext readerContext,
             TableRead tableRead,
             @Nullable Long limit) {
+        this(
+                recordsFunction,
+                readerContext,
+                tableRead,
+                limit == null ? null : new RecordLimiter(limit));
+    }
+
+    private FileStoreSourceReader(
+            RecordsFunction<T> recordsFunction,
+            SourceReaderContext readerContext,
+            TableRead tableRead,
+            @Nullable RecordLimiter limiter) {
+        // limiter is created in SourceReader, it can be shared in all split readers
         super(
-                () -> new FileStoreSourceSplitReader<>(recordsFunction, tableRead, limit),
+                () -> new FileStoreSourceSplitReader<>(recordsFunction, tableRead, limiter),
                 recordsFunction,
                 readerContext.getConfiguration(),
                 readerContext);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/RecordLimiter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/RecordLimiter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A limiter to limit record reading. */
+public class RecordLimiter {
+
+    private final long limit;
+    private final AtomicLong counter;
+
+    public RecordLimiter(long limit) {
+        this.limit = limit;
+        this.counter = new AtomicLong(0);
+    }
+
+    public boolean reachLimit() {
+        return counter.get() >= limit;
+    }
+
+    public void increment() {
+        counter.incrementAndGet();
+    }
+
+    public void add(long delta) {
+        counter.addAndGet(delta);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
@@ -77,12 +77,9 @@ public class StaticFileStoreSplitEnumerator
         }
 
         // The following batch assignment operation is for two purposes:
-        // 1. To distribute splits evenly when batch reading to prevent a few tasks from reading all
+        // To distribute splits evenly when batch reading to prevent a few tasks from reading all
         // the data (for example, the current resource can only schedule part of the tasks).
-        // 2. Optimize limit reading. In limit reading, the task will repeatedly create SplitFetcher
-        // to read the data of the limit number for each coming split (the limit status is in the
-        // SplitFetcher). So if the assigment are divided too small, the task will cost more time on
-        // creating SplitFetcher and reading data.
+        // TODO: assignment is already created in constructor, here can just assign per batch
         List<FileStoreSourceSplit> splits = pendingSplitAssignment.remove(subtask);
         if (splits != null && splits.size() > 0) {
             context.assignSplits(new SplitsAssignment<>(Collections.singletonMap(subtask, splits)));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitReaderTest.java
@@ -105,7 +105,10 @@ public class FileStoreSourceSplitReaderTest {
 
     private FileStoreSourceSplitReader<RecordAndPosition<RowData>> createReader(
             TableRead tableRead, @Nullable Long limit) {
-        return new FileStoreSourceSplitReader<>(RecordsFunction.forIterate(), tableRead, limit);
+        return new FileStoreSourceSplitReader<>(
+                RecordsFunction.forIterate(),
+                tableRead,
+                limit == null ? null : new RecordLimiter(limit));
     }
 
     private void innerTestOnce(boolean valueCountMode, int skip) throws Exception {


### PR DESCRIPTION

### Purpose

Limit should not rely on assign all splits in StaticFileStoreSplitEnumerator.

Assign all splits in one time will produce exceed `akka.framesize` to exceptions.

We can add a global limiter in `FileStoreSourceReader`, limiter is created in SourceReader, it can be shared in all split readers.

### Tests

Test Exists.
