### PR TITLE
[FLINK-31558] Support updating schema type with restrictions in CDC sink

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -85,7 +85,13 @@ public class TypeUtils {
             case BIGINT:
                 return Long.valueOf(s);
             case FLOAT:
-                return Float.valueOf(s);
+                double d = Double.parseDouble(s);
+                if (d == ((float) d)) {
+                    return (float) d;
+                } else {
+                    throw new NumberFormatException(
+                            s + " cannot be cast to float due to precision loss");
+                }
             case DOUBLE:
                 return Double.valueOf(s);
             case DATE:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/SchemaChangeProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/SchemaChangeProcessFunction.java
@@ -52,12 +52,16 @@ public class SchemaChangeProcessFunction extends ProcessFunction<SchemaChange, V
         if (schemaChange instanceof SchemaChange.AddColumn) {
             try {
                 schemaManager.commitChanges(schemaChange);
-            } catch (Exception e) {
+            } catch (IllegalArgumentException e) {
                 // This is normal. For example when a table is split into multiple database tables,
                 // all these tables will be added the same column. However schemaManager can't
                 // handle duplicated column adds, so we just catch the exception and log it.
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Failed to perform SchemaChange.AddColumn {}", schemaChange, e);
+                    LOG.debug(
+                            "Failed to perform SchemaChange.AddColumn {}, "
+                                    + "possibly due to duplicated column name",
+                            schemaChange,
+                            e);
                 }
             }
         } else if (schemaChange instanceof SchemaChange.UpdateColumnType) {


### PR DESCRIPTION
### Purpose

It is common for database users to update column types to a wider type, such as changing `INT` types to `BIGINT`s, and `CHAR`s to `VARCHAR`s. We should support these common usages.

### Tests

* SchemaAwareStoreWriteOperatorTest
* FlinkCdcSinkITCase

### API and Format 

N/A

### Documentation

N/A
