### PR TITLE
[hive] Dropping table deletes table directory to avoid schema in filesystem exists

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -206,10 +206,9 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             client.dropTable(
                     identifier.getDatabaseName(), identifier.getObjectName(), true, false, true);
-        } catch (TException e) {
-            throw new RuntimeException("Failed to drop table " + identifier.getFullName(), e);
-        } finally {
-            // Deletes table directory to avoid schema in filesystem exists.
+            // Deletes table directory to avoid schema in filesystem exists after dropping hive
+            // table successfully to keep the table consistency between which in filesystem and
+            // which in Hive metastore.
             Path path = getDataTableLocation(identifier);
             try {
                 if (fileIO.exists(path)) {
@@ -218,6 +217,8 @@ public class HiveCatalog extends AbstractCatalog {
             } catch (Exception ee) {
                 LOG.error("Delete directory[{}] fail for table {}", path, identifier, ee);
             }
+        } catch (TException e) {
+            throw new RuntimeException("Failed to drop table " + identifier.getFullName(), e);
         }
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -208,6 +208,16 @@ public class HiveCatalog extends AbstractCatalog {
                     identifier.getDatabaseName(), identifier.getObjectName(), true, false, true);
         } catch (TException e) {
             throw new RuntimeException("Failed to drop table " + identifier.getFullName(), e);
+        } finally {
+            // Deletes table directory to avoid schema in filesystem exists.
+            Path path = getDataTableLocation(identifier);
+            try {
+                if (fileIO.exists(path)) {
+                    fileIO.deleteDirectoryQuietly(path);
+                }
+            } catch (Exception ee) {
+                LOG.error("Delete directory[{}] fail for table {}", path, identifier, ee);
+            }
         }
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -241,7 +241,7 @@ public abstract class HiveCatalogITCaseBase {
                         .contains("Table Type:         \tEXTERNAL_TABLE      \tNULL"));
         tEnv.executeSql("DROP TABLE t").await();
         Path tablePath = new Path(path, "test_db.db/t");
-        Assert.assertTrue(tablePath.getFileSystem().exists(tablePath));
+        Assert.assertFalse(tablePath.getFileSystem().exists(tablePath));
     }
 
     @Test


### PR DESCRIPTION
### Purpose

`HiveCatalog#dropTable` interface should delete table directory to avoid schema in filesystem exists, especially for external table which doesn't delete directory in filesystem so that recreating the same table cause exception that schema in filesystem exists.

Fix #694.

### Tests

`HiveCatalog#dropTable` forces to delete table directory to avoid schema in filesystem exists.

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*