### PR TITLE
[pom] Rename paimon-shade to paimon-bundle

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -128,7 +128,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-shade</artifactId>
+            <artifactId>paimon-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/paimon-bundle/pom.xml
+++ b/paimon-bundle/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>0.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-shade</artifactId>
-    <name>Paimon : Shade</name>
+    <artifactId>paimon-bundle</artifactId>
+    <name>Paimon : Bundle</name>
 
     <packaging>jar</packaging>
 

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -259,7 +259,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <!--
-                                    TODO change these to paimon-shade once we get rid of flink-shaded dependencies
+                                    TODO change these to paimon-bundle once we get rid of flink-shaded dependencies
                                     -->
                                     <include>org.apache.paimon:paimon-common</include>
                                     <include>org.apache.paimon:paimon-core</include>

--- a/paimon-flink/pom.xml
+++ b/paimon-flink/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
     <dependencies>
         <!--
-        TODO change these to paimon-shade once we get rid of flink-shaded dependencies
+        TODO change these to paimon-bundle once we get rid of flink-shaded dependencies
         -->
 
         <dependency>

--- a/paimon-hive/paimon-hive-connector-2.3/pom.xml
+++ b/paimon-hive/paimon-hive-connector-2.3/pom.xml
@@ -60,7 +60,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-shade</artifactId>
+            <artifactId>paimon-bundle</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/paimon-hive/paimon-hive-connector-3.1/pom.xml
+++ b/paimon-hive/paimon-hive-connector-3.1/pom.xml
@@ -67,7 +67,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-shade</artifactId>
+            <artifactId>paimon-bundle</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/paimon-hive/paimon-hive-connector-common/pom.xml
+++ b/paimon-hive/paimon-hive-connector-common/pom.xml
@@ -42,7 +42,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-shade</artifactId>
+            <artifactId>paimon-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -554,7 +554,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-hive-common</include>
-                                    <include>org.apache.paimon:paimon-shade</include>
+                                    <include>org.apache.paimon:paimon-bundle</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -95,7 +95,7 @@ under the License.
                         <configuration>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>org.apache.paimon:paimon-shade</include>
+                                    <include>org.apache.paimon:paimon-bundle</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/pom.xml
+++ b/paimon-spark/pom.xml
@@ -48,7 +48,7 @@ under the License.
     <dependencies>
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-shade</artifactId>
+            <artifactId>paimon-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ under the License.
         <module>paimon-e2e-tests</module>
         <module>paimon-filesystems</module>
         <module>paimon-format</module>
-        <module>paimon-shade</module>
+        <module>paimon-bundle</module>
         <module>paimon-hive</module>
         <module>paimon-spark</module>
         <module>paimon-test-utils</module>


### PR DESCRIPTION

### Purpose

https://github.com/apache/incubator-paimon-shade contains a number of shaded dependencies.

But paimon-shade is in main repo. We should rename it to avoid conflicts with incubator-paimon-shade.