### PR TITLE
[core] support JDK 11

### DIFF
--- a/.github/workflows/e2e-tests-1.14-jdk11.yml
+++ b/.github/workflows/e2e-tests-1.14-jdk11.yml
@@ -16,20 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-name: End to End Tests Flink 1.15
+name: End to End Tests Flink 1.14 on JDK 11
 
 on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  issue_comment:
+    types: [created, edited, deleted]
+
+  # daily run
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
-  JDK_VERSION: 8
+  JDK_VERSION: 11
 
 jobs:
   build:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/jdk11')
     runs-on: ubuntu-latest
 
     steps:
@@ -40,13 +42,12 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
-      - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
-      - name: Test Flink 1.15
-        timeout-minutes: 60
+      - name: Build Flink 1.14
+        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.14
+      - name: Test Flink 1.14
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.15
+          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.14

--- a/.github/workflows/e2e-tests-1.14.yml
+++ b/.github/workflows/e2e-tests-1.14.yml
@@ -25,6 +25,9 @@ on:
       - 'docs/**'
       - '**/*.md'
 
+env:
+  JDK_VERSION: 8
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,10 +35,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'adopt'
       - name: Build Flink 1.14
         run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.14
       - name: Test Flink 1.14

--- a/.github/workflows/e2e-tests-1.15-jdk11.yml
+++ b/.github/workflows/e2e-tests-1.15-jdk11.yml
@@ -16,20 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-name: End to End Tests Flink 1.15
+name: End to End Tests Flink 1.15 on JDK 11
 
 on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  issue_comment:
+    types: [created, edited, deleted]
+
+  # daily run
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
-  JDK_VERSION: 8
+  JDK_VERSION: 11
 
 jobs:
   build:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/jdk11')
     runs-on: ubuntu-latest
 
     steps:
@@ -43,7 +45,6 @@ jobs:
       - name: Build Flink 1.15
         run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
       - name: Test Flink 1.15
-        timeout-minutes: 60
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh

--- a/.github/workflows/e2e-tests-1.16-jdk11.yml
+++ b/.github/workflows/e2e-tests-1.16-jdk11.yml
@@ -16,20 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-name: End to End Tests Flink 1.15
+name: End to End Tests Flink 1.16 on JDK 11
 
 on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  issue_comment:
+    types: [created, edited, deleted]
+
+  # daily run
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
-  JDK_VERSION: 8
+  JDK_VERSION: 11
 
 jobs:
   build:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/jdk11')
     runs-on: ubuntu-latest
 
     steps:
@@ -40,13 +42,12 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
-      - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
-      - name: Test Flink 1.15
-        timeout-minutes: 60
+      - name: Build Flink 1.16
+        run: ./mvnw clean install -DskipTests
+      - name: Test Flink 1.16
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.15
+          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone

--- a/.github/workflows/e2e-tests-1.16.yml
+++ b/.github/workflows/e2e-tests-1.16.yml
@@ -25,6 +25,9 @@ on:
       - 'docs/**'
       - '**/*.md'
 
+env:
+  JDK_VERSION: 8
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,10 +35,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'adopt'
       - name: Build Flink 1.16
         run: ./mvnw clean install -DskipTests
       - name: Test Flink 1.16

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,6 +23,10 @@ on:
     # At the end of every day
     - cron: '0 0 * * *'
   workflow_dispatch:
+
+env:
+  JDK_VERSION: 8
+
 jobs:
   publish-snapshot:
     if: github.repository == 'apache/incubator-paimon'
@@ -30,10 +34,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      # temporarily publish the jdk8 version to maven
+      # lately when jdk is deprecated, we need update it to jdk11
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'adopt'
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unitcase-flink-jdk11.yml
+++ b/.github/workflows/unitcase-flink-jdk11.yml
@@ -16,20 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-name: End to End Tests Flink 1.15
+name: UTCase and ITCase Flink on JDK 11
 
 on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  issue_comment:
+    types: [created, edited, deleted]
+
+  # daily run
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
-  JDK_VERSION: 8
+  JDK_VERSION: 11
 
 jobs:
   build:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/jdk11')
     runs-on: ubuntu-latest
 
     steps:
@@ -40,13 +42,12 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
-      - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
-      - name: Test Flink 1.15
-        timeout-minutes: 60
+      - name: Build
+        run: ./mvnw clean install -DskipTests
+      - name: Test
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.15
+          ./mvnw clean install -pl 'org.apache.paimon:paimon-flink-common' -Duser.timezone=$jvm_timezone

--- a/.github/workflows/unitcase-jdk11.yml
+++ b/.github/workflows/unitcase-jdk11.yml
@@ -16,20 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-name: End to End Tests Flink 1.15
+name: UTCase and ITCase Non Flink on JDK 11
 
 on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  issue_comment:
+    types: [created, edited, deleted]
+
+  # daily run
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
-  JDK_VERSION: 8
+  JDK_VERSION: 11
 
 jobs:
   build:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/jdk11')
     runs-on: ubuntu-latest
 
     steps:
@@ -40,13 +42,12 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
-      - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
-      - name: Test Flink 1.15
-        timeout-minutes: 60
+      - name: Build
+        run: ./mvnw clean install -DskipTests
+      - name: Test
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          ./mvnw test -pl paimon-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.15
+          ./mvnw clean install -pl '!paimon-e2e-tests,!org.apache.paimon:paimon-flink-common' -Duser.timezone=$jvm_timezone

--- a/.github/workflows/utitcase-flink.yml
+++ b/.github/workflows/utitcase-flink.yml
@@ -25,6 +25,9 @@ on:
       - 'docs/**'
       - '**/*.md'
 
+env:
+  JDK_VERSION: 8
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,10 +35,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'adopt'
       - name: Build
         run: ./mvnw clean install -DskipTests
       - name: Test

--- a/.github/workflows/utitcase.yml
+++ b/.github/workflows/utitcase.yml
@@ -25,6 +25,9 @@ on:
       - 'docs/**'
       - '**/*.md'
 
+env:
+  JDK_VERSION: 8
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,10 +35,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'adopt'
       - name: Build
         run: ./mvnw clean install -DskipTests
       - name: Test

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Paimon tracks issues in GitHub and prefers to receive contributions as pull requ
 <b style="color:red">Please make sure you are subscribed to the mailing list you are posting to!</b> If you are not subscribed to the mailing list, your message will either be rejected (dev@ list) or you won't receive the response (user@ list).
 
 ## Building
-JDK 8 is required for building the project.
+JDK 8/11 is required for building the project.
 
 - Run the `mvn clean package -DskipTests` command to build the project.
 - Run the `mvn spotless:apply` to format the project (both Java and Scala).

--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -78,6 +78,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -93,6 +97,10 @@ under the License.
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -79,6 +79,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CachedRandomInputView.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CachedRandomInputView.java
@@ -73,9 +73,12 @@ public class CachedRandomInputView extends AbstractPagedInputView
     }
 
     private MemorySegment getCurrentPage() {
-        return segments.computeIfAbsent(
-                currentSegmentIndex,
-                key -> cacheManager.getPage(file, currentSegmentIndex, this::invalidPage));
+        MemorySegment segment = segments.get(currentSegmentIndex);
+        if (segment == null) {
+            segment = cacheManager.getPage(file, currentSegmentIndex, this::invalidPage);
+            segments.put(currentSegmentIndex, segment);
+        }
+        return segment;
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/io/cache/CachedRandomInputViewTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/cache/CachedRandomInputViewTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /** Test for {@link CachedRandomInputView}. */
 public class CachedRandomInputViewTest {
@@ -68,26 +69,27 @@ public class CachedRandomInputViewTest {
         CachedRandomInputView view = new CachedRandomInputView(file, cacheManager);
 
         // read first one
-        view.setReadPosition(0);
+        // this assertThatCode check the ConcurrentModificationException is not threw.
+        assertThatCode(() -> view.setReadPosition(0)).doesNotThrowAnyException();
         assertThat(view.readLong()).isEqualTo(segment.getLongBigEndian(0));
 
         // read mid
         int mid = bytes.length / 2;
-        view.setReadPosition(mid);
+        assertThatCode(() -> view.setReadPosition(mid)).doesNotThrowAnyException();
         assertThat(view.readLong()).isEqualTo(segment.getLongBigEndian(mid));
 
         // read special
-        view.setReadPosition(1021);
+        assertThatCode(() -> view.setReadPosition(1021)).doesNotThrowAnyException();
         assertThat(view.readLong()).isEqualTo(segment.getLongBigEndian(1021));
 
         // read last one
-        view.setReadPosition(bytes.length - 1);
+        assertThatCode(() -> view.setReadPosition(bytes.length - 1)).doesNotThrowAnyException();
         assertThat(view.readByte()).isEqualTo(bytes[bytes.length - 1]);
 
         // random read
         for (int i = 0; i < 10000; i++) {
             int position = rnd.nextInt(bytes.length - 8);
-            view.setReadPosition(position);
+            assertThatCode(() -> view.setReadPosition(position)).doesNotThrowAnyException();
             assertThat(view.readLong()).isEqualTo(segment.getLongBigEndian(position));
         }
 

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -93,6 +93,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -142,6 +146,10 @@ under the License.
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -115,7 +115,7 @@ public class DataFileMeta {
                 schemaId,
                 level,
                 Collections.emptyList(),
-                Timestamp.now());
+                Timestamp.fromEpochMillis(System.currentTimeMillis()));
     }
 
     public DataFileMeta(

--- a/paimon-filesystems/paimon-s3-impl/pom.xml
+++ b/paimon-filesystems/paimon-s3-impl/pom.xml
@@ -53,6 +53,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jdk.tools</groupId>
+                        <artifactId>jdk.tools</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/paimon-flink/paimon-flink-1.14/pom.xml
+++ b/paimon-flink/paimon-flink-1.14/pom.xml
@@ -120,6 +120,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-flink/paimon-flink-1.15/pom.xml
+++ b/paimon-flink/paimon-flink-1.15/pom.xml
@@ -127,6 +127,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -98,6 +98,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -171,6 +175,10 @@ under the License.
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -72,6 +72,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -238,6 +242,10 @@ under the License.
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-hive/paimon-hive-catalog/pom.xml
+++ b/paimon-hive/paimon-hive-catalog/pom.xml
@@ -76,6 +76,10 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -96,6 +100,10 @@ under the License.
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-hive/paimon-hive-common/pom.xml
+++ b/paimon-hive/paimon-hive-common/pom.xml
@@ -71,6 +71,10 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/paimon-hive/paimon-hive-connector-3.1/pom.xml
+++ b/paimon-hive/paimon-hive-connector-3.1/pom.xml
@@ -569,6 +569,10 @@ under the License.
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>

--- a/paimon-hive/paimon-hive-connector-common/pom.xml
+++ b/paimon-hive/paimon-hive-connector-common/pom.xml
@@ -64,6 +64,10 @@ under the License.
                     <groupId>org.pentaho</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-spark/paimon-spark-2/pom.xml
+++ b/paimon-spark/paimon-spark-2/pom.xml
@@ -34,6 +34,7 @@ under the License.
     <properties>
         <spark2.version>2.4.8</spark2.version>
         <jackson.version>2.13.3</jackson.version>
+        <asm6.version>4.10</asm6.version>
     </properties>
 
     <dependencies>
@@ -75,6 +76,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.xbean</groupId>
+                    <artifactId>xbean-asm6-shaded</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -83,6 +88,11 @@ under the License.
             <artifactId>jackson-module-scala_2.11</artifactId>
             <version>${jackson.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xbean</groupId>
+            <artifactId>xbean-asm6-shaded</artifactId>
+            <version>${asm6.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION

### Purpose
Support JDK11
issue ref: https://github.com/apache/incubator-paimon/issues/693

### Tests

regression it/e2e case

### API and Format 

no

### Documentation

ye

### Note
all the java code change is because different behavior between jdk8 and jdk11:
1. `LocalDateTime.now()` return micro seconds in jdk11 (only return millisecond in jdk8), and the DataFileMeta serialize and deserialize both specify the TimeStamp(3). In jdk11, all the related cases will be broken.
2. Changes in `CachedRandomInputView.java` is to fix concurrency issues.

