### PR TITLE
[flink][bug] Datetime parsing should not be affected by server time zone in MySqlDebeziumJsonEventParser

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
@@ -72,6 +72,7 @@ public class MySqlActionITCaseBase extends ActionITCaseBase {
                         .withSetupSQL("mysql/setup.sql")
                         .withUsername(USER)
                         .withPassword(PASSWORD)
+                        .withEnv("TZ", "America/Los_Angeles")
                         .withLogConsumer(new Slf4jLogConsumer(LOG));
     }
 
@@ -124,7 +125,8 @@ public class MySqlActionITCaseBase extends ActionITCaseBase {
         config.put("port", String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
         config.put("username", USER);
         config.put("password", PASSWORD);
-        config.put("server-time-zone", ZoneId.of("+00:00").toString());
+        // see mysql/my.cnf in test resources
+        config.put("server-time-zone", ZoneId.of("America/New_York").toString());
         return config;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -505,9 +505,14 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                                 + "1.2345678987654322E32, 1.2345678987654322E32, 1.2345678987654322E32, "
                                 + "11111, 22222, 33333, "
                                 + "19439, "
+                                // display value of datetime is not affected by timezone
                                 + "2023-03-23T14:30:05, 2023-03-23T14:30:05.123, 2023-03-23T14:30:05.123456, "
                                 + "2023-03-24T14:30, 2023-03-24T14:30:05.120, "
-                                + "2023-03-23T15:00:10.123456, "
+                                // display value of timestamp is affected by timezone
+                                // we store 2023-03-23T15:00:10.123456 in UTC-8 system timezone
+                                // and query this timestamp in UTC-5 MySQL server timezone
+                                // so the display value should increase by 3 hour
+                                + "2023-03-23T18:00:10.123456, "
                                 + "Paimon, Apache Paimon, Apache Paimon MySQL Test Data, Apache Paimon MySQL Long Test Data, "
                                 + "[98, 121, 116, 101, 115, 0, 0, 0, 0, 0], "
                                 + "[109, 111, 114, 101, 32, 98, 121, 116, 101, 115], "

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/my.cnf
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/my.cnf
@@ -63,3 +63,6 @@ binlog_format     = row
 # MySQL will set current timestamp to any timestamp field with NULL value
 # which is bad for our tests
 explicit_defaults_for_timestamp = ON
+
+# We need a default time zone different from UTC+0 for test
+default-time-zone = America/New_York


### PR DESCRIPTION
### Purpose

This PR fixes #945.

According to [MySQL standard](https://dev.mysql.com/doc/refman/8.0/en/datetime.html), display value of datetime is not affected by server time zone. So current implementation of `MySqlDebeziumJsonEventParser` is not correct when parsing datetime.

### Tests

* MySqlSyncTableActionITCase#testAllTypes

### API and Format 

N/A

### Documentation

N/A
