### PR TITLE
 [Feature] Optimize SortMergeReader: use loser tree to reduce comparisons

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -189,6 +189,12 @@
             <td>Specify the merge engine for table with primary key.<br /><br />Possible values:<ul><li>"deduplicate": De-duplicate and keep the last row.</li><li>"partial-update": Partial update non-null fields.</li><li>"aggregation": Aggregate fields with same primary key.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>sort-engine</h5></td>
+            <td style="word-wrap: break-word;">loser-tree</td>
+            <td><p>Enum</p></td>
+            <td>Specify the sort engine for table with primary key.<br /><br />Possible values:<ul><li>"min-heap": Use min-heap for multiway sorting.</li><li>"loser-tree": Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>num-levels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -186,6 +186,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether to ignore delete records in partial-update mode.");
 
+    public static final ConfigOption<SortEngine> SORT_ENGINE =
+            key("sort-engine")
+                    .enumType(SortEngine.class)
+                    .defaultValue(SortEngine.LOSER_TREE)
+                    .withDescription("Specify the sort engine for table with primary key.");
+
     @Immutable
     public static final ConfigOption<WriteMode> WRITE_MODE =
             key("write-mode")
@@ -706,6 +712,10 @@ public class CoreOptions implements Serializable {
         return options.get(MERGE_ENGINE);
     }
 
+    public SortEngine sortEngine() {
+        return options.get(SORT_ENGINE);
+    }
+
     public long splitTargetSize() {
         return options.get(SOURCE_SPLIT_TARGET_SIZE).getBytes();
     }
@@ -1190,5 +1200,31 @@ public class CoreOptions implements Serializable {
             }
         }
         return immutableKeys;
+    }
+
+    /** Specifies the sort engine for table with primary key. */
+    public enum SortEngine implements DescribedEnum {
+        MIN_HEAP("min-heap", "Use min-heap for multiway sorting."),
+        LOSER_TREE(
+                "loser-tree",
+                "Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.");
+
+        private final String value;
+        private final String description;
+
+        SortEngine(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
@@ -35,29 +35,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import static org.apache.paimon.CoreOptions.SORT_ENGINE;
 import static org.apache.paimon.CoreOptions.SortEngine;
 
 /** Utility class to create commonly used {@link RecordReader}s for merge trees. */
 public class MergeTreeReaders {
 
     private MergeTreeReaders() {}
-
-    public static RecordReader<KeyValue> readerForMergeTree(
-            List<List<SortedRun>> sections,
-            boolean dropDelete,
-            KeyValueFileReaderFactory readerFactory,
-            Comparator<InternalRow> userKeyComparator,
-            MergeFunction<KeyValue> mergeFunction)
-            throws IOException {
-        return readerForMergeTree(
-                sections,
-                dropDelete,
-                readerFactory,
-                userKeyComparator,
-                mergeFunction,
-                SORT_ENGINE.defaultValue());
-    }
 
     public static RecordReader<KeyValue> readerForMergeTree(
             List<List<SortedRun>> sections,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
@@ -34,8 +35,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-
-import static org.apache.paimon.CoreOptions.SortEngine;
 
 /** Utility class to create commonly used {@link RecordReader}s for merge trees. */
 public class MergeTreeReaders {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import static org.apache.paimon.CoreOptions.SortEngine;
+
 /** A {@link MergeTreeCompactRewriter} which produces changelog files for the compaction. */
 public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewriter {
 
@@ -42,8 +44,9 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
-            MergeFunctionFactory<KeyValue> mfFactory) {
-        super(readerFactory, writerFactory, keyComparator, mfFactory);
+            MergeFunctionFactory<KeyValue> mfFactory,
+            SortEngine sortEngine) {
+        super(readerFactory, writerFactory, keyComparator, mfFactory, sortEngine);
     }
 
     protected abstract boolean rewriteChangelog(
@@ -71,8 +74,8 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                     () -> {
                         List<RecordReader<KeyValue>> runReaders =
                                 MergeTreeReaders.readerForSection(section, readerFactory);
-                        return new SortMergeReader<>(
-                                runReaders, keyComparator, createMergeWrapper(outputLevel));
+                        return SortMergeReader.createSortMergeReader(
+                                runReaders, keyComparator, createMergeWrapper(outputLevel), sortEngine);
                     });
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
@@ -34,8 +35,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import static org.apache.paimon.CoreOptions.SortEngine;
 
 /** A {@link MergeTreeCompactRewriter} which produces changelog files for the compaction. */
 public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewriter {
@@ -75,7 +74,10 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                         List<RecordReader<KeyValue>> runReaders =
                                 MergeTreeReaders.readerForSection(section, readerFactory);
                         return SortMergeReader.createSortMergeReader(
-                                runReaders, keyComparator, createMergeWrapper(outputLevel), sortEngine);
+                                runReaders,
+                                keyComparator,
+                                createMergeWrapper(outputLevel),
+                                sortEngine);
                     });
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
@@ -40,8 +41,9 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
-            MergeFunctionFactory<KeyValue> mfFactory) {
-        super(readerFactory, writerFactory, keyComparator, mfFactory);
+            MergeFunctionFactory<KeyValue> mfFactory,
+            SortEngine sortEngine) {
+        super(readerFactory, writerFactory, keyComparator, mfFactory, sortEngine);
         this.maxLevel = maxLevel;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
@@ -44,8 +45,9 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
-            MergeFunctionFactory<KeyValue> mfFactory) {
-        super(readerFactory, writerFactory, keyComparator, mfFactory);
+            MergeFunctionFactory<KeyValue> mfFactory,
+            SortEngine sortEngine) {
+        super(readerFactory, writerFactory, keyComparator, mfFactory, sortEngine);
         this.lookupLevels = lookupLevels;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.ExceptionUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A variant of the loser tree. In the LSM-Tree architecture, there will be duplicate Keys in
+ * multiple {@link RecordReader}, and these Keys need to be merged. In the loser tree, we return in
+ * the order of the Keys, but because the returned objects may be reused in the {@link RecordReader}
+ * or the {@link MergeFunction}, for a single {@link RecordReader}, we cannot get the next Key
+ * immediately after returning a Key, and we need to wait until the same Key in all {@link
+ * RecordReader} is returned before proceeding to the next Key.
+ *
+ * <p>The process of building the loser tree is the same as a regular loser tree. The difference is
+ * that in the process of adjusting the tree, we need to record the index of the same key and the
+ * state of the winner/loser for subsequent quick adjustment of the position of the winner.
+ */
+public class LoserTree<T> implements Closeable {
+    private final int[] tree;
+    private final int size;
+    private final List<LeafIterator<T>> leaves;
+    private final Comparator<T> firstComparator;
+    private final Comparator<T> secondComparator;
+
+    private boolean initialized;
+
+    public LoserTree(
+            List<RecordReader<T>> nextBatchReaders,
+            Comparator<T> firstComparator,
+            Comparator<T> secondComparator) {
+        this.size = nextBatchReaders.size();
+        this.leaves = new ArrayList<>(size);
+        this.tree = new int[size];
+        this.firstComparator = firstComparator;
+        this.secondComparator = secondComparator;
+        this.initialized = false;
+
+        for (RecordReader<T> reader : nextBatchReaders) {
+            LeafIterator<T> iterator = new LeafIterator<>(reader);
+            this.leaves.add(iterator);
+        }
+    }
+
+    /** Initialize the loser tree in the same way as the regular loser tree. */
+    public void initializeIfNeeded() throws IOException {
+        if (!initialized) {
+            Arrays.fill(tree, -1);
+            for (int i = size - 1; i >= 0; i--) {
+                leaves.get(i).advanceIfAvailable();
+                adjust(i);
+            }
+            initialized = true;
+        }
+    }
+
+    /** Adjust the Key that needs to be returned in the next round. */
+    public void adjustForNextLoop() throws IOException {
+        LeafIterator<T> winner = leaves.get(tree[0]);
+        while (winner.state == State.WINNER_POPPED) {
+            winner.advanceIfAvailable();
+            adjust(tree[0]);
+            winner = leaves.get(tree[0]);
+        }
+    }
+
+    /** Pop the current winner and update its state to {@link State#WINNER_POPPED}. */
+    public T popWinner() {
+        LeafIterator<T> winner = leaves.get(tree[0]);
+        if (winner.state == State.WINNER_POPPED) {
+            // if the winner has already been popped, it means that all the same key has been
+            // processed.
+            return null;
+        }
+        T result = winner.pop();
+        adjust(tree[0]);
+        return result;
+    }
+
+    /** Peek the current winner, mainly for key comparisons. */
+    public T peekWinner() {
+        return leaves.get(tree[0]).state != State.WINNER_POPPED ? leaves.get(tree[0]).peek() : null;
+    }
+
+    /**
+     * Adjust the winner from bottom to top. Using different {@link State}, we can quickly compare
+     * whether all the current same keys have been processed.
+     */
+    private void adjust(int winner) {
+        for (int parent = (winner + this.size) / 2; parent > 0 && winner >= 0; parent /= 2) {
+            LeafIterator<T> winnerNode = leaves.get(winner);
+            LeafIterator<T> parentNode;
+            if (winnerNode.state == State.WINNER_POPPED) {
+                // adjust the current winner node
+                if (winnerNode.firstSameKeyIndex < 0) {
+                    // fast path, which means that the same key is not yet processed in the current
+                    // tree.
+                    break;
+                }
+                // fast path. Directly exchange positions with the same key that has not yet been
+                // processed,
+                // no need to compare level by level.
+                parent = winnerNode.firstSameKeyIndex;
+                parentNode = leaves.get(this.tree[parent]);
+                winnerNode.state = State.LOSER_POPPED;
+                parentNode.state = State.WINNER_WITH_SAME_KEY;
+            } else if (this.tree[parent] == -1) {
+                // initialize the tree.
+                winnerNode.state = State.LOSER_WITH_NEW_KEY;
+            } else {
+                // adjust according to the state of parent and winner nodes.
+                parentNode = leaves.get(this.tree[parent]);
+                this.adjustNodeState(parent, parentNode, winnerNode);
+            }
+
+            // if the winner loses, exchange nodes.
+            if (!winnerNode.state.isWinner()) {
+                int tmp = winner;
+                winner = this.tree[parent];
+                this.tree[parent] = tmp;
+            }
+        }
+        this.tree[0] = winner;
+    }
+
+    /**
+     * Decide how to compare with the new winner according to the state of the last loser, which can
+     * reduce the number of comparisons.
+     */
+    private void adjustNodeState(
+            int index, LeafIterator<T> parentNode, LeafIterator<T> winnerNode) {
+        switch (parentNode.state) {
+            case LOSER_WITH_NEW_KEY:
+                adjustWithNewLoserKey(index, parentNode, winnerNode);
+                return;
+            case LOSER_WITH_SAME_KEY:
+                adjustWithSameLoserKey(index, parentNode, winnerNode);
+                return;
+            case LOSER_POPPED:
+                adjustWithPoppedLoserKey(parentNode, winnerNode);
+                return;
+            default:
+                throw new UnsupportedOperationException(
+                        "unknown state for " + winnerNode.state.name());
+        }
+    }
+
+    /**
+     * The previous loser is a new key, which means it is not the same key as the previous winner.
+     */
+    private void adjustWithNewLoserKey(
+            int index, LeafIterator<T> parentNode, LeafIterator<T> winnerNode) {
+        switch (winnerNode.state) {
+            case WINNER_WITH_NEW_KEY:
+                // when the new winner is also a new key, it needs to be compared.
+                T parentKey = parentNode.peek();
+                T childKey = winnerNode.peek();
+                int firstResult = firstComparator.compare(parentKey, childKey);
+                if (firstResult == 0) {
+                    // if the compared keys are the same, we need to update the state of the node
+                    // and record the index of the same key for the winner.
+                    int secondResult = secondComparator.compare(parentKey, childKey);
+                    if (secondResult < 0) {
+                        parentNode.state = State.LOSER_WITH_SAME_KEY;
+                        winnerNode.setFirstSameKeyIndex(index);
+                    } else {
+                        winnerNode.state = State.LOSER_WITH_SAME_KEY;
+                        parentNode.state = State.WINNER_WITH_NEW_KEY;
+                        parentNode.setFirstSameKeyIndex(index);
+                    }
+                } else if (firstResult > 0) {
+                    // the two keys are completely different and just need to update the state.
+                    parentNode.state = State.WINNER_WITH_NEW_KEY;
+                    winnerNode.state = State.LOSER_WITH_NEW_KEY;
+                }
+                return;
+            case WINNER_WITH_SAME_KEY:
+                // the winner has the same key as the winner of the previous time, so the comparison
+                // is skipped directly.
+                return;
+                // there is no need to deal with the WINNER_POPPED, because the fast path is used
+                // first.
+            default:
+                throw new UnsupportedOperationException(
+                        "unknown state for " + winnerNode.state.name());
+        }
+    }
+
+    /**
+     * The key of the previous loser is the same as the previous winner, which can greatly reduce
+     * the number of comparisons.
+     */
+    private void adjustWithSameLoserKey(
+            int index, LeafIterator<T> parentNode, LeafIterator<T> winnerNode) {
+        switch (winnerNode.state) {
+            case WINNER_WITH_NEW_KEY:
+                // the previous loser has the same key as the winner of the previous time,
+                // so the comparison is skipped directly.
+                parentNode.state = State.WINNER_WITH_SAME_KEY;
+                winnerNode.state = State.LOSER_WITH_NEW_KEY;
+                return;
+            case WINNER_WITH_SAME_KEY:
+                // the key of the previous loser is the same as the key of the current winner,
+                // only the sequence needs to be compared.
+                T parentKey = parentNode.peek();
+                T childKey = winnerNode.peek();
+                int secondResult = secondComparator.compare(parentKey, childKey);
+                if (secondResult > 0) {
+                    parentNode.state = State.WINNER_WITH_SAME_KEY;
+                    winnerNode.state = State.LOSER_WITH_SAME_KEY;
+                    parentNode.setFirstSameKeyIndex(index);
+                } else {
+                    winnerNode.setFirstSameKeyIndex(index);
+                }
+                return;
+                // there is no need to deal with the WINNER_POPPED, because the fast path is used
+                // first.
+            default:
+                throw new UnsupportedOperationException(
+                        "unknown state for " + winnerNode.state.name());
+        }
+    }
+
+    /**
+     * The loser's key is the same as the previous winner's key and has been processed. This means
+     * that when encountering a new key, we can win directly.
+     */
+    private void adjustWithPoppedLoserKey(LeafIterator<T> parentNode, LeafIterator<T> winnerNode) {
+        switch (winnerNode.state) {
+            case WINNER_WITH_NEW_KEY:
+                parentNode.state = State.WINNER_POPPED;
+                parentNode.firstSameKeyIndex = -1;
+                winnerNode.state = State.LOSER_WITH_NEW_KEY;
+                return;
+            case WINNER_WITH_SAME_KEY:
+                return;
+                // there is no need to deal with the WINNER_POPPED, because the fast path is used
+                // first.
+            default:
+                throw new UnsupportedOperationException(
+                        "unknown state for " + winnerNode.state.name());
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOException exception = null;
+        for (LeafIterator<T> iterator : leaves) {
+            try {
+                iterator.close();
+            } catch (IOException e) {
+                exception = ExceptionUtils.firstOrSuppressed(e, exception);
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    /** Leaf node, used to manage {@link RecordReader}. */
+    private static class LeafIterator<T> implements Closeable {
+        /** The reader that reads the batches of records. */
+        private final RecordReader<T> reader;
+
+        /** The iterator used by the current batch. */
+        private RecordReader.RecordIterator<T> iterator;
+
+        /** The current minimum kv. */
+        private T kv;
+
+        /** Mark whether the visit is complete. */
+        private boolean endOfInput;
+
+        /** The index of the first same key that wins. */
+        private int firstSameKeyIndex;
+
+        /** The state of the current node. */
+        private State state;
+
+        private LeafIterator(RecordReader<T> reader) {
+            this.reader = reader;
+            this.endOfInput = false;
+            this.firstSameKeyIndex = -1;
+            this.state = State.WINNER_WITH_NEW_KEY;
+        }
+
+        public T peek() {
+            return kv;
+        }
+
+        public T pop() {
+            this.state = State.WINNER_POPPED;
+            return kv;
+        }
+
+        public void setFirstSameKeyIndex(int index) {
+            if (firstSameKeyIndex == -1) {
+                firstSameKeyIndex = index;
+            }
+        }
+
+        /** Reads the next kv if any, otherwise returns null. */
+        public void advanceIfAvailable() throws IOException {
+            this.firstSameKeyIndex = -1;
+            this.state = State.WINNER_WITH_NEW_KEY;
+            if (iterator == null || (kv = iterator.next()) == null) {
+                while (!endOfInput) {
+                    if (iterator != null) {
+                        iterator.releaseBatch();
+                    }
+
+                    iterator = reader.readBatch();
+                    if (iterator == null) {
+                        endOfInput = true;
+                        kv = null;
+                        reader.close();
+                    } else if ((kv = iterator.next()) != null) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (this.iterator != null) {
+                this.iterator.releaseBatch();
+            }
+            this.reader.close();
+        }
+    }
+
+    /** The state of the node in the loser tree. */
+    private enum State {
+        LOSER_WITH_NEW_KEY(false),
+        LOSER_WITH_SAME_KEY(false),
+        LOSER_POPPED(false),
+        WINNER_WITH_NEW_KEY(true),
+        WINNER_WITH_SAME_KEY(true),
+        WINNER_POPPED(true);
+
+        private final boolean winner;
+
+        State(boolean winner) {
+            this.winner = winner;
+        }
+
+        public boolean isWinner() {
+            return winner;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
@@ -40,8 +40,7 @@ import java.util.List;
  * that in the process of adjusting the tree, we need to record the index of the same key and the
  * state of the winner/loser for subsequent quick adjustment of the position of the winner.
  *
- * <p>Detailed design can refer to
- * https://docs.google.com/document/d/1OPyb9o9K226Fb4O-SzZpBYgwfsvNY7X0H5T3ivdu1ck/edit?usp=sharing
+ * <p>Detailed design can refer to https://cwiki.apache.org/confluence/x/9Ak0Dw.
  */
 public class LoserTree<T> implements Closeable {
     private final int[] tree;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
@@ -134,13 +134,11 @@ public class LoserTree<T> implements Closeable {
                     case WINNER_POPPED:
                         if (winnerNode.firstSameKeyIndex < 0) {
                             // fast path, which means that the same key is not yet processed in the
-                            // current
-                            // tree.
+                            // current tree.
                             parent = -1;
                         } else {
                             // fast path. Directly exchange positions with the same key that has not
-                            // yet been
-                            // processed, no need to compare level by level.
+                            // yet been processed, no need to compare level by level.
                             parent = winnerNode.firstSameKeyIndex;
                             parentNode = leaves.get(this.tree[parent]);
                             winnerNode.state = State.LOSER_POPPED;
@@ -221,11 +219,11 @@ public class LoserTree<T> implements Closeable {
                 }
                 return;
             case LOSER_WITH_SAME_KEY:
-                // the previous loser has the same key as the winner of the previous time,
-                // so the comparison is skipped directly.
-                parentNode.state = State.WINNER_WITH_SAME_KEY;
-                winnerNode.state = State.LOSER_WITH_NEW_KEY;
-                return;
+                // A node in the WINNER_WITH_NEW_KEY state cannot encounter a node in the
+                // LOSER_WITH_SAME_KEY state.
+                throw new RuntimeException(
+                        "This is a bug. Please file an issue. A node in the WINNER_WITH_NEW_KEY "
+                                + "state cannot encounter a node in the LOSER_WITH_SAME_KEY state.");
             case LOSER_POPPED:
                 parentNode.state = State.WINNER_POPPED;
                 parentNode.firstSameKeyIndex = -1;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
@@ -47,7 +47,14 @@ public class LoserTree<T> implements Closeable {
     private final int[] tree;
     private final int size;
     private final List<LeafIterator<T>> leaves;
+
+    /**
+     * if comparator.compare('a', 'b') > 0, then 'a' is the winner. In the following implementation,
+     * we always let 'a' represent the parent node.
+     */
     private final Comparator<T> firstComparator;
+
+    /** same as firstComparator, but mainly used to compare sequenceNumber. */
     private final Comparator<T> secondComparator;
 
     private boolean initialized;
@@ -59,6 +66,8 @@ public class LoserTree<T> implements Closeable {
         this.size = nextBatchReaders.size();
         this.leaves = new ArrayList<>(size);
         this.tree = new int[size];
+        // if e1 and e2 are both null, it doesn't matter who becomes the new winner. But if
+        // firstComparator returns 0, it means that secondComparator must be used to compare again.
         this.firstComparator =
                 (e1, e2) -> e1 == null ? -1 : (e2 == null ? 1 : firstComparator.compare(e1, e2));
         this.secondComparator =
@@ -225,6 +234,7 @@ public class LoserTree<T> implements Closeable {
                         "This is a bug. Please file an issue. A node in the WINNER_WITH_NEW_KEY "
                                 + "state cannot encounter a node in the LOSER_WITH_SAME_KEY state.");
             case LOSER_POPPED:
+                // this case will only happen during adjustForNextLoop.
                 parentNode.state = State.WINNER_POPPED;
                 parentNode.firstSameKeyIndex = -1;
                 winnerNode.state = State.LOSER_WITH_NEW_KEY;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
@@ -32,8 +33,6 @@ import org.apache.paimon.reader.RecordReaderIterator;
 
 import java.util.Comparator;
 import java.util.List;
-
-import static org.apache.paimon.CoreOptions.SortEngine;
 
 /** Default {@link CompactRewriter} for merge trees. */
 public class MergeTreeCompactRewriter extends AbstractCompactRewriter {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -18,14 +18,13 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
 
 import java.util.Comparator;
 import java.util.List;
-
-import static org.apache.paimon.CoreOptions.SortEngine;
 
 /**
  * This reader is to read a list of {@link RecordReader}, which is already sorted by key and

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -112,8 +112,7 @@ public class SortMergeReader<T> implements RecordReader<T> {
             Preconditions.checkState(
                     !released, "SortMergeIterator#nextImpl is called after release");
 
-            while (loserTree.peekWinner() != null
-                    && userKeyComparator.compare(winner.key(), loserTree.peekWinner().key()) == 0) {
+            while (loserTree.peekWinner() != null) {
                 mergeFunctionWrapper.add(loserTree.popWinner());
             }
             return mergeFunctionWrapper.getResult();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -26,10 +26,8 @@ import org.apache.paimon.utils.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.PriorityQueue;
 
 /**
  * This reader is to read a list of {@link RecordReader}, which is already sorted by key and
@@ -40,73 +38,50 @@ import java.util.PriorityQueue;
  */
 public class SortMergeReader<T> implements RecordReader<T> {
 
-    private final List<RecordReader<KeyValue>> nextBatchReaders;
     private final Comparator<InternalRow> userKeyComparator;
     private final MergeFunctionWrapper<T> mergeFunctionWrapper;
-
-    private final PriorityQueue<Element> minHeap;
-    private final List<Element> polled;
+    private final LoserTree<KeyValue> loserTree;
 
     public SortMergeReader(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
-        this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
         this.mergeFunctionWrapper = mergeFunctionWrapper;
 
-        this.minHeap =
-                new PriorityQueue<>(
+        this.loserTree =
+                new LoserTree<>(
+                        readers,
                         (e1, e2) -> {
-                            int result = userKeyComparator.compare(e1.kv.key(), e2.kv.key());
-                            if (result != 0) {
-                                return result;
+                            if (e1 == null) {
+                                return -1;
+                            } else {
+                                return e2 == null
+                                        ? 1
+                                        : userKeyComparator.compare(e2.key(), e1.key());
                             }
-                            return Long.compare(e1.kv.sequenceNumber(), e2.kv.sequenceNumber());
+                        },
+                        (e1, e2) -> {
+                            if (e1 == null) {
+                                return -1;
+                            } else {
+                                return e2 == null
+                                        ? 1
+                                        : Long.compare(e2.sequenceNumber(), e1.sequenceNumber());
+                            }
                         });
-        this.polled = new ArrayList<>();
     }
 
     @Nullable
     @Override
     public RecordIterator<T> readBatch() throws IOException {
-        for (RecordReader<KeyValue> reader : nextBatchReaders) {
-            while (true) {
-                RecordIterator<KeyValue> iterator = reader.readBatch();
-                if (iterator == null) {
-                    // no more batches, permanently remove this reader
-                    reader.close();
-                    break;
-                }
-                KeyValue kv = iterator.next();
-                if (kv == null) {
-                    // empty iterator, clean up and try next batch
-                    iterator.releaseBatch();
-                } else {
-                    // found next kv
-                    minHeap.offer(new Element(kv, iterator, reader));
-                    break;
-                }
-            }
-        }
-        nextBatchReaders.clear();
-
-        return minHeap.isEmpty() ? null : new SortMergeIterator();
+        loserTree.initializeIfNeeded();
+        return loserTree.peekWinner() == null ? null : new SortMergeIterator();
     }
 
     @Override
     public void close() throws IOException {
-        for (RecordReader<KeyValue> reader : nextBatchReaders) {
-            reader.close();
-        }
-        for (Element element : minHeap) {
-            element.iterator.releaseBatch();
-            element.reader.close();
-        }
-        for (Element element : polled) {
-            element.iterator.releaseBatch();
-            element.reader.close();
-        }
+        loserTree.close();
     }
 
     /** The iterator iterates on {@link SortMergeReader}. */
@@ -114,92 +89,39 @@ public class SortMergeReader<T> implements RecordReader<T> {
 
         private boolean released = false;
 
+        @Nullable
         @Override
         public T next() throws IOException {
             while (true) {
-                boolean hasMore = nextImpl();
-                if (!hasMore) {
+                loserTree.adjustForNextLoop();
+                KeyValue winner = loserTree.popWinner();
+                if (winner == null) {
                     return null;
                 }
-                T result = mergeFunctionWrapper.getResult();
+                mergeFunctionWrapper.reset();
+                mergeFunctionWrapper.add(winner);
+
+                T result = merge(winner);
                 if (result != null) {
                     return result;
                 }
             }
         }
 
-        private boolean nextImpl() throws IOException {
+        private T merge(KeyValue winner) {
             Preconditions.checkState(
-                    !released, "SortMergeIterator#advanceNext is called after release");
-            Preconditions.checkState(
-                    nextBatchReaders.isEmpty(),
-                    "SortMergeIterator#advanceNext is called even if the last call returns null. "
-                            + "This is a bug.");
+                    !released, "SortMergeIterator#nextImpl is called after release");
 
-            // add previously polled elements back to priority queue
-            for (Element element : polled) {
-                if (element.update()) {
-                    // still kvs left, add back to priority queue
-                    minHeap.offer(element);
-                } else {
-                    // reach end of batch, clean up
-                    element.iterator.releaseBatch();
-                    nextBatchReaders.add(element.reader);
-                }
+            while (loserTree.peekWinner() != null
+                    && userKeyComparator.compare(winner.key(), loserTree.peekWinner().key()) == 0) {
+                mergeFunctionWrapper.add(loserTree.popWinner());
             }
-            polled.clear();
-
-            // there are readers reaching end of batch, so we end current batch
-            if (!nextBatchReaders.isEmpty()) {
-                return false;
-            }
-
-            mergeFunctionWrapper.reset();
-            InternalRow key =
-                    Preconditions.checkNotNull(minHeap.peek(), "Min heap is empty. This is a bug.")
-                            .kv
-                            .key();
-
-            // fetch all elements with the same key
-            // note that the same iterator should not produce the same keys, so this code is correct
-            while (!minHeap.isEmpty()) {
-                Element element = minHeap.peek();
-                if (userKeyComparator.compare(key, element.kv.key()) != 0) {
-                    break;
-                }
-                minHeap.poll();
-                mergeFunctionWrapper.add(element.kv);
-                polled.add(element);
-            }
-            return true;
+            return mergeFunctionWrapper.getResult();
         }
 
         @Override
         public void releaseBatch() {
             released = true;
-        }
-    }
-
-    private static class Element {
-        private KeyValue kv;
-        private final RecordIterator<KeyValue> iterator;
-        private final RecordReader<KeyValue> reader;
-
-        private Element(
-                KeyValue kv, RecordIterator<KeyValue> iterator, RecordReader<KeyValue> reader) {
-            this.kv = kv;
-            this.iterator = iterator;
-            this.reader = reader;
-        }
-
-        // IMPORTANT: Must not call this for elements still in priority queue!
-        private boolean update() throws IOException {
-            KeyValue nextKv = iterator.next();
-            if (nextKv == null) {
-                return false;
-            }
-            kv = nextKv;
-            return true;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -34,15 +34,9 @@ import static org.apache.paimon.CoreOptions.SortEngine;
  *
  * <p>NOTE: {@link KeyValue}s from the same {@link RecordReader} must not contain the same key.
  */
-public abstract class SortMergeReader<T> implements RecordReader<T> {
+public interface SortMergeReader<T> extends RecordReader<T> {
 
-    protected final MergeFunctionWrapper<T> mergeFunctionWrapper;
-
-    public SortMergeReader(MergeFunctionWrapper<T> mergeFunctionWrapper) {
-        this.mergeFunctionWrapper = mergeFunctionWrapper;
-    }
-
-    public static <T> SortMergeReader<T> createSortMergeReader(
+    static <T> SortMergeReader<T> createSortMergeReader(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/** {@link SortMergeReader} implemented with loser-tree. */
+public class SortMergeReaderWithLoserTree<T> extends SortMergeReader<T> {
+
+    private final LoserTree<KeyValue> loserTree;
+
+    public SortMergeReaderWithLoserTree(
+            List<RecordReader<KeyValue>> readers,
+            Comparator<InternalRow> userKeyComparator,
+            MergeFunctionWrapper<T> mergeFunctionWrapper) {
+        super(mergeFunctionWrapper);
+        this.loserTree =
+                new LoserTree<>(
+                        readers,
+                        (e1, e2) -> userKeyComparator.compare(e2.key(), e1.key()),
+                        (e1, e2) -> Long.compare(e2.sequenceNumber(), e1.sequenceNumber()));
+    }
+
+    /** Compared with heapsort, {@link LoserTree} will only produce one batch. */
+    @Nullable
+    @Override
+    public RecordIterator<T> readBatch() throws IOException {
+        loserTree.initializeIfNeeded();
+        return loserTree.peekWinner() == null ? null : new SortMergeIterator();
+    }
+
+    @Override
+    public void close() throws IOException {
+        loserTree.close();
+    }
+
+    /** The iterator iterates on {@link SortMergeReaderWithLoserTree}. */
+    private class SortMergeIterator implements RecordIterator<T> {
+
+        private boolean released = false;
+
+        @Nullable
+        @Override
+        public T next() throws IOException {
+            while (true) {
+                loserTree.adjustForNextLoop();
+                KeyValue winner = loserTree.popWinner();
+                if (winner == null) {
+                    return null;
+                }
+                mergeFunctionWrapper.reset();
+                mergeFunctionWrapper.add(winner);
+
+                T result = merge();
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+
+        private T merge() {
+            Preconditions.checkState(
+                    !released, "SortMergeIterator#nextImpl is called after release");
+
+            while (loserTree.peekWinner() != null) {
+                mergeFunctionWrapper.add(loserTree.popWinner());
+            }
+            return mergeFunctionWrapper.getResult();
+        }
+
+        @Override
+        public void releaseBatch() {
+            released = true;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
@@ -30,15 +30,16 @@ import java.util.Comparator;
 import java.util.List;
 
 /** {@link SortMergeReader} implemented with loser-tree. */
-public class SortMergeReaderWithLoserTree<T> extends SortMergeReader<T> {
+public class SortMergeReaderWithLoserTree<T> implements SortMergeReader<T> {
 
+    private final MergeFunctionWrapper<T> mergeFunctionWrapper;
     private final LoserTree<KeyValue> loserTree;
 
     public SortMergeReaderWithLoserTree(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
-        super(mergeFunctionWrapper);
+        this.mergeFunctionWrapper = mergeFunctionWrapper;
         this.loserTree =
                 new LoserTree<>(
                         readers,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/** {@link SortMergeReader} implemented with min-heap. */
+public class SortMergeReaderWithMinHeap<T> extends SortMergeReader<T> {
+
+    private final List<RecordReader<KeyValue>> nextBatchReaders;
+    private final Comparator<InternalRow> userKeyComparator;
+
+    private final PriorityQueue<Element> minHeap;
+    private final List<Element> polled;
+
+    public SortMergeReaderWithMinHeap(
+            List<RecordReader<KeyValue>> readers,
+            Comparator<InternalRow> userKeyComparator,
+            MergeFunctionWrapper<T> mergeFunctionWrapper) {
+        super(mergeFunctionWrapper);
+        this.nextBatchReaders = new ArrayList<>(readers);
+        this.userKeyComparator = userKeyComparator;
+
+        this.minHeap =
+                new PriorityQueue<>(
+                        (e1, e2) -> {
+                            int result = userKeyComparator.compare(e1.kv.key(), e2.kv.key());
+                            if (result != 0) {
+                                return result;
+                            }
+                            return Long.compare(e1.kv.sequenceNumber(), e2.kv.sequenceNumber());
+                        });
+        this.polled = new ArrayList<>();
+    }
+
+    @Nullable
+    @Override
+    public RecordIterator<T> readBatch() throws IOException {
+        for (RecordReader<KeyValue> reader : nextBatchReaders) {
+            while (true) {
+                RecordIterator<KeyValue> iterator = reader.readBatch();
+                if (iterator == null) {
+                    // no more batches, permanently remove this reader
+                    reader.close();
+                    break;
+                }
+                KeyValue kv = iterator.next();
+                if (kv == null) {
+                    // empty iterator, clean up and try next batch
+                    iterator.releaseBatch();
+                } else {
+                    // found next kv
+                    minHeap.offer(new Element(kv, iterator, reader));
+                    break;
+                }
+            }
+        }
+        nextBatchReaders.clear();
+
+        return minHeap.isEmpty() ? null : new SortMergeIterator();
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (RecordReader<KeyValue> reader : nextBatchReaders) {
+            reader.close();
+        }
+        for (Element element : minHeap) {
+            element.iterator.releaseBatch();
+            element.reader.close();
+        }
+        for (Element element : polled) {
+            element.iterator.releaseBatch();
+            element.reader.close();
+        }
+    }
+
+    /** The iterator iterates on {@link SortMergeReaderWithMinHeap}. */
+    private class SortMergeIterator implements RecordIterator<T> {
+
+        private boolean released = false;
+
+        @Override
+        public T next() throws IOException {
+            while (true) {
+                boolean hasMore = nextImpl();
+                if (!hasMore) {
+                    return null;
+                }
+                T result = mergeFunctionWrapper.getResult();
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+
+        private boolean nextImpl() throws IOException {
+            Preconditions.checkState(
+                    !released, "SortMergeIterator#advanceNext is called after release");
+            Preconditions.checkState(
+                    nextBatchReaders.isEmpty(),
+                    "SortMergeIterator#advanceNext is called even if the last call returns null. "
+                            + "This is a bug.");
+
+            // add previously polled elements back to priority queue
+            for (Element element : polled) {
+                if (element.update()) {
+                    // still kvs left, add back to priority queue
+                    minHeap.offer(element);
+                } else {
+                    // reach end of batch, clean up
+                    element.iterator.releaseBatch();
+                    nextBatchReaders.add(element.reader);
+                }
+            }
+            polled.clear();
+
+            // there are readers reaching end of batch, so we end current batch
+            if (!nextBatchReaders.isEmpty()) {
+                return false;
+            }
+
+            mergeFunctionWrapper.reset();
+            InternalRow key =
+                    Preconditions.checkNotNull(minHeap.peek(), "Min heap is empty. This is a bug.")
+                            .kv
+                            .key();
+
+            // fetch all elements with the same key
+            // note that the same iterator should not produce the same keys, so this code is correct
+            while (!minHeap.isEmpty()) {
+                Element element = minHeap.peek();
+                if (userKeyComparator.compare(key, element.kv.key()) != 0) {
+                    break;
+                }
+                minHeap.poll();
+                mergeFunctionWrapper.add(element.kv);
+                polled.add(element);
+            }
+            return true;
+        }
+
+        @Override
+        public void releaseBatch() {
+            released = true;
+        }
+    }
+
+    private static class Element {
+        private KeyValue kv;
+        private final RecordIterator<KeyValue> iterator;
+        private final RecordReader<KeyValue> reader;
+
+        private Element(
+                KeyValue kv, RecordIterator<KeyValue> iterator, RecordReader<KeyValue> reader) {
+            this.kv = kv;
+            this.iterator = iterator;
+            this.reader = reader;
+        }
+
+        // IMPORTANT: Must not call this for elements still in priority queue!
+        private boolean update() throws IOException {
+            KeyValue nextKv = iterator.next();
+            if (nextKv == null) {
+                return false;
+            }
+            kv = nextKv;
+            return true;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
@@ -32,10 +32,11 @@ import java.util.List;
 import java.util.PriorityQueue;
 
 /** {@link SortMergeReader} implemented with min-heap. */
-public class SortMergeReaderWithMinHeap<T> extends SortMergeReader<T> {
+public class SortMergeReaderWithMinHeap<T> implements SortMergeReader<T> {
 
     private final List<RecordReader<KeyValue>> nextBatchReaders;
     private final Comparator<InternalRow> userKeyComparator;
+    private final MergeFunctionWrapper<T> mergeFunctionWrapper;
 
     private final PriorityQueue<Element> minHeap;
     private final List<Element> polled;
@@ -44,9 +45,9 @@ public class SortMergeReaderWithMinHeap<T> extends SortMergeReader<T> {
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
-        super(mergeFunctionWrapper);
         this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
+        this.mergeFunctionWrapper = mergeFunctionWrapper;
 
         this.minHeap =
                 new PriorityQueue<>(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
@@ -33,6 +33,7 @@ import org.apache.paimon.mergetree.compact.IntervalPartition;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
 import org.apache.paimon.mergetree.compact.ReducerMergeFunctionWrapper;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
@@ -53,6 +54,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.CoreOptions.SORT_ENGINE;
+import static org.apache.paimon.CoreOptions.SortEngine;
 import static org.apache.paimon.io.DataFilePathFactory.CHANGELOG_FILE_PREFIX;
 import static org.apache.paimon.predicate.PredicateBuilder.containsFields;
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
@@ -65,6 +68,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
     private final Comparator<InternalRow> keyComparator;
     private final MergeFunctionFactory<KeyValue> mfFactory;
     private final boolean valueCountMode;
+    private final SortEngine sortEngine;
 
     @Nullable private int[][] keyProjectedFields;
 
@@ -99,6 +103,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
         this.keyComparator = keyComparator;
         this.mfFactory = mfFactory;
         this.valueCountMode = tableSchema.trimmedPrimaryKeys().isEmpty();
+        this.sortEngine = Options.fromMap(tableSchema.options()).get(SORT_ENGINE);
     }
 
     public KeyValueFileStoreRead withKeyProjection(int[][] projectedFields) {
@@ -196,7 +201,8 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
                                                 ? overlappedSectionFactory
                                                 : nonOverlappedSectionFactory,
                                         keyComparator,
-                                        mergeFuncWrapper));
+                                        mergeFuncWrapper,
+                                        sortEngine));
             }
             DropDeleteReader reader =
                     new DropDeleteReader(ConcatRecordReader.create(sectionReaders));

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.data.InternalRow;
@@ -55,7 +56,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.SORT_ENGINE;
-import static org.apache.paimon.CoreOptions.SortEngine;
 import static org.apache.paimon.io.DataFilePathFactory.CHANGELOG_FILE_PREFIX;
 import static org.apache.paimon.predicate.PredicateBuilder.containsFields;
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -210,14 +210,24 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         readerFactory,
                         writerFactory,
                         keyComparator,
-                        mfFactory);
+                        mfFactory,
+                        options.sortEngine());
             case LOOKUP:
                 LookupLevels lookupLevels = createLookupLevels(levels, readerFactory);
                 return new LookupMergeTreeCompactRewriter(
-                        lookupLevels, readerFactory, writerFactory, keyComparator, mfFactory);
+                        lookupLevels,
+                        readerFactory,
+                        writerFactory,
+                        keyComparator,
+                        mfFactory,
+                        options.sortEngine());
             default:
                 return new MergeTreeCompactRewriter(
-                        readerFactory, writerFactory, keyComparator, mfFactory);
+                        readerFactory,
+                        writerFactory,
+                        keyComparator,
+                        mfFactory,
+                        options.sortEngine());
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.mergetree.compact;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordComparator;
@@ -78,10 +77,6 @@ public abstract class CombiningRecordReaderTestBase {
                             random.nextInt(100) + 1, addOnly()));
         }
         return readersData;
-    }
-
-    protected void runTest(List<List<ReusingTestData>> readersData) throws IOException {
-        runTest(readersData, CoreOptions.SORT_ENGINE.defaultValue());
     }
 
     protected void runTest(List<List<ReusingTestData>> readersData, SortEngine sortEngine)

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
@@ -18,13 +18,16 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.utils.ReusingTestData;
 import org.apache.paimon.utils.TestReusingRecordReader;
 
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,11 +50,14 @@ public abstract class CombiningRecordReaderTestBase {
     protected abstract List<ReusingTestData> getExpected(List<ReusingTestData> input);
 
     protected abstract RecordReader<KeyValue> createRecordReader(
-            List<TestReusingRecordReader> readers);
+            List<TestReusingRecordReader> readers, SortEngine sortEngine);
 
-    @RepeatedTest(100)
-    public void testRandom() throws IOException {
-        runTest(generateRandomData());
+    @ParameterizedTest
+    @EnumSource(SortEngine.class)
+    public void testRandom(SortEngine sortEngine) throws IOException {
+        for (int i = 0; i < 100; i++) {
+            runTest(generateRandomData(), sortEngine);
+        }
     }
 
     protected List<List<ReusingTestData>> parseData(String... stringsData) {
@@ -75,6 +81,11 @@ public abstract class CombiningRecordReaderTestBase {
     }
 
     protected void runTest(List<List<ReusingTestData>> readersData) throws IOException {
+        runTest(readersData, CoreOptions.SORT_ENGINE.defaultValue());
+    }
+
+    protected void runTest(List<List<ReusingTestData>> readersData, SortEngine sortEngine)
+            throws IOException {
         Iterator<ReusingTestData> expectedIterator =
                 getExpected(
                                 readersData.stream()
@@ -85,7 +96,7 @@ public abstract class CombiningRecordReaderTestBase {
         for (List<ReusingTestData> readerData : readersData) {
             readers.add(new TestReusingRecordReader(readerData));
         }
-        RecordReader<KeyValue> recordReader = createRecordReader(readers);
+        RecordReader<KeyValue> recordReader = createRecordReader(readers, sortEngine);
 
         RecordReader.RecordIterator<KeyValue> batch;
         while ((batch = recordReader.readBatch()) != null) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ConcatRecordReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ConcatRecordReaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.utils.ReusingTestData;
@@ -43,7 +44,8 @@ public class ConcatRecordReaderTest extends CombiningRecordReaderTestBase {
     }
 
     @Override
-    protected RecordReader<KeyValue> createRecordReader(List<TestReusingRecordReader> readers) {
+    protected RecordReader<KeyValue> createRecordReader(
+            List<TestReusingRecordReader> readers, SortEngine sortEngine) {
         return new ConcatRecordReader(
                 readers.stream()
                         .map(r -> (ConcatRecordReader.ReaderSupplier) () -> r)

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ConcatRecordReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ConcatRecordReaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.reader.RecordReader;
@@ -66,5 +67,9 @@ public class ConcatRecordReaderTest extends CombiningRecordReaderTestBase {
                                 + " 7, 40, +, 700 |  9, 200, -, 900",
                         "",
                         " 12, 60, +, 1200 |  14, 70, -, 1400 |  16, 80, +, 1600 |  18, 90, -, 1800"));
+    }
+
+    private void runTest(List<List<ReusingTestData>> readersData) throws IOException {
+        runTest(readersData, CoreOptions.SORT_ENGINE.defaultValue());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LoserTreeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LoserTreeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.ReusingTestData;
+import org.apache.paimon.utils.TestReusingRecordReader;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link LoserTree}. */
+public class LoserTreeTest {
+    private static final Comparator<KeyValue> KEY_COMPARATOR =
+            Comparator.comparingInt(o -> o.key().getInt(0));
+    private static final Comparator<KeyValue> SEQUENCE_COMPARATOR =
+            Comparator.comparingLong(KeyValue::sequenceNumber);
+
+    @RepeatedTest(100)
+    public void testLoserTreeIsOrdered() throws IOException {
+        List<ReusingTestData> reusingTestData = ReusingTestData.generateData(1000, false);
+        List<RecordReader<KeyValue>> sortedTestReaders = new ArrayList<>();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int numberReaders = random.nextInt(20) + 1;
+        int lowerBound = 0, upperBound = reusingTestData.size();
+        for (int i = 0; i < numberReaders; i++) {
+            int subUpperBound = random.nextInt(lowerBound, upperBound);
+            List<ReusingTestData> subReusingTestData =
+                    reusingTestData.subList(lowerBound, subUpperBound);
+            Collections.sort(subReusingTestData);
+            sortedTestReaders.add(new TestReusingRecordReader(subReusingTestData));
+            lowerBound = subUpperBound;
+        }
+        Collections.sort(reusingTestData);
+        checkLoserTree(sortedTestReaders, reusingTestData);
+    }
+
+    private void checkLoserTree(
+            List<RecordReader<KeyValue>> sortedTestReaders, List<ReusingTestData> expectedData)
+            throws IOException {
+        try (LoserTree<KeyValue> loserTree =
+                new LoserTree<>(sortedTestReaders, KEY_COMPARATOR, SEQUENCE_COMPARATOR)) {
+            Iterator<ReusingTestData> expectedIterator = expectedData.iterator();
+            do {
+                loserTree.adjustForNextLoop();
+                for (KeyValue winner = loserTree.popWinner();
+                        winner != null;
+                        winner = loserTree.popWinner()) {
+                    assertThat(expectedIterator.hasNext());
+                    expectedIterator.next().assertEquals(winner);
+                }
+            } while (loserTree.peekWinner() != null && expectedIterator.hasNext());
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

 [Feature] Optimize SortMergeReader: use loser tree to reduce comparisons (#741)

### Tests

- Unit Tests: `SortMergeReaderTestBase` already exists to verify the correctness of `SortMergeReader`.
- Benchmark：I created a jmh benchmark to compare the performance of different implementations，Here is the [benchmark code](https://github.com/liming30/paimon-benchmark/blob/master/src/main/java/com/bytedance/MergeReaderBenchmark.java).

From the benchmark results, there is almost no difference between `loser-tree` and `min-heap` when `RecordReader`/`data volume` is small. With the increase of `RecordReader`/`data volume`, there can be about 10% performance improvement.

```
Benchmark                               (readersNum)  (recordNum)  Mode  Cnt     Score    Error  Units
MergeReaderBenchmark.group:min-heap            2         1000  avgt   10     0.172 ±  0.017  ms/op
MergeReaderBenchmark.group:loser-tree          2         1000  avgt   10     0.172 ±  0.015  ms/op
MergeReaderBenchmark.group:min-heap            2        10000  avgt   10     1.829 ±  0.247  ms/op
MergeReaderBenchmark.group:loser-tree          2        10000  avgt   10     1.633 ±  0.217  ms/op
MergeReaderBenchmark.group:min-heap            2       100000  avgt   10    17.664 ±  1.678  ms/op
MergeReaderBenchmark.group:loser-tree          2       100000  avgt   10    17.355 ±  1.238  ms/op
MergeReaderBenchmark.group:min-heap            5         1000  avgt   10     0.615 ±  0.095  ms/op
MergeReaderBenchmark.group:loser-tree          5         1000  avgt   10     0.616 ±  0.092  ms/op
MergeReaderBenchmark.group:min-heap            5        10000  avgt   10     6.207 ±  0.261  ms/op
MergeReaderBenchmark.group:loser-tree          5        10000  avgt   10     6.169 ±  0.221  ms/op
MergeReaderBenchmark.group:min-heap            5       100000  avgt   10    76.777 ±  6.675  ms/op
MergeReaderBenchmark.group:loser-tree          5       100000  avgt   10    61.951 ±  5.007  ms/op
MergeReaderBenchmark.group:min-heap           10         1000  avgt   10     1.719 ±  0.127  ms/op
MergeReaderBenchmark.group:loser-tree         10         1000  avgt   10     1.474 ±  0.109  ms/op
MergeReaderBenchmark.group:min-heap           10        10000  avgt   10    20.064 ±  2.266  ms/op
MergeReaderBenchmark.group:loser-tree         10        10000  avgt   10    17.543 ±  1.530  ms/op
MergeReaderBenchmark.group:min-heap           10       100000  avgt   10   186.422 ± 13.484  ms/op
MergeReaderBenchmark.group:loser-tree         10       100000  avgt   10   165.942 ± 11.544  ms/op
MergeReaderBenchmark.group:min-heap           20         1000  avgt   10     3.686 ±  0.084  ms/op
MergeReaderBenchmark.group:loser-tree         20         1000  avgt   10     3.333 ±  0.079  ms/op
MergeReaderBenchmark.group:min-heap           20        10000  avgt   10    40.124 ±  0.496  ms/op
MergeReaderBenchmark.group:loser-tree         20        10000  avgt   10    35.157 ±  0.239  ms/op
MergeReaderBenchmark.group:min-heap           20       100000  avgt   10   405.549 ± 10.104  ms/op
MergeReaderBenchmark.group:loser-tree         20       100000  avgt   10   361.460 ±  8.872  ms/op
MergeReaderBenchmark.group:min-heap           50         1000  avgt   10    11.097 ±  1.025  ms/op
MergeReaderBenchmark.group:loser-tree         50         1000  avgt   10     9.721 ±  0.975  ms/op
MergeReaderBenchmark.group:min-heap           50        10000  avgt   10   155.610 ± 18.069  ms/op
MergeReaderBenchmark.group:loser-tree         50        10000  avgt   10   131.680 ± 13.984  ms/op
MergeReaderBenchmark.group:min-heap           50       100000  avgt   10  1394.615 ± 97.327  ms/op
MergeReaderBenchmark.group:loser-tree         50       100000  avgt   10  1283.037 ± 84.270  ms/op
```

### API and Format 

No

### Documentation

A variant implementation of loser tree is introduced to optimize the comparison times of `SortMergeReader`.

Different from the traditional loser tree, since `RecordReader` and `MergeFunction` may reuse objects, we can iterate data forward for `RecordReader` only after all the same keys in the entire tree are processed.
