### PR TITLE
[core] AppendOnly table full reading order is wrong

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -534,6 +534,15 @@ public class CoreOptions implements Serializable {
                     .defaultValue(1024)
                     .withDescription("Read batch size for orc and parquet.");
 
+    @Deprecated
+    @ExcludeFromDocumentation("For compatibility with older versions")
+    public static final ConfigOption<Boolean> APPEND_ONLY_ASSERT_DISORDER =
+            key("append-only.assert-disorder")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Should assert disorder files, this just for compatibility with older versions.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
@@ -329,11 +329,6 @@ public class AppendOnlyCompactManager extends CompactFutureManager {
     }
 
     private static boolean isOverlap(DataFileMeta o1, DataFileMeta o2) {
-        if (o1.minSequenceNumber() <= o2.maxSequenceNumber()
-                && o1.maxSequenceNumber() >= o2.minSequenceNumber()) {
-            return true;
-        }
-
         return o2.minSequenceNumber() <= o1.maxSequenceNumber()
                 && o2.maxSequenceNumber() >= o1.minSequenceNumber();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -38,6 +38,7 @@ import org.apache.paimon.utils.RecordWriter;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -116,7 +117,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
     }
 
     @Override
-    public List<DataFileMeta> dataFiles() {
+    public Collection<DataFileMeta> dataFiles() {
         return compactManager.allFiles();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -42,8 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
-
 /**
  * A {@link RecordWriter} implementation that only accepts records which are always insert
  * operations and don't have any unique keys or sort keys.
@@ -135,10 +133,6 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
         if (writer != null) {
             writer.close();
             flushedFiles.addAll(writer.result());
-
-            // Reopen the writer to accept further records.
-            seqNumCounter.reset();
-            seqNumCounter.add(getMaxSequenceNumber(flushedFiles) + 1);
             writer = createRollingRowWriter();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
@@ -21,7 +21,7 @@ package org.apache.paimon.compact;
 import org.apache.paimon.io.DataFileMeta;
 
 import java.io.Closeable;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -34,7 +34,7 @@ public interface CompactManager extends Closeable {
     /** Add a new file. */
     void addNewFile(DataFileMeta file);
 
-    List<DataFileMeta> allFiles();
+    Collection<DataFileMeta> allFiles();
 
     /**
      * Trigger a new compaction task.

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -31,16 +31,10 @@ public abstract class CompactTask implements Callable<CompactResult> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CompactTask.class);
 
-    private final List<DataFileMeta> inputs;
-
-    public CompactTask(List<DataFileMeta> inputs) {
-        this.inputs = inputs;
-    }
-
     @Override
     public CompactResult call() throws Exception {
         long startMillis = System.currentTimeMillis();
-        CompactResult result = doCompact(inputs);
+        CompactResult result = doCompact();
 
         if (LOG.isDebugEnabled()) {
             logMetric(startMillis, result.before(), result.after());
@@ -64,10 +58,9 @@ public abstract class CompactTask implements Callable<CompactResult> {
     /**
      * Perform compaction.
      *
-     * @param inputs the candidate files to be compacted
      * @return {@link CompactResult} of compact before and compact after files.
      */
-    protected abstract CompactResult doCompact(List<DataFileMeta> inputs) throws Exception;
+    protected abstract CompactResult doCompact() throws Exception;
 
     private long collectRewriteSize(List<DataFileMeta> files) {
         return files.stream().mapToLong(DataFileMeta::fileSize).sum();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -40,6 +40,7 @@ import org.apache.paimon.utils.RecordWriter;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -163,7 +164,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
-    public List<DataFileMeta> dataFiles() {
+    public Collection<DataFileMeta> dataFiles() {
         return compactManager.allFiles();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
@@ -51,7 +51,6 @@ public class MergeTreeCompactTask extends CompactTask {
             CompactRewriter rewriter,
             CompactUnit unit,
             boolean dropDelete) {
-        super(unit.files());
         this.minFileSize = minFileSize;
         this.rewriter = rewriter;
         this.outputLevel = unit.outputLevel();
@@ -62,7 +61,7 @@ public class MergeTreeCompactTask extends CompactTask {
     }
 
     @Override
-    protected CompactResult doCompact(List<DataFileMeta> inputs) throws Exception {
+    protected CompactResult doCompact() throws Exception {
         List<List<SortedRun>> candidate = new ArrayList<>();
         CompactResult result = new CompactResult();
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -236,7 +236,7 @@ public abstract class AbstractFileStoreWrite<T>
                 }
                 // writer.allFiles() must be fetched after writer.prepareCommit(), because
                 // compaction result might be updated during prepareCommit
-                List<DataFileMeta> dataFiles = writerContainer.writer.dataFiles();
+                Collection<DataFileMeta> dataFiles = writerContainer.writer.dataFiles();
                 result.add(
                         new State(
                                 partition,
@@ -378,13 +378,13 @@ public abstract class AbstractFileStoreWrite<T>
                 int bucket,
                 long baseSnapshotId,
                 long lastModifiedCommitIdentifier,
-                List<DataFileMeta> dataFiles,
+                Collection<DataFileMeta> dataFiles,
                 CommitIncrement commitIncrement) {
             this.partition = partition;
             this.bucket = bucket;
             this.baseSnapshotId = baseSnapshotId;
             this.lastModifiedCommitIdentifier = lastModifiedCommitIdentifier;
-            this.dataFiles = dataFiles;
+            this.dataFiles = new ArrayList<>(dataFiles);
             this.commitIncrement = commitIncrement;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -43,7 +43,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -97,7 +96,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
             ExecutorService compactExecutor) {
         // let writer and compact manager hold the same reference
         // and make restore files mutable to update
-        LinkedList<DataFileMeta> restored = new LinkedList<>(restoredFiles);
+        long maxSequenceNumber = getMaxSequenceNumber(restoredFiles);
         DataFilePathFactory factory = pathFactory.createDataFilePathFactory(partition, bucket);
         CompactManager compactManager =
                 skipCompaction
@@ -105,7 +104,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
                         : new AppendOnlyCompactManager(
                                 fileIO,
                                 compactExecutor,
-                                restored,
+                                restoredFiles,
                                 compactionMinFileNum,
                                 compactionMaxFileNum,
                                 targetFileSize,
@@ -117,7 +116,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
                 fileFormat,
                 targetFileSize,
                 rowType,
-                getMaxSequenceNumber(restored),
+                maxSequenceNumber,
                 compactManager,
                 commitForceCompact,
                 factory,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import static org.apache.paimon.CoreOptions.APPEND_ONLY_ASSERT_DISORDER;
 import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
 
 /** {@link FileStoreWrite} for {@link AppendOnlyFileStore}. */
@@ -62,6 +63,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
     private final int compactionMaxFileNum;
     private final boolean commitForceCompact;
     private final boolean skipCompaction;
+    private final boolean assertDisorder;
 
     public AppendOnlyFileStoreWrite(
             FileIO fileIO,
@@ -85,6 +87,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
         this.compactionMaxFileNum = options.compactionMaxFileNum();
         this.commitForceCompact = options.commitForceCompact();
         this.skipCompaction = options.writeOnly();
+        this.assertDisorder = options.toConfiguration().get(APPEND_ONLY_ASSERT_DISORDER);
     }
 
     @Override
@@ -109,7 +112,8 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
                                 compactionMaxFileNum,
                                 targetFileSize,
                                 compactRewriter(partition, bucket),
-                                factory);
+                                factory,
+                                assertDisorder);
         return new AppendOnlyWriter(
                 fileIO,
                 schemaId,

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
@@ -24,6 +24,8 @@ import org.apache.paimon.utils.OrderedPacking;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.paimon.append.AppendOnlyCompactManager.sortFiles;
+
 /** Append only implementation of {@link SplitGenerator}. */
 public class AppendOnlySplitGenerator implements SplitGenerator {
 
@@ -36,8 +38,8 @@ public class AppendOnlySplitGenerator implements SplitGenerator {
     }
 
     @Override
-    public List<List<DataFileMeta>> split(List<DataFileMeta> files) {
+    public List<List<DataFileMeta>> split(List<DataFileMeta> input) {
         Function<DataFileMeta, Long> weightFunc = file -> Math.max(file.fileSize(), openFileCost);
-        return OrderedPacking.pack(files, weightFunc, targetSplitSize);
+        return OrderedPacking.pack(sortFiles(input), weightFunc, targetSplitSize);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
@@ -21,10 +21,11 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.utils.OrderedPacking;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.apache.paimon.append.AppendOnlyCompactManager.sortFiles;
+import static org.apache.paimon.append.AppendOnlyCompactManager.fileComparator;
 
 /** Append only implementation of {@link SplitGenerator}. */
 public class AppendOnlySplitGenerator implements SplitGenerator {
@@ -39,7 +40,9 @@ public class AppendOnlySplitGenerator implements SplitGenerator {
 
     @Override
     public List<List<DataFileMeta>> split(List<DataFileMeta> input) {
+        List<DataFileMeta> files = new ArrayList<>(input);
+        files.sort(fileComparator(false));
         Function<DataFileMeta, Long> weightFunc = file -> Math.max(file.fileSize(), openFileCost);
-        return OrderedPacking.pack(sortFiles(input), weightFunc, targetSplitSize);
+        return OrderedPacking.pack(files, weightFunc, targetSplitSize);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -20,6 +20,7 @@ package org.apache.paimon.utils;
 
 import org.apache.paimon.io.DataFileMeta;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public interface RecordWriter<T> {
     void addNewFiles(List<DataFileMeta> files);
 
     /** Get all data files maintained by this writer. */
-    List<DataFileMeta> dataFiles();
+    Collection<DataFileMeta> dataFiles();
 
     /**
      * Prepare for a commit.

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
@@ -210,8 +210,8 @@ public class AppendOnlyCompactManagerTest {
                         maxFileNum,
                         targetFileSize,
                         null, // not used
-                        null // not used
-                        );
+                        null, // not used
+                        false);
         Optional<List<DataFileMeta>> actual = manager.pickCompactBefore();
         assertThat(actual.isPresent()).isEqualTo(expectedPresent);
         if (expectedPresent) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
@@ -62,10 +62,10 @@ public class AppendOnlyCompactManagerTest {
                         newFile(1L, 1024L),
                         newFile(1025L, 2049L),
                         newFile(2050L, 2100L),
-                        newFile(2100L, 2110L)),
+                        newFile(2101L, 2110L)),
                 false,
                 Collections.emptyList(),
-                Arrays.asList(newFile(2050L, 2100L), newFile(2100L, 2110L)));
+                Arrays.asList(newFile(2050L, 2100L), newFile(2101L, 2110L)));
         innerTest(
                 Arrays.asList(newFile(1L, 1024L), newFile(1025L, 2049L), newFile(2050L, 2500L)),
                 false,

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
@@ -25,12 +25,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.apache.paimon.io.DataFileTestUtils.newFile;
+import static org.apache.paimon.table.source.SplitGeneratorTest.newFileFromSequence;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link AppendOnlyCompactManager}. */
 public class AppendOnlyCompactManagerTest {
@@ -191,6 +194,42 @@ public class AppendOnlyCompactManagerTest {
                 true,
                 toCompact3.subList(3, toCompact3.size() - 1),
                 Collections.singletonList(newFile(2621L, 2630L)));
+    }
+
+    @Test
+    public void testAppendOverlap() {
+        Comparator<DataFileMeta> comparator = AppendOnlyCompactManager.fileComparator(true);
+        assertThatThrownBy(
+                        () ->
+                                comparator.compare(
+                                        newFileFromSequence("1", 11, 0, 20),
+                                        newFileFromSequence("2", 13, 20, 30)))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(0, 20), Range2(20, 30)");
+
+        assertThatThrownBy(
+                        () ->
+                                comparator.compare(
+                                        newFileFromSequence("1", 11, 20, 30),
+                                        newFileFromSequence("2", 13, 0, 20)))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(20, 30), Range2(0, 20)");
+
+        assertThatThrownBy(
+                        () ->
+                                comparator.compare(
+                                        newFileFromSequence("1", 11, 0, 30),
+                                        newFileFromSequence("2", 13, 10, 20)))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(0, 30), Range2(10, 20)");
+
+        assertThatThrownBy(
+                        () ->
+                                comparator.compare(
+                                        newFileFromSequence("1", 11, 10, 20),
+                                        newFileFromSequence("2", 13, 0, 30)))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(10, 20), Range2(0, 30)");
     }
 
     private void innerTest(

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -321,7 +321,8 @@ public class AppendOnlyWriterTest {
                                         ? Collections.emptyList()
                                         : Collections.singletonList(
                                                 generateCompactAfter(compactBefore)),
-                        pathFactory);
+                        pathFactory,
+                        false);
         AppendOnlyWriter writer =
                 new AppendOnlyWriter(
                         LocalFileIO.create(),

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 
@@ -235,10 +236,10 @@ public class AppendOnlyWriterTest {
 
         // increase target file size to test compaction
         long targetFileSize = 1024 * 1024L;
-        Pair<AppendOnlyWriter, LinkedList<DataFileMeta>> writerAndToCompact =
+        Pair<AppendOnlyWriter, TreeSet<DataFileMeta>> writerAndToCompact =
                 createWriter(targetFileSize, true, firstInc.newFilesIncrement().newFiles());
         writer = writerAndToCompact.getLeft();
-        LinkedList<DataFileMeta> toCompact = writerAndToCompact.getRight();
+        TreeSet<DataFileMeta> toCompact = writerAndToCompact.getRight();
         assertThat(toCompact).containsExactlyElementsOf(firstInc.newFilesIncrement().newFiles());
         writer.write(row(id, String.format("%03d", id), PART));
         writer.sync();
@@ -302,7 +303,7 @@ public class AppendOnlyWriterTest {
         return createWriter(targetFileSize, false, Collections.emptyList()).getLeft();
     }
 
-    private Pair<AppendOnlyWriter, LinkedList<DataFileMeta>> createWriter(
+    private Pair<AppendOnlyWriter, TreeSet<DataFileMeta>> createWriter(
             long targetFileSize, boolean forceCompact, List<DataFileMeta> scannedFiles) {
         FileFormat fileFormat = FileFormat.fromIdentifier(AVRO, new Options());
         LinkedList<DataFileMeta> toCompact = new LinkedList<>(scannedFiles);
@@ -333,7 +334,7 @@ public class AppendOnlyWriterTest {
                         forceCompact,
                         pathFactory,
                         null);
-        return Pair.of(writer, (LinkedList<DataFileMeta>) compactManager.allFiles());
+        return Pair.of(writer, (TreeSet<DataFileMeta>) compactManager.allFiles());
     }
 
     private DataFileMeta generateCompactAfter(List<DataFileMeta> toCompact) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
@@ -271,7 +271,8 @@ public class IterativeCompactTaskTest {
                     minFileNum,
                     maxFileNum,
                     rewriter,
-                    null);
+                    null,
+                    false);
             deleted = new HashSet<>();
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
@@ -241,7 +241,7 @@ public class IterativeCompactTaskTest {
                 new MockIterativeCompactTask(
                         compactFiles, TARGET_FILE_SIZE, MIN_FILE_NUM, MAX_FILE_NUM, rewriter());
         try {
-            CompactResult actual = task.doCompact(compactFiles);
+            CompactResult actual = task.doCompact();
             assertThat(actual.before()).containsExactlyInAnyOrderElementsOf(expectBefore);
             assertThat(actual.after()).containsExactlyInAnyOrderElementsOf(expectAfter);
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/IterativeCompactTaskTest.java
@@ -67,7 +67,7 @@ public class IterativeCompactTaskTest {
 
         // almost-full files
         innerTest(
-                Arrays.asList(newFile(1L, 1024L), newFile(2L, 2048L)),
+                Arrays.asList(newFile(1L, 1024L), newFile(1025L, 2048L)),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList());
@@ -248,7 +248,7 @@ public class IterativeCompactTaskTest {
             // assert the temporary files are deleted
             assertThat(task.deleted).containsExactlyInAnyOrderElementsOf(expectDeleted);
         } catch (Exception e) {
-            fail("This should not happen");
+            fail("This should not happen", e);
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -76,7 +76,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                                 10,
                                 10,
                                 null,
-                                dataFilePathFactory), // not used
+                                dataFilePathFactory,
+                                false), // not used
                         false,
                         dataFilePathFactory,
                         null);

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -35,6 +35,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 
@@ -261,6 +262,57 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         dataset.get(partition).get(bucket).stream()
                                 .map(STREAMING_ROW_TO_STRING)
                                 .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testBatchOrderWithCompaction() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        int number = 61;
+        List<Integer> expected = new ArrayList<>();
+
+        {
+            StreamTableWrite write = table.newWrite(commitUser);
+            StreamTableCommit commit = table.newCommit(commitUser);
+
+            for (int i = 0; i < number; i++) {
+                write.write(rowData(1, i, (long) i));
+                commit.commit(i, write.prepareCommit(false, i));
+                expected.add(i);
+            }
+            write.close();
+
+            ReadBuilder readBuilder = table.newReadBuilder();
+            List<Split> splits = readBuilder.newScan().plan().splits();
+            List<Integer> result = new ArrayList<>();
+            readBuilder
+                    .newRead()
+                    .createReader(splits)
+                    .forEachRemaining(r -> result.add(r.getInt(1)));
+            assertThat(result).containsExactlyElementsOf(expected);
+        }
+
+        // restore
+        {
+            StreamTableWrite write = table.newWrite(commitUser);
+            StreamTableCommit commit = table.newCommit(commitUser);
+
+            for (int i = number; i < number + 51; i++) {
+                write.write(rowData(1, i, (long) i));
+                commit.commit(i, write.prepareCommit(false, i));
+                expected.add(i);
+            }
+            write.close();
+
+            ReadBuilder readBuilder = table.newReadBuilder();
+            List<Split> splits = readBuilder.newScan().plan().splits();
+            List<Integer> result = new ArrayList<>();
+            readBuilder
+                    .newRead()
+                    .createReader(splits)
+                    .forEachRemaining(r -> result.add(r.getInt(1)));
+            assertThat(result).containsExactlyElementsOf(expected);
+        }
     }
 
     private void writeData() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -32,12 +32,11 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.io.DataFileTestUtils.fromMinMax;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link AppendOnlySplitGenerator} and {@link MergeTreeSplitGenerator}. */
 public class SplitGeneratorTest {
 
-    private static DataFileMeta newFileFromSequence(
+    public static DataFileMeta newFileFromSequence(
             String name, int rowCount, long minSequence, long maxSequence) {
         return new DataFileMeta(
                 name,
@@ -83,46 +82,6 @@ public class SplitGeneratorTest {
                         Collections.singletonList("4"),
                         Collections.singletonList("5"),
                         Collections.singletonList("6"));
-    }
-
-    @Test
-    public void testAppendOverlap() {
-        AppendOnlySplitGenerator generator = new AppendOnlySplitGenerator(40, 2);
-        assertThatThrownBy(
-                        () ->
-                                generator.split(
-                                        Arrays.asList(
-                                                newFileFromSequence("1", 11, 0, 20),
-                                                newFileFromSequence("2", 13, 20, 30))))
-                .hasMessageContaining(
-                        "There should no overlap in append files, there is a bug! Range1(20, 30), Range2(0, 20)");
-
-        assertThatThrownBy(
-                        () ->
-                                generator.split(
-                                        Arrays.asList(
-                                                newFileFromSequence("1", 11, 20, 30),
-                                                newFileFromSequence("2", 13, 0, 20))))
-                .hasMessageContaining(
-                        "There should no overlap in append files, there is a bug! Range1(0, 20), Range2(20, 30)");
-
-        assertThatThrownBy(
-                        () ->
-                                generator.split(
-                                        Arrays.asList(
-                                                newFileFromSequence("1", 11, 0, 30),
-                                                newFileFromSequence("2", 13, 10, 20))))
-                .hasMessageContaining(
-                        "There should no overlap in append files, there is a bug! Range1(10, 20), Range2(0, 30)");
-
-        assertThatThrownBy(
-                        () ->
-                                generator.split(
-                                        Arrays.asList(
-                                                newFileFromSequence("1", 11, 10, 20),
-                                                newFileFromSequence("2", 13, 0, 30))))
-                .hasMessageContaining(
-                        "There should no overlap in append files, there is a bug! Range1(0, 30), Range2(10, 20)");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -105,6 +105,24 @@ public class SplitGeneratorTest {
                                                 newFileFromSequence("2", 13, 0, 20))))
                 .hasMessageContaining(
                         "There should no overlap in append files, there is a bug! Range1(0, 20), Range2(20, 30)");
+
+        assertThatThrownBy(
+                        () ->
+                                generator.split(
+                                        Arrays.asList(
+                                                newFileFromSequence("1", 11, 0, 30),
+                                                newFileFromSequence("2", 13, 10, 20))))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(10, 20), Range2(0, 30)");
+
+        assertThatThrownBy(
+                        () ->
+                                generator.split(
+                                        Arrays.asList(
+                                                newFileFromSequence("1", 11, 10, 20),
+                                                newFileFromSequence("2", 13, 0, 30))))
+                .hasMessageContaining(
+                        "There should no overlap in append files, there is a bug! Range1(0, 30), Range2(10, 20)");
     }
 
     @Test


### PR DESCRIPTION
### Purpose

When latest-full streaming reading.
The records order of full reading is wrong. This is because:

New files may be created during the compaction process, then the results of the compaction may be put after the new files, and this order will be disrupted.

We need to ensure this order, so we force the order of files by sequence.

### Tests

`AppendOnlyFileStoreTableTest.testBatchOrderWithCompaction`
