### PR TITLE
[flink] Add the compatibility check between StartupMode and LOG_SYSTEM

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -125,8 +125,8 @@ public abstract class AbstractFlinkTableFactory
                 || configOptions.get(SCAN_MODE) == FROM_SNAPSHOT_FULL) {
             throw new ValidationException(
                     String.format(
-                            "%s must be null when you use %s for %s",
-                            LOG_SYSTEM.key(), configOptions.get(SCAN_MODE), SCAN_MODE.key()));
+                            "Log system does not support %s and %s scan mode",
+                            FROM_SNAPSHOT, FROM_SNAPSHOT_FULL));
         }
 
         return Optional.of(discoverLogStoreFactory(classLoader, configOptions.get(LOG_SYSTEM)));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -54,7 +54,10 @@ import java.util.Set;
 
 import static org.apache.paimon.CoreOptions.LOG_CHANGELOG_MODE;
 import static org.apache.paimon.CoreOptions.LOG_CONSISTENCY;
+import static org.apache.paimon.CoreOptions.SCAN_MODE;
 import static org.apache.paimon.CoreOptions.STREAMING_READ_MODE;
+import static org.apache.paimon.CoreOptions.StartupMode.FROM_SNAPSHOT;
+import static org.apache.paimon.CoreOptions.StartupMode.FROM_SNAPSHOT_FULL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOG_SYSTEM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.NONE;
 import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
@@ -118,6 +121,12 @@ public abstract class AbstractFlinkTableFactory
             // Use file store continuous reading
             validateFileStoreContinuous(configOptions);
             return Optional.empty();
+        } else if (configOptions.get(SCAN_MODE) == FROM_SNAPSHOT
+                || configOptions.get(SCAN_MODE) == FROM_SNAPSHOT_FULL) {
+            throw new ValidationException(
+                    String.format(
+                            "%s must be null when you use %s for %s",
+                            LOG_SYSTEM.key(), configOptions.get(SCAN_MODE), SCAN_MODE.key()));
         }
 
         return Optional.of(discoverLogStoreFactory(classLoader, configOptions.get(LOG_SYSTEM)));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AbstractFlinkTableFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AbstractFlinkTableFactoryTest.java
@@ -18,14 +18,31 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.paimon.flink.kafka.KafkaLogStoreFactory;
+import org.apache.paimon.flink.kafka.KafkaLogTestUtils;
+import org.apache.paimon.flink.log.LogStoreTableFactory;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
+import static org.apache.paimon.CoreOptions.LogChangelogMode;
+import static org.apache.paimon.CoreOptions.LogConsistency;
+import static org.apache.paimon.CoreOptions.SCAN_MODE;
+import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
+import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
+import static org.apache.paimon.CoreOptions.StartupMode;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link AbstractFlinkTableFactory}. */
@@ -51,6 +68,42 @@ public class AbstractFlinkTableFactoryTest {
                                 new RowType.RowField("foo", new VarCharType()),
                                 new RowType.RowField("bar", new IntType(), "comment about bar"))),
                 true);
+    }
+
+    @ParameterizedTest
+    @EnumSource(StartupMode.class)
+    public void testCreateKafkaLogStoreFactory(StartupMode startupMode) {
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(FlinkConnectorOptions.LOG_SYSTEM.key(), "kafka");
+        dynamicOptions.put(SCAN_MODE.key(), startupMode.toString());
+        if (startupMode == StartupMode.FROM_SNAPSHOT
+                || startupMode == StartupMode.FROM_SNAPSHOT_FULL) {
+            dynamicOptions.put(SCAN_SNAPSHOT_ID.key(), "1");
+        } else if (startupMode == StartupMode.FROM_TIMESTAMP) {
+            dynamicOptions.put(
+                    SCAN_TIMESTAMP_MILLIS.key(), String.valueOf(System.currentTimeMillis()));
+        }
+        dynamicOptions.put(SCAN_MODE.key(), startupMode.toString());
+        DynamicTableFactory.Context context =
+                KafkaLogTestUtils.testContext(
+                        "table",
+                        "",
+                        LogChangelogMode.AUTO,
+                        LogConsistency.TRANSACTIONAL,
+                        RowType.of(new IntType(), new IntType()),
+                        new int[] {0},
+                        dynamicOptions);
+
+        try {
+            Optional<LogStoreTableFactory> optional =
+                    AbstractFlinkTableFactory.createOptionalLogStoreFactory(context);
+            assertThat(startupMode)
+                    .isNotIn(StartupMode.FROM_SNAPSHOT, StartupMode.FROM_SNAPSHOT_FULL);
+            assertThat(optional.isPresent()).isTrue();
+            assertThat(optional.get()).isInstanceOf(KafkaLogStoreFactory.class);
+        } catch (ValidationException e) {
+            assertThat(startupMode).isIn(StartupMode.FROM_SNAPSHOT, StartupMode.FROM_SNAPSHOT_FULL);
+        }
     }
 
     private void innerTest(RowType r1, RowType r2, boolean expectEquals) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
@@ -178,7 +178,8 @@ public class KafkaLogTestUtils {
                 changelogMode,
                 consistency,
                 RowType.of(new IntType(), new IntType()),
-                keyed ? new int[] {0} : new int[0]);
+                keyed ? new int[] {0} : new int[0],
+                new HashMap<>());
     }
 
     public static DynamicTableFactory.Context testContext(
@@ -187,12 +188,14 @@ public class KafkaLogTestUtils {
             LogChangelogMode changelogMode,
             LogConsistency consistency,
             RowType type,
-            int[] keys) {
+            int[] keys,
+            Map<String, String> dynamicOptions) {
         Map<String, String> options = new HashMap<>();
         options.put(LOG_CHANGELOG_MODE.key(), changelogMode.toString());
         options.put(LOG_CONSISTENCY.key(), consistency.toString());
         options.put(BOOTSTRAP_SERVERS.key(), servers);
         options.put(TOPIC.key(), UUID.randomUUID().toString());
+        options.putAll(dynamicOptions);
         return createContext(name, type, keys, options);
     }
 


### PR DESCRIPTION


### Purpose

Add the compatibility check between `StartupMode` and `LOG_SYSTEM`.  #846

### Tests

Added `org.apache.paimon.flink.AbstractFlinkTableFactoryTest#testCreateKafkaLogStoreFactory` to verify compatibility between `StartupMode` and `LOG_SYSTEM`.

### API and Format 

No.

### Documentation

No.
