### PR TITLE
[flink] Introduce process functions and sinks for CDC database syncing

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -95,6 +95,11 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
         }
     }
 
+    @Override
+    public String tableName() {
+        return payload.get("source").get("table").asText();
+    }
+
     private void updateFieldTypes(JsonNode schema) {
         mySqlFieldTypes = new HashMap<>();
         fieldClassNames = new HashMap<>();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -25,7 +25,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.sink.cdc.EventParser;
-import org.apache.paimon.flink.sink.cdc.FlinkCdcSinkBuilder;
+import org.apache.paimon.flink.sink.cdc.FlinkCdcSyncTableSinkBuilder;
 import org.apache.paimon.flink.sink.cdc.SchemaChangeProcessFunction;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
@@ -167,8 +167,8 @@ public class MySqlSyncTableAction implements Action {
             parserFactory = MySqlDebeziumJsonEventParser::new;
         }
 
-        FlinkCdcSinkBuilder<String> sinkBuilder =
-                new FlinkCdcSinkBuilder<String>()
+        FlinkCdcSyncTableSinkBuilder<String> sinkBuilder =
+                new FlinkCdcSyncTableSinkBuilder<String>()
                         .withInput(
                                 env.fromSource(
                                         source, WatermarkStrategy.noWatermarks(), "MySQL Source"))

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -32,6 +32,8 @@ public interface EventParser<T> {
 
     void setRawEvent(T rawEvent);
 
+    String tableName();
+
     boolean isSchemaChange();
 
     List<SchemaChange> getSchemaChanges();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.flink.sink.BucketingStreamPartitioner;
+import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builder for {@link FlinkCdcSink} when syncing the whole database into one Paimon database. Each
+ * database table will be written into a separate Paimon table.
+ *
+ * <p>This builder will create a separate sink for each Paimon sink table. Thus this implementation
+ * is not very efficient in resource saving.
+ *
+ * @param <T> CDC change event type
+ */
+public class FlinkCdcSyncDatabaseSinkBuilder<T> {
+
+    private DataStream<T> input = null;
+    private EventParser.Factory<T> parserFactory = null;
+    private List<FileStoreTable> tables = new ArrayList<>();
+    private Lock.Factory lockFactory = Lock.emptyFactory();
+
+    @Nullable private Integer parallelism;
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withInput(DataStream<T> input) {
+        this.input = input;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withParserFactory(
+            EventParser.Factory<T> parserFactory) {
+        this.parserFactory = parserFactory;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withTables(List<FileStoreTable> tables) {
+        this.tables = tables;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withLockFactory(Lock.Factory lockFactory) {
+        this.lockFactory = lockFactory;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withParallelism(@Nullable Integer parallelism) {
+        this.parallelism = parallelism;
+        return this;
+    }
+
+    public void build() {
+        Preconditions.checkNotNull(input);
+        Preconditions.checkNotNull(parserFactory);
+
+        StreamExecutionEnvironment env = input.getExecutionEnvironment();
+
+        SingleOutputStreamOperator<Void> parsed =
+                input.forward()
+                        .process(new CdcMultiTableParsingProcessFunction<>(parserFactory))
+                        .setParallelism(input.getParallelism());
+
+        for (FileStoreTable table : tables) {
+            DataStream<Void> schemaChangeProcessFunction =
+                    SingleOutputStreamOperatorUtils.getSideOutput(
+                                    parsed,
+                                    CdcMultiTableParsingProcessFunction.createSchemaChangeOutputTag(
+                                            table.name()))
+                            .process(
+                                    new SchemaChangeProcessFunction(
+                                            new SchemaManager(table.fileIO(), table.location())));
+            schemaChangeProcessFunction.getTransformation().setParallelism(1);
+
+            BucketingStreamPartitioner<CdcRecord> partitioner =
+                    new BucketingStreamPartitioner<>(new CdcRecordChannelComputer(table.schema()));
+            PartitionTransformation<CdcRecord> partitioned =
+                    new PartitionTransformation<>(
+                            SingleOutputStreamOperatorUtils.getSideOutput(
+                                            parsed,
+                                            CdcMultiTableParsingProcessFunction
+                                                    .createRecordOutputTag(table.name()))
+                                    .getTransformation(),
+                            partitioner);
+            if (parallelism != null) {
+                partitioned.setParallelism(parallelism);
+            }
+
+            FlinkCdcSink sink = new FlinkCdcSink(table, lockFactory);
+            sink.sinkFrom(new DataStream<>(env, partitioned));
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -100,6 +100,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
                                     new SchemaChangeProcessFunction(
                                             new SchemaManager(table.fileIO(), table.location())));
             schemaChangeProcessFunction.getTransformation().setParallelism(1);
+            schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
             BucketingStreamPartitioner<CdcRecord> partitioner =
                     new BucketingStreamPartitioner<>(new CdcRecordChannelComputer(table.schema()));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkBuilder.java
@@ -34,11 +34,11 @@ import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import javax.annotation.Nullable;
 
 /**
- * Builder for {@link FlinkCdcSink}.
+ * Builder for {@link FlinkCdcSink} when syncing multiple database tables into one Paimon table.
  *
  * @param <T> CDC change event type
  */
-public class FlinkCdcSinkBuilder<T> {
+public class FlinkCdcSyncTableSinkBuilder<T> {
 
     private DataStream<T> input = null;
     private EventParser.Factory<T> parserFactory = null;
@@ -47,27 +47,27 @@ public class FlinkCdcSinkBuilder<T> {
 
     @Nullable private Integer parallelism;
 
-    public FlinkCdcSinkBuilder<T> withInput(DataStream<T> input) {
+    public FlinkCdcSyncTableSinkBuilder<T> withInput(DataStream<T> input) {
         this.input = input;
         return this;
     }
 
-    public FlinkCdcSinkBuilder<T> withParserFactory(EventParser.Factory<T> parserFactory) {
+    public FlinkCdcSyncTableSinkBuilder<T> withParserFactory(EventParser.Factory<T> parserFactory) {
         this.parserFactory = parserFactory;
         return this;
     }
 
-    public FlinkCdcSinkBuilder<T> withTable(FileStoreTable table) {
+    public FlinkCdcSyncTableSinkBuilder<T> withTable(FileStoreTable table) {
         this.table = table;
         return this;
     }
 
-    public FlinkCdcSinkBuilder<T> withLockFactory(Lock.Factory lockFactory) {
+    public FlinkCdcSyncTableSinkBuilder<T> withLockFactory(Lock.Factory lockFactory) {
         this.lockFactory = lockFactory;
         return this;
     }
 
-    public FlinkCdcSinkBuilder<T> withParallelism(@Nullable Integer parallelism) {
+    public FlinkCdcSyncTableSinkBuilder<T> withParallelism(@Nullable Integer parallelism) {
         this.parallelism = parallelism;
         return this;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkBuilder.java
@@ -89,6 +89,7 @@ public class FlinkCdcSyncTableSinkBuilder<T> {
                                 new SchemaChangeProcessFunction(
                                         new SchemaManager(table.fileIO(), table.location())));
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
+        schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
         BucketingStreamPartitioner<CdcRecord> partitioner =
                 new BucketingStreamPartitioner<>(new CdcRecordChannelComputer(table.schema()));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogUtils;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.util.AbstractTestBase;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReaderIterator;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FailingFileIO;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** IT cases for {@link FlinkCdcSyncDatabaseSinkBuilder}. */
+public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
+
+    private static final String DATABASE_NAME = "test";
+    private static final String TABLE_NAME = "test_tbl";
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    @Timeout(120)
+    public void testRandomCdcEvents() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        int numTables = random.nextInt(3) + 1;
+        boolean enableFailure = random.nextBoolean();
+
+        int maxEvents = 1500;
+        int maxSchemaChanges = 10;
+        int maxPartitions = 3;
+        int maxKeys = 150;
+        int maxBuckets = 5;
+
+        String failingName = UUID.randomUUID().toString();
+
+        List<TestTable> testTables = new ArrayList<>();
+        List<FileStoreTable> fileStoreTables = new ArrayList<>();
+        for (int i = 0; i < numTables; i++) {
+            String tableName = TABLE_NAME + i;
+            TestTable testTable =
+                    new TestTable(
+                            tableName,
+                            random.nextInt(maxEvents) + 1,
+                            random.nextInt(maxSchemaChanges) + 1,
+                            random.nextInt(maxPartitions) + 1,
+                            random.nextInt(maxKeys) + 1);
+            testTables.add(testTable);
+
+            Path tablePath;
+            FileIO fileIO;
+            if (enableFailure) {
+                tablePath =
+                        new Path(
+                                FailingFileIO.getFailingPath(
+                                        failingName,
+                                        CatalogUtils.stringifyPath(
+                                                tempDir.toString(), DATABASE_NAME, tableName)));
+                fileIO = new FailingFileIO();
+            } else {
+                tablePath =
+                        new Path(
+                                TraceableFileIO.SCHEME
+                                        + "://"
+                                        + CatalogUtils.stringifyPath(
+                                                tempDir.toString(), DATABASE_NAME, tableName));
+                fileIO = LocalFileIO.create();
+            }
+
+            // no failure when creating table
+            FailingFileIO.reset(failingName, 0, 1);
+
+            FileStoreTable fileStoreTable =
+                    createFileStoreTable(
+                            tablePath,
+                            fileIO,
+                            testTable.initialRowType(),
+                            Collections.singletonList("pt"),
+                            Arrays.asList("pt", "k"),
+                            random.nextInt(maxBuckets) + 1);
+            fileStoreTables.add(fileStoreTable);
+        }
+
+        List<TestCdcEvent> events = mergeTestTableEvents(testTables);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getCheckpointConfig().setCheckpointInterval(100);
+        if (!enableFailure) {
+            env.setRestartStrategy(RestartStrategies.noRestart());
+        }
+
+        TestCdcSourceFunction sourceFunction = new TestCdcSourceFunction(events);
+        DataStreamSource<TestCdcEvent> source = env.addSource(sourceFunction);
+        source.setParallelism(2);
+        new FlinkCdcSyncDatabaseSinkBuilder<TestCdcEvent>()
+                .withInput(source)
+                .withParserFactory(TestCdcEventParser::new)
+                .withTables(fileStoreTables)
+                // because we have at most 3 tables and 8 slots in AbstractTestBase
+                // each table can only get 2 slots
+                .withParallelism(2)
+                .build();
+
+        // enable failure when running jobs if needed
+        FailingFileIO.reset(failingName, 10, 10000);
+
+        env.execute();
+
+        // no failure when checking results
+        FailingFileIO.reset(failingName, 0, 1);
+
+        for (int i = 0; i < numTables; i++) {
+            FileStoreTable table = fileStoreTables.get(i).copyWithLatestSchema();
+            SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+            TableSchema schema = schemaManager.latest().get();
+
+            TableScan.Plan plan = table.newScan().plan();
+            try (RecordReaderIterator<InternalRow> it =
+                    new RecordReaderIterator<>(table.newRead().createReader(plan))) {
+                testTables.get(i).assertResult(schema, it);
+            }
+        }
+    }
+
+    private FileStoreTable createFileStoreTable(
+            Path tablePath,
+            FileIO fileIO,
+            RowType rowType,
+            List<String> partitions,
+            List<String> primaryKeys,
+            int numBucket)
+            throws Exception {
+        Options conf = new Options();
+        conf.set(CoreOptions.BUCKET, numBucket);
+        conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
+        conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
+
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(fileIO, tablePath),
+                        new Schema(rowType.getFields(), partitions, primaryKeys, conf.toMap(), ""));
+        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema);
+    }
+
+    private List<TestCdcEvent> mergeTestTableEvents(List<TestTable> testTables) {
+        List<Integer> toShuffle = new ArrayList<>();
+        for (int i = 0; i < testTables.size(); i++) {
+            for (int j = 0; j < testTables.get(i).events().size(); j++) {
+                toShuffle.add(i);
+            }
+        }
+        Collections.shuffle(toShuffle);
+
+        List<TestCdcEvent> events = new ArrayList<>();
+        for (int idx : toShuffle) {
+            events.add(testTables.get(idx).events().poll());
+        }
+        return events;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEvent.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEvent.java
@@ -28,17 +28,27 @@ public class TestCdcEvent implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private final String tableName;
     private final SchemaChange schemaChange;
     private final List<CdcRecord> records;
+    private final int keyHash;
 
-    public TestCdcEvent(SchemaChange schemaChange) {
+    public TestCdcEvent(String tableName, SchemaChange schemaChange) {
+        this.tableName = tableName;
         this.schemaChange = schemaChange;
         this.records = null;
+        this.keyHash = 0;
     }
 
-    public TestCdcEvent(List<CdcRecord> records) {
+    public TestCdcEvent(String tableName, List<CdcRecord> records, int keyHash) {
+        this.tableName = tableName;
         this.schemaChange = null;
         this.records = records;
+        this.keyHash = keyHash;
+    }
+
+    public String tableName() {
+        return tableName;
     }
 
     public SchemaChange schemaChange() {
@@ -50,7 +60,14 @@ public class TestCdcEvent implements Serializable {
     }
 
     @Override
+    public int hashCode() {
+        return keyHash;
+    }
+
+    @Override
     public String toString() {
-        return String.format("{schemChange = %s, records = %s}", schemaChange, records);
+        return String.format(
+                "{tableName = %s, schemChange = %s, records = %s}",
+                tableName, schemaChange, records);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
@@ -34,6 +34,11 @@ public class TestCdcEventParser implements EventParser<TestCdcEvent> {
     }
 
     @Override
+    public String tableName() {
+        return raw.tableName();
+    }
+
+    @Override
     public boolean isSchemaChange() {
         return raw.schemaChange() != null;
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestTable.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestTable.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Generate test data for {@link FlinkCdcSyncTableSinkITCase} and {@link
+ * FlinkCdcSyncDatabaseSinkITCase}.
+ */
+public class TestTable {
+
+    private final RowType initialRowType;
+
+    private final Queue<TestCdcEvent> events;
+    private final Map<Integer, Map<String, String>> expected;
+
+    public TestTable(
+            String tableName, int numEvents, int numSchemaChanges, int numPartitions, int numKeys) {
+        List<String> fieldNames = new ArrayList<>();
+        List<Boolean> isBigInt = new ArrayList<>();
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int numFields = random.nextInt(5) + 1;
+
+        DataType[] initialFieldTypes = new DataType[2 + numFields];
+        initialFieldTypes[0] = DataTypes.INT();
+        initialFieldTypes[1] = DataTypes.INT();
+
+        String[] initialFieldNames = new String[2 + numFields];
+        initialFieldNames[0] = "pt";
+        initialFieldNames[1] = "k";
+
+        for (int i = 0; i < numFields; i++) {
+            fieldNames.add("v" + i);
+            initialFieldNames[2 + i] = "v" + i;
+
+            if (random.nextBoolean()) {
+                isBigInt.add(true);
+                initialFieldTypes[2 + i] = DataTypes.BIGINT();
+            } else {
+                isBigInt.add(false);
+                initialFieldTypes[2 + i] = DataTypes.INT();
+            }
+        }
+
+        initialRowType = RowType.of(initialFieldTypes, initialFieldNames);
+
+        Set<Integer> schemaChangePositions = new HashSet<>();
+
+        // if numSchemaChanges is larger than numEvents, the following loop will never end
+        // we can, of course, use fisher's algorithm or such, but let's make things simple for tests
+        numSchemaChanges = Math.min(numSchemaChanges, numEvents / 2);
+        for (int i = 0; i < numSchemaChanges; i++) {
+            int pos;
+            do {
+                pos = random.nextInt(numEvents);
+            } while (schemaChangePositions.contains(pos));
+            schemaChangePositions.add(pos);
+        }
+
+        events = new LinkedList<>();
+        expected = new HashMap<>();
+        for (int i = 0; i < numEvents; i++) {
+            if (schemaChangePositions.contains(i)) {
+                if (random.nextBoolean()) {
+                    int idx = random.nextInt(fieldNames.size());
+                    isBigInt.set(idx, true);
+                    events.add(
+                            new TestCdcEvent(
+                                    tableName,
+                                    SchemaChange.updateColumnType(
+                                            fieldNames.get(idx), DataTypes.BIGINT())));
+                } else {
+                    String newName = "v" + fieldNames.size();
+                    fieldNames.add(newName);
+                    isBigInt.add(false);
+                    events.add(
+                            new TestCdcEvent(
+                                    tableName, SchemaChange.addColumn(newName, DataTypes.INT())));
+                }
+            } else {
+                Map<String, String> fields = new HashMap<>();
+                int key = random.nextInt(numKeys);
+                fields.put("k", String.valueOf(key));
+                int pt = key % numPartitions;
+                fields.put("pt", String.valueOf(pt));
+
+                for (int j = 0; j < fieldNames.size(); j++) {
+                    String fieldName = fieldNames.get(j);
+                    if (isBigInt.get(j)) {
+                        fields.put(fieldName, String.valueOf(random.nextLong()));
+                    } else {
+                        fields.put(fieldName, String.valueOf(random.nextInt()));
+                    }
+                }
+
+                List<CdcRecord> records = new ArrayList<>();
+                if (expected.containsKey(key)) {
+                    records.add(new CdcRecord(RowKind.DELETE, expected.get(key)));
+                }
+                records.add(new CdcRecord(RowKind.INSERT, fields));
+                events.add(new TestCdcEvent(tableName, records, Objects.hash(tableName, key)));
+                expected.put(key, fields);
+            }
+        }
+    }
+
+    public RowType initialRowType() {
+        return initialRowType;
+    }
+
+    public Queue<TestCdcEvent> events() {
+        return events;
+    }
+
+    public void assertResult(TableSchema schema, Iterator<InternalRow> it) {
+        Map<Integer, Map<String, String>> actual = new HashMap<>();
+        while (it.hasNext()) {
+            InternalRow row = it.next();
+            Map<String, String> fields = new HashMap<>();
+            for (int i = 0; i < schema.fieldNames().size(); i++) {
+                if (!row.isNullAt(i)) {
+                    fields.put(
+                            schema.fieldNames().get(i),
+                            String.valueOf(
+                                    schema.fields().get(i).type().equals(DataTypes.BIGINT())
+                                            ? row.getLong(i)
+                                            : row.getInt(i)));
+                }
+            }
+            actual.put(Integer.valueOf(fields.get("k")), fields);
+        }
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
### Purpose

This PR introduces `CdcMultiTableParsingProcessFunction` and `FlinkCdcSyncDatabaseSinkBuilder` which creates a separate Paimon sink for each table in the source database. With the new sink, we can support CDC database syncing.

The current implementation is not very efficient in resource saving. We may refine this implementation by merging all sinks into one instance in the future.

### Tests

* FlinkCdcSyncDatabaseSinkITCase

### API and Format 

N/A

### Documentation

N/A
