### PR TITLE
[flink][bug] Provided kafka-client to avoid classloader conflicts(#705)

### DIFF
--- a/paimon-flink/pom.xml
+++ b/paimon-flink/pom.xml
@@ -127,6 +127,7 @@ under the License.
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

flink1.16-connector-kafka dependencies on kafka-clients 3.x, but paimon-flink-common dependencies on kafka-client version is 2.x, which may leads to classloader conflicts or class not found.so we can provided the Kafka-client dependency. When the user needs to use the external log systems or the kafka connector, user needs to add the flink-connetor-kafka connector dependency in the lib directory

### Tests

LogSystemITCase

### API and Format 


### Documentation

