### PR TITLE
[test] Set docker environment with network name instead of netword id

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
@@ -91,6 +91,7 @@ public abstract class E2eTestBase {
         services.add("taskmanager");
 
         network = Network.newNetwork();
+        LOG.info("Network {} created", network.getId());
         environment =
                 new DockerComposeContainer<>(
                                 new File(
@@ -98,7 +99,7 @@ public abstract class E2eTestBase {
                                                 .getClassLoader()
                                                 .getResource("docker-compose.yaml")
                                                 .toURI()))
-                        .withEnv("NETWORK_ID", network.getId())
+                        .withEnv("NETWORK_ID", ((Network.NetworkImpl) network).getName())
                         .withLogConsumer("jobmanager_1", new LogConsumer(LOG))
                         .withLogConsumer("taskmanager_1", new LogConsumer(LOG))
                         .withLocalCompose(true);


### PR DESCRIPTION
### Purpose

fix #874 

![image](https://user-images.githubusercontent.com/26704332/231227099-80a9de63-bebe-4737-8bb2-0357c8a2b8bc.png)

### Why e2e tests can be passed on github actions, while it doesn't work on local MacOS?
I'll give the conclusion at first: the version of docker compose on Mac(v2.17.2) is higher than github actions environment(v1.29.2). 

Docker Compose is introduced by Docker Desktop in the local MacOS environment. While in the CI container of github actions,  Docker Compose is not pre-installed, which is introduced by testcontainers in ContainerisedDockerCompose. The version of Docker Compose is hard coded as "docker/compose:1.29.2"

#### Github Actions with Docker Compose v1.29.2
In Docker Compose v1.29.2, it'll call NetworkInspect API of the docker engine for external network searching. Within the backend implementation, it'll search the external networks with filter 'idOrName'，that's why the e2e tests can always be passed whether the $NETWORK_ID  is set with netword.id or netword.name.

**Docker compose: call inspect() by docker client.**
![image](https://user-images.githubusercontent.com/26704332/232194507-ff49d749-b7cf-44de-ac01-adde2c91f497.png)
![image](https://user-images.githubusercontent.com/26704332/232194513-f56e5e05-ac9d-4bbd-8c9a-bc03a995c733.png)

**docker-py client: send request to docker engine with url /networks/{id}**
![image](https://user-images.githubusercontent.com/26704332/232194536-6b4576b4-8745-4673-89bf-a21e80d49dcd.png)

**Docker engine: handle inspect request in getNetwork()**
![image](https://user-images.githubusercontent.com/26704332/232194598-b4fb07da-af87-4534-abdc-715c39f7f1b5.png)

**Docker engine: Filter networks whose name is equal to the query param or the id starts with the query param.**
![image](https://user-images.githubusercontent.com/26704332/232194662-bf463e60-9123-41a8-a746-bc6c238eb0c9.png)

#### Local MacOS with Docker Compose 2.17.2
In the local MacOS environment, Docker Compose calls NetworkList API with exact Name filter instead of NetworkInspect to avoid returning mismatched network by the prefix of network ID, which is explained in the comment.  So when Docker Compose is trying to find the external network with name = network.id, it couldn't be found. We need to set the environment with network.name in this case.

![image](https://user-images.githubusercontent.com/26704332/232194695-56f969a6-52b2-4e16-ac84-879cd377f972.png)


So, for both local and containerized environments compatibility, I suggest setting the network environment with network.name.