### PR TITLE
[hotfix] add column 'already exists' and 'does not exist' exception type

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -283,4 +283,58 @@ public interface Catalog extends AutoCloseable {
             return identifier;
         }
     }
+
+    /** Exception for trying to alter a column that already exists. */
+    class ColumnAlreadyExistException extends Exception {
+
+        private static final String MSG = "Column %s already exists in the %s table.";
+
+        private final Identifier identifier;
+        private final String column;
+
+        public ColumnAlreadyExistException(Identifier identifier, String column) {
+            this(identifier, column, null);
+        }
+
+        public ColumnAlreadyExistException(Identifier identifier, String column, Throwable cause) {
+            super(String.format(MSG, column, identifier.getFullName()), cause);
+            this.identifier = identifier;
+            this.column = column;
+        }
+
+        public Identifier identifier() {
+            return identifier;
+        }
+
+        public String column() {
+            return column;
+        }
+    }
+
+    /** Exception for trying to operate on a table that doesn't exist. */
+    class ColumnNotExistException extends Exception {
+
+        private static final String MSG = "Column %s does not exist in the %s table.";
+
+        private final Identifier identifier;
+        private final String column;
+
+        public ColumnNotExistException(Identifier identifier, String column) {
+            this(identifier, column, null);
+        }
+
+        public ColumnNotExistException(Identifier identifier, String column, Throwable cause) {
+            super(String.format(MSG, column, identifier.getFullName()), cause);
+            this.identifier = identifier;
+            this.column = column;
+        }
+
+        public Identifier identifier() {
+            return identifier;
+        }
+
+        public String column() {
+            return column;
+        }
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -439,7 +439,7 @@ public abstract class CatalogTestBase {
                                         false))
                 .withMessage("Table test_db.non_existing_table does not exist.");
 
-        // Alter table adds a column throws Exception when column already exists
+        // Alter table adds a column throws ColumnAlreadyExistException when column already exists
         assertThatThrownBy(
                         () ->
                                 catalog.alterTable(
@@ -447,8 +447,8 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.addColumn("col1", DataTypes.INT())),
                                         false))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("The column [col1] exists in the table");
+                .hasRootCauseInstanceOf(Catalog.ColumnAlreadyExistException.class)
+                .hasRootCauseMessage("Column col1 already exists in the test_db.test_table table.");
     }
 
     @Test
@@ -476,7 +476,8 @@ public abstract class CatalogTestBase {
         assertThat(table.rowType().getFieldIndex("col1")).isLessThan(0);
         assertThat(table.rowType().getFieldIndex("new_col1")).isEqualTo(0);
 
-        // Alter table renames a new column throws Exception when column already exists
+        // Alter table renames a new column throws ColumnAlreadyExistException when column already
+        // exists
         assertThatThrownBy(
                         () ->
                                 catalog.alterTable(
@@ -484,10 +485,11 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.renameColumn("col1", "new_col1")),
                                         false))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("The column [new_col1] exists in the table");
+                .hasRootCauseInstanceOf(Catalog.ColumnAlreadyExistException.class)
+                .hasRootCauseMessage(
+                        "Column new_col1 already exists in the test_db.test_table table.");
 
-        // Alter table renames a column throws Exception when column does not exist
+        // Alter table renames a column throws ColumnNotExistException when column does not exist
         assertThatThrownBy(
                         () ->
                                 catalog.alterTable(
@@ -496,7 +498,9 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.renameColumn(
                                                         "non_existing_col", "new_col2")),
                                         false))
-                .hasMessageContaining("Can not find column: [non_existing_col]");
+                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
+                .hasRootCauseMessage(
+                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
     }
 
     @Test
@@ -532,7 +536,7 @@ public abstract class CatalogTestBase {
                 .hasRootCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(" Cannot drop all fields in table");
 
-        // Alter table drop a column throws Exception when column does not exist
+        // Alter table drop a column ColumnNotExistException when column does not exist
         assertThatThrownBy(
                         () ->
                                 catalog.alterTable(
@@ -540,7 +544,9 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.dropColumn("non_existing_col")),
                                         false))
-                .hasMessageContaining("The column [non_existing_col] doesn't exist in the table");
+                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
+                .hasRootCauseMessage(
+                        "Column non_existing_col does not exist in the test_db.test_table table.");
     }
 
     @Test
@@ -583,7 +589,8 @@ public abstract class CatalogTestBase {
                 .hasMessageContaining(
                         "Column type col1[DOUBLE] cannot be converted to STRING without loosing information.");
 
-        // Alter table update a column type throws Exception when column does not exist
+        // Alter table update a column type throws ColumnNotExistException when column does not
+        // exist
         assertThatThrownBy(
                         () ->
                                 catalog.alterTable(
@@ -592,7 +599,9 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnType(
                                                         "non_existing_col", DataTypes.INT())),
                                         false))
-                .hasMessageContaining("Can not find column: [non_existing_col]");
+                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
+                .hasRootCauseMessage(
+                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
 
         // Alter table update a column type throws Exception when column is partition columns
         assertThatThrownBy(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/SchemaChangeProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/SchemaChangeProcessFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -57,7 +58,7 @@ public class SchemaChangeProcessFunction extends ProcessFunction<SchemaChange, V
         if (schemaChange instanceof SchemaChange.AddColumn) {
             try {
                 schemaManager.commitChanges(schemaChange);
-            } catch (IllegalArgumentException e) {
+            } catch (Catalog.ColumnAlreadyExistException e) {
                 // This is normal. For example when a table is split into multiple database tables,
                 // all these tables will be added the same column. However schemaManager can't
                 // handle duplicated column adds, so we just catch the exception and log it.

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.FileIO;
@@ -55,6 +56,8 @@ import java.util.concurrent.ThreadLocalRandom;
 public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
 
     @TempDir java.nio.file.Path tempDir;
+    private static final String DATABASE_NAME = "test";
+    private static final String TABLE_NAME = "test_tbl";
 
     @Test
     @Timeout(120)
@@ -69,16 +72,26 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         boolean enableFailure = random.nextBoolean();
 
         TestTable testTable =
-                new TestTable("test_tbl", numEvents, numSchemaChanges, numPartitions, numKeys);
+                new TestTable(TABLE_NAME, numEvents, numSchemaChanges, numPartitions, numKeys);
 
         Path tablePath;
         FileIO fileIO;
         String failingName = UUID.randomUUID().toString();
+
         if (enableFailure) {
-            tablePath = new Path(FailingFileIO.getFailingPath(failingName, tempDir.toString()));
+            tablePath =
+                    new Path(
+                            FailingFileIO.getFailingPath(
+                                    failingName,
+                                    CatalogUtils.stringifyPath(
+                                            tempDir.toString(), DATABASE_NAME, TABLE_NAME)));
             fileIO = new FailingFileIO();
         } else {
-            tablePath = new Path(TraceableFileIO.SCHEME + "://" + tempDir.toString());
+            tablePath =
+                    new Path(
+                            TraceableFileIO.SCHEME + "://",
+                            CatalogUtils.stringifyPath(
+                                    tempDir.toString(), DATABASE_NAME, TABLE_NAME));
             fileIO = LocalFileIO.create();
         }
 


### PR DESCRIPTION
*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

*(What is the purpose of the change, or the associated issue)*

This pr closes #900 

At present, the columns `already exists` and `does not exist` abnormal printing information are as follows:

![image](https://user-images.githubusercontent.com/37063904/231715023-020b95df-1dae-4092-b628-e20a3387b825.png)

![image](https://user-images.githubusercontent.com/37063904/231715068-b1cdc096-3856-42db-9791-32fdf9ca8b01.png)

Modified:

![iShot_2023-04-13_17 23 20](https://user-images.githubusercontent.com/37063904/231725474-a27f04ef-bb06-412f-87e7-1a2ffddbe7ad.png)

![iShot_2023-04-13_17 23 09](https://user-images.githubusercontent.com/37063904/231725492-5e6d01bc-de52-4312-87a8-a408b04a092d.png)



### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
