### PR TITLE
[flink][bug] MergeIntoAction and DeleteAction work abnormally with partial update merge engine

### DIFF
--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -263,7 +263,8 @@ filter_spec is equal to the 'WHERE' clause in SQL DELETE statement. Examples:
 ```
 
 {{< hint info >}}
-If you have set `merge-engine` = `partial-update`, it will be disabled temporarily. 
+If you have set `merge-engine` = `partial-update` or `aggregation`, it will be reset by dynamic options 
+(no affect to file system).
 {{< /hint >}}
 
 For more information of 'delete', see
@@ -288,7 +289,8 @@ Paimon supports "MERGE INTO" via submitting the 'merge-into' job through `flink 
 Important table properties setting:
 1. Only [primary key table]({{< ref "concepts/primary-key-table" >}}) supports this feature.
 2. The action won't produce UPDATE_BEFORE, so it's not recommended to set 'changelog-producer' = 'input'.
-3. If you have set `merge-engine` = `partial-update`, it will be disabled temporarily.
+3. If you have set `merge-engine` = `partial-update` or `aggregation`, it will be reset by dynamic options
+(no affect to file system).
 {{< /hint >}}
 
 The design referenced such syntax:

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -262,6 +262,10 @@ filter_spec is equal to the 'WHERE' clause in SQL DELETE statement. Examples:
     id > (SELECT count(*) FROM employee)
 ```
 
+{{< hint info >}}
+If you have set `merge-engine` = `partial-update`, it will be disabled temporarily. 
+{{< /hint >}}
+
 For more information of 'delete', see
 
 ```bash
@@ -284,6 +288,7 @@ Paimon supports "MERGE INTO" via submitting the 'merge-into' job through `flink 
 Important table properties setting:
 1. Only [primary key table]({{< ref "concepts/primary-key-table" >}}) supports this feature.
 2. The action won't produce UPDATE_BEFORE, so it's not recommended to set 'changelog-producer' = 'input'.
+3. If you have set `merge-engine` = `partial-update`, it will be disabled temporarily.
 {{< /hint >}}
 
 The design referenced such syntax:

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -262,11 +262,6 @@ filter_spec is equal to the 'WHERE' clause in SQL DELETE statement. Examples:
     id > (SELECT count(*) FROM employee)
 ```
 
-{{< hint info >}}
-If you have set `merge-engine` = `partial-update` or `aggregation`, it will be reset by dynamic options 
-(no affect to file system).
-{{< /hint >}}
-
 For more information of 'delete', see
 
 ```bash
@@ -289,8 +284,6 @@ Paimon supports "MERGE INTO" via submitting the 'merge-into' job through `flink 
 Important table properties setting:
 1. Only [primary key table]({{< ref "concepts/primary-key-table" >}}) supports this feature.
 2. The action won't produce UPDATE_BEFORE, so it's not recommended to set 'changelog-producer' = 'input'.
-3. If you have set `merge-engine` = `partial-update` or `aggregation`, it will be reset by dynamic options
-(no affect to file system).
 {{< /hint >}}
 
 The design referenced such syntax:

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -43,7 +43,6 @@ import org.apache.paimon.utils.SnapshotManager;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -106,16 +105,10 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     protected abstract FileStoreTable copy(TableSchema newTableSchema);
 
+    // sometimes we have to change some Immutable options to implement features, so don't check it
     @Override
     public FileStoreTable copy(Map<String, String> dynamicOptions) {
-        // check option is not immutable
         Map<String, String> options = new HashMap<>(tableSchema.options());
-        dynamicOptions.forEach(
-                (k, v) -> {
-                    if (!Objects.equals(v, options.get(k))) {
-                        SchemaManager.checkAlterTableOption(k);
-                    }
-                });
 
         // merge non-null dynamic options into schema.options
         dynamicOptions.forEach(

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -72,6 +72,9 @@ public interface FileStoreTable extends DataTable {
     @Override
     FileStoreTable copy(Map<String, String> dynamicOptions);
 
+    /** Sometimes we have to change some Immutable options to implement features. */
+    FileStoreTable internalCopyWithoutCheck(Map<String, String> dynamicOptions);
+
     FileStoreTable copyWithLatestSchema();
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
@@ -157,14 +157,17 @@ public abstract class ActionBase implements Action {
      * want these records to be sunk directly. This method is a workaround. Actions that may produce
      * -U/-D records can call this to disable merge engine settings and force compaction.
      */
-    protected void forceSinking() {
-        Map<String, String> dynamicOptions = new HashMap<>();
-        dynamicOptions.put(
-                CoreOptions.MERGE_ENGINE.key(), CoreOptions.MergeEngine.DEDUPLICATE.toString());
-        // force compaction
-        dynamicOptions.put(CoreOptions.FULL_COMPACTION_DELTA_COMMITS.key(), "1");
-        Preconditions.checkArgument(
-                table instanceof FileStoreTable, "Only supports FileStoreTable.");
-        table = ((FileStoreTable) table).internalCopyWithoutCheck(dynamicOptions);
+    protected void changeIgnoreMergeEngine() {
+        if (CoreOptions.fromMap(table.options()).mergeEngine()
+                != CoreOptions.MergeEngine.DEDUPLICATE) {
+            Map<String, String> dynamicOptions = new HashMap<>();
+            dynamicOptions.put(
+                    CoreOptions.MERGE_ENGINE.key(), CoreOptions.MergeEngine.DEDUPLICATE.toString());
+            // force compaction
+            dynamicOptions.put(CoreOptions.FULL_COMPACTION_DELTA_COMMITS.key(), "1");
+            Preconditions.checkArgument(
+                    table instanceof FileStoreTable, "Only supports FileStoreTable.");
+            table = ((FileStoreTable) table).internalCopyWithoutCheck(dynamicOptions);
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
@@ -45,7 +45,7 @@ public class DeleteAction extends ActionBase {
 
     public DeleteAction(String warehouse, String databaseName, String tableName, String filter) {
         super(warehouse, databaseName, tableName);
-        disablePartialUpdateMergeEngine();
+        forceSinking();
         this.filter = filter;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
@@ -45,7 +45,7 @@ public class DeleteAction extends ActionBase {
 
     public DeleteAction(String warehouse, String databaseName, String tableName, String filter) {
         super(warehouse, databaseName, tableName);
-        forceSinking();
+        changeIgnoreMergeEngine();
         this.filter = filter;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
@@ -45,6 +45,7 @@ public class DeleteAction extends ActionBase {
 
     public DeleteAction(String warehouse, String databaseName, String tableName, String filter) {
         super(warehouse, databaseName, tableName);
+        disablePartialUpdateMergeEngine();
         this.filter = filter;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -131,7 +131,7 @@ public class MergeIntoAction extends ActionBase {
                             table.getClass().getName()));
         }
 
-        forceSinking();
+        changeIgnoreMergeEngine();
 
         // init primaryKeys of target table
         primaryKeys = ((FileStoreTable) table).schema().primaryKeys();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -131,7 +131,7 @@ public class MergeIntoAction extends ActionBase {
                             table.getClass().getName()));
         }
 
-        disablePartialUpdateMergeEngine();
+        forceSinking();
 
         // init primaryKeys of target table
         primaryKeys = ((FileStoreTable) table).schema().primaryKeys();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -131,6 +131,8 @@ public class MergeIntoAction extends ActionBase {
                             table.getClass().getName()));
         }
 
+        disablePartialUpdateMergeEngine();
+
         // init primaryKeys of target table
         primaryKeys = ((FileStoreTable) table).schema().primaryKeys();
         if (primaryKeys.isEmpty()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.table.FileStoreTable;
@@ -28,6 +29,7 @@ import org.apache.paimon.utils.BlockingIterator;
 
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +42,8 @@ import java.util.List;
 import static org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow;
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.buildSimpleQuery;
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.init;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.insertInto;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.testBatchRead;
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.testStreamingRead;
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.validateStreamingReadResult;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,6 +80,58 @@ public class DeleteActionITCase extends ActionITCaseBase {
 
         validateStreamingReadResult(iterator, expected);
         iterator.close();
+    }
+
+    @Test
+    public void testWorkWithPartialUpdateTable() throws Exception {
+        createFileStoreTable(
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()},
+                        new String[] {"k", "a", "b"}),
+                Collections.emptyList(),
+                Collections.singletonList("k"),
+                new HashMap<String, String>() {
+                    {
+                        put(
+                                CoreOptions.MERGE_ENGINE.key(),
+                                CoreOptions.MergeEngine.PARTIAL_UPDATE.toString());
+                        put(CoreOptions.PARTIAL_UPDATE_IGNORE_DELETE.key(), "true");
+                        put(
+                                CoreOptions.CHANGELOG_PRODUCER.key(),
+                                CoreOptions.ChangelogProducer.FULL_COMPACTION.toString());
+                    }
+                });
+
+        DeleteAction action = new DeleteAction(warehouse, database, tableName, "k < 3");
+
+        insertInto(
+                tableName, "(1, 'Say', 'A'), (2, 'Hi', 'B'), (3, 'To', 'C'), (4, 'Paimon', 'D')");
+
+        BlockingIterator<Row, Row> streamItr =
+                testStreamingRead(
+                        buildSimpleQuery(tableName),
+                        Arrays.asList(
+                                changelogRow("+I", 1, "Say", "A"),
+                                changelogRow("+I", 2, "Hi", "B"),
+                                changelogRow("+I", 3, "To", "C"),
+                                changelogRow("+I", 4, "Paimon", "D")));
+
+        action.run();
+
+        // test delete records hasn't been thrown
+        validateStreamingReadResult(
+                streamItr,
+                Arrays.asList(changelogRow("-D", 1, "Say", "A"), changelogRow("-D", 2, "Hi", "B")));
+        streamItr.close();
+
+        // test partial update still works after action
+        insertInto(
+                tableName, "(4, CAST (NULL AS STRING), '$')", "(4, 'Test', CAST (NULL AS STRING))");
+
+        testBatchRead(
+                buildSimpleQuery(tableName),
+                Arrays.asList(
+                        changelogRow("+I", 3, "To", "C"), changelogRow("+I", 4, "Test", "$")));
     }
 
     private void prepareTable(boolean hasPk) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
@@ -76,8 +76,9 @@ public class DeleteActionITCase extends ActionITCaseBase {
         action.run();
 
         Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
-        assertThat(snapshot.id()).isEqualTo(2);
-        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+        // due to force compaction
+        assertThat(snapshot.id()).isEqualTo(3);
+        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
 
         validateStreamingReadResult(iterator, expected);
         iterator.close();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DeleteActionITCase.java
@@ -76,9 +76,8 @@ public class DeleteActionITCase extends ActionITCaseBase {
         action.run();
 
         Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
-        // due to force compaction
-        assertThat(snapshot.id()).isEqualTo(3);
-        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
+        assertThat(snapshot.id()).isEqualTo(2);
+        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
 
         validateStreamingReadResult(iterator, expected);
         iterator.close();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -121,6 +121,29 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                         changelogRow("+I", 8, "v_8", "insert", "02-29"),
                         changelogRow("+I", 11, "v_11", "insert", "02-29"),
                         changelogRow("+I", 12, "v_12", "insert", "02-29")));
+
+        if (producer == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
+            // test partial update still works after action
+            testWorkWithPartialUpdate();
+        }
+    }
+
+    private void testWorkWithPartialUpdate() throws Exception {
+        insertInto(
+                "T",
+                "(12, CAST (NULL AS STRING), '$', '02-29')",
+                "(12, 'Test', CAST (NULL AS STRING), '02-29')");
+
+        testBatchRead(
+                buildSimpleQuery("T"),
+                Arrays.asList(
+                        changelogRow("+I", 1, "v_1", "creation", "02-27"),
+                        changelogRow("+U", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+U", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+U", 7, "Seven", "matched_upsert", "02-28"),
+                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
+                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
+                        changelogRow("+I", 12, "Test", "$", "02-29")));
     }
 
     @ParameterizedTest(name = "in-default = {0}")
@@ -415,6 +438,13 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                         new HashMap<String, String>() {
                             {
                                 put(CHANGELOG_PRODUCER.key(), producer.toString());
+                                // test works with partial update normally
+                                if (producer == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
+                                    put(
+                                            CoreOptions.MERGE_ENGINE.key(),
+                                            CoreOptions.MergeEngine.PARTIAL_UPDATE.toString());
+                                    put(CoreOptions.PARTIAL_UPDATE_IGNORE_DELETE.key(), "true");
+                                }
                             }
                         }));
 


### PR DESCRIPTION
### Purpose
Currently, the partial update merge engine cannot accept -U/-D records, thus actions that may produce -U/-D records will produce error results. This PR try to solve it.

### Tests

`DeleteActionITCase`
`MergeIntoActionITCase`

### API and Format 

No.

### Documentation

Add hint to how-to#writing tables