### PR TITLE
[hotfix] Add IssueNavigationLink for IDEA git log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .classpath
-.idea
+.idea/*
+!.idea/vcs.xml
 .metadata
 .settings
 .project

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="[A-Z]+\-\d+" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/apache/incubator-paimon/pull/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
### Purpose

Add IssueNavigationLink for IDEA, so we would click the link to jira and PR from IDEA

![image](https://user-images.githubusercontent.com/37108074/233821000-9bbeaf10-973d-4a2e-bb32-90b8cd3cad3e.png)


### Tests

None

### API and Format 

None

### Documentation

None
