### PR TITLE
[core] Improve the exception information when the changelog producer is `lookup` , the table has no primary key

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -93,7 +93,9 @@ public class SchemaValidation {
                 case LOOKUP:
                     if (schema.primaryKeys().isEmpty()) {
                         throw new UnsupportedOperationException(
-                                "Changelog table with full compaction must have primary keys");
+                                "Changelog table with "
+                                        + options.changelogProducer()
+                                        + " must have primary keys");
                     }
                     break;
                 default:
@@ -107,7 +109,7 @@ public class SchemaValidation {
                             checkState(
                                     !SYSTEM_FIELD_NAMES.contains(f),
                                     String.format(
-                                            "Field name[%s] in schema cannot be exist in [%s]",
+                                            "Field name[%s] in schema cannot be exist in %s",
                                             f, SYSTEM_FIELD_NAMES));
                             checkState(
                                     !f.startsWith(KEY_FIELD_PREFIX),

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -260,7 +260,7 @@ public class SchemaManagerTest {
                         "");
         assertThatThrownBy(() -> manager.createTable(schemaWithoutPrimaryKeys))
                 .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Changelog table with full compaction must have primary keys");
+                .hasMessage("Changelog table with full-compaction must have primary keys");
 
         final Schema schemaWithPrimaryKeys =
                 new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -333,8 +333,8 @@ public class SchemaEvolutionTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(
                         String.format(
-                                "Field name[%s] in schema cannot be exist in [%s]",
-                                "_VALUE_KIND", SYSTEM_FIELD_NAMES.toString()));
+                                "Field name[%s] in schema cannot be exist in %s",
+                                "_VALUE_KIND", SYSTEM_FIELD_NAMES));
     }
 
     private List<String> readRecords(FileStoreTable table, Predicate filter) throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -296,8 +296,8 @@ public class SchemaEvolutionTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(
                         String.format(
-                                "Field name[%s] in schema cannot be exist in [%s]",
-                                "_VALUE_COUNT", SYSTEM_FIELD_NAMES.toString()));
+                                "Field name[%s] in schema cannot be exist in %s",
+                                "_VALUE_COUNT", SYSTEM_FIELD_NAMES));
 
         Schema schema2 =
                 new Schema(


### PR DESCRIPTION
*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

*(What is the purpose of the change, or the associated issue)*

Q1:
when the changelog producer is `lookup` , the table has no primary key, The exception information is: `Changelog table with full-compaction must have primary keys`

Improve:

`Changelog table with lookup must have primary keys`


Q2:
When the system field ["_VALUE_COUNT", "_SEQUENCE_NUMBER", "_VALUE_KIND"] is included in the schema, the exception information is: `Field name["_VALUE_COUNT"] in schema cannot be exist in [["_VALUE_COUNT", "_SEQUENCE_NUMBER", "_VALUE_KIND"]]`

Improve:
`Field name["_VALUE_COUNT"] in schema cannot be exist in ["_VALUE_COUNT", "_SEQUENCE_NUMBER", "_VALUE_KIND"]`


### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
