### PR TITLE
[core] Return sorted snapshot rows by default

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -163,6 +164,7 @@ public class SnapshotManager implements Serializable {
     public Iterator<Snapshot> snapshots() throws IOException {
         return listVersionedFiles(fileIO, snapshotDirectory(), SNAPSHOT_PREFIX)
                 .map(this::snapshot)
+                .sorted(Comparator.comparingLong(Snapshot::id))
                 .iterator();
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -53,8 +53,9 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES (3, 4)");
 
         List<Row> result = sql("SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots");
-        assertThat(result)
-                .containsExactlyInAnyOrder(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
+
+        // check correctness and sequence snapshots.
+        assertThat(result).containsExactly(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
     }
 
     @Test


### PR DESCRIPTION
### Purpose

The system snapshots table return unordered snapshot rows by default, it's better to return sorted rows by default.

### Tests

_**Before**_
![image](https://user-images.githubusercontent.com/95013770/227213464-13f462f0-c9dc-4477-bf71-aa806230cdc8.png)

_**Enhance**_
![image](https://user-images.githubusercontent.com/95013770/227213571-4d5c697e-b925-442f-b6f0-652eff9ae811.png)

