### PR TITLE
[core]Add streaming read from option

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink;
 
 import org.apache.paimon.CoreOptions.LogChangelogMode;
 import org.apache.paimon.CoreOptions.LogConsistency;
+import org.apache.paimon.CoreOptions.StreamReadType;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.flink.log.LogStoreTableFactory;
@@ -53,6 +54,7 @@ import java.util.Set;
 
 import static org.apache.paimon.CoreOptions.LOG_CHANGELOG_MODE;
 import static org.apache.paimon.CoreOptions.LOG_CONSISTENCY;
+import static org.apache.paimon.CoreOptions.STREAMING_READ_FROM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOG_SYSTEM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.NONE;
 import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
@@ -123,6 +125,7 @@ public abstract class AbstractFlinkTableFactory
 
     private static void validateFileStoreContinuous(Options options) {
         LogChangelogMode changelogMode = options.get(LOG_CHANGELOG_MODE);
+        StreamReadType streamReadType = options.get(STREAMING_READ_FROM);
         if (changelogMode == LogChangelogMode.UPSERT) {
             throw new ValidationException(
                     "File store continuous reading dose not support upsert changelog mode.");
@@ -131,6 +134,10 @@ public abstract class AbstractFlinkTableFactory
         if (consistency == LogConsistency.EVENTUAL) {
             throw new ValidationException(
                     "File store continuous reading dose not support eventual consistency mode.");
+        }
+        if (streamReadType == StreamReadType.LOG_STORE) {
+            throw new ValidationException(
+                    "Table data is stored only in the file store, can not reading from the log_store.");
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -57,7 +57,7 @@ public class FlinkConnectorOptions {
                                     .list(
                                             TextElement.text(
                                                     "\"kafka\": Kafka log system, the data is double written to file"
-                                                            + " store and kafka, and the streaming read will be read from kafka."))
+                                                            + " store and kafka, the user can configure streaming-read-from to determine the store of streaming reads. For example, streaming-read-from=log-store will read data from kafka and streaming-read-from=file-store will read from the file store."))
                                     .build());
 
     public static final ConfigOption<Integer> SINK_PARALLELISM =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.StartupMode;
+import org.apache.paimon.CoreOptions.StreamReadType;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.Projection;
 import org.apache.paimon.flink.log.LogSourceProvider;
@@ -46,6 +47,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.paimon.CoreOptions.StreamReadType.FILE_STORE;
 import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
 
 /**
@@ -142,7 +144,8 @@ public class FlinkSourceBuilder {
 
             // TODO visit all options through CoreOptions
             StartupMode startupMode = CoreOptions.startupMode(conf);
-            if (logSourceProvider == null) {
+            StreamReadType streamReadType = CoreOptions.streamReadType(conf);
+            if (logSourceProvider == null || streamReadType == FILE_STORE) {
                 return buildContinuousFileSource();
             } else {
                 if (startupMode != StartupMode.LATEST_FULL) {


### PR DESCRIPTION

### Purpose

The user can determine the reading mode of the external log table by configuring the streaming-read-from option. The default value is file-store, which will read data from the file system. If 'streaming-read-from' = 'log-store', data will be read from the message queue. #778 

### Tests

LogSystemITCase

### API and Format 

CoreOptions:

New: streaming-read-from

### Documentation


