### PR TITLE
[flink] support tables inherit not built-in configurations from catalog

### DIFF
--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -66,12 +66,12 @@ The following shell command registers a paimon catalog named `paimon`. Metadata 
 spark-sql ... \
     --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
     --conf spark.sql.catalog.paimon.warehouse=hdfs://path/to/warehouse \
-    --conf spark.sql.catalog.paimon.table_default.key=value
+    --conf spark.sql.catalog.paimon.table-default.key=value
 ```
 
-The conf `--conf spark.sql.catalog.paimon.table_default.key=value` specifies the default property `'key' = 'value'` for tables created in the catalog.
+The conf `--conf spark.sql.catalog.paimon.table-default.key=value` specifies the default property `'key' = 'value'` for tables created in the catalog.
 
-You can define any default properties with the prefix `spark.sql.catalog.paimon.table_default.` configuration. If the table defines the same properties with the default properties, the table's properties will be taken.
+You can define any default properties with the prefix `spark.sql.catalog.paimon.table-default.` configuration. If the table defines the same properties with the default properties, the table's properties will be taken.
 
 After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
 
@@ -126,7 +126,7 @@ spark-sql ... \
     --conf spark.sql.catalog.paimon.uri=thrift://<hive-metastore-host-name>:<port>
 ```
 
-You can also define any default properties with the prefix `spark.sql.catalog.paimon.table_default.` configuration for tables as above `Catalog with Filesystem Metastore`.
+You can also define any default properties with the prefix `spark.sql.catalog.paimon.table-default.` configuration for tables as above `Catalog with Filesystem Metastore`.
 
 After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
 

--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -44,11 +44,17 @@ The following Flink SQL registers and uses a Paimon catalog named `my_catalog`. 
 ```sql
 CREATE CATALOG my_catalog WITH (
     'type' = 'paimon',
-    'warehouse' = 'hdfs://path/to/warehouse'
+    'warehouse' = 'hdfs://path/to/warehouse',
+    'table-default.key' = 'value'
 );
 
 USE CATALOG my_catalog;
 ```
+
+The property `'table-default.key' = 'value'` specifies the default property `'key' = 'value'` for tables created in the catalog.
+
+You can define any default properties with the prefix `table-default.`. If the table defines the same properties with the default properties, the table's properties will be taken.
+
 
 {{< /tab >}}
 
@@ -59,8 +65,13 @@ The following shell command registers a paimon catalog named `paimon`. Metadata 
 ```bash
 spark-sql ... \
     --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.warehouse=hdfs://path/to/warehouse
+    --conf spark.sql.catalog.paimon.warehouse=hdfs://path/to/warehouse \
+    --conf spark.sql.catalog.paimon.table_default.key=value
 ```
+
+The conf `--conf spark.sql.catalog.paimon.table_default.key=value` specifies the default property `'key' = 'value'` for tables created in the catalog.
+
+You can define any default properties with the prefix `spark.sql.catalog.paimon.table_default.` configuration. If the table defines the same properties with the default properties, the table's properties will be taken.
 
 After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
 
@@ -97,6 +108,8 @@ CREATE CATALOG my_hive WITH (
 USE CATALOG my_hive;
 ```
 
+You can also use the property with the prefix `table-default.` to define default properties for tables as above `Catalog with Filesystem Metastore`.
+
 {{< /tab >}}
 
 {{< tab "Spark3" >}}
@@ -112,6 +125,8 @@ spark-sql ... \
     --conf spark.sql.catalog.paimon.metastore=hive \
     --conf spark.sql.catalog.paimon.uri=thrift://<hive-metastore-host-name>:<port>
 ```
+
+You can also define any default properties with the prefix `spark.sql.catalog.paimon.table_default.` configuration for tables as above `Catalog with Filesystem Metastore`.
 
 After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -28,15 +28,36 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.utils.StringUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** Common implementation of {@link Catalog}. */
 public abstract class AbstractCatalog implements Catalog {
 
     protected static final String DB_SUFFIX = ".db";
 
+    protected static final String TABLE_DEFAULT_OPTION_PREFIX = "table-default.";
+
     protected final FileIO fileIO;
+
+    protected final Map<String, String> tableDefaultOptions;
 
     protected AbstractCatalog(FileIO fileIO) {
         this.fileIO = fileIO;
+        this.tableDefaultOptions = new HashMap<>();
+    }
+
+    protected AbstractCatalog(FileIO fileIO, Map<String, String> options) {
+        this.fileIO = fileIO;
+        this.tableDefaultOptions = new HashMap<>();
+
+        options.keySet().stream()
+                .filter(key -> key.startsWith(TABLE_DEFAULT_OPTION_PREFIX))
+                .forEach(
+                        key ->
+                                this.tableDefaultOptions.put(
+                                        key.substring(TABLE_DEFAULT_OPTION_PREFIX.length()),
+                                        options.get(key)));
     }
 
     @Override
@@ -93,6 +114,12 @@ public abstract class AbstractCatalog implements Catalog {
                             "Cannot '%s' for system table '%s', please use data table.",
                             method, identifier));
         }
+    }
+
+    protected void copyTableDefaultOptions(Map<String, String> options) {
+        tableDefaultOptions.keySet().stream()
+                .filter(key -> !options.containsKey(key))
+                .forEach(key -> options.put(key, tableDefaultOptions.get(key)));
     }
 
     private String[] tableAndSystemName(Identifier identifier) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -117,9 +117,7 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected void copyTableDefaultOptions(Map<String, String> options) {
-        tableDefaultOptions
-                .keySet()
-                .forEach(key -> options.putIfAbsent(key, tableDefaultOptions.get(key)));
+        tableDefaultOptions.forEach((k, v) -> options.putIfAbsent(k, v));
     }
 
     private String[] tableAndSystemName(Identifier identifier) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -117,9 +117,9 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected void copyTableDefaultOptions(Map<String, String> options) {
-        tableDefaultOptions.keySet().stream()
-                .filter(key -> !options.containsKey(key))
-                .forEach(key -> options.put(key, tableDefaultOptions.get(key)));
+        tableDefaultOptions
+                .keySet()
+                .forEach(key -> options.putIfAbsent(key, tableDefaultOptions.get(key)));
     }
 
     private String[] tableAndSystemName(Identifier identifier) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -28,6 +28,7 @@ import org.apache.paimon.schema.TableSchema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -38,6 +39,11 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     public FileSystemCatalog(FileIO fileIO, Path warehouse) {
         super(fileIO);
+        this.warehouse = warehouse;
+    }
+
+    public FileSystemCatalog(FileIO fileIO, Path warehouse, Map<String, String> options) {
+        super(fileIO, options);
         this.warehouse = warehouse;
     }
 
@@ -152,6 +158,8 @@ public class FileSystemCatalog extends AbstractCatalog {
 
             throw new TableAlreadyExistException(identifier);
         }
+
+        copyTableDefaultOptions(schema.options());
 
         uncheck(() -> new SchemaManager(fileIO, path).createTable(schema));
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
@@ -40,6 +40,6 @@ public class FileSystemCatalogFactory implements CatalogFactory {
             throw new IllegalArgumentException(
                     "Only managed table is supported in File system catalog.");
         }
-        return new FileSystemCatalog(fileIO, warehouse);
+        return new FileSystemCatalog(fileIO, warehouse, context.options().toMap());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileSystemCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileSystemCatalogITCase.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,18 +53,19 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         path = getTempDirPath();
         tEnv.executeSql(
                 String.format("CREATE CATALOG fs WITH ('type'='paimon', 'warehouse'='%s')", path));
-        tEnv.useCatalog("fs");
         env.setParallelism(1);
     }
 
     @Test
     public void testWriteRead() throws Exception {
+        tEnv.useCatalog("fs");
         tEnv.executeSql("CREATE TABLE T (a STRING, b STRING, c STRING)");
         innerTestWriteRead();
     }
 
     @Test
     public void testRenameTable() throws Exception {
+        tEnv.useCatalog("fs");
         tEnv.executeSql("CREATE TABLE t1 (a INT)").await();
         tEnv.executeSql("CREATE TABLE t2 (a INT)").await();
         tEnv.executeSql("INSERT INTO t1 VALUES(1),(2)").await();
@@ -98,6 +100,7 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         createTopicIfNotExists(topic, 1);
 
         try {
+            tEnv.useCatalog("fs");
             tEnv.executeSql(
                     String.format(
                             "CREATE TABLE T (a STRING, b STRING, c STRING) WITH ("
@@ -118,6 +121,7 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         createTopicIfNotExists(topic, 1);
 
         try {
+            tEnv.useCatalog("fs");
             tEnv.executeSql(
                     String.format(
                             "CREATE TABLE T ("
@@ -140,6 +144,50 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         } finally {
             deleteTopicIfExists(topic);
         }
+    }
+
+    @Test
+    public void testCatalogOptionsInheritAndOverride() throws Exception {
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG fs_with_options WITH ("
+                                + "'type'='paimon', "
+                                + "'warehouse'='%s', "
+                                + "'table-default.opt1'='value1', "
+                                + "'table-default.opt2'='value2', "
+                                + "'table-default.opt3'='value3', "
+                                + "'fs.allow-hadoop-fallback'='false',"
+                                + "'lock.enabled'='true'"
+                                + ")",
+                        path));
+        tEnv.useCatalog("fs_with_options");
+
+        // check table inherit catalog options
+        tEnv.executeSql("CREATE TABLE t1_options (a STRING, b STRING, c STRING)");
+
+        Identifier identifier = new Identifier(DB_NAME, "t1_options");
+        Catalog catalog =
+                ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
+        Map<String, String> tableOptions = catalog.getTable(identifier).options();
+
+        assertThat(tableOptions).containsEntry("opt1", "value1");
+        assertThat(tableOptions).containsEntry("opt2", "value2");
+        assertThat(tableOptions).containsEntry("opt3", "value3");
+        assertThat(tableOptions).doesNotContainKey("fs.allow-hadoop-fallback");
+        assertThat(tableOptions).doesNotContainKey("lock.enabled");
+
+        // check table options override catalog's
+        tEnv.executeSql(
+                "CREATE TABLE t2_options (a STRING, b STRING, c STRING) WITH ('opt3'='value4')");
+
+        identifier = new Identifier(DB_NAME, "t2_options");
+        tableOptions = catalog.getTable(identifier).options();
+
+        assertThat(tableOptions).containsEntry("opt1", "value1");
+        assertThat(tableOptions).containsEntry("opt2", "value2");
+        assertThat(tableOptions).containsEntry("opt3", "value4");
+        assertThat(tableOptions).doesNotContainKey("fs.allow-hadoop-fallback");
+        assertThat(tableOptions).doesNotContainKey("lock.enabled");
     }
 
     private void innerTestWriteRead() throws Exception {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -99,6 +100,17 @@ public class HiveCatalog extends AbstractCatalog {
     public HiveCatalog(FileIO fileIO, HiveConf hiveConf, String clientClassName) {
         super(fileIO);
         this.hiveConf = hiveConf;
+        this.clientClassName = clientClassName;
+        this.client = createClient(hiveConf, clientClassName);
+    }
+
+    public HiveCatalog(
+            FileIO fileIO,
+            Configuration hadoopConfig,
+            String clientClassName,
+            Map<String, String> options) {
+        super(fileIO, options);
+        this.hiveConf = new HiveConf(hadoopConfig, HiveConf.class);
         this.clientClassName = clientClassName;
         this.client = createClient(hiveConf, clientClassName);
     }
@@ -250,6 +262,9 @@ public class HiveCatalog extends AbstractCatalog {
         checkFieldNamesUpperCase(schema.rowType().getFieldNames());
         // first commit changes to underlying files
         // if changes on Hive fails there is no harm to perform the same changes to files again
+
+        copyTableDefaultOptions(schema.options());
+
         TableSchema tableSchema;
         try {
             tableSchema = schemaManager(identifier).createTable(schema);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -105,12 +105,9 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     public HiveCatalog(
-            FileIO fileIO,
-            Configuration hadoopConfig,
-            String clientClassName,
-            Map<String, String> options) {
+            FileIO fileIO, HiveConf hiveConf, String clientClassName, Map<String, String> options) {
         super(fileIO, options);
-        this.hiveConf = new HiveConf(hadoopConfig, HiveConf.class);
+        this.hiveConf = hiveConf;
         this.clientClassName = clientClassName;
         this.client = createClient(hiveConf, clientClassName);
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
@@ -73,6 +73,10 @@ public class HiveCatalogFactory implements CatalogFactory {
 
         String clientClassName = context.options().get(METASTORE_CLIENT_CLASS);
 
-        return new HiveCatalog(fileIO, hiveConf, clientClassName);
+        return new HiveCatalog(
+                fileIO,
+                hiveConf,
+                clientClassName,
+                context.options().toMap());
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
@@ -73,10 +73,6 @@ public class HiveCatalogFactory implements CatalogFactory {
 
         String clientClassName = context.options().get(METASTORE_CLIENT_CLASS);
 
-        return new HiveCatalog(
-                fileIO,
-                hiveConf,
-                clientClassName,
-                context.options().toMap());
+        return new HiveCatalog(fileIO, hiveConf, clientClassName, context.options().toMap());
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -515,6 +516,51 @@ public abstract class HiveCatalogITCaseBase {
         new LocalFileIO().delete(new org.apache.paimon.fs.Path(path, "test_db.db/t"), true);
         tables = collect("SHOW TABLES");
         Assert.assertEquals("[]", tables.toString());
+    }
+
+    @Test
+    public void testCatalogOptionsInheritAndOverride() throws Exception {
+        tEnv.executeSql(
+                        String.join(
+                                "\n",
+                                "CREATE CATALOG my_hive_options WITH (",
+                                "  'type' = 'paimon',",
+                                "  'metastore' = 'hive',",
+                                "  'uri' = '',",
+                                "  'warehouse' = '" + path + "',",
+                                "  'lock.enabled' = 'true',",
+                                "  'table-default.opt1' = 'value1',",
+                                "  'table-default.opt2' = 'value2',",
+                                "  'table-default.opt3' = 'value3',",
+                                "  'lock.enabled' = 'true'",
+                                ")"))
+                .await();
+        tEnv.executeSql("USE CATALOG my_hive_options").await();
+
+        // check inherit
+        tEnv.executeSql("CREATE TABLE table_without_options (a INT, b STRING)").await();
+
+        Identifier identifier = new Identifier("default", "table_without_options");
+        Catalog catalog =
+                ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
+        Map<String, String> tableOptions = catalog.getTable(identifier).options();
+
+        Assertions.assertThat(tableOptions).containsEntry("opt1", "value1");
+        Assertions.assertThat(tableOptions).containsEntry("opt2", "value2");
+        Assertions.assertThat(tableOptions).containsEntry("opt3", "value3");
+        Assertions.assertThat(tableOptions).doesNotContainKey("lock.enabled");
+
+        // check override
+        tEnv.executeSql(
+                        "CREATE TABLE table_with_options (a INT, b STRING) WITH ('opt1' = 'new_value')")
+                .await();
+        identifier = new Identifier("default", "table_with_options");
+        tableOptions = catalog.getTable(identifier).options();
+
+        Assertions.assertThat(tableOptions).containsEntry("opt1", "new_value");
+        Assertions.assertThat(tableOptions).containsEntry("opt2", "value2");
+        Assertions.assertThat(tableOptions).containsEntry("opt3", "value3");
+        Assertions.assertThat(tableOptions).doesNotContainKey("lock.enabled");
     }
 
     protected List<Row> collect(String sql) throws Exception {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -527,12 +527,15 @@ public abstract class HiveCatalogITCaseBase {
                                 "  'type' = 'paimon',",
                                 "  'metastore' = 'hive',",
                                 "  'uri' = '',",
+                                "  'hive-conf-dir' = '"
+                                        + hiveShell.getBaseDir().getRoot().getPath()
+                                        + HIVE_CONF
+                                        + "',",
                                 "  'warehouse' = '" + path + "',",
                                 "  'lock.enabled' = 'true',",
                                 "  'table-default.opt1' = 'value1',",
                                 "  'table-default.opt2' = 'value2',",
-                                "  'table-default.opt3' = 'value3',",
-                                "  'lock.enabled' = 'true'",
+                                "  'table-default.opt3' = 'value3'",
                                 ")"))
                 .await();
         tEnv.executeSql("USE CATALOG my_hive_options").await();


### PR DESCRIPTION


### Purpose
issue ref: https://github.com/apache/incubator-paimon/issues/754

### Tests
Add test cases in ITCase.

Now we lack the UT for the catalog, but there's already an issue https://github.com/apache/incubator-paimon/issues/751 to track this.  So I add the test cases in ITCase temporarily.

### API and Format 

no

### Documentation

no
