### PR TITLE
[core] Use enum instead of string for file.format

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -84,7 +84,7 @@
             <td><h5>file.format</h5></td>
             <td style="word-wrap: break-word;">orc</td>
             <td><p>Enum</p></td>
-            <td>Specify the message format of data files, currently orc, parquet and avro are supported.<br /><br />Possible values:<ul><li>"orc": ORC format for file store.</li><li>"parquet": Parquet format for file store.</li><li>"avro": Avro format for file store.</li></ul></td>
+            <td>Specify the message format of data files, currently orc, parquet and avro are supported.<br /><br />Possible values:<ul><li>"orc": ORC file format.</li><li>"parquet": Parquet file format.</li><li>"avro": Avro file format.</li></ul></td>
         </tr>
         <tr>
             <td><h5>local-sort.max-num-file-handles</h5></td>
@@ -150,7 +150,7 @@
             <td><h5>manifest.format</h5></td>
             <td style="word-wrap: break-word;">avro</td>
             <td><p>Enum</p></td>
-            <td>Specify the message format of manifest files.<br /><br />Possible values:<ul><li>"orc": ORC format for file store.</li><li>"parquet": Parquet format for file store.</li><li>"avro": Avro format for file store.</li></ul></td>
+            <td>Specify the message format of manifest files.<br /><br />Possible values:<ul><li>"orc": ORC file format.</li><li>"parquet": Parquet file format.</li><li>"avro": Avro file format.</li></ul></td>
         </tr>
         <tr>
             <td><h5>manifest.merge-min-count</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -82,9 +82,9 @@
         </tr>
         <tr>
             <td><h5>file.format</h5></td>
-            <td style="word-wrap: break-word;">"orc"</td>
-            <td>String</td>
-            <td>Specify the message format of data files.</td>
+            <td style="word-wrap: break-word;">orc</td>
+            <td><p>Enum</p></td>
+            <td>Specify the message format of data files, currently orc, parquet and avro are supported.<br /><br />Possible values:<ul><li>"orc": ORC format for file store.</li><li>"parquet": Parquet format for file store.</li><li>"avro": Avro format for file store.</li></ul></td>
         </tr>
         <tr>
             <td><h5>local-sort.max-num-file-handles</h5></td>
@@ -148,9 +148,9 @@
         </tr>
         <tr>
             <td><h5>manifest.format</h5></td>
-            <td style="word-wrap: break-word;">"avro"</td>
-            <td>String</td>
-            <td>Specify the message format of manifest files.</td>
+            <td style="word-wrap: break-word;">avro</td>
+            <td><p>Enum</p></td>
+            <td>Specify the message format of manifest files.<br /><br />Possible values:<ul><li>"orc": ORC format for file store.</li><li>"parquet": Parquet format for file store.</li><li>"avro": Avro format for file store.</li></ul></td>
         </tr>
         <tr>
             <td><h5>manifest.merge-min-count</h5></td>
@@ -361,12 +361,6 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
-        </tr>
-        <tr>
-            <td><h5>read.batch-size</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>Read batch size for orc and parquet.</td>
         </tr>
     </tbody>
 </table>

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableWriterBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableWriterBenchmark.java
@@ -36,7 +36,7 @@ public class TableWriterBenchmark extends TableBenchmark {
     @Test
     public void testAvro() throws Exception {
         Options options = new Options();
-        options.set(CoreOptions.FILE_FORMAT, "avro");
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         innerTest("avro", options);
         /*
          * Java HotSpot(TM) 64-Bit Server VM 1.8.0_301-b09 on Mac OS X 10.16
@@ -50,7 +50,7 @@ public class TableWriterBenchmark extends TableBenchmark {
     @Test
     public void testOrcNoCompression() throws Exception {
         Options options = new Options();
-        options.set(CoreOptions.FILE_FORMAT, "orc");
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.ORC);
         options.set("orc.compress", "none");
         innerTest("orc", options);
         /*
@@ -65,7 +65,7 @@ public class TableWriterBenchmark extends TableBenchmark {
     @Test
     public void testParquet() throws Exception {
         Options options = new Options();
-        options.set(CoreOptions.FILE_FORMAT, "parquet");
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.PARQUET);
         innerTest("parquet", options);
         /*
          * Java HotSpot(TM) 64-Bit Server VM 1.8.0_301-b09 on Mac OS X 10.16
@@ -79,7 +79,7 @@ public class TableWriterBenchmark extends TableBenchmark {
     @Test
     public void testOrc() throws Exception {
         Options options = new Options();
-        options.set(CoreOptions.FILE_FORMAT, "orc");
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.ORC);
         innerTest("orc", options);
         /*
          * Java HotSpot(TM) 64-Bit Server VM 1.8.0_301-b09 on Mac OS X 10.16

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -964,9 +964,9 @@ public class CoreOptions implements Serializable {
 
     /** Specifies the file format type for store. */
     public enum FileFormatType implements DescribedEnum {
-        ORC("orc", "ORC format for file store."),
-        PARQUET("parquet", "Parquet format for file store."),
-        AVRO("avro", "Avro format for file store.");
+        ORC("orc", "ORC file format."),
+        PARQUET("parquet", "Parquet file format."),
+        AVRO("avro", "Avro file format.");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -79,11 +79,12 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("The file path of this table in the filesystem.");
 
-    public static final ConfigOption<String> FILE_FORMAT =
+    public static final ConfigOption<FileFormatType> FILE_FORMAT =
             key("file.format")
-                    .stringType()
-                    .defaultValue("orc")
-                    .withDescription("Specify the message format of data files.");
+                    .enumType(FileFormatType.class)
+                    .defaultValue(FileFormatType.ORC)
+                    .withDescription(
+                            "Specify the message format of data files, currently orc, parquet and avro are supported.");
 
     public static final ConfigOption<String> ORC_BLOOM_FILTER_COLUMNS =
             key("orc.bloom.filter.columns")
@@ -109,10 +110,10 @@ public class CoreOptions implements Serializable {
                                     + "could be NONE, ZLIB, SNAPPY, LZO, LZ4, for parquet file format, the compression value could be "
                                     + "UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD.");
 
-    public static final ConfigOption<String> MANIFEST_FORMAT =
+    public static final ConfigOption<FileFormatType> MANIFEST_FORMAT =
             key("manifest.format")
-                    .stringType()
-                    .defaultValue("avro")
+                    .enumType(FileFormatType.class)
+                    .defaultValue(FileFormatType.AVRO)
                     .withDescription("Specify the message format of manifest files.");
 
     public static final ConfigOption<MemorySize> MANIFEST_TARGET_FILE_SIZE =
@@ -564,6 +565,10 @@ public class CoreOptions implements Serializable {
         return new Path(options.get(PATH));
     }
 
+    public FileFormatType formatType() {
+        return options.get(FILE_FORMAT);
+    }
+
     public FileFormat fileFormat() {
         return createFileFormat(options, FILE_FORMAT);
     }
@@ -580,11 +585,12 @@ public class CoreOptions implements Serializable {
         return options.get(PARTITION_DEFAULT_NAME);
     }
 
-    public static FileFormat createFileFormat(Options options, ConfigOption<String> formatOption) {
-        String formatIdentifier = options.get(formatOption);
+    public static FileFormat createFileFormat(
+            Options options, ConfigOption<FileFormatType> formatOption) {
+        FileFormatType formatIdentifier = options.get(formatOption);
         int readBatchSize = options.get(READ_BATCH_SIZE);
         return FileFormat.fromIdentifier(
-                formatIdentifier,
+                formatIdentifier.toString(),
                 new FormatContext(options.removePrefix(formatIdentifier + "."), readBatchSize));
     }
 
@@ -941,6 +947,31 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         ChangelogProducer(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Specifies the file format type for store. */
+    public enum FileFormatType implements DescribedEnum {
+        ORC("orc", "ORC format for file store."),
+        PARQUET("parquet", "Parquet format for file store."),
+        AVRO("avro", "Avro format for file store.");
+
+        private final String value;
+        private final String description;
+
+        FileFormatType(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -20,6 +20,7 @@ package org.apache.paimon;
 
 import org.apache.paimon.annotation.Documentation.ExcludeFromDocumentation;
 import org.apache.paimon.annotation.Documentation.Immutable;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.fs.Path;
@@ -29,11 +30,13 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
+import org.apache.paimon.utils.StringUtils;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -984,6 +987,21 @@ public class CoreOptions implements Serializable {
         @Override
         public InlineElement getDescription() {
             return text(description);
+        }
+
+        @VisibleForTesting
+        public static FileFormatType fromValue(String value) {
+            for (FileFormatType formatType : FileFormatType.values()) {
+                if (formatType.value.equals(value)) {
+                    return formatType;
+                }
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Invalid format type %s, only support [%s]",
+                            value,
+                            StringUtils.join(
+                                    Arrays.stream(FileFormatType.values()).iterator(), ",")));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -44,7 +44,6 @@ import static org.apache.paimon.WriteMode.APPEND_ONLY;
 import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 import static org.apache.paimon.schema.SystemColumns.SYSTEM_FIELD_NAMES;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkNotNull;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Validation utils for {@link TableSchema}. */
@@ -101,8 +100,10 @@ public class SchemaValidation {
             }
         }
 
-        // Valid the format type
-        checkNotNull(options.formatType());
+        // Get the format type here which will try to convert string value to {@Code
+        // FileFormatType}. If the string value is illegal, an exception will be thrown.
+        // TODO Check fields type according to the format type
+        options.formatType();
 
         // Check column names in schema
         schema.fieldNames()

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -44,6 +44,7 @@ import static org.apache.paimon.WriteMode.APPEND_ONLY;
 import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 import static org.apache.paimon.schema.SystemColumns.SYSTEM_FIELD_NAMES;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Validation utils for {@link TableSchema}. */
@@ -99,6 +100,9 @@ public class SchemaValidation {
                 default:
             }
         }
+
+        // Valid the format type
+        checkNotNull(options.formatType());
 
         // Check column names in schema
         schema.fieldNames()

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -58,7 +58,7 @@ public class FileStorePathFactory {
                 root,
                 RowType.builder().build(),
                 PARTITION_DEFAULT_NAME.defaultValue(),
-                CoreOptions.FILE_FORMAT.defaultValue());
+                CoreOptions.FILE_FORMAT.defaultValue().toString());
     }
 
     // for tables without partition, partitionType should be a row type with 0 columns (not null)

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -90,7 +90,7 @@ public class FileFormatTest {
     @Test
     public void testCreateFileFormat() {
         Options tableOptions = new Options();
-        tableOptions.set(CoreOptions.FILE_FORMAT, IDENTIFIER);
+        tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.valueOf(IDENTIFIER));
         tableOptions.set(CoreOptions.READ_BATCH_SIZE, 1024);
         tableOptions.setString(IDENTIFIER + ".hello", "world");
         FileFormat fileFormat = CoreOptions.createFileFormat(tableOptions, CoreOptions.FILE_FORMAT);
@@ -103,7 +103,7 @@ public class FileFormatTest {
 
     public FileFormat createFileFormat(String codec) {
         Options tableOptions = new Options();
-        tableOptions.set(CoreOptions.FILE_FORMAT, "avro");
+        tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         tableOptions.setString("avro.codec", codec);
         return CoreOptions.createFileFormat(tableOptions, CoreOptions.FILE_FORMAT);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -90,7 +90,7 @@ public class FileFormatTest {
     @Test
     public void testCreateFileFormat() {
         Options tableOptions = new Options();
-        tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.valueOf(IDENTIFIER));
+        tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.fromValue(IDENTIFIER));
         tableOptions.set(CoreOptions.READ_BATCH_SIZE, 1024);
         tableOptions.setString(IDENTIFIER + ".hello", "world");
         FileFormat fileFormat = CoreOptions.createFileFormat(tableOptions, CoreOptions.FILE_FORMAT);

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -534,8 +534,8 @@ public class TestFileStore extends KeyValueFileStore {
                     CoreOptions.MANIFEST_TARGET_FILE_SIZE,
                     MemorySize.parse((ThreadLocalRandom.current().nextInt(16) + 1) + "kb"));
 
-            conf.set(CoreOptions.FILE_FORMAT, format);
-            conf.set(CoreOptions.MANIFEST_FORMAT, format);
+            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.valueOf(format));
+            conf.set(CoreOptions.MANIFEST_FORMAT, CoreOptions.FileFormatType.valueOf(format));
             conf.set(CoreOptions.PATH, root);
             conf.set(CoreOptions.BUCKET, numBuckets);
 

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -534,8 +534,8 @@ public class TestFileStore extends KeyValueFileStore {
                     CoreOptions.MANIFEST_TARGET_FILE_SIZE,
                     MemorySize.parse((ThreadLocalRandom.current().nextInt(16) + 1) + "kb"));
 
-            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.valueOf(format));
-            conf.set(CoreOptions.MANIFEST_FORMAT, CoreOptions.FileFormatType.valueOf(format));
+            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.fromValue(format));
+            conf.set(CoreOptions.MANIFEST_FORMAT, CoreOptions.FileFormatType.fromValue(format));
             conf.set(CoreOptions.PATH, root);
             conf.set(CoreOptions.BUCKET, numBuckets);
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -295,7 +295,7 @@ public class AppendOnlyWriterTest {
                 new Path(tempDir.toString()),
                 "dt=" + PART,
                 0,
-                CoreOptions.FILE_FORMAT.defaultValue());
+                CoreOptions.FILE_FORMAT.defaultValue().toString());
     }
 
     private AppendOnlyWriter createEmptyWriter(long targetFileSize) {

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -38,7 +38,7 @@ public class DataFilePathFactoryTest {
                         new Path(tempDir.toString()),
                         "",
                         123,
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
@@ -64,7 +64,7 @@ public class DataFilePathFactoryTest {
                         new Path(tempDir.toString()),
                         "dt=20211224",
                         123,
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -68,7 +68,9 @@ public class RollingFileWriterTest {
                                                         new Path(tempDir.toString()),
                                                         "",
                                                         0,
-                                                        CoreOptions.FILE_FORMAT.defaultValue())
+                                                        CoreOptions.FILE_FORMAT
+                                                                .defaultValue()
+                                                                .toString())
                                                 .newPath(),
                                         SCHEMA,
                                         fileFormat.createStatsExtractor(SCHEMA).orElse(null),

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -150,7 +150,7 @@ public class ManifestFileMetaTest {
                                 path,
                                 PARTITION_TYPE,
                                 "default",
-                                CoreOptions.FILE_FORMAT.defaultValue()),
+                                CoreOptions.FILE_FORMAT.defaultValue().toString()),
                         Long.MAX_VALUE)
                 .create();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -95,7 +95,10 @@ public class ManifestFileTest {
         Path path = new Path(pathStr);
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
-                        path, DEFAULT_PART_TYPE, "default", CoreOptions.FILE_FORMAT.defaultValue());
+                        path,
+                        DEFAULT_PART_TYPE,
+                        "default",
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         return new ManifestFile.Factory(

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
@@ -94,7 +94,7 @@ public class ManifestListTest {
                         path,
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
         return new ManifestList.Factory(
                         FileIOFinder.find(path),
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.paimon.CoreOptions.FILE_FORMAT;
 import static org.apache.paimon.utils.FailingFileIO.retryArtificialException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -306,5 +307,24 @@ public class SchemaManagerTest {
 
         manager.deleteSchema(manager.latest().get().id());
         assertThat(manager.latest().get().toString()).isEqualTo(schemaContent);
+    }
+
+    @Test
+    public void testInvalidFormatType() {
+        Map<String, String> options = new HashMap<>();
+        options.put(FILE_FORMAT.key(), "test");
+        Schema schema =
+                new Schema(
+                        rowType.getFields(),
+                        partitionKeys,
+                        primaryKeys,
+                        options,
+                        "append-only table with primary key");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), path);
+        assertThatThrownBy(() -> manager.createTable(schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        String.format(
+                                "Could not parse value 'test' for key '%s'.", FILE_FORMAT.key()));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
@@ -148,7 +149,8 @@ public abstract class FileStoreTableTestBase {
 
     @Test
     public void testChangeFormat() throws Exception {
-        FileStoreTable table = createFileStoreTable(conf -> conf.set(FILE_FORMAT, "orc"));
+        FileStoreTable table =
+                createFileStoreTable(conf -> conf.set(FILE_FORMAT, CoreOptions.FileFormatType.ORC));
 
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);
@@ -167,7 +169,9 @@ public abstract class FileStoreTableTestBase {
                         "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
                         "2|20|200|binary|varbinary|mapKey:mapVal|multiset");
 
-        table = createFileStoreTable(conf -> conf.set(FILE_FORMAT, "avro"));
+        table =
+                createFileStoreTable(
+                        conf -> conf.set(FILE_FORMAT, CoreOptions.FileFormatType.AVRO));
         write = table.newWrite(commitUser);
         commit = table.newCommit(commitUser);
         write.write(rowData(1, 11, 111L));

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -84,7 +84,7 @@ public class FileStorePathFactoryTest {
                                 new DataType[] {new VarCharType(10), new IntType()},
                                 new String[] {"dt", "hr"}),
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
 
         assertPartition("20211224", 16, pathFactory, "/dt=20211224/hr=16");
         assertPartition("20211224", null, pathFactory, "/dt=20211224/hr=default");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileStoreITCase.java
@@ -417,7 +417,7 @@ public class FileStoreITCase extends AbstractTestBase {
             FailingFileIO.reset(failingName, 3, 100);
             options.set(PATH, FailingFileIO.getFailingPath(failingName, temporaryPath));
         }
-        options.set(FILE_FORMAT, "avro");
+        options.set(FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         return options;
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ForceCompactionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ForceCompactionITCase.java
@@ -231,7 +231,7 @@ public class ForceCompactionITCase extends CatalogITCaseBase {
                         getTableDirectory(tableName),
                         partType,
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
 
         List<ManifestFileMeta> manifestFileMetas =
                 new ManifestList.Factory(LocalFileIO.create(), partType, avro, pathFactory)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -100,7 +100,7 @@ public class TestChangelogDataReadWrite {
                         tablePath,
                         RowType.of(new IntType()),
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
         this.snapshotManager = new SnapshotManager(LocalFileIO.create(), new Path(root));
         this.commitUser = UUID.randomUUID().toString();
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -600,7 +600,7 @@ public class PaimonStorageHandlerITCase {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, path);
         conf.set(CoreOptions.BUCKET, 2);
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(conf, rowType, partitionKeys, primaryKeys);
 
@@ -613,7 +613,7 @@ public class PaimonStorageHandlerITCase {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, path);
         conf.set(CoreOptions.BUCKET, 2);
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         conf.set(CoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
@@ -653,7 +653,7 @@ public class PaimonStorageHandlerITCase {
         String root = folder.newFolder().toString();
         Options conf = new Options();
         conf.set(CoreOptions.PATH, root);
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,
@@ -769,7 +769,7 @@ public class PaimonStorageHandlerITCase {
         String path = folder.newFolder().toURI().toString();
         Options conf = new Options();
         conf.set(CoreOptions.PATH, path);
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,
@@ -858,7 +858,7 @@ public class PaimonStorageHandlerITCase {
         String path = folder.newFolder().toURI().toString();
         Options conf = new Options();
         conf.set(CoreOptions.PATH, path);
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -65,7 +65,7 @@ public class PaimonRecordReaderTest {
     public void testPk() throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tempDir.toString());
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,
@@ -103,7 +103,7 @@ public class PaimonRecordReaderTest {
     public void testValueCount() throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tempDir.toString());
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,
@@ -142,7 +142,7 @@ public class PaimonRecordReaderTest {
     public void testProjectionPushdown() throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tempDir.toString());
-        conf.set(CoreOptions.FILE_FORMAT, "avro");
+        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
         FileStoreTable table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,


### PR DESCRIPTION
### Purpose

Use enum instead of string for file.format and validate the format value in ddl

### Tests

1. Added the test `SchemaManagerTest.testInvalidFormatType` to validate the format value

### API and Format 

*(Does this change affect API or storage format)* no

### Documentation

*(Does this change introduce a new feature)* no
