### PR TITLE
[pom] Comment the repositories tag in pom.xml to speed up maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ JDK 8/11 is required for building the project.
 - Run the `mvn spotless:apply` to format the project (both Java and Scala).
 - IDE: Mark `paimon-common/target/generated-sources/antlr4` as Sources Root.
 
+If you fail to download paimon-bundle snapshot files during the build, it is likely that your maven settings file does not include a snapshot repository. Uncomment the "repositories" tag in [pom.xml](pom.xml) file for a workaround.
+
 ## License
 
 The code in this repository is licensed under the [Apache Software License 2](LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -927,6 +927,12 @@ under the License.
         </pluginManagement>
     </build>
 
+    <!--
+    Uncomment the following "repositories" tag if your maven fails to download paimon-bundle snapshot files.
+    We comment these tags by default because downloading from apache repositories is very slow for both github and developers.
+    -->
+
+    <!--
     <repositories>
         <repository>
             <id>apache-releases</id>
@@ -939,4 +945,5 @@ under the License.
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+    -->
 </project>


### PR DESCRIPTION
### Purpose

After #884, project building time increases from 5 minutes to 15 minutes in a github action. This is because downloading dependencies from apache repositories is very slow.

This PR comments the repositories tag in pom.xml to speed up maven build. This PR also adds a notice in the README file for users who do not have a snapshot repositories in their maven settings.

### Tests

N/A

### API and Format 

N/A

### Documentation

N/A
