### PR TITLE
[Bug] Timestamp LTZ is unsupported for orc

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypes.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypes.java
@@ -90,6 +90,10 @@ public class DataTypes {
         return new LocalZonedTimestampType();
     }
 
+    public static LocalZonedTimestampType TIMESTAMP_WITH_LOCAL_TIME_ZONE(int precision) {
+        return new LocalZonedTimestampType(precision);
+    }
+
     public static DecimalType DECIMAL(int precision, int scale) {
         return new DecimalType(precision, scale);
     }

--- a/paimon-common/src/test/java/org/apache/paimon/format/FileStatsExtractorTestBase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/format/FileStatsExtractorTestBase.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.paimon.types.DataTypeChecks.getPrecision;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link org.apache.paimon.format.FileStatsExtractor}. */
@@ -170,7 +171,7 @@ public abstract class FileStatsExtractorTestBase {
                 return random.nextInt(10000);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                return randomTimestampData((TimestampType) type);
+                return randomTimestampData(getPrecision(type));
             case ARRAY:
                 return randomArray((ArrayType) type);
             case MAP:
@@ -207,10 +208,10 @@ public abstract class FileStatsExtractorTestBase {
         return Decimal.fromBigDecimal(new BigDecimal(builder.toString()), p, s);
     }
 
-    private Timestamp randomTimestampData(TimestampType type) {
+    private Timestamp randomTimestampData(int precision) {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         long p = 1;
-        for (int i = type.getPrecision(); i < TimestampType.MAX_PRECISION; i++) {
+        for (int i = precision; i < TimestampType.MAX_PRECISION; i++) {
             p *= 10;
         }
         long currentSecond = System.currentTimeMillis() / 1000;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -213,6 +214,15 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
     public void testComplexType() {
         batchSql("INSERT INTO complex_table VALUES (1, CAST(NULL AS MAP<INT, INT>))");
         assertThat(batchSql("SELECT * FROM complex_table")).containsExactly(Row.of(1, null));
+    }
+
+    @Test
+    public void testTimestampLzType() {
+        sql(
+                "CREATE TABLE t_table (id INT, data TIMESTAMP_LTZ(3)) WITH ('write-mode'='append-only')");
+        batchSql("INSERT INTO t_table VALUES (1, TIMESTAMP '2023-02-03 20:20:20')");
+        assertThat(batchSql("SELECT * FROM t_table"))
+                .containsExactly(Row.of(1, Instant.parse("2023-02-03T12:20:20Z")));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -25,7 +25,8 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -222,7 +223,12 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
                 "CREATE TABLE t_table (id INT, data TIMESTAMP_LTZ(3)) WITH ('write-mode'='append-only')");
         batchSql("INSERT INTO t_table VALUES (1, TIMESTAMP '2023-02-03 20:20:20')");
         assertThat(batchSql("SELECT * FROM t_table"))
-                .containsExactly(Row.of(1, Instant.parse("2023-02-03T12:20:20Z")));
+                .containsExactly(
+                        Row.of(
+                                1,
+                                LocalDateTime.parse("2023-02-03T20:20:20")
+                                        .atZone(ZoneId.systemDefault())
+                                        .toInstant()));
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -201,6 +201,7 @@ public class OrcPredicateFunctionVisitor
             case VARCHAR:
                 return PredicateLeaf.Type.STRING;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return PredicateLeaf.Type.TIMESTAMP;
             case DATE:
                 return PredicateLeaf.Type.DATE;

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
@@ -73,6 +73,7 @@ public class OrcSplitReaderUtil {
             case DATE:
                 return TypeDescription.createDate();
             case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return TypeDescription.createTimestamp();
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileFormatTest.java
@@ -24,7 +24,6 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -74,26 +73,13 @@ public class OrcFileFormatTest {
         dataFields.add(new DataField(index++, "binary_type", DataTypes.BINARY(20)));
         dataFields.add(new DataField(index++, "varbinary_type", DataTypes.VARBINARY(20)));
         dataFields.add(new DataField(index++, "timestamp_type", DataTypes.TIMESTAMP(3)));
-        dataFields.add(new DataField(index++, "date_type", DataTypes.DATE()));
-        dataFields.add(new DataField(index++, "decimal_type", DataTypes.DECIMAL(10, 3)));
-        orc.validateDataFields(new RowType(dataFields));
-    }
-
-    @Test
-    public void testUnSupportedDataTypes() {
-        OrcFileFormat orc =
-                new OrcFileFormatFactory().create(new FormatContext(new Options(), 1024));
-
-        int index = 0;
-        List<DataField> dataFields = new ArrayList<DataField>();
         dataFields.add(
                 new DataField(
                         index++,
-                        "timestamp_with_timezone",
-                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()));
-        Assertions.assertThrows(
-                UnsupportedOperationException.class,
-                () -> orc.validateDataFields(new RowType(dataFields)));
-        dataFields.clear();
+                        "timestamp_ltz_type",
+                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)));
+        dataFields.add(new DataField(index++, "date_type", DataTypes.DATE()));
+        dataFields.add(new DataField(index++, "decimal_type", DataTypes.DECIMAL(10, 3)));
+        orc.validateDataFields(new RowType(dataFields));
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileStatsExtractorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileStatsExtractorTest.java
@@ -32,6 +32,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
@@ -68,6 +69,7 @@ public class OrcFileStatsExtractorTest extends FileStatsExtractorTestBase {
                         new DecimalType(38, 18),
                         new DateType(),
                         new TimestampType(3),
+                        new LocalZonedTimestampType(3),
                         // orc reader & writer currently cannot preserve a high precision timestamp
                         // new TimestampType(9),
                         new ArrayType(new IntType()),


### PR DESCRIPTION
Fix Timestamp LTZ support for orc and flink.

NOTE: hive spark trino, parquet still not support Timestamp LTZ.