### PR TITLE
[core] BatchWriteBuilder#withOverwrite should not accept multiple partitions list

### DIFF
--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -145,6 +145,13 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.manifest.ManifestCommittable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,24 +52,26 @@ public interface FileStoreCommit {
     /** Commit from manifest committable. */
     void commit(ManifestCommittable committable, Map<String, String> properties);
 
-    /** Overwrite a single partition from manifest committable. */
-    default void overwrite(
-            Map<String, String> partition,
-            ManifestCommittable committable,
-            Map<String, String> properties) {
-        overwrite(Collections.singletonList(partition), committable, properties);
-    }
-
     /**
-     * Overwrite multiple partitions from manifest committable.
+     * Overwrite from manifest committable and partition.
      *
-     * @param partitions A list of partition {@link Map}s that maps each partition key to a
-     *     partition value. Depending on the user-defined statement, the partition might not include
-     *     all partition keys. Also note that this partition does not necessarily equal to the
-     *     partitions of the newly added key-values. This is just the partition to be cleaned up.
+     * <p>TODO: The method's semantics can be dynamic or static overwrite according to properties.
+     *
+     * @param partition A single partition maps each partition key to a partition value. Depending
+     *     on the user-defined statement, the partition might not include all partition keys. Also
+     *     note that this partition does not necessarily equal to the partitions of the newly added
+     *     key-values. This is just the partition to be cleaned up.
      */
     void overwrite(
-            List<Map<String, String>> partitions,
+            Map<String, String> partition,
             ManifestCommittable committable,
             Map<String, String> properties);
+
+    /**
+     * Drop multiple partitions. The {@link Snapshot.CommitKind} of generated snapshot is {@link
+     * Snapshot.CommitKind#OVERWRITE}.
+     *
+     * @param partitions A list of partition {@link Map}s. NOTE: cannot be empty!
+     */
+    void dropPartitions(List<Map<String, String>> partitions);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -20,7 +20,6 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.partition.PartitionTimeExtractor;
 import org.apache.paimon.types.RowType;
@@ -30,7 +29,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,9 +99,7 @@ public class PartitionExpire {
         }
 
         if (expired.size() > 0) {
-            // identifier is MAX_VALUE to avoid conflict.
-            ManifestCommittable committable = new ManifestCommittable(Long.MAX_VALUE);
-            commit.overwrite(expired, committable, Collections.emptyMap());
+            commit.dropPartitions(expired);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilder.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.InternalRow;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -63,15 +62,7 @@ public interface BatchWriteBuilder extends WriteBuilder {
     }
 
     /** Overwrite writing, same as the 'INSERT OVERWRITE T PARTITION (...)' semantics of SQL. */
-    default BatchWriteBuilder withOverwrite(@Nullable Map<String, String> staticPartition) {
-        if (staticPartition != null) {
-            withOverwrite(Collections.singletonList(staticPartition));
-        }
-        return this;
-    }
-
-    /** Overwrite writing, multiple static partitions can be specified. */
-    BatchWriteBuilder withOverwrite(@Nullable List<Map<String, String>> staticPartitions);
+    BatchWriteBuilder withOverwrite(@Nullable Map<String, String> staticPartition);
 
     /** Create a {@link TableWrite} to write {@link InternalRow}s. */
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
@@ -23,7 +23,6 @@ import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -35,7 +34,7 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
     private final InnerTable table;
     private final String commitUser = UUID.randomUUID().toString();
 
-    private List<Map<String, String>> staticPartitions;
+    private Map<String, String> staticPartition;
 
     public BatchWriteBuilderImpl(InnerTable table) {
         this.table = table;
@@ -52,19 +51,19 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
     }
 
     @Override
-    public BatchWriteBuilder withOverwrite(@Nullable List<Map<String, String>> staticPartitions) {
-        this.staticPartitions = staticPartitions;
+    public BatchWriteBuilder withOverwrite(@Nullable Map<String, String> staticPartition) {
+        this.staticPartition = staticPartition;
         return this;
     }
 
     @Override
     public BatchTableWrite newWrite() {
-        return table.newWrite(commitUser).withOverwrite(staticPartitions != null);
+        return table.newWrite(commitUser).withOverwrite(staticPartition != null);
     }
 
     @Override
     public BatchTableCommit newCommit() {
-        InnerTableCommit commit = table.newCommit(commitUser).withOverwrite(staticPartitions);
+        InnerTableCommit commit = table.newCommit(commitUser).withOverwrite(staticPartition);
         commit.ignoreEmptyCommit(true);
         return commit;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
@@ -22,26 +22,17 @@ import org.apache.paimon.operation.Lock;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /** Inner {@link TableCommit} contains overwrite setter. */
 public interface InnerTableCommit extends StreamTableCommit, BatchTableCommit {
 
     /** Overwrite writing, same as the 'INSERT OVERWRITE T PARTITION (...)' semantics of SQL. */
-    default InnerTableCommit withOverwrite(@Nullable Map<String, String> staticPartition) {
-        if (staticPartition != null) {
-            withOverwrite(Collections.singletonList(staticPartition));
-        }
-        return this;
-    }
-
-    InnerTableCommit withOverwrite(@Nullable List<Map<String, String>> overwritePartitions);
+    InnerTableCommit withOverwrite(@Nullable Map<String, String> staticPartition);
 
     /**
      * If this is set to true, when there is no new data, no snapshot will be generated. By default,
-     * empty commit is be ignored.
+     * empty commit is ignored.
      *
      * <ul>
      *   <li>For Streaming: the default value of 'ignoreEmptyCommit' is false.

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -44,7 +44,7 @@ public class TableCommitImpl implements InnerTableCommit {
     @Nullable private final FileStoreExpire expire;
     @Nullable private final PartitionExpire partitionExpire;
 
-    @Nullable private List<Map<String, String>> overwritePartitions = null;
+    @Nullable private Map<String, String> overwritePartition = null;
     @Nullable private Lock lock;
 
     private boolean batchCommitted = false;
@@ -59,8 +59,8 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     @Override
-    public TableCommitImpl withOverwrite(@Nullable List<Map<String, String>> overwritePartitions) {
-        this.overwritePartitions = overwritePartitions;
+    public TableCommitImpl withOverwrite(@Nullable Map<String, String> overwritePartitions) {
+        this.overwritePartition = overwritePartitions;
         return this;
     }
 
@@ -97,10 +97,10 @@ public class TableCommitImpl implements InnerTableCommit {
         for (CommitMessage commitMessage : commitMessages) {
             committable.addFileCommittable(commitMessage);
         }
-        if (overwritePartitions == null) {
+        if (overwritePartition == null) {
             commit.commit(committable, new HashMap<>());
         } else {
-            commit.overwrite(overwritePartitions, committable, new HashMap<>());
+            commit.overwrite(overwritePartition, committable, new HashMap<>());
         }
         expire();
     }
@@ -110,7 +110,7 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public void commitMultiple(List<ManifestCommittable> committables) {
-        if (overwritePartitions == null) {
+        if (overwritePartition == null) {
             for (ManifestCommittable committable : committables) {
                 commit.commit(committable, new HashMap<>());
             }
@@ -128,7 +128,7 @@ public class TableCommitImpl implements InnerTableCommit {
                 // TODO maybe it can be produced by CommitterOperator
                 committable = new ManifestCommittable(Long.MAX_VALUE);
             }
-            commit.overwrite(overwritePartitions, committable, new HashMap<>());
+            commit.overwrite(overwritePartition, committable, new HashMap<>());
         }
 
         expire();

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -152,9 +152,7 @@ public class TestFileStore extends KeyValueFileStore {
                 false,
                 null,
                 watermark,
-                (commit, committable) -> {
-                    commit.commit(committable, Collections.emptyMap());
-                });
+                (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
     }
 
     public List<Snapshot> commitData(
@@ -191,6 +189,23 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 (commit, committable) ->
                         commit.overwrite(partition, committable, Collections.emptyMap()));
+    }
+
+    public Snapshot dropPartitions(List<Map<String, String>> partitions) {
+        FileStoreCommit commit = newCommit(commitUser);
+
+        SnapshotManager snapshotManager = snapshotManager();
+        Long snapshotIdBeforeCommit = snapshotManager.latestSnapshotId();
+        if (snapshotIdBeforeCommit == null) {
+            snapshotIdBeforeCommit = Snapshot.FIRST_SNAPSHOT_ID - 1;
+        }
+        commit.dropPartitions(partitions);
+
+        Long snapshotIdAfterCommit = snapshotManager.latestSnapshotId();
+        assertThat(snapshotIdAfterCommit).isNotNull();
+        assertThat(snapshotIdBeforeCommit + 1).isEqualTo(snapshotIdAfterCommit);
+
+        return snapshotManager.snapshot(snapshotIdAfterCommit);
     }
 
     public List<Snapshot> commitDataImpl(


### PR DESCRIPTION
### Purpose

`BatchWriteBuilder` is API for table, and currently there is no need to modify multiple partitions from table layer.
This PR removes the `BatchWriteBuilder#withOverwrite(List<Map<String, String>>)` method.

The abilities to drop multiple partitions is taken by `FileStoreCommit#dropPartitions(List<Map<String, String>>)`.

### Tests
`DropPartitionActionITCase`
`PartitionExpireTest`

Added:
`FileStoreCommitTest#testDropPartitions`

### API and Format 

Remove public API `BatchWriteBuilder#withOverwrite(List<Map<String, String>>)`.

### Documentation

No.