### PR TITLE
Imgrate MinioTestContainer from the module of spark to paimon-s3 

### DIFF
--- a/paimon-filesystems/paimon-s3-impl/pom.xml
+++ b/paimon-filesystems/paimon-s3-impl/pom.xml
@@ -32,7 +32,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <fs.s3.aws.version>1.12.319</fs.s3.aws.version>
         <japicmp.skip>true</japicmp.skip>
     </properties>
 

--- a/paimon-filesystems/paimon-s3/pom.xml
+++ b/paimon-filesystems/paimon-s3/pom.xml
@@ -52,16 +52,54 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${fs.s3.aws.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${fs.s3.aws.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <!-- jaxb-api is packaged as an optional dependency that is only accessible on Java 11 -->
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-oss-jar</id>
+                        <id>copy-s3-jar</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>copy</goal>

--- a/paimon-filesystems/paimon-s3/src/test/java/org/apache/paimon/s3/MinioTestContainer.java
+++ b/paimon-filesystems/paimon-s3/src/test/java/org/apache/paimon/s3/MinioTestContainer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark;
+package org.apache.paimon.s3;
 
 import org.apache.paimon.testutils.junit.DockerImageVersions;
 import org.apache.paimon.utils.Preconditions;

--- a/paimon-filesystems/pom.xml
+++ b/paimon-filesystems/pom.xml
@@ -41,6 +41,7 @@
 
     <properties>
         <fs.hadoopshaded.version>3.3.4</fs.hadoopshaded.version>
+        <fs.s3.aws.version>1.12.319</fs.s3.aws.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
     </properties>
 

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkS3ITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkS3ITCase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.s3.MinioTestContainer;
 import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
 import org.apache.paimon.testutils.junit.parameterized.Parameters;
 

--- a/paimon-spark/pom.xml
+++ b/paimon-spark/pom.xml
@@ -66,6 +66,14 @@ under the License.
             <artifactId>paimon-s3</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-s3</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Imgrate MinioTestContainer from the module of spark to paimon-s3 ,in order that orther module such as flink,hive,presto can test the s3 FileSystem.