### PR TITLE
[flink] MySqlSyncTableAction now supports flink run

### DIFF
--- a/.github/workflows/e2e-tests-1.14-jdk11.yml
+++ b/.github/workflows/e2e-tests-1.14-jdk11.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
       - name: Build Flink 1.14
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.14
+        run: ./mvnw clean install -DskipTests -Pflink-1.14
       - name: Test Flink 1.14
         run: |
           # run tests with random timezone to find out timezone related bugs

--- a/.github/workflows/e2e-tests-1.14.yml
+++ b/.github/workflows/e2e-tests-1.14.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
       - name: Build Flink 1.14
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.14
+        run: ./mvnw clean install -DskipTests -Pflink-1.14
       - name: Test Flink 1.14
         timeout-minutes: 60
         run: |

--- a/.github/workflows/e2e-tests-1.15-jdk11.yml
+++ b/.github/workflows/e2e-tests-1.15-jdk11.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
       - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
+        run: ./mvnw clean install -DskipTests -Pflink-1.15
       - name: Test Flink 1.15
         run: |
           # run tests with random timezone to find out timezone related bugs

--- a/.github/workflows/e2e-tests-1.15.yml
+++ b/.github/workflows/e2e-tests-1.15.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'adopt'
       - name: Build Flink 1.15
-        run: ./mvnw clean install -Dmaven.test.skip=true -Pflink-1.15
+        run: ./mvnw clean install -DskipTests -Pflink-1.15
       - name: Test Flink 1.15
         timeout-minutes: 60
         run: |

--- a/docs/content/engines/hive.md
+++ b/docs/content/engines/hive.md
@@ -69,7 +69,7 @@ You can also manually build bundled jar from the source code.
 To build from source code, [clone the git repository]({{< github_repo >}}).
 
 Build bundled jar with the following command.
-`mvn clean install -Dmaven.test.skip=true`
+`mvn clean install -DskipTests`
 
 You can find Hive connector jar in `./paimon-hive/paimon-hive-connector-<hive-version>/target/paimon-hive-connector-<hive-version>-{{< version >}}.jar`.
 

--- a/paimon-e2e-tests/pom.xml
+++ b/paimon-e2e-tests/pom.xml
@@ -33,6 +33,7 @@ under the License.
 
     <properties>
         <flink.shaded.hadoop.version>2.8.3-10.0</flink.shaded.hadoop.version>
+        <flink.cdc.version>2.3.0</flink.cdc.version>
         <flink.sql.connector.kafka>flink-sql-connector-kafka</flink.sql.connector.kafka>
         <flink.sql.connector.hive>flink-sql-connector-hive-2.3.9_${scala.binary.version}</flink.sql.connector.hive>
     </properties>
@@ -61,6 +62,21 @@ under the License.
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${flink.cdc.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- testcontainers -->
 
         <dependency>
@@ -73,6 +89,13 @@ under the License.
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
@@ -134,6 +157,16 @@ under the License.
                             <outputDirectory>/tmp/paimon-e2e-tests-jars
                             </outputDirectory>
                         </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ververica</groupId>
+                            <artifactId>flink-sql-connector-mysql-cdc</artifactId>
+                            <version>${flink.cdc.version}</version>
+                            <destFileName>mysql-cdc.jar</destFileName>
+                            <type>jar</type>
+                            <overWrite>true</overWrite>
+                            <outputDirectory>/tmp/paimon-e2e-tests-jars
+                            </outputDirectory>
+                        </artifactItem>
                         <!-- test paimon with kafka sql jar -->
                         <artifactItem>
                             <groupId>org.apache.flink</groupId>
@@ -159,7 +192,36 @@ under the License.
                     </artifactItems>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>FLINK-31695</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!--
+                    Due to FLINK-31695, we need to delete conflicting classes from jar file.
+                    Remove this work-around after we make our own e2e docker image,
+                    with both Flink and Hadoop in the same docker.
+                    -->
+                    <executable>zip</executable>
+                    <arguments>
+                        <argument>-d</argument>
+                        <argument>/tmp/paimon-e2e-tests-jars/bundled-hadoop.jar</argument>
+                        <argument>org/apache/commons/cli/CommandLine.class</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
         </plugins>
+
         <resources>
             <resource>
                 <directory>src/test/resources</directory>

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySql57E2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySql57E2eTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tests.cdc;
+
+import org.apache.paimon.flink.action.cdc.mysql.MySqlVersion;
+
+/**
+ * E2e tests for {@link org.apache.paimon.flink.action.cdc.mysql.MySqlSyncTableAction} with MySQL
+ * 5.7.
+ */
+public class MySql57E2eTest extends MySqlCdcE2eTestBase {
+
+    public MySql57E2eTest() {
+        super(MySqlVersion.V5_7);
+    }
+}

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySql80E2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySql80E2eTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tests.cdc;
+
+import org.apache.paimon.flink.action.cdc.mysql.MySqlVersion;
+
+/**
+ * E2e tests for {@link org.apache.paimon.flink.action.cdc.mysql.MySqlSyncTableAction} with MySQL
+ * 8.0.
+ */
+public class MySql80E2eTest extends MySqlCdcE2eTestBase {
+
+    public MySql80E2eTest() {
+        super(MySqlVersion.V8_0);
+    }
+}

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tests.cdc;
+
+import org.apache.paimon.flink.action.cdc.mysql.MySqlContainer;
+import org.apache.paimon.flink.action.cdc.mysql.MySqlVersion;
+import org.apache.paimon.tests.E2eTestBase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/** E2e tests for {@link org.apache.paimon.flink.action.cdc.mysql.MySqlSyncTableAction}. */
+public abstract class MySqlCdcE2eTestBase extends E2eTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MySqlCdcE2eTestBase.class);
+
+    private static final String USER = "paimonuser";
+    private static final String PASSWORD = "paimonpw";
+    private static final String DATABASE_NAME = "paimon_test";
+
+    private final MySqlVersion mySqlVersion;
+    private MySqlContainer mySqlContainer;
+
+    private String warehousePath;
+    private String catalogDdl;
+    private String useCatalogCmd;
+
+    protected MySqlCdcE2eTestBase(MySqlVersion mySqlVersion) {
+        this.mySqlVersion = mySqlVersion;
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        mySqlContainer = createMySqlContainer(mySqlVersion);
+        Startables.deepStart(Stream.of(mySqlContainer)).join();
+
+        warehousePath = TEST_DATA_DIR + "/" + UUID.randomUUID() + ".store";
+        catalogDdl =
+                String.format(
+                        "CREATE CATALOG ts_catalog WITH (\n"
+                                + "    'type' = 'paimon',\n"
+                                + "    'warehouse' = '%s'\n"
+                                + ");",
+                        warehousePath);
+
+        useCatalogCmd = "USE CATALOG ts_catalog;";
+    }
+
+    private MySqlContainer createMySqlContainer(MySqlVersion version) {
+        return (MySqlContainer)
+                new MySqlContainer(version)
+                        .withConfigurationOverride("mysql/my.cnf")
+                        .withSetupSQL("mysql/setup.sql")
+                        .withUsername(USER)
+                        .withPassword(PASSWORD)
+                        .withDatabaseName(DATABASE_NAME)
+                        .withLogConsumer(new Slf4jLogConsumer(LOG))
+                        // connect with docker-compose.yaml
+                        .withNetwork(network)
+                        .withNetworkAliases("mysql-1");
+    }
+
+    @AfterEach
+    public void after() {
+        mySqlContainer.stop();
+        super.after();
+    }
+
+    @Test
+    public void testSyncTable() throws Exception {
+        String runActionCommand =
+                String.join(
+                        " ",
+                        "bin/flink",
+                        "run",
+                        "-c",
+                        "org.apache.paimon.flink.action.FlinkActions",
+                        "-D",
+                        "execution.checkpointing.interval=1s",
+                        "--detached",
+                        "lib/paimon-flink.jar",
+                        "mysql-sync-table",
+                        "--warehouse",
+                        warehousePath,
+                        "--database",
+                        "default",
+                        "--table",
+                        "ts_table",
+                        "--partition-keys",
+                        "pt",
+                        "--primary-keys",
+                        "pt,_id",
+                        "--sink-parallelism",
+                        "2",
+                        "--mysql-conf",
+                        "hostname=mysql-1",
+                        "--mysql-conf",
+                        String.format("port=%d", MySqlContainer.MYSQL_PORT),
+                        "--mysql-conf",
+                        String.format("username='%s'", mySqlContainer.getUsername()),
+                        "--mysql-conf",
+                        String.format("password='%s'", mySqlContainer.getPassword()),
+                        "--mysql-conf",
+                        String.format("database-name='%s'", DATABASE_NAME),
+                        "--mysql-conf",
+                        "table-name='schema_evolution_.+'",
+                        "--paimon-conf",
+                        "bucket=2");
+        Container.ExecResult execResult =
+                jobManager.execInContainer("su", "flink", "-c", runActionCommand);
+        LOG.info(execResult.getStdout());
+        LOG.info(execResult.getStderr());
+
+        try (Connection conn =
+                DriverManager.getConnection(
+                        String.format(
+                                "jdbc:mysql://%s:%s/",
+                                mySqlContainer.getHost(), mySqlContainer.getDatabasePort()),
+                        mySqlContainer.getUsername(),
+                        mySqlContainer.getPassword())) {
+            try (Statement statement = conn.createStatement()) {
+                testSyncTableImpl(statement);
+            }
+        }
+    }
+
+    private void testSyncTableImpl(Statement statement) throws Exception {
+        statement.executeUpdate("USE paimon_test");
+
+        statement.executeUpdate("INSERT INTO schema_evolution_1 VALUES (1, 1, 'one')");
+        statement.executeUpdate(
+                "INSERT INTO schema_evolution_2 VALUES (1, 2, 'two'), (2, 4, 'four')");
+
+        String jobId =
+                runSql(
+                        "INSERT INTO result1 SELECT * FROM ts_table;",
+                        catalogDdl,
+                        useCatalogCmd,
+                        "",
+                        createResultSink("result1", "pt INT, _id INT, v1 VARCHAR(10)"));
+        checkResult("1, 1, one", "1, 2, two", "2, 4, four");
+        clearCurrentResults();
+        Container.ExecResult execResult = jobManager.execInContainer("bin/flink", "cancel", jobId);
+        LOG.info(execResult.getStdout());
+        LOG.info(execResult.getStderr());
+
+        statement.executeUpdate("ALTER TABLE schema_evolution_1 ADD COLUMN v2 INT");
+        statement.executeUpdate(
+                "INSERT INTO schema_evolution_1 VALUES (2, 3, 'three', 30), (1, 5, 'five', 50)");
+        statement.executeUpdate("ALTER TABLE schema_evolution_2 ADD COLUMN v2 INT");
+        statement.executeUpdate("INSERT INTO schema_evolution_2 VALUES (1, 6, 'six', 60)");
+
+        jobId =
+                runSql(
+                        "INSERT INTO result2 SELECT * FROM ts_table;",
+                        catalogDdl,
+                        useCatalogCmd,
+                        "",
+                        createResultSink("result2", "pt INT, _id INT, v1 VARCHAR(10), v2 INT"));
+        checkResult(
+                "1, 1, one, null",
+                "1, 2, two, null",
+                "2, 3, three, 30",
+                "2, 4, four, null",
+                "1, 5, five, 50",
+                "1, 6, six, 60");
+        clearCurrentResults();
+        jobManager.execInContainer("bin/flink", "cancel", jobId);
+
+        statement.executeUpdate("ALTER TABLE schema_evolution_1 MODIFY COLUMN v2 BIGINT");
+        statement.executeUpdate(
+                "INSERT INTO schema_evolution_1 VALUES (2, 7, 'seven', 70000000000)");
+        statement.executeUpdate("UPDATE schema_evolution_1 SET v2 = 30000000000 WHERE _id = 3");
+        statement.executeUpdate("ALTER TABLE schema_evolution_2 MODIFY COLUMN v2 BIGINT");
+        statement.executeUpdate(
+                "INSERT INTO schema_evolution_2 VALUES (2, 8, 'eight', 80000000000)");
+
+        jobId =
+                runSql(
+                        "INSERT INTO result3 SELECT * FROM ts_table;",
+                        catalogDdl,
+                        useCatalogCmd,
+                        "",
+                        createResultSink("result3", "pt INT, _id INT, v1 VARCHAR(10), v2 BIGINT"));
+        checkResult(
+                "1, 1, one, null",
+                "1, 2, two, null",
+                "2, 3, three, 30000000000",
+                "2, 4, four, null",
+                "1, 5, five, 50",
+                "1, 6, six, 60",
+                "2, 7, seven, 70000000000",
+                "2, 8, eight, 80000000000");
+        clearCurrentResults();
+        jobManager.execInContainer("bin/flink", "cancel", jobId);
+    }
+
+    private String runSql(String sql, String... ddls) throws Exception {
+        return runSql(String.join("\n", ddls) + "\n" + sql);
+    }
+}

--- a/paimon-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/paimon-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - /tmp/paimon-e2e-tests-jars:/jars
     entrypoint: >
       /bin/bash -c "
-      cp /jars/paimon-flink.jar /jars/bundled-hadoop.jar
+      cp /jars/paimon-flink.jar /jars/bundled-hadoop.jar /jars/mysql-cdc.jar
       /jars/flink-sql-connector-kafka.jar /jars/flink-sql-connector-hive.jar /opt/flink/lib ;
       echo 'See FLINK-31659 for why we need the following two steps' ;
       mv /opt/flink/opt/flink-table-planner*.jar /opt/flink/lib/ ;
@@ -54,7 +54,7 @@ services:
       - /tmp/paimon-e2e-tests-jars:/jars
     entrypoint: >
       /bin/bash -c "
-      cp /jars/paimon-flink.jar /jars/bundled-hadoop.jar
+      cp /jars/paimon-flink.jar /jars/bundled-hadoop.jar /jars/mysql-cdc.jar
       /jars/flink-sql-connector-kafka.jar /jars/flink-sql-connector-hive.jar /opt/flink/lib ;
       echo 'See FLINK-31659 for why we need the following two steps' ;
       mv /opt/flink/opt/flink-table-planner*.jar /opt/flink/lib/ ;
@@ -222,3 +222,5 @@ volumes:
 
 networks:
   testnetwork:
+    name: ${NETWORK_ID}
+    external: true

--- a/paimon-e2e-tests/src/test/resources/mysql/my.cnf
+++ b/paimon-e2e-tests/src/test/resources/mysql/my.cnf
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+#datadir=/var/lib/mysql
+#socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+#log-error=/var/log/mysqld.log
+#pid-file=/var/run/mysqld/mysqld.pid
+
+# ----------------------------------------------
+# Enable the binlog for replication & CDC
+# ----------------------------------------------
+
+# Enable binary replication log and set the prefix, expiration, and log format.
+# The prefix is arbitrary, expiration can be short for integration tests but would
+# be longer on a production system. Row-level info is required for ingest to work.
+# Server ID is required, but this will vary on production systems
+server-id         = 223344
+log_bin           = mysql-bin
+expire_logs_days  = 1
+binlog_format     = row
+
+# If this option is off
+# MySQL will set current timestamp to any timestamp field with NULL value
+# which is bad for our tests
+explicit_defaults_for_timestamp = ON

--- a/paimon-e2e-tests/src/test/resources/mysql/setup.sql
+++ b/paimon-e2e-tests/src/test/resources/mysql/setup.sql
@@ -1,0 +1,42 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- In production you would almost certainly limit the replication user must be on the follower (slave) machine,
+-- to prevent other clients accessing the log from other machines. For example, 'replicator'@'follower.acme.com'.
+-- However, in this database we'll grant 2 users different privileges:
+--
+-- 1) 'paimonuser' - all privileges required by the snapshot reader AND binlog reader (used for testing)
+-- 2) 'mysqluser' - all privileges
+--
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'paimonuser'@'%';
+CREATE USER 'mysqluser' IDENTIFIED BY 'mysqlpw';
+GRANT ALL PRIVILEGES ON *.* TO 'mysqluser'@'%';
+
+USE paimon_test;
+
+CREATE TABLE schema_evolution_1 (
+    pt INT,
+    _id INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (_id)
+);
+
+CREATE TABLE schema_evolution_2 (
+    pt INT,
+    _id INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (_id)
+);

--- a/paimon-flink/paimon-flink-1.14/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
+++ b/paimon-flink/paimon-flink-1.14/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Utility methods for {@link SingleOutputStreamOperator}.
+ *
+ * <p>TODO: merge all Flink version related utils into one class.
+ */
+public class SingleOutputStreamOperatorUtils {
+
+    public static <T> DataStream<T> getSideOutput(
+            SingleOutputStreamOperator<?> input, OutputTag<T> outputTag) {
+        return input.getSideOutput(outputTag);
+    }
+}

--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Utility methods for {@link SingleOutputStreamOperator}.
+ *
+ * <p>TODO: merge all Flink version related utils into one class.
+ */
+public class SingleOutputStreamOperatorUtils {
+
+    public static <T> DataStream<T> getSideOutput(
+            SingleOutputStreamOperator<?> input, OutputTag<T> outputTag) {
+        return input.getSideOutput(outputTag);
+    }
+}

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -294,6 +294,18 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/Action.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/Action.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.action;
 
 import org.apache.paimon.catalog.CatalogUtils;
+import org.apache.paimon.flink.action.cdc.mysql.MySqlSyncTableAction;
 
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.utils.MultipleParameterTool;
@@ -116,6 +117,8 @@ public interface Action {
         private static final String DROP_PARTITION = "drop-partition";
         private static final String DELETE = "delete";
         private static final String MERGE_INTO = "merge-into";
+        // cdc actions
+        private static final String MYSQL_SYNC_TABLE = "mysql-sync-table";
 
         public static Optional<Action> create(String[] args) {
             String action = args[0].toLowerCase();
@@ -130,6 +133,8 @@ public interface Action {
                     return DeleteAction.create(actionArgs);
                 case MERGE_INTO:
                     return MergeIntoAction.create(actionArgs);
+                case MYSQL_SYNC_TABLE:
+                    return MySqlSyncTableAction.create(actionArgs);
                 default:
                     System.err.println("Unknown action \"" + action + "\"");
                     printHelp();
@@ -146,6 +151,7 @@ public interface Action {
             System.out.println("  " + DROP_PARTITION);
             System.out.println("  " + DELETE);
             System.out.println("  " + MERGE_INTO);
+            System.out.println("  " + MYSQL_SYNC_TABLE);
 
             System.out.println("For detailed options of each action, run <action> --help");
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSinkBuilder.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.sink.LogSinkFunction;
+import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -89,7 +90,8 @@ public class FlinkCdcSinkBuilder<T> {
                         .setParallelism(input.getParallelism());
 
         DataStream<Void> schemaChangeProcessFunction =
-                parsed.getSideOutput(CdcParsingProcessFunction.SCHEMA_CHANGE_OUTPUT_TAG)
+                SingleOutputStreamOperatorUtils.getSideOutput(
+                                parsed, CdcParsingProcessFunction.SCHEMA_CHANGE_OUTPUT_TAG)
                         .process(
                                 new SchemaChangeProcessFunction(
                                         new SchemaManager(table.fileIO(), table.location())));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/SingleOutputStreamOperatorUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Utility methods for {@link SingleOutputStreamOperator}.
+ *
+ * <p>TODO: merge all Flink version related utils into one class.
+ */
+public class SingleOutputStreamOperatorUtils {
+
+    public static <T> DataStream<T> getSideOutput(
+            SingleOutputStreamOperator<?> input, OutputTag<T> outputTag) {
+        return input.getSideOutput(outputTag);
+    }
+}


### PR DESCRIPTION
### Purpose

`MySqlSyncTableAction` now supports being used from `bin/flink run`. Users can use `MySqlSyncTableAction` without writing and compiling their own data stream jobs.

### Tests

* MySql57E2eTest
* MySql80E2eTest

### API and Format 

N/A

### Documentation

Document will be introduced in the next PR.
