### PR TITLE
[Paimon-794][Improvement] Display the specific table name in the error message when the table doesn't support lookup join

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -86,8 +86,15 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     public FileStoreLookupFunction(
             Table table, int[] projection, int[] joinKeyIndex, @Nullable Predicate predicate) {
         checkArgument(
-                table.partitionKeys().isEmpty(), "Currently only support non-partitioned table.");
-        checkArgument(table.primaryKeys().size() > 0, "Currently only support primary key table.");
+                table.partitionKeys().isEmpty(),
+                String.format(
+                        "Currently only support non-partitioned table, the lookup table is [%s].",
+                        table.name()));
+        checkArgument(
+                table.primaryKeys().size() > 0,
+                String.format(
+                        "Currently only support primary key table, the lookup table is [%s].",
+                        table.name()));
         TableScanUtils.streamingReadingValidate(table);
 
         this.table = table;


### PR DESCRIPTION

fix: #794 
module: flink

### Purpose

Show more detailed msg which include the table name when the table doesn't support the lookup join ability.

### Tests

*(List UT and IT cases to verify this change)* no

### API and Format 

*(Does this change affect API or storage format)* no

### Documentation

*(Does this change introduce a new feature)* no
