### PR TITLE
[core][bug] BoundedChecker may check non-existing snapshot at fully read phase

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
@@ -40,8 +40,8 @@ public class DataFilePlan implements TableScan.Plan {
 
     public static DataFilePlan fromResult(StartingScanner.Result result) {
         return new DataFilePlan(
-                result instanceof StartingScanner.NoSnapshot
-                        ? Collections.emptyList()
-                        : result.splits());
+                result instanceof StartingScanner.ScannedResult
+                        ? ((StartingScanner.ScannedResult) result).splits()
+                        : Collections.emptyList());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
@@ -20,8 +20,6 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.table.source.snapshot.StartingScanner;
 
-import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +38,10 @@ public class DataFilePlan implements TableScan.Plan {
         return new ArrayList<>(splits);
     }
 
-    public static DataFilePlan fromResult(@Nullable StartingScanner.Result result) {
-        return new DataFilePlan(result == null ? Collections.emptyList() : result.splits());
+    public static DataFilePlan fromResult(StartingScanner.Result result) {
+        return new DataFilePlan(
+                result instanceof StartingScanner.NullResult
+                        ? Collections.emptyList()
+                        : result.splits());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
@@ -40,7 +40,7 @@ public class DataFilePlan implements TableScan.Plan {
 
     public static DataFilePlan fromResult(StartingScanner.Result result) {
         return new DataFilePlan(
-                result instanceof StartingScanner.NullResult
+                result instanceof StartingScanner.NoSnapshot
                         ? Collections.emptyList()
                         : result.splits());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -95,7 +95,8 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
         if (result != null) {
             long snapshotId = result.snapshotId();
             nextSnapshotId = snapshotId + 1;
-            if (boundedChecker.shouldEndInput(snapshotManager.snapshot(snapshotId))) {
+            if (result.hasRead()
+                    && boundedChecker.shouldEndInput(snapshotManager.snapshot(snapshotId))) {
                 isEnd = true;
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -93,11 +93,12 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
     private Plan tryFirstPlan() {
         StartingScanner.Result result = startingScanner.scan(snapshotManager, snapshotSplitReader);
         if (result instanceof StartingScanner.ScannedResult) {
-            nextSnapshotId = result.snapshotId() + 1;
+            long currentSnapshotId = ((StartingScanner.ScannedResult) result).currentSnapshotId();
+            nextSnapshotId = currentSnapshotId + 1;
             isFullPhaseEnd =
-                    boundedChecker.shouldEndInput(snapshotManager.snapshot(result.snapshotId()));
+                    boundedChecker.shouldEndInput(snapshotManager.snapshot(currentSnapshotId));
         } else if (result instanceof StartingScanner.NextSnapshot) {
-            nextSnapshotId = result.snapshotId();
+            nextSnapshotId = ((StartingScanner.NextSnapshot) result).nextSnapshotId();
             isFullPhaseEnd =
                     snapshotManager.snapshotExists(nextSnapshotId - 1)
                             && boundedChecker.shouldEndInput(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -50,6 +50,7 @@ public class CompactedStartingScanner implements StartingScanner {
 
         return new Result(
                 startingSnapshotId,
+                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshotId)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -33,14 +33,13 @@ public class CompactedStartingScanner implements StartingScanner {
     private static final Logger LOG = LoggerFactory.getLogger(CompactedStartingScanner.class);
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long startingSnapshotId = pick(snapshotManager);
         if (startingSnapshotId == null) {
             startingSnapshotId = snapshotManager.latestSnapshotId();
             if (startingSnapshotId == null) {
                 LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-                return null;
+                return new NullResult();
             } else {
                 LOG.debug(
                         "No compact snapshot found, reading from the latest snapshot {}.",
@@ -48,9 +47,8 @@ public class CompactedStartingScanner implements StartingScanner {
             }
         }
 
-        return new Result(
+        return new ExistingSnapshotResult(
                 startingSnapshotId,
-                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshotId)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -39,7 +39,7 @@ public class CompactedStartingScanner implements StartingScanner {
             startingSnapshotId = snapshotManager.latestSnapshotId();
             if (startingSnapshotId == null) {
                 LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-                return new NullResult();
+                return new NoSnapshot();
             } else {
                 LOG.debug(
                         "No compact snapshot found, reading from the latest snapshot {}.",
@@ -47,7 +47,7 @@ public class CompactedStartingScanner implements StartingScanner {
             }
         }
 
-        return new ExistingSnapshotResult(
+        return new ScannedResult(
                 startingSnapshotId,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
@@ -36,20 +36,20 @@ public class ContinuousCompactorStartingScanner implements StartingScanner {
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (latestSnapshotId == null || earliestSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-            return new NullResult();
+            return new NoSnapshot();
         }
 
         for (long id = latestSnapshotId; id >= earliestSnapshotId; id--) {
             Snapshot snapshot = snapshotManager.snapshot(id);
             if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
                 LOG.debug("Found latest compact snapshot {}, reading from the next snapshot.", id);
-                return new ExistingSnapshotResult(id);
+                return new NextSnapshot(id + 1);
             }
         }
 
         LOG.debug(
                 "No compact snapshot found, reading from the earliest snapshot {}.",
                 earliestSnapshotId);
-        return new NonExistingSnapshotResult(earliestSnapshotId - 1);
+        return new NextSnapshot(earliestSnapshotId);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
@@ -24,8 +24,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 /** {@link StartingScanner} used internally for stand-alone streaming compact job sources. */
 public class ContinuousCompactorStartingScanner implements StartingScanner {
 
@@ -33,26 +31,25 @@ public class ContinuousCompactorStartingScanner implements StartingScanner {
             LoggerFactory.getLogger(ContinuousCompactorStartingScanner.class);
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (latestSnapshotId == null || earliestSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-            return null;
+            return new NullResult();
         }
 
         for (long id = latestSnapshotId; id >= earliestSnapshotId; id--) {
             Snapshot snapshot = snapshotManager.snapshot(id);
             if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
                 LOG.debug("Found latest compact snapshot {}, reading from the next snapshot.", id);
-                return new Result(id);
+                return new ExistingSnapshotResult(id);
             }
         }
 
         LOG.debug(
                 "No compact snapshot found, reading from the earliest snapshot {}.",
                 earliestSnapshotId);
-        return new Result(earliestSnapshotId - 1);
+        return new NonExistingSnapshotResult(earliestSnapshotId - 1);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -37,12 +37,10 @@ public class ContinuousFromSnapshotStartingScanner implements StartingScanner {
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (earliestSnapshotId == null) {
-            return new NullResult();
+            return new NoSnapshot();
         }
-        // We should use `snapshotId - 1` here to start to scan delta data from specific snapshot
-        // id. If the snapshotId < earliestSnapshotId, start to scan from the earliest.
-        return snapshotId > earliestSnapshotId
-                ? new ExistingSnapshotResult(snapshotId - 1)
-                : new NonExistingSnapshotResult(earliestSnapshotId - 1);
+        // We should return the specified snapshot as next snapshot to indicate to scan delta data
+        // from it. If the snapshotId < earliestSnapshotId, start from the earliest.
+        return new NextSnapshot(Math.max(snapshotId, earliestSnapshotId));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -21,8 +21,6 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.utils.SnapshotManager;
 
-import javax.annotation.Nullable;
-
 /**
  * {@link StartingScanner} for the {@link CoreOptions.StartupMode#FROM_SNAPSHOT} startup mode of a
  * streaming read.
@@ -36,15 +34,15 @@ public class ContinuousFromSnapshotStartingScanner implements StartingScanner {
     }
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (earliestSnapshotId == null) {
-            return null;
+            return new NullResult();
         }
         // We should use `snapshotId - 1` here to start to scan delta data from specific snapshot
         // id. If the snapshotId < earliestSnapshotId, start to scan from the earliest.
-        return new Result(
-                snapshotId >= earliestSnapshotId ? snapshotId - 1 : earliestSnapshotId - 1);
+        return snapshotId > earliestSnapshotId
+                ? new ExistingSnapshotResult(snapshotId - 1)
+                : new NonExistingSnapshotResult(earliestSnapshotId - 1);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -44,10 +44,8 @@ public class ContinuousFromTimestampStartingScanner implements StartingScanner {
         Long startingSnapshotId = snapshotManager.earlierThanTimeMills(startupMillis);
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
-            return new NullResult();
+            return new NoSnapshot();
         }
-        return snapshotManager.snapshotExists(startingSnapshotId)
-                ? new ExistingSnapshotResult(startingSnapshotId)
-                : new NonExistingSnapshotResult(startingSnapshotId);
+        return new NextSnapshot(startingSnapshotId + 1);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -24,8 +24,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 /**
  * {@link StartingScanner} for the {@link CoreOptions.StartupMode#FROM_TIMESTAMP} startup mode of a
  * streaming read.
@@ -42,13 +40,14 @@ public class ContinuousFromTimestampStartingScanner implements StartingScanner {
     }
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long startingSnapshotId = snapshotManager.earlierThanTimeMills(startupMillis);
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
-            return null;
+            return new NullResult();
         }
-        return new Result(startingSnapshotId);
+        return snapshotManager.snapshotExists(startingSnapshotId)
+                ? new ExistingSnapshotResult(startingSnapshotId)
+                : new NonExistingSnapshotResult(startingSnapshotId);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
@@ -24,8 +24,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 /**
  * {@link StartingScanner} for the {@link CoreOptions.StartupMode#LATEST} startup mode of a
  * streaming read.
@@ -36,13 +34,12 @@ public class ContinuousLatestStartingScanner implements StartingScanner {
             LoggerFactory.getLogger(ContinuousLatestStartingScanner.class);
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-            return null;
+            return new NullResult();
         }
-        return new Result(startingSnapshotId);
+        return new ExistingSnapshotResult(startingSnapshotId);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
@@ -38,8 +38,8 @@ public class ContinuousLatestStartingScanner implements StartingScanner {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
-            return new NullResult();
+            return new NoSnapshot();
         }
-        return new ExistingSnapshotResult(startingSnapshotId);
+        return new NextSnapshot(startingSnapshotId + 1);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
@@ -35,9 +35,9 @@ public class FullStartingScanner implements StartingScanner {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
-            return new NullResult();
+            return new NoSnapshot();
         }
-        return new ExistingSnapshotResult(
+        return new ScannedResult(
                 startingSnapshotId,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
@@ -25,24 +25,20 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 /** {@link StartingScanner} for the {@link CoreOptions.StartupMode#LATEST_FULL} startup mode. */
 public class FullStartingScanner implements StartingScanner {
 
     private static final Logger LOG = LoggerFactory.getLogger(FullStartingScanner.class);
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
-            return null;
+            return new NullResult();
         }
-        return new Result(
+        return new ExistingSnapshotResult(
                 startingSnapshotId,
-                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshotId)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
@@ -42,6 +42,7 @@ public class FullStartingScanner implements StartingScanner {
         }
         return new Result(
                 startingSnapshotId,
+                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshotId)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
@@ -37,14 +37,17 @@ public interface StartingScanner {
     class Result {
 
         private final long snapshotId;
+        // whether the given snapshot has been fully read
+        private final boolean hasRead;
         private final List<DataSplit> splits;
 
         public Result(long snapshotId) {
-            this(snapshotId, Collections.emptyList());
+            this(snapshotId, false, Collections.emptyList());
         }
 
-        public Result(long snapshotId, List<DataSplit> splits) {
+        public Result(long snapshotId, boolean hasRead, List<DataSplit> splits) {
             this.snapshotId = snapshotId;
+            this.hasRead = hasRead;
             this.splits = splits;
         }
 
@@ -54,6 +57,10 @@ public interface StartingScanner {
 
         public List<DataSplit> splits() {
             return splits;
+        }
+
+        public boolean hasRead() {
+            return hasRead;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
@@ -22,7 +22,6 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.utils.SnapshotManager;
 
-import java.util.Collections;
 import java.util.List;
 
 /** Helper class for the first planning of {@link TableScan}. */
@@ -31,24 +30,10 @@ public interface StartingScanner {
     Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader);
 
     /** Scan result of {@link #scan}. */
-    interface Result {
-        long snapshotId();
-
-        List<DataSplit> splits();
-    }
+    interface Result {}
 
     /** Currently, there is no snapshot, need to wait for the snapshot to be generated. */
-    class NoSnapshot implements Result {
-        @Override
-        public long snapshotId() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public List<DataSplit> splits() {
-            throw new UnsupportedOperationException();
-        }
-    }
+    class NoSnapshot implements Result {}
 
     /** Result with scanned snapshot. Next snapshot should be the current snapshot plus 1. */
     class ScannedResult implements Result {
@@ -60,20 +45,18 @@ public interface StartingScanner {
             this.splits = splits;
         }
 
-        @Override
-        public long snapshotId() {
+        public long currentSnapshotId() {
             return currentSnapshotId;
         }
 
-        @Override
         public List<DataSplit> splits() {
             return splits;
         }
     }
 
     /**
-     * Return the next snapshot for followup scanning. The current snapshot is not scanned, so
-     * splits are always empty.
+     * Return the next snapshot for followup scanning. The current snapshot is not scanned (even
+     * doesn't exist), so there are no splits.
      */
     class NextSnapshot implements Result {
 
@@ -83,14 +66,8 @@ public interface StartingScanner {
             this.nextSnapshotId = nextSnapshotId;
         }
 
-        @Override
-        public long snapshotId() {
+        public long nextSnapshotId() {
             return nextSnapshotId;
-        }
-
-        @Override
-        public List<DataSplit> splits() {
-            return Collections.emptyList();
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -44,6 +44,7 @@ public class StaticFromSnapshotStartingScanner implements StartingScanner {
         }
         return new Result(
                 snapshotId,
+                true,
                 snapshotSplitReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).splits());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -22,8 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.utils.SnapshotManager;
 
-import javax.annotation.Nullable;
-
 /**
  * {@link StartingScanner} for the {@link CoreOptions.StartupMode#FROM_SNAPSHOT} or {@link
  * CoreOptions.StartupMode#FROM_SNAPSHOT_FULL} startup mode of a batch read.
@@ -36,15 +34,13 @@ public class StaticFromSnapshotStartingScanner implements StartingScanner {
     }
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         if (snapshotManager.earliestSnapshotId() == null
                 || snapshotId < snapshotManager.earliestSnapshotId()) {
-            return null;
+            return new NullResult();
         }
-        return new Result(
+        return new ExistingSnapshotResult(
                 snapshotId,
-                true,
                 snapshotSplitReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).splits());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -37,9 +37,9 @@ public class StaticFromSnapshotStartingScanner implements StartingScanner {
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         if (snapshotManager.earliestSnapshotId() == null
                 || snapshotId < snapshotManager.earliestSnapshotId()) {
-            return new NullResult();
+            return new NoSnapshot();
         }
-        return new ExistingSnapshotResult(
+        return new ScannedResult(
                 snapshotId,
                 snapshotSplitReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).splits());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -55,6 +55,7 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
         }
         return new Result(
                 startingSnapshot.id(),
+                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshot.id())

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -44,18 +44,16 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
     }
 
     @Override
-    @Nullable
     public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
         Snapshot startingSnapshot = timeTravelToTimestamp(snapshotManager, startupMillis);
         if (startingSnapshot == null) {
             LOG.debug(
                     "There is currently no snapshot earlier than or equal to timestamp[{}]",
                     startupMillis);
-            return null;
+            return new NullResult();
         }
-        return new Result(
+        return new ExistingSnapshotResult(
                 startingSnapshot.id(),
-                true,
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)
                         .withSnapshot(startingSnapshot.id())

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -50,9 +50,9 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
             LOG.debug(
                     "There is currently no snapshot earlier than or equal to timestamp[{}]",
                     startupMillis);
-            return new NullResult();
+            return new NoSnapshot();
         }
-        return new ExistingSnapshotResult(
+        return new ScannedResult(
                 startingSnapshot.id(),
                 snapshotSplitReader
                         .withKind(ScanKind.ALL)

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
@@ -58,6 +58,7 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
         CompactedStartingScanner scanner = new CompactedStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(3);
+        assertThat(result.hasRead()).isTrue();
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
@@ -58,7 +58,6 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
         CompactedStartingScanner scanner = new CompactedStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(3);
-        assertThat(result.hasRead()).isTrue();
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 
@@ -70,7 +69,8 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         CompactedStartingScanner scanner = new CompactedStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
@@ -56,8 +56,9 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(4);
 
         CompactedStartingScanner scanner = new CompactedStartingScanner();
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(3);
+        StartingScanner.ScannedResult result =
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.currentSnapshotId()).isEqualTo(3);
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 
@@ -89,7 +90,9 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
         CompactedStartingScanner scanner = new CompactedStartingScanner();
 
         // No compact snapshot found, reading from the latest snapshot
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader).snapshotId()).isEqualTo(1);
+        StartingScanner.ScannedResult result =
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.currentSnapshotId()).isEqualTo(1);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
@@ -70,7 +70,7 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
         SnapshotManager snapshotManager = table.snapshotManager();
         CompactedStartingScanner scanner = new CompactedStartingScanner();
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
@@ -59,10 +59,9 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(5);
 
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        // next snapshot
-        assertThat(result.snapshotId()).isEqualTo(4);
-        assertThat(result.splits()).isEmpty();
+        StartingScanner.NextSnapshot result =
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.nextSnapshotId()).isEqualTo(4);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
@@ -71,6 +71,7 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
@@ -60,7 +60,8 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
 
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(3);
+        // next snapshot
+        assertThat(result.snapshotId()).isEqualTo(4);
         assertThat(result.splits()).isEmpty();
 
         write.close();
@@ -72,6 +73,6 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -61,6 +61,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
+        assertThat(result.hasRead()).isFalse();
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -61,7 +61,6 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
-        assertThat(result.hasRead()).isFalse();
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();
@@ -73,7 +72,8 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(System.currentTimeMillis());
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -59,10 +59,9 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        // next snapshot
-        assertThat(result.snapshotId()).isEqualTo(3);
-        assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
+        StartingScanner.NextSnapshot result =
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.nextSnapshotId()).isEqualTo(3);
 
         write.close();
         commit.close();
@@ -94,10 +93,10 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
+        StartingScanner.NextSnapshot result =
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
         // next snapshot
-        assertThat(result.snapshotId()).isEqualTo(1);
-        assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
+        assertThat(result.nextSnapshotId()).isEqualTo(1);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -60,7 +60,8 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(2);
+        // next snapshot
+        assertThat(result.snapshotId()).isEqualTo(3);
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();
@@ -73,7 +74,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(System.currentTimeMillis());
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
     @Test
@@ -94,7 +95,8 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(0);
+        // next snapshot
+        assertThat(result.snapshotId()).isEqualTo(1);
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
@@ -51,6 +51,7 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
+        assertThat(result.hasRead()).isFalse();
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
@@ -50,7 +50,8 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
 
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(2);
+        // next snapshot
+        assertThat(result.snapshotId()).isEqualTo(3);
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();
@@ -62,6 +63,6 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
@@ -49,10 +49,9 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(2);
 
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        // next snapshot
-        assertThat(result.snapshotId()).isEqualTo(3);
-        assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
+        StartingScanner.NextSnapshot result =
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.nextSnapshotId()).isEqualTo(3);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
@@ -51,7 +51,6 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
-        assertThat(result.hasRead()).isFalse();
         assertThat(getResult(table.newRead(), toSplits(result.splits()))).isEmpty();
 
         write.close();
@@ -62,6 +61,7 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
@@ -57,7 +57,8 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
@@ -58,7 +58,7 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
@@ -46,8 +46,9 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(10);
 
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(8);
+        StartingScanner.ScannedResult result =
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.currentSnapshotId()).isEqualTo(8);
 
         write.close();
         commit.close();
@@ -87,7 +88,9 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
 
         // No compact snapshot found, reading from the latest snapshot
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader).snapshotId()).isEqualTo(4);
+        StartingScanner.ScannedResult result =
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.currentSnapshotId()).isEqualTo(4);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
@@ -65,6 +65,6 @@ public class FullStartingScannerTest extends ScannerTestBase {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullStartingScanner scanner = new FullStartingScanner();
         assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
-                .isInstanceOf(StartingScanner.NullResult.class);
+                .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
@@ -51,8 +51,9 @@ public class FullStartingScannerTest extends ScannerTestBase {
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(2);
 
         FullStartingScanner scanner = new FullStartingScanner();
-        StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
-        assertThat(result.snapshotId()).isEqualTo(2);
+        StartingScanner.ScannedResult result =
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+        assertThat(result.currentSnapshotId()).isEqualTo(2);
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
@@ -53,6 +53,7 @@ public class FullStartingScannerTest extends ScannerTestBase {
         FullStartingScanner scanner = new FullStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
+        assertThat(result.hasRead()).isTrue();
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
@@ -53,7 +53,6 @@ public class FullStartingScannerTest extends ScannerTestBase {
         FullStartingScanner scanner = new FullStartingScanner();
         StartingScanner.Result result = scanner.scan(snapshotManager, snapshotSplitReader);
         assertThat(result.snapshotId()).isEqualTo(2);
-        assertThat(result.hasRead()).isTrue();
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 
@@ -65,6 +64,7 @@ public class FullStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullStartingScanner scanner = new FullStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader)).isNull();
+        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+                .isInstanceOf(StartingScanner.NullResult.class);
     }
 }


### PR DESCRIPTION
### Purpose

At fully read phase of streaming scan,  the snapshot may not existed in some start up modes. BoundedChecker should not check the snapshot.

### Tests

`StreamTableScanTest#testStartingFromNonExistingSnapshot`

### API and Format 

No
### Documentation

No