### PR TITLE
[flink] Use new ReadBuilder and WriteBuilder API in tests of paimon-flink module

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -150,8 +151,10 @@ public class DeleteActionITCase extends ActionITCaseBase {
                         hasPk ? Collections.singletonList("k") : Collections.emptyList(),
                         new HashMap<>());
         snapshotManager = table.snapshotManager();
-        write = table.newWrite(commitUser);
-        commit = table.newCommit(commitUser);
+        StreamWriteBuilder streamWriteBuilder =
+                table.newStreamWriteBuilder().withCommitUser(commitUser);
+        write = streamWriteBuilder.newWrite();
+        commit = streamWriteBuilder.newCommit();
 
         // prepare data
         writeData(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.action.cdc.mysql;
 
 import org.apache.paimon.flink.action.ActionITCaseBase;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
@@ -101,10 +102,11 @@ public class MySqlActionITCaseBase extends ActionITCaseBase {
         List<String> sortedExpected = new ArrayList<>(expected);
         Collections.sort(sortedExpected);
         while (true) {
-            TableScan.Plan plan = table.newScan().plan();
+            ReadBuilder readBuilder = table.newReadBuilder();
+            TableScan.Plan plan = readBuilder.newScan().plan();
             List<String> result =
                     getResult(
-                            table.newRead(),
+                            readBuilder.newRead(),
                             plan == null ? Collections.emptyList() : plan.splits(),
                             rowType);
             List<String> sortedActual = new ArrayList<>(result);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTestBase.java
@@ -61,9 +61,10 @@ public abstract class CommitterOperatorTestBase {
     }
 
     protected void assertResults(FileStoreTable table, String... expected) {
-        TableRead read = table.newRead();
+        TableRead read = table.newReadBuilder().newRead();
         List<String> actual = new ArrayList<>();
-        table.newScan()
+        table.newReadBuilder()
+                .newScan()
                 .plan()
                 .splits()
                 .forEach(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -34,6 +34,7 @@ import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FailingFileIO;
@@ -157,9 +158,10 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
             SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
             TableSchema schema = schemaManager.latest().get();
 
-            TableScan.Plan plan = table.newScan().plan();
+            ReadBuilder readBuilder = table.newReadBuilder();
+            TableScan.Plan plan = readBuilder.newScan().plan();
             try (RecordReaderIterator<InternalRow> it =
-                    new RecordReaderIterator<>(table.newRead().createReader(plan))) {
+                    new RecordReaderIterator<>(readBuilder.newRead().createReader(plan))) {
                 testTables.get(i).assertResult(schema, it);
             }
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -33,6 +33,7 @@ import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FailingFileIO;
@@ -122,9 +123,10 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
         TableSchema schema = schemaManager.latest().get();
 
-        TableScan.Plan plan = table.newScan().plan();
+        ReadBuilder readBuilder = table.newReadBuilder();
+        TableScan.Plan plan = readBuilder.newScan().plan();
         try (RecordReaderIterator<InternalRow> it =
-                new RecordReaderIterator<>(table.newRead().createReader(plan))) {
+                new RecordReaderIterator<>(readBuilder.newRead().createReader(plan))) {
             testTable.assertResult(schema, it);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -89,8 +90,10 @@ public class CompactorSourceITCase extends AbstractTestBase {
             // change options to test whether CompactorSourceBuilder work normally
             table = table.copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "2"));
         }
-        StreamTableWrite write = table.newWrite(commitUser);
-        StreamTableCommit commit = table.newCommit(commitUser);
+        StreamWriteBuilder streamWriteBuilder =
+                table.newStreamWriteBuilder().withCommitUser(commitUser);
+        StreamTableWrite write = streamWriteBuilder.newWrite();
+        StreamTableCommit commit = streamWriteBuilder.newCommit();
 
         write.write(rowData(1, 1510, BinaryString.fromString("20221208"), 15));
         write.write(rowData(2, 1620, BinaryString.fromString("20221208"), 16));
@@ -138,8 +141,10 @@ public class CompactorSourceITCase extends AbstractTestBase {
             dynamicOptions.put(CoreOptions.SCAN_BOUNDED_WATERMARK.key(), "0");
             table = table.copy(dynamicOptions);
         }
-        StreamTableWrite write = table.newWrite(commitUser);
-        StreamTableCommit commit = table.newCommit(commitUser);
+        StreamWriteBuilder streamWriteBuilder =
+                table.newStreamWriteBuilder().withCommitUser(commitUser);
+        StreamTableWrite write = streamWriteBuilder.newWrite();
+        StreamTableCommit commit = streamWriteBuilder.newCommit();
 
         write.write(rowData(1, 1510, BinaryString.fromString("20221208"), 15));
         write.write(rowData(2, 1620, BinaryString.fromString("20221208"), 16));
@@ -234,8 +239,10 @@ public class CompactorSourceITCase extends AbstractTestBase {
             List<String> expected)
             throws Exception {
         FileStoreTable table = createFileStoreTable();
-        StreamTableWrite write = table.newWrite(commitUser);
-        StreamTableCommit commit = table.newCommit(commitUser);
+        StreamWriteBuilder streamWriteBuilder =
+                table.newStreamWriteBuilder().withCommitUser(commitUser);
+        StreamTableWrite write = streamWriteBuilder.newWrite();
+        StreamTableCommit commit = streamWriteBuilder.newCommit();
 
         write.write(rowData(1, 1510, BinaryString.fromString("20221208"), 15));
         write.write(rowData(2, 1620, BinaryString.fromString("20221208"), 16));


### PR DESCRIPTION
Use new ReadBuilder and WriteBuilder API in tests of paimon-flink module

sub-task of #639 