### PR TITLE
[doc] Provide jar download url in documentation

### DIFF
--- a/docs/content/engines/download.md
+++ b/docs/content/engines/download.md
@@ -1,0 +1,41 @@
+---
+title: "Download"
+weight: 100
+type: docs
+aliases:
+- /engines/download.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Paimon Engines Download page
+
+This documentation is a guide for using Table Store in Flink.
+{{< not_stable >}}
+# Engines snapshots jar
+-------------------
+**The snapshot version is not recommended for production use**
+download link [paimon snapshots jar](https://repository.apache.org/content/repositories/snapshots/org/apache/paimon/)
+{{< /not_stable >}}
+# connectors jar
+-------------------
+{{< sql_optional_connectors >}}
+
+
+

--- a/docs/content/engines/overview.md
+++ b/docs/content/engines/overview.md
@@ -39,3 +39,5 @@ Apache Spark and Apache Hive.
 | Spark     | 3.3/3.2/3.1 | batch read, batch write, create/drop table, create/drop database | Projection, Filter |
 | Spark     | 2.4 | batch read | Projection, Filter |
 | Trino     | 388/358 | batch read | Projection, Filter |
+
+[download link]({{< ref "engines/download#changelog-producers" >}})

--- a/docs/content/filesystems/download.md
+++ b/docs/content/filesystems/download.md
@@ -1,0 +1,39 @@
+---
+title: "Download"
+weight: 100
+type: docs
+aliases:
+- /filesystems/download.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Paimon Filesystems Download page
+
+This documentation is a guide for using Table Store in Flink.
+{{< not_stable >}}
+# Filesystems snapshots jar
+-------------------
+**The snapshot version is not recommended for production use**
+download link [paimon snapshots jar](https://repository.apache.org/content/repositories/snapshots/org/apache/paimon/)
+{{< /not_stable >}}
+# connectors jar
+-------------------
+{{< sql_optional_filesystems >}}
+

--- a/docs/content/filesystems/overview.md
+++ b/docs/content/filesystems/overview.md
@@ -41,3 +41,5 @@ FileSystem pluggable jars for user to query tables from Spark/Hive side.
 | HDFS              | hdfs://          | N         | Built-in Support, ensure that the cluster is in the hadoop environment |
 | Aliyun OSS        | oss://           | Y         |  |
 | S3                | s3://            | Y         |  |
+
+[download link]({{< ref "filesystems/download#changelog-producers" >}})

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+# INSTRUCTIONS:
+#
+# In order to add a new connector/format add a new entry to this file.
+# You need specify a name that will be used in e.g. the description of the connector/format and
+# a category (either "format" or "connector"). The category determines which table will the entry
+# end up in on the Download page. The "maven" parameter describes the name of the maven module. The
+# three parameters are required.
+#
+# If you specify "builtin=true" the corresponding table on the connector/format will not contain
+# a link, but just a "Built-in" entry. If the built-in is set to true you do not need to provide the
+# sql_url.
+#
+# If a connector comes with different versions for the external system, you can put those under a
+# "versions" property. Each entry in the "versions" section should have a "version", which
+# determines name for the version and "maven" and "sql_url" entries for that particular version.
+# If you use the "versions" property, "maven" and "sql_url" should not be present in the top level
+# section of the connector. (Multiple versions are supported only for the connector for now. If you
+# need multiple versions support for formats, please update downloads.md)
+#
+# NOTE: You can use the variables $scala_version and $version in "sql_url" and "maven" properties.
+
+paimon-spark:
+  name: paimon-spark3
+  category: connectors
+  versions:
+    - version: paimon-spark-3.1
+      maven: paimon-spark
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.1/$version/paimon-spark-3.1-$version.jar
+    - version: paimon-spark-3.2
+      maven: paimon-spark
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.2/$version/paimon-spark-3.2-$version.jar
+    - version: paimon-spark-3.3
+      maven: paimon-spark
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.3/$version/paimon-spark-3.3-$version.jar
+
+paimon-spark2:
+  name: paimon-spark2
+  category: connectors
+  versions:
+    - version: paimon-spark-2
+      maven: paimon-spark2
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-2/$version/paimon-spark-2-$version.jar
+
+paimon-flink:
+  name: paimon-flink
+  category: connectors
+  versions:
+    - version: paimon-flink-1.16
+      maven: paimon-flink
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-flink-1.16/$version/paimon-flink-1.16-$version.jar
+
+    - version: paimon-flink-1.15
+      maven: paimon-flink
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-flink-1.15/$version/paimon-flink-1.15-$version.jar
+
+    - version: paimon-flink-1.14
+      maven: paimon-flink
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-flink-1.14/$version/paimon-flink-1.14-$version.jar
+
+paimon-hive-catalog:
+  name: paimon-hive-catalog
+  category: connectors
+  versions:
+    - version:
+      maven: paimon-hive-catalog
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-catalog/$version/ppaimon-hive-catalog-$version.jar
+
+paimon-hive:
+  name: paimon-hive
+  category: connectors
+  versions:
+    - version: paimon-hive-connector-2.1-cdh-6.3
+      maven: paimon-hive
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-connector-2.1-cdh-6.3/$version/paimon-hive-connector-2.1-cdh-6.3-$version.jar
+
+    - version: paimon-hive-connector-2.1
+      maven: paimon-hive
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-connector-2.1/$version/paimon-hive-connector-2.1-$version.jar
+
+    - version: paimon-hive-connector-2.2
+      maven: paimon-hive
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-connector-2.2/$version/paimon-hive-connector-2.2-$version.jar
+
+    - version: paimon-hive-connector-2.3
+      maven: paimon-hive
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-connector-2.3/$version/paimon-hive-connector-2.3-$version.jar
+
+    - version: paimon-hive-connector-3.1
+      maven: paimon-hive
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-hive-connector-3.1/$version/paimon-hive-connector-3.1-$version.jar

--- a/docs/data/sql_filesystems.yml
+++ b/docs/data/sql_filesystems.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+# INSTRUCTIONS:
+#
+# In order to add a new connector/format add a new entry to this file.
+# You need specify a name that will be used in e.g. the description of the connector/format and
+# a category (either "format" or "connector"). The category determines which table will the entry
+# end up in on the Download page. The "maven" parameter describes the name of the maven module. The
+# three parameters are required.
+#
+# If you specify "builtin=true" the corresponding table on the connector/format will not contain
+# a link, but just a "Built-in" entry. If the built-in is set to true you do not need to provide the
+# sql_url.
+#
+# If a connector comes with different versions for the external system, you can put those under a
+# "versions" property. Each entry in the "versions" section should have a "version", which
+# determines name for the version and "maven" and "sql_url" entries for that particular version.
+# If you use the "versions" property, "maven" and "sql_url" should not be present in the top level
+# section of the connector. (Multiple versions are supported only for the connector for now. If you
+# need multiple versions support for formats, please update downloads.md)
+#
+# NOTE: You can use the variables $scala_version and $version in "sql_url" and "maven" properties.
+
+paimon-oss:
+  name: paimon-oss
+  category: filesystems
+  versions:
+    - version:
+      maven: paimon-oss
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-oss/$version/paimon-oss-$version.jar
+
+paimon-s3:
+  name: paimon-s3
+  category: filesystems
+  versions:
+    - version:
+      maven: paimon-s3
+      sql_url: https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-s3/$version/paimon-s3-$version.jar
+
+

--- a/docs/layouts/shortcodes/not_stable.html
+++ b/docs/layouts/shortcodes/not_stable.html
@@ -1,0 +1,23 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+  Shortcode that only renders its contents if the site
+  is marked as stable.
+
+  Parameters: Markdown text
+*/}}{{ if not $.Site.Params.IsStable }}{{ .Inner | markdownify }}{{ end }}

--- a/docs/layouts/shortcodes/sql_optional_connectors.html
+++ b/docs/layouts/shortcodes/sql_optional_connectors.html
@@ -1,0 +1,63 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+Generates the SQL download connector table.
+*/}}
+
+
+<table class="table table-bordered">
+    {{ if $.Site.Params.IsStable }}
+    <thead>
+    <tr>
+        <th style="text-align: left">Name</th>
+        <th style="text-align: left">Version</th>
+        <th style="text-align: left">Download Link</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{ range .Site.Data.sql_connectors }}
+    {{ if eq .category "connectors" }}{{ if eq .builtin nil }}
+    {{ if eq .versions nil }}
+    <tr>
+        <td style="text-align: left">{{- .name -}}</td>
+        <td></td>
+        <td style="text-align: left">
+            <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+            (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+            <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+    </tr>
+    {{ else }}
+    {{ $name := .name }}
+    {{ range .versions }}
+    <tr>
+        <td style="text-align: left">{{- $name -}}</td>
+        <td>{{- .version -}}</td>
+        <td style="text-align: left">
+            <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+            (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+            <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+    </tr>
+    {{ end }}
+    {{ end }}
+    {{ end }}{{ end }}
+    {{ end }}
+    {{ else }}
+    The current document is an unreleased version and does not provide downloads. If necessary, you can refer to the snapshot to download it yourself</td>
+    {{ end }}
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/sql_optional_filesystems.html
+++ b/docs/layouts/shortcodes/sql_optional_filesystems.html
@@ -1,0 +1,63 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+Generates the SQL download connector table.
+*/}}
+
+
+<table class="table table-bordered">
+    {{ if $.Site.Params.IsStable }}
+    <thead>
+    <tr>
+        <th style="text-align: left">Name</th>
+        <th style="text-align: left">Version</th>
+        <th style="text-align: left">Download Link</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{ range .Site.Data.sql_filesystems }}
+    {{ if eq .category "filesystems" }}{{ if eq .builtin nil }}
+    {{ if eq .versions nil }}
+    <tr>
+        <td style="text-align: left">{{- .name -}}</td>
+        <td></td>
+        <td style="text-align: left">
+            <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+            (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+            <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+    </tr>
+    {{ else }}
+    {{ $name := .name }}
+    {{ range .versions }}
+    <tr>
+        <td style="text-align: left">{{- $name -}}</td>
+        <td>{{- .version -}}</td>
+        <td style="text-align: left">
+            <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+            (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+            <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+    </tr>
+    {{ end }}
+    {{ end }}
+    {{ end }}{{ end }}
+    {{ end }}
+    {{ else }}
+    The current document is an unreleased version and does not provide downloads. If necessary, you can refer to the snapshot to download it yourself</td>
+    {{ end }}
+    </tbody>
+</table>


### PR DESCRIPTION
### Purpose

Provide jar download url in documentation #632 

> Now we have already published to snapshot jar to nexus repository.
We can just provide download in documentation, user don't need to build by themselve.