### PR TITLE
[release] Fix the NOTICE years of the META-INFO/NOTICE file nested in the generated jars are not correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@ under the License.
     </modules>
 
     <properties>
+        <project.build.outputTimestamp>${maven.build.timestamp}</project.build.outputTimestamp>
         <paimon.shade.jackson.version>2.14.2</paimon.shade.jackson.version>
         <paimon.shade.guava.version>30.1.1-jre</paimon.shade.guava.version>
         <paimon.shade.caffeine.version>2.9.3</paimon.shade.caffeine.version>


### PR DESCRIPTION

*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

*(What is the purpose of the change, or the associated issue)*

 the NOTICE years of the META-INFO/NOTICE file nested in the generated jars are not correct(This problem exists in all modules that automatically generate NOTICE files.)
![iShot_2023-04-20_15 04 00](https://user-images.githubusercontent.com/37063904/233290937-08c11b70-93ab-4b5c-a877-018ca9f7bb19.png)
![image](https://user-images.githubusercontent.com/37063904/233292033-99a1e506-8ec5-4e50-b4ac-23a2c0ca1447.png)

The cause of the problem is that the parent class `apache-23` has a maven attribute `<project.build.outputTimestamp>2020-01-22T15:10:15Z</project.build.outputTimestamp>`

https://github.com/apache/maven-apache-parent/blob/99592e229c20f079c1998875e5c24556d217b491/pom.xml#L95

Modified:
![iShot_2023-04-20_15 15 33](https://user-images.githubusercontent.com/37063904/233291518-e13609f3-5505-483a-be63-16f5a949517b.png)
![image](https://user-images.githubusercontent.com/37063904/233292842-5a034bfb-c0b4-4355-9efb-605901539310.png)


### Tests

*(List UT and IT cases to verify this change)*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
