### PR TITLE
[Bug][Flink] Calculate splits with predicate in DataTableSource

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -34,10 +34,8 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.ChangelogValueCountFileStoreTable;
 import org.apache.paimon.table.ChangelogWithKeyFileStoreTable;
-import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Projection;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -220,10 +218,7 @@ public class DataTableSource extends FlinkTableSource
             if (streaming) {
                 parallelism = options.get(CoreOptions.BUCKET);
             } else {
-
-                Preconditions.checkState(table instanceof DataTable);
                 splits = table.newReadBuilder().withFilter(predicate).newScan().plan().splits();
-
                 if (null != splits) {
                     parallelism = splits.size();
                 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -36,6 +36,7 @@ import org.apache.paimon.table.ChangelogValueCountFileStoreTable;
 import org.apache.paimon.table.ChangelogWithKeyFileStoreTable;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.BatchDataTableScan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Projection;
@@ -223,7 +224,11 @@ public class DataTableSource extends FlinkTableSource
 
                 Preconditions.checkState(table instanceof DataTable);
                 DataTable dataTable = (DataTable) table;
-                splits = dataTable.newScan().plan().splits();
+                BatchDataTableScan tableScan = dataTable.newScan();
+                if (predicate != null) {
+                    tableScan = tableScan.withFilter(predicate);
+                }
+                splits = tableScan.plan().splits();
 
                 if (null != splits) {
                     parallelism = splits.size();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -36,7 +36,6 @@ import org.apache.paimon.table.ChangelogValueCountFileStoreTable;
 import org.apache.paimon.table.ChangelogWithKeyFileStoreTable;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.table.source.BatchDataTableScan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Projection;
@@ -223,12 +222,7 @@ public class DataTableSource extends FlinkTableSource
             } else {
 
                 Preconditions.checkState(table instanceof DataTable);
-                DataTable dataTable = (DataTable) table;
-                BatchDataTableScan tableScan = dataTable.newScan();
-                if (predicate != null) {
-                    tableScan = tableScan.withFilter(predicate);
-                }
-                splits = tableScan.plan().splits();
+                splits = table.newReadBuilder().withFilter(predicate).newScan().plan().splits();
 
                 if (null != splits) {
                     parallelism = splits.size();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -1218,6 +1218,18 @@ public class ReadWriteTableITCase extends AbstractTestBase {
                                             }
                                         })))
                 .isEqualTo(2);
+        assertThat(
+                        sourceParallelism(
+                                buildQueryWithTableOptions(
+                                        table,
+                                        "*",
+                                        "WHERE currency='Euro'",
+                                        new HashMap<String, String>() {
+                                            {
+                                                put(INFER_SCAN_PARALLELISM.key(), "true");
+                                            }
+                                        })))
+                .isEqualTo(1);
 
         // 2 splits and limit is 1, the parallelism is the limit value : 1
         assertThat(


### PR DESCRIPTION
### Purpose

Calculate splits with predicate in DataTableSource for #820 

### Tests

Test case `testInferParallelism` in `ReadWriteTableITCase`

### API and Format 

*(Does this change affect API or storage format)* no

### Documentation

*(Does this change introduce a new feature)* no
