### PR TITLE
[flink][bug] Table alias cannot work in merge-into action

### DIFF
--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -446,7 +446,7 @@ When sqls changed current catalog and database, it's OK to not qualify the sourc
 \--source-sql "CREATE DATABASE my_db"\
 \--source-sql "USE my_db"\
 \--source-sql "CREATE TABLE S ..."\
-\--source-table my_cat.my_db.S\
+\--source-table S\
 but you must qualify it in the following case:\
 \--source-sql "CREATE CATALOG my_cat WITH (...)"\
 \--source-sql "CREATE TABLE my_cat.\`default`.S ..."\

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -435,16 +435,25 @@ is equal to source's).
 5. not-matched-by-source-condition cannot use source table's columns to construct condition expression.
 
 {{< hint warning >}}
-1. source-alias cannot be duplicated with existed table name. If you use --source-ddl, source-alias 
-must be specified and equal to the table name in "CREATE" statement.
-2. If the source table is not in the same place as target table, the source-table-name or the source-alias 
-should be qualified (database.table or catalog.database.table if in different catalog). For examples:\
+1. Table aliases cannot be duplicated with existed table name. 
+2. If the source table is not in the default catalog and default database, the source-table-name and 
+the source-alias should be qualified (database.table or catalog.database.table if created a new catalog). 
+For examples:\
+(1) If source table 'my_source' is in 'my_db', qualify it:\
+\--source-table "my_db.my_source"\
+\--source-as "S"\
+(2)Example for source sqls:\
 \--source-sql "CREATE CATALOG my_cat WITH (...)"\
 \--source-sql "USE CATALOG my_cat"\
 \--source-sql "CREATE DATABASE my_db"\
 \--source-sql "USE my_db"\
 \--source-sql "CREATE TABLE S ..."\
-\--source-as my_cat.my_db.S
+\--source-as my_cat.my_db.S\
+another scenario:\
+\--source-sql "CREATE CATALOG my_cat WITH (...)"\
+\--source-sql "CREATE TABLE my_cat.\`default`.S ..."\
+\--source-as my_cat.default.S\
+You can just use 'S' as source table name in following arguments.
 3. At least one merge action must be specified.
 4. If both matched-upsert and matched-delete actions are present, their conditions must both be present too 
 (same to not-matched-by-source-upsert and not-matched-by-source-delete). Otherwise, all conditions are optional.

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -320,8 +320,8 @@ Run the following command to submit a 'merge-into' job for the table.
     --database <database-name> \
     --table <target-table> \
     [--target-as <target-table-alias>] \
-    --source-name <source-table-name> \
-    [--sql <sql> ...]\
+    --source-table <source-table-name> \
+    [--source-sql <sql> ...]\
     --on <merge-condition> \
     --merge-actions <matched-upsert,matched-delete,not-matched-insert,not-matched-by-source-upsert,not-matched-by-source-delete> \
     --matched-upsert-condition <matched-condition> \
@@ -333,7 +333,7 @@ Run the following command to submit a 'merge-into' job for the table.
     --not-matched-by-source-upsert-set <not-matched-upsert-changes> \
     --not-matched-by-source-delete-condition <not-matched-by-source-condition>
     
-You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment and tables at runtime.
+You can pass sqls by '--source-sql <sql> [, --source-sql <sql> ...]' to config environment and create source table at runtime.
     
 -- Examples:
 -- Find all orders mentioned in the source table, then mark as important if the price is above 100 
@@ -346,7 +346,7 @@ You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment an
     --warehouse <warehouse-path> \
     --database <database-name> \
     --table T \
-    --source-name S \
+    --source-table S \
     --on "T.id = S.order_id" \
     --merge-actions \
     matched-upsert,matched-delete \
@@ -364,7 +364,7 @@ You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment an
     --warehouse <warehouse-path> \
     --database <database-name> \
     --table T \
-    --source-name S \
+    --source-table S \
     --on "T.id = S.order_id" \
     --merge-actions \
     matched-upsert,not-matched-insert \
@@ -381,7 +381,7 @@ You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment an
     --warehouse <warehouse-path> \
     --database <database-name> \
     --table T \
-    --source-name S \
+    --source-table S \
     --on "T.id = S.order_id" \
     --merge-actions \
     not-matched-by-source-upsert,not-matched-by-source-delete \
@@ -389,7 +389,7 @@ You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment an
     --not-matched-by-source-upsert-set "price = T.price - 20" \
     --not-matched-by-source-delete-condition "T.mark = 'trivial'"
     
--- A --sql example: 
+-- A --source-sql example: 
 -- Create a temporary view S in new catalog and use it as source table
 ./flink run \
     -c org.apache.paimon.flink.action.FlinkActions \
@@ -399,9 +399,9 @@ You can pass sqls by '--sql <sql> [, ---sql <sql> ...]' to config environment an
     --warehouse <warehouse-path> \
     --database <database-name> \
     --table T \
-    --sql "CREATE CATALOG test_cat WITH (...)" \
-    --sql "CREATE TEMPORARY VIEW test_cat.`default`.S AS SELECT order_id, price, 'important' FROM important_order" \
-    --source-name test_cat.default.S \
+    --source-sql "CREATE CATALOG test_cat WITH (...)" \
+    --source-sql "CREATE TEMPORARY VIEW test_cat.`default`.S AS SELECT order_id, price, 'important' FROM important_order" \
+    --source-table test_cat.default.S \
     --on "T.id = S.order_id" \
     --merge-actions not-matched-insert\
     --not-matched-insert-values *
@@ -438,19 +438,19 @@ is equal to source's).
 qualified (database.table or catalog.database.table if created a new catalog). 
 For examples:\
 (1) If source table 'my_source' is in 'my_db', qualify it:\
-\--source-name "my_db.my_source"\
+\--source-table "my_db.my_source"\
 (2) Example for sqls:\
-if sqls changed current catalog and database, it's OK to not qualify the source table name:\
-\--sql "CREATE CATALOG my_cat WITH (...)"\
-\--sql "USE CATALOG my_cat"\
-\--sql "CREATE DATABASE my_db"\
-\--sql "USE my_db"\
-\--sql "CREATE TABLE S ..."\
-\--source-name my_cat.my_db.S\
+When sqls changed current catalog and database, it's OK to not qualify the source table name:\
+\--source-sql "CREATE CATALOG my_cat WITH (...)"\
+\--source-sql "USE CATALOG my_cat"\
+\--source-sql "CREATE DATABASE my_db"\
+\--source-sql "USE my_db"\
+\--source-sql "CREATE TABLE S ..."\
+\--source-table my_cat.my_db.S\
 but you must qualify it in the following case:\
-\--sql "CREATE CATALOG my_cat WITH (...)"\
-\--sql "CREATE TABLE my_cat.\`default`.S ..."\
-\--source-name my_cat.default.S\
+\--source-sql "CREATE CATALOG my_cat WITH (...)"\
+\--source-sql "CREATE TABLE my_cat.\`default`.S ..."\
+\--source-table my_cat.default.S\
 You can use just 'S' as source table name in following arguments.
 3. At least one merge action must be specified.
 4. If both matched-upsert and matched-delete actions are present, their conditions must both be present too 
@@ -458,7 +458,7 @@ You can use just 'S' as source table name in following arguments.
 5. All conditions, set changes and values should use Flink SQL syntax. To ensure the whole command runs normally
 in Shell, please quote them with \"\" to escape blank spaces and use '\\' to escape special characters in statement. 
 For example:\
-\--sql "CREATE TABLE T (k INT) WITH ('special-key' = '123\\!')"
+\--source-sql "CREATE TABLE T (k INT) WITH ('special-key' = '123\\!')"
 
 {{< /hint >}}
 

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -417,9 +417,7 @@ row based on merge-condition and optional not-matched-condition (source - target
 3. not-matched-by-source: changed rows are from target table and all row cannot match any source 
 table row based on merge-condition and optional not-matched-by-source-condition (target - source).
 
-Parameters format:\
-All conditions, set changes and values should use Flink SQL syntax. Please quote them
-with \" to escape special characters.
+Parameters format:
 1. matched-upsert-changes:\
 col = \<source-table>.col | expression [, ...] (Means setting \<target-table>.col with given value. Do not 
 add '\<target-table>.' before 'col'.)\
@@ -440,10 +438,20 @@ is equal to source's).
 1. source-alias cannot be duplicated with existed table name. If you use --source-ddl, source-alias 
 must be specified and equal to the table name in "CREATE" statement.
 2. If the source table is not in the same place as target table, the source-table-name or the source-alias 
-should be qualified (database.table or catalog.database.table if in different catalog).
+should be qualified (database.table or catalog.database.table if in different catalog). For examples:\
+\--source-sql "CREATE CATALOG my_cat WITH (...)"\
+\--source-sql "USE CATALOG my_cat"\
+\--source-sql "CREATE DATABASE my_db"\
+\--source-sql "USE my_db"\
+\--source-sql "CREATE TABLE S ..."\
+\--source-as my_cat.my_db.S
 3. At least one merge action must be specified.
 4. If both matched-upsert and matched-delete actions are present, their conditions must both be present too 
 (same to not-matched-by-source-upsert and not-matched-by-source-delete). Otherwise, all conditions are optional.
+5. All conditions, set changes and values should use Flink SQL syntax. To ensure the whole command runs normally
+in Shell, please quote them with \"\" to escape blank spaces and use '\\' to escape special characters in statement. 
+For example:\
+\--source-sql "CREATE TABLE T (k INT) WITH ('special-key' = '123\\!')"
 
 {{< /hint >}}
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -454,7 +454,7 @@ public class MergeIntoAction extends ActionBase {
     public void run() throws Exception {
         // handle target alias
         if (targetAlias != null) {
-            tEnv.registerTable(targetAlias, tEnv.from(identifier.getObjectName()));
+            tEnv.createTemporaryView(escapedTargetName(), tEnv.from(identifier.getObjectName()));
         }
 
         // prepare source table

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -100,7 +100,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
         // WHEN NOT MATCHED BY SOURCE AND (dt >= '02-28') THEN DELETE
         MergeIntoAction action = new MergeIntoAction(warehouse, database, "T");
         // here test if it works when table S is in default and qualified both
-        action.withSourceName("default.S")
+        action.withSourceTable("default.S")
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withMatchedUpsert(
                         "T.v <> S.v AND S.v IS NOT NULL", "v = S.v, last_action = 'matched_upsert'")
@@ -142,7 +142,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
         }
 
         action.withTargetAlias("TT")
-                .withSourceName("S")
+                .withSourceTable("S")
                 .withMergeCondition("TT.k = S.k AND TT.dt = S.dt")
                 .withMatchedDelete("S.v IS NULL");
 
@@ -178,7 +178,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
             sourceTableName = "test_db.S";
         }
 
-        action.withSourceName(sourceTableName)
+        action.withSourceTable(sourceTableName)
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withMatchedDelete("S.v IS NULL");
 
@@ -228,12 +228,12 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
         MergeIntoAction action = new MergeIntoAction(warehouse, database, "T");
 
         if (useCatalog) {
-            action.withSqls(catalog, "USE CATALOG test_cat", ddl);
+            action.withSourceSqls(catalog, "USE CATALOG test_cat", ddl);
             // test current catalog and current database
-            action.withSourceName("S");
+            action.withSourceTable("S");
         } else {
-            action.withSqls(catalog, ddl);
-            action.withSourceName("test_cat.default.S");
+            action.withSourceSqls(catalog, ddl);
+            action.withSourceTable("test_cat.default.S");
         }
 
         action.withMergeCondition("T.k = S.k AND T.dt = S.dt").withMatchedDelete("S.v IS NULL");
@@ -259,8 +259,8 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
     public void testMatchedUpsertSetAll(boolean qualified) throws Exception {
         // build MergeIntoAction
         MergeIntoAction action = new MergeIntoAction(warehouse, database, "T");
-        action.withSqls("CREATE TEMPORARY VIEW SS AS SELECT k, v, 'unknown', dt FROM S")
-                .withSourceName(qualified ? "default.SS" : "SS")
+        action.withSourceSqls("CREATE TEMPORARY VIEW SS AS SELECT k, v, 'unknown', dt FROM S")
+                .withSourceTable(qualified ? "default.SS" : "SS")
                 .withMergeCondition("T.k = SS.k AND T.dt = SS.dt")
                 .withMatchedUpsert(null, "*");
 
@@ -293,8 +293,8 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
     public void testNotMatchedInsertAll(boolean qualified) throws Exception {
         // build MergeIntoAction
         MergeIntoAction action = new MergeIntoAction(warehouse, database, "T");
-        action.withSqls("CREATE TEMPORARY VIEW SS AS SELECT k, v, 'unknown', dt FROM S")
-                .withSourceName(qualified ? "default.SS" : "SS")
+        action.withSourceSqls("CREATE TEMPORARY VIEW SS AS SELECT k, v, 'unknown', dt FROM S")
+                .withSourceTable(qualified ? "default.SS" : "SS")
                 .withMergeCondition("T.k = SS.k AND T.dt = SS.dt")
                 .withNotMatchedInsert("SS.k < 12", "*");
 
@@ -340,7 +340,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
     public void testIncompatibleSchema() {
         // build MergeIntoAction
         MergeIntoAction action = new MergeIntoAction(warehouse, database, "T");
-        action.withSourceName("S")
+        action.withSourceTable("S")
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withNotMatchedInsert(null, "S.k, S.v, 0, S.dt");
 
@@ -362,7 +362,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
 
         MergeIntoAction action = new MergeIntoAction(warehouse, "default", "T");
         // the qualified path of source table is absent
-        action.withSourceName("S")
+        action.withSourceTable("S")
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withMatchedDelete("S.v IS NULL");
 
@@ -378,11 +378,11 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
         sEnv.executeSql("DROP TABLE S");
 
         MergeIntoAction action = new MergeIntoAction(warehouse, "default", "T");
-        action.withSqls(
+        action.withSourceSqls(
                         "CREATE DATABASE test_db",
                         "CREATE TEMPORARY TABLE test_db.S (k INT, v STRING, dt STRING) WITH ('connector' = 'values', 'bounded' = 'true')")
                 // the qualified path of source table  is absent
-                .withSourceName("S")
+                .withSourceTable("S")
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withMatchedDelete("S.v IS NULL");
 


### PR DESCRIPTION
### Purpose

Fix bug.

1. Register alias as table  is not correct because the registerTable API doesn't handle qualified path. Replace it with #createTemporaryView. 
2. Refactor source table and sql: now source name is required. Source alias should be defined in sql now.
3. Refactor test.

### Tests

`MergeIntoActionITCase`

### API and Format 

Delete `--source-as` argument in merge-into action

### Documentation

Improve writing-tables#Merging into table