### PR TITLE
[flink] check compatibility for some data type

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -184,12 +184,14 @@ public class MySqlTypeUtils {
             case VARCHAR:
                 return DataTypes.VARCHAR(Preconditions.checkNotNull(length));
             case TEXT:
+            case LONGTEXT:
                 return DataTypes.STRING();
             case BINARY:
                 return DataTypes.BINARY(Preconditions.checkNotNull(length));
             case VARBINARY:
                 return DataTypes.VARBINARY(Preconditions.checkNotNull(length));
             case BLOB:
+            case LONGBLOB:
                 return DataTypes.BYTES();
             default:
                 throw new UnsupportedOperationException(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -415,9 +415,11 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                             DataTypes.CHAR(10), // _char
                             DataTypes.VARCHAR(20), // _varchar
                             DataTypes.STRING(), // _text
+                            DataTypes.STRING(), // _longtext
                             DataTypes.BINARY(10), // _bin
                             DataTypes.VARBINARY(20), // _varbin
-                            DataTypes.BYTES() // _blob
+                            DataTypes.BYTES(), // _blob
+                            DataTypes.BYTES() // _longblob
                         },
                         new String[] {
                             "_id",
@@ -469,9 +471,11 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                             "_char",
                             "_varchar",
                             "_text",
+                            "_longtext",
                             "_bin",
                             "_varbin",
-                            "_blob"
+                            "_blob",
+                            "_longblob"
                         });
         FileStoreTable table = getFileStoreTable();
         List<String> expected =
@@ -493,10 +497,11 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                                 + "2023-03-23T14:30:05, 2023-03-23T14:30:05.123, 2023-03-23T14:30:05.123456, "
                                 + "2023-03-24T14:30, 2023-03-24T14:30:05.120, "
                                 + "2023-03-23T15:00:10.123456, "
-                                + "Paimon, Apache Paimon, Apache Paimon MySQL Test Data, "
+                                + "Paimon, Apache Paimon, Apache Paimon MySQL Test Data, Apache Paimon MySQL Long Test Data, "
                                 + "[98, 121, 116, 101, 115, 0, 0, 0, 0, 0], "
                                 + "[109, 111, 114, 101, 32, 98, 121, 116, 101, 115], "
-                                + "[118, 101, 114, 121, 32, 108, 111, 110, 103, 32, 98, 121, 116, 101, 115, 32, 116, 101, 115, 116, 32, 100, 97, 116, 97]"
+                                + "[118, 101, 114, 121, 32, 108, 111, 110, 103, 32, 98, 121, 116, 101, 115, 32, 116, 101, 115, 116, 32, 100, 97, 116, 97], "
+                                + "[108, 111, 110, 103, 32, 98, 108, 111, 98, 32, 98, 121, 116, 101, 115, 32, 116, 101, 115, 116, 32, 100, 97, 116, 97]"
                                 + "]",
                         "+I["
                                 + "2, NULL, NULL, NULL, NULL, "
@@ -515,8 +520,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                                 + "NULL, NULL, NULL, "
                                 + "NULL, NULL, "
                                 + "NULL, "
-                                + "NULL, NULL, NULL, "
-                                + "NULL, NULL, NULL"
+                                + "NULL, NULL, NULL, NULL, "
+                                + "NULL, NULL, NULL, NULL"
                                 + "]");
         waitForResult(expected, table, rowType, Collections.singletonList("_id"));
     }

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
@@ -116,10 +116,12 @@ CREATE TABLE all_types_table (
     _char CHAR(10),
     _varchar VARCHAR(20),
     _text TEXT,
+    _longtext LONGTEXT,
     -- BINARY
     _bin BINARY(10),
     _varbin VARBINARY(20),
     _blob BLOB,
+    _longblob LONGBLOB,
     PRIMARY KEY (_id)
 );
 
@@ -158,9 +160,9 @@ INSERT INTO all_types_table VALUES (
     -- TIMESTAMP
     '2023-03-23 15:00:10.123456',
     -- string
-    'Paimon', 'Apache Paimon', 'Apache Paimon MySQL Test Data',
+    'Paimon', 'Apache Paimon', 'Apache Paimon MySQL Test Data', 'Apache Paimon MySQL Long Test Data',
     -- BINARY
-    'bytes', 'more bytes', 'very long bytes test data'
+    'bytes', 'more bytes', 'very long bytes test data', 'long blob bytes test data'
 ), (
     2,
     NULL, NULL, NULL, NULL,
@@ -179,8 +181,8 @@ INSERT INTO all_types_table VALUES (
     NULL, NULL, NULL,
     NULL, NULL,
     NULL,
-    NULL, NULL, NULL,
-    NULL, NULL, NULL
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL
 );
 
 CREATE TABLE incompatible_field_1 (


### PR DESCRIPTION
fix https://github.com/apache/incubator-paimon/issues/943

### Purpose

* check compatibility for some data type : decimal , date ，timestamp, longtext, longblob *

### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
