### PR TITLE
[test] FileStoreTableTestBases should use TraceableFileIO

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.WriteMode;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
@@ -353,7 +354,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new AppendOnlyFileStoreTable(FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 
     @Override
@@ -370,6 +371,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new AppendOnlyFileStoreTable(FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.WriteMode;
+import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFilePathFactory;
@@ -223,7 +224,8 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new ChangelogValueCountFileStoreTable(
+                FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 
     @Override
@@ -240,6 +242,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Arrays.asList("pk", "pt0", "pt1"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new ChangelogValueCountFileStoreTable(
+                FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.WriteMode;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
@@ -868,7 +869,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 Arrays.asList("pk", "pt0", "pt1"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new ChangelogWithKeyFileStoreTable(
+                FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 
     private FileStoreTable createFileStoreTable(Consumer<Options> configure, RowType rowType)
@@ -886,6 +888,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(LocalFileIO.create(), tablePath, tableSchema);
+        return new ChangelogWithKeyFileStoreTable(
+                FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.WriteMode;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
@@ -106,7 +107,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(LocalFileIO.create(), tablePath, schema);
+        return new ChangelogWithKeyFileStoreTable(FileIOFinder.find(tablePath), tablePath, schema);
     }
 
     @Override
@@ -128,6 +129,6 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pk", "pt0", "pt1"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(LocalFileIO.create(), tablePath, schema);
+        return new ChangelogWithKeyFileStoreTable(FileIOFinder.find(tablePath), tablePath, schema);
     }
 }


### PR DESCRIPTION
### Purpose

TraceableFileIO is for testing connection leak