### PR TITLE
[core]Fix the typo in the description of orc.bloom.filter.columns

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -210,7 +210,7 @@
             <td><h5>orc.bloom.filter.columns</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>A comma-separated list of columns for which to create a bloon filter when writing.</td>
+            <td>A comma-separated list of columns for which to create a bloom filter when writing.</td>
         </tr>
         <tr>
             <td><h5>orc.bloom.filter.fpp</h5></td>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -94,7 +94,7 @@ public class CoreOptions implements Serializable {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "A comma-separated list of columns for which to create a bloon filter when writing.");
+                            "A comma-separated list of columns for which to create a bloom filter when writing.");
 
     public static final ConfigOption<Double> ORC_BLOOM_FILTER_FPP =
             key("orc.bloom.filter.fpp")


### PR DESCRIPTION

### Purpose

Fix the typo in the description of orc.bloom.filter.columns

### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
