### PR TITLE
[doc] Paimon is misspelled

### DIFF
--- a/docs/content/project/contributing.md
+++ b/docs/content/project/contributing.md
@@ -83,7 +83,7 @@ lists, contributing code or documentation, improving website, testing release ca
 
 ## Code Contribution Guide
 
-Apache Paimon is maintained, improved, and extended by code contributions of volunteers. We welcome contributions to Paimpn.
+Apache Paimon is maintained, improved, and extended by code contributions of volunteers. We welcome contributions to Paimon.
 
 Please feel free to ask questions at any time. Either send a mail to the Dev mailing list or comment on the issue you are working on.
 


### PR DESCRIPTION
*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

fix doc, spell error.
Paimpn --> Paimon

### Tests

no change

### API and Format 

yes

### Documentation

Only to fix paimon spell.
