### PR TITLE
[doc] Path style config for S3

### DIFF
--- a/docs/content/filesystems/s3.md
+++ b/docs/content/filesystems/s3.md
@@ -138,3 +138,13 @@ The S3 Filesystem also support using S3 compliant object stores such as IBM’s 
 ```yaml
 s3.endpoint: your-endpoint-hostname
 ```
+
+## Configure Path Style Access
+
+Some S3 compliant object stores might not have virtual host style addressing enabled by default, for example when using Standalone MinIO for testing purpose.
+In such cases, you will have to provide the property to enable path style access.
+
+```yaml
+s3.path.style.access: true
+```
+


### PR DESCRIPTION
Add path style config doc  for some  S3 compliant  object stores which  might not have virtual host style addressing enabled by default.