### PR TITLE
[spark] Use new ReadBuilder and WriteBuilder API in tests of paimon-spark module

### DIFF
--- a/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SimpleTableTestHelper.java
+++ b/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SimpleTableTestHelper.java
@@ -29,6 +29,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.RowType;
 
 import java.util.Collections;
@@ -59,9 +60,9 @@ public class SimpleTableTestHelper {
         conf.setString("path", path.toString());
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), conf);
 
-        String commitUser = "user";
-        this.writer = table.newWrite(commitUser);
-        this.commit = table.newCommit(commitUser);
+        StreamWriteBuilder streamWriteBuilder = table.newStreamWriteBuilder();
+        writer = streamWriteBuilder.newWrite();
+        commit = streamWriteBuilder.newCommit();
 
         this.commitIdentifier = 0;
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -78,7 +78,9 @@ public class SparkReadITCase extends SparkReadTestBase {
                 spark.table("`t1$snapshots`")
                         .select("snapshot_id", "schema_id", "commit_user", "commit_kind")
                         .collectAsList();
-        assertThat(rows.toString()).isEqualTo("[[1,0,user,APPEND]]");
+        String commitUser = rows.get(0).getString(2);
+        String rowString = String.format("[[1,0,%s,APPEND]]", commitUser);
+        assertThat(rows.toString()).isEqualTo(rowString);
 
         spark.sql(
                 "CREATE TABLE schemasTable (\n"

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowKind;
 
@@ -173,8 +174,9 @@ public abstract class SparkReadTestBase {
                 FileStoreTableFactory.create(
                         LocalFileIO.create(),
                         new Path(warehousePath, String.format("default.db/%s", tableName)));
-        StreamTableWrite writer = fileStoreTable.newWrite(COMMIT_USER);
-        StreamTableCommit commit = fileStoreTable.newCommit(COMMIT_USER);
+        StreamWriteBuilder streamWriteBuilder = fileStoreTable.newStreamWriteBuilder();
+        StreamTableWrite writer = streamWriteBuilder.newWrite();
+        StreamTableCommit commit = streamWriteBuilder.newCommit();
         for (GenericRow row : rows) {
             writer.write(row);
         }


### PR DESCRIPTION
 Use new ReadBuilder and WriteBuilder API in tests of paimon-spark module

sub-task of #639 

