### PR TITLE
[core] Return sorted snapshot rows when query by default

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -50,6 +50,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -199,6 +200,12 @@ public class SnapshotsTable implements ReadonlyTable {
                         Iterators.transform(
                                 rows, row -> ProjectedRow.from(projection).replaceRow(row));
             }
+
+            rows =
+                    Arrays.stream(Iterators.toArray(rows, InternalRow.class))
+                            .sorted(Comparator.comparingLong(row -> row.getLong(0)))
+                            .iterator();
+
             return new IteratorRecordReader<>(rows);
         }
 


### PR DESCRIPTION
### Purpose

The system snapshots table return unordered snapshot rows by default, it's better to return sorted rows by default.

### Tests

_**Before**_
![image](https://user-images.githubusercontent.com/95013770/227213464-13f462f0-c9dc-4477-bf71-aa806230cdc8.png)

_**Enhance**_
![image](https://user-images.githubusercontent.com/95013770/227213571-4d5c697e-b925-442f-b6f0-652eff9ae811.png)

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
****