### PR TITLE
[core] add interface listPartitions and dropPartitions to paimon Catalog

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -195,12 +195,6 @@
             <td>Specify the merge engine for table with primary key.<br /><br />Possible values:<ul><li>"deduplicate": De-duplicate and keep the last row.</li><li>"partial-update": Partial update non-null fields.</li><li>"aggregation": Aggregate fields with same primary key.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>sort-engine</h5></td>
-            <td style="word-wrap: break-word;">loser-tree</td>
-            <td><p>Enum</p></td>
-            <td>Specify the sort engine for table with primary key.<br /><br />Possible values:<ul><li>"min-heap": Use min-heap for multiway sorting.</li><li>"loser-tree": Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>num-levels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -297,6 +291,12 @@
             <td>End condition "watermark" for bounded streaming mode. Stream reading will end when a larger watermark snapshot is encountered.</td>
         </tr>
         <tr>
+            <td><h5>scan.manifest.parallelism</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The parallelism of scanning manifest files, default value is the size of cpu processor.Note: Scale-up this parameter will increase memory usage while scanning manifest files.We can consider downsize it when we encounter an out of memory exception while scanning</td>
+        </tr>
+        <tr>
             <td><h5>scan.mode</h5></td>
             <td style="word-wrap: break-word;">default</td>
             <td><p>Enum</p></td>
@@ -343,6 +343,12 @@
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
             <td>The maximum time of completed snapshots to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>sort-engine</h5></td>
+            <td style="word-wrap: break-word;">loser-tree</td>
+            <td><p>Enum</p></td>
+            <td>Specify the sort engine for table with primary key.<br /><br />Possible values:<ul><li>"min-heap": Use min-heap for multiway sorting.</li><li>"loser-tree": Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.</li></ul></td>
         </tr>
         <tr>
             <td><h5>source.split.open-file-cost</h5></td>

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -96,7 +96,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                 manifestFileFactory(forWrite),
                 manifestListFactory(forWrite),
                 options.bucket(),
-                forWrite);
+                forWrite,
+                options.scanManifestParallelism());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -387,6 +387,15 @@ public class CoreOptions implements Serializable {
                             "End condition \"watermark\" for bounded streaming mode. Stream"
                                     + " reading will end when a larger watermark snapshot is encountered.");
 
+    public static final ConfigOption<Integer> SCAN_MANIFEST_PARALLELISM =
+            key("scan.manifest.parallelism")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The parallelism of scanning manifest files, default value is the size of cpu processor."
+                                    + "Note: Scale-up this parameter will increase memory usage while scanning manifest files."
+                                    + "We can consider downsize it when we encounter an out of memory exception while scanning");
+
     public static final ConfigOption<LogConsistency> LOG_CONSISTENCY =
             key("log.consistency")
                     .enumType(LogConsistency.class)
@@ -842,6 +851,10 @@ public class CoreOptions implements Serializable {
 
     public Long scanSnapshotId() {
         return options.get(SCAN_SNAPSHOT_ID);
+    }
+
+    public Integer scanManifestParallelism() {
+        return options.get(SCAN_MANIFEST_PARALLELISM);
     }
 
     public Optional<String> sequenceField() {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -121,7 +121,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 manifestFileFactory(forWrite),
                 manifestListFactory(forWrite),
                 options.bucket(),
-                forWrite);
+                forWrite,
+                options.scanManifestParallelism());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -187,6 +187,34 @@ public interface Catalog extends AutoCloseable {
         return true;
     }
 
+    /**
+     * List partitions by the given identifier
+     *
+     * <p>NOTE: cause paimon use dynamic partition all the time, Exists Partitions is not a table
+     * properties cached in memory, the method will cause io read every time it called.
+     *
+     * @param identifier path of the table
+     * @return a list of partitions of the specified table in identifier
+     * @throws TableNotExistException if the table does not exist
+     */
+    default List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Drop a table partition
+     *
+     * <p>NOTE: drop the specified table partition, will do nothing if the partition doesn't exist.
+     *
+     * @param identifier the table that need to be operated
+     * @param partitions the given table partitions that needed to be dropped
+     * @throws TableNotExistException if the table does not exist
+     */
+    default void dropPartitions(Identifier identifier, List<Partition> partitions)
+            throws TableNotExistException {
+        throw new UnsupportedOperationException();
+    }
+
     /** Exception for trying to drop on a database that is not empty. */
     class DatabaseNotEmptyException extends Exception {
         private static final String MSG = "Database %s is not empty.";

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -200,6 +200,19 @@ public class FileSystemCatalog extends AbstractCatalog {
                                 .commitChanges(changes));
     }
 
+    @Override
+    public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
+        checkNotSystemTable(identifier, "listPartitions");
+        return getTable(identifier).newReadBuilder().newScan().partitions();
+    }
+
+    @Override
+    public void dropPartitions(Identifier identifier, List<Partition> partitions)
+            throws TableNotExistException {
+        // todo realize drop partition method
+        throw new UnsupportedOperationException("not support yet, will commit this soon");
+    }
+
     private static <T> T uncheck(Callable<T> callable) {
         try {
             return callable.call();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Partition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Partition.java
@@ -16,31 +16,41 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.table.source;
+package org.apache.paimon.catalog;
 
-import org.apache.paimon.catalog.Partition;
+import org.apache.paimon.annotation.Public;
 
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Objects;
 
-/** An {@link InnerTableScan} for reading only once, this is for batch scan. */
-public abstract class ReadOnceTableScan implements InnerTableScan {
+/**
+ * Partition with the specified values.
+ *
+ * @since 0.4.0
+ */
+@Public
+public class Partition {
+    private final LinkedHashMap<String, String> partitionSpec;
 
-    private boolean hasNext = true;
-
-    @Override
-    public Plan plan() {
-        if (hasNext) {
-            hasNext = false;
-            return innerPlan();
-        } else {
-            throw new EndOfScanException();
-        }
+    public Partition(LinkedHashMap<String, String> partitionSpec) {
+        this.partitionSpec = partitionSpec;
     }
 
-    protected abstract Plan innerPlan();
+    public LinkedHashMap<String, String> partitionSpec() {
+        return partitionSpec;
+    }
 
     @Override
-    public List<Partition> partitions() {
-        throw new UnsupportedOperationException();
+    public int hashCode() {
+        return Objects.hash(partitionSpec);
+    }
+
+    @Override
+    public String toString() {
+        return "Partition{" + partitionSpec + '}';
+    }
+
+    public static Partition of(LinkedHashMap<String, String> spec) {
+        return new Partition(spec);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/AbstractManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/AbstractManifestEntry.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.Preconditions;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Abstract a simplest model of manifest file. */
+public abstract class AbstractManifestEntry {
+    protected final FileKind kind;
+    protected final String fileName;
+    // for tables without partition this field should be a row with 0 columns (not null)
+    protected final BinaryRow partition;
+    protected final int bucket;
+    protected final int totalBuckets;
+    protected final int level;
+
+    public AbstractManifestEntry(
+            FileKind kind,
+            String fileName,
+            BinaryRow partition,
+            int bucket,
+            int totalBuckets,
+            int level) {
+        this.kind = kind;
+        this.fileName = fileName;
+        this.partition = partition;
+        this.bucket = bucket;
+        this.totalBuckets = totalBuckets;
+        this.level = level;
+    }
+
+    public FileKind kind() {
+        return kind;
+    }
+
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    public int bucket() {
+        return bucket;
+    }
+
+    public int totalBuckets() {
+        return totalBuckets;
+    }
+
+    public int level() {
+        return level;
+    }
+
+    public Identifier identifier() {
+        return new Identifier(partition, bucket, level, fileName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AbstractManifestEntry)) {
+            return false;
+        }
+        AbstractManifestEntry that = (AbstractManifestEntry) o;
+        return Objects.equals(kind, that.kind)
+                && Objects.equals(partition, that.partition)
+                && bucket == that.bucket
+                && level == that.level
+                && Objects.equals(fileName, that.fileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, partition, bucket, level, fileName);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{%s, %s, %d, %d, %s}", kind, partition, bucket, level, fileName);
+    }
+
+    public static <T extends AbstractManifestEntry> Collection<T> mergeEntries(
+            Iterable<T> entries) {
+        LinkedHashMap<Identifier, T> map = new LinkedHashMap<>();
+        mergeEntries(entries, map);
+        return map.values();
+    }
+
+    public static <T extends AbstractManifestEntry> void mergeEntries(
+            Iterable<T> entries, Map<Identifier, T> map) {
+        for (T entry : entries) {
+            Identifier identifier = entry.identifier();
+            switch (entry.kind()) {
+                case ADD:
+                    Preconditions.checkState(
+                            !map.containsKey(identifier),
+                            "Trying to add file %s which is already added. Manifest might be corrupted.",
+                            identifier);
+                    map.put(identifier, entry);
+                    break;
+                case DELETE:
+                    // each dataFile will only be added once and deleted once,
+                    // if we know that it is added before then both add and delete entry can be
+                    // removed because there won't be further operations on this file,
+                    // otherwise we have to keep the delete entry because the add entry must be
+                    // in the previous manifest files
+                    if (map.containsKey(identifier)) {
+                        map.remove(identifier);
+                    } else {
+                        map.put(identifier, entry);
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            "Unknown value kind " + entry.kind().name());
+            }
+        }
+    }
+
+    /**
+     * The same {@link Identifier} indicates that the {@link AbstractManifestEntry} refers to the
+     * same data file.
+     */
+    public static class Identifier {
+        public final BinaryRow partition;
+        public final int bucket;
+        public final int level;
+        public final String fileName;
+
+        private Identifier(BinaryRow partition, int bucket, int level, String fileName) {
+            this.partition = partition;
+            this.bucket = bucket;
+            this.level = level;
+            this.fileName = fileName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Identifier)) {
+                return false;
+            }
+            Identifier that = (Identifier) o;
+            return Objects.equals(partition, that.partition)
+                    && bucket == that.bucket
+                    && level == that.level
+                    && Objects.equals(fileName, that.fileName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(partition, bucket, level, fileName);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("{%s, %d, %d, %s}", partition, bucket, level, fileName);
+        }
+
+        public String toString(FileStorePathFactory pathFactory) {
+            return pathFactory.getPartitionString(partition)
+                    + ", bucket "
+                    + bucket
+                    + ", level "
+                    + level
+                    + ", file "
+                    + fileName;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/AbstractManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/AbstractManifestEntry.java
@@ -56,6 +56,10 @@ public abstract class AbstractManifestEntry {
         return kind;
     }
 
+    public String fileName() {
+        return fileName;
+    }
+
     public BinaryRow partition() {
         return partition;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -24,59 +24,28 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TinyIntType;
-import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 
 /** Entry of a manifest file, representing an addition / deletion of a data file. */
-public class ManifestEntry {
+public class ManifestEntry extends AbstractManifestEntry {
 
-    private final FileKind kind;
-    // for tables without partition this field should be a row with 0 columns (not null)
-    private final BinaryRow partition;
-    private final int bucket;
-    private final int totalBuckets;
     private final DataFileMeta file;
 
     public ManifestEntry(
             FileKind kind, BinaryRow partition, int bucket, int totalBuckets, DataFileMeta file) {
-        this.kind = kind;
-        this.partition = partition;
-        this.bucket = bucket;
-        this.totalBuckets = totalBuckets;
+        super(kind, file.fileName(), partition, bucket, totalBuckets, file.level());
         this.file = file;
-    }
-
-    public FileKind kind() {
-        return kind;
-    }
-
-    public BinaryRow partition() {
-        return partition;
-    }
-
-    public int bucket() {
-        return bucket;
-    }
-
-    public int totalBuckets() {
-        return totalBuckets;
     }
 
     public DataFileMeta file() {
         return file;
-    }
-
-    public Identifier identifier() {
-        return new Identifier(partition, bucket, file.level(), file.fileName());
     }
 
     public static RowType schema() {
@@ -112,99 +81,12 @@ public class ManifestEntry {
         return String.format("{%s, %s, %d, %d, %s}", kind, partition, bucket, totalBuckets, file);
     }
 
-    public static Collection<ManifestEntry> mergeEntries(List<ManifestEntry> entries) {
-        LinkedHashMap<Identifier, ManifestEntry> map = new LinkedHashMap<>();
-        mergeEntries(entries, map);
-        return map.values();
-    }
-
-    public static void mergeEntries(
-            List<ManifestEntry> entries, Map<Identifier, ManifestEntry> map) {
-        for (ManifestEntry entry : entries) {
-            ManifestEntry.Identifier identifier = entry.identifier();
-            switch (entry.kind()) {
-                case ADD:
-                    Preconditions.checkState(
-                            !map.containsKey(identifier),
-                            "Trying to add file %s which is already added. Manifest might be corrupted.",
-                            identifier);
-                    map.put(identifier, entry);
-                    break;
-                case DELETE:
-                    // each dataFile will only be added once and deleted once,
-                    // if we know that it is added before then both add and delete entry can be
-                    // removed because there won't be further operations on this file,
-                    // otherwise we have to keep the delete entry because the add entry must be
-                    // in the previous manifest files
-                    if (map.containsKey(identifier)) {
-                        map.remove(identifier);
-                    } else {
-                        map.put(identifier, entry);
-                    }
-                    break;
-                default:
-                    throw new UnsupportedOperationException(
-                            "Unknown value kind " + entry.kind().name());
-            }
-        }
-    }
-
     public static void assertNoDelete(Collection<ManifestEntry> entries) {
         for (ManifestEntry entry : entries) {
             Preconditions.checkState(
                     entry.kind() != FileKind.DELETE,
                     "Trying to delete file %s which is not previously added. Manifest might be corrupted.",
                     entry.file().fileName());
-        }
-    }
-
-    /**
-     * The same {@link Identifier} indicates that the {@link ManifestEntry} refers to the same data
-     * file.
-     */
-    public static class Identifier {
-        public final BinaryRow partition;
-        public final int bucket;
-        public final int level;
-        public final String fileName;
-
-        private Identifier(BinaryRow partition, int bucket, int level, String fileName) {
-            this.partition = partition;
-            this.bucket = bucket;
-            this.level = level;
-            this.fileName = fileName;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!(o instanceof Identifier)) {
-                return false;
-            }
-            Identifier that = (Identifier) o;
-            return Objects.equals(partition, that.partition)
-                    && bucket == that.bucket
-                    && level == that.level
-                    && Objects.equals(fileName, that.fileName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(partition, bucket, level, fileName);
-        }
-
-        @Override
-        public String toString() {
-            return String.format("{%s, %d, %d, %s}", partition, bucket, level, fileName);
-        }
-
-        public String toString(FileStorePathFactory pathFactory) {
-            return pathFactory.getPartitionString(partition)
-                    + ", bucket "
-                    + bucket
-                    + ", level "
-                    + level
-                    + ", file "
-                    + fileName;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -188,5 +188,19 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                     suggestedFileSize,
                     cache);
         }
+
+        // this reader read simple manifest information, would be faster.
+        public SimpleManifestReader createSimpleManifestReader() {
+            RowType partitionEntryType =
+                    VersionedObjectSerializer.versionType(SimpleManifestEntry.schema());
+            return new SimpleManifestReader(
+                    fileIO,
+                    new SimpleManifestEntrySerializer(),
+                    partitionType,
+                    fileFormat.createReaderFactory(partitionEntryType),
+                    pathFactory.manifestFileFactory(),
+                    null // do not use cache for now
+                    );
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestEntry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TinyIntType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.paimon.utils.SerializationUtils.newBytesType;
+import static org.apache.paimon.utils.SerializationUtils.newStringType;
+
+/** Partition Entry pojo read from manifest file. */
+public class SimpleManifestEntry extends AbstractManifestEntry {
+
+    public SimpleManifestEntry(
+            FileKind kind,
+            BinaryRow partition,
+            int bucket,
+            int totalBuckets,
+            String fileName,
+            int level) {
+        super(kind, fileName, partition, bucket, totalBuckets, level);
+    }
+
+    public static RowType schema() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "_KIND", new TinyIntType(false)));
+        fields.add(new DataField(1, "_PARTITION", newBytesType(false)));
+        fields.add(new DataField(2, "_BUCKET", new IntType(false)));
+        fields.add(new DataField(3, "_TOTAL_BUCKETS", new IntType(false)));
+        fields.add(new DataField(4, "_FILE", schemaDataFileName()));
+        return new RowType(fields);
+    }
+
+    public static RowType schemaDataFileName() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "_FILE_NAME", newStringType(false)));
+        fields.add(new DataField(1, "_LEVEL", new IntType(false)));
+        return new RowType(fields);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestEntrySerializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.utils.VersionedObjectSerializer;
+
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** PartitionEntry Serializer for {@link SimpleManifestEntry}. */
+public class SimpleManifestEntrySerializer extends VersionedObjectSerializer<SimpleManifestEntry> {
+
+    private static final long serialVersionUID = 1L;
+
+    public SimpleManifestEntrySerializer() {
+        super(SimpleManifestEntry.schema());
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+
+    @Override
+    public InternalRow convertTo(SimpleManifestEntry entry) {
+        GenericRow row = new GenericRow(5);
+        row.setField(0, entry.kind().toByteValue());
+        row.setField(1, serializeBinaryRow(entry.partition()));
+        row.setField(2, entry.bucket());
+        row.setField(3, entry.totalBuckets());
+        row.setField(4, GenericRow.of(BinaryString.fromString(entry.fileName()), entry.level()));
+        return row;
+    }
+
+    @Override
+    public SimpleManifestEntry convertFrom(int version, InternalRow row) {
+        if (version != 2) {
+            if (version == 1) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The current version %s is not compatible with the version %s, please recreate the table.",
+                                getVersion(), version));
+            }
+            throw new IllegalArgumentException("Unsupported version: " + version);
+        }
+        return new SimpleManifestEntry(
+                FileKind.fromByteValue(row.getByte(0)),
+                deserializeBinaryRow(row.getBinary(1)),
+                row.getInt(2),
+                row.getInt(3),
+                row.getRow(4, 2).getString(0).toString(),
+                row.getRow(4, 2).getInt(1));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleManifestReader.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ObjectSerializer;
+import org.apache.paimon.utils.ObjectsFile;
+import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.SegmentsCache;
+
+import javax.annotation.Nullable;
+
+/** This class read partitions from manifest file, only decode the partition related bytes. */
+public class SimpleManifestReader extends ObjectsFile<SimpleManifestEntry> {
+
+    private final RowType partitionType;
+
+    public SimpleManifestReader(
+            FileIO fileIO,
+            ObjectSerializer<SimpleManifestEntry> serializer,
+            RowType partitionType,
+            FormatReaderFactory readerFactory,
+            PathFactory pathFactory,
+            @Nullable SegmentsCache<String> cache) {
+        super(fileIO, serializer, readerFactory, pathFactory, cache);
+        this.partitionType = partitionType;
+    }
+
+    public RowType getPartitionType() {
+        return partitionType;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -52,7 +52,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
-            boolean checkNumOfBuckets) {
+            boolean checkNumOfBuckets,
+            Integer scanManifestParallelism) {
         super(
                 partitionType,
                 bucketKeyType,
@@ -61,7 +62,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 manifestFileFactory,
                 manifestListFactory,
                 numOfBuckets,
-                checkNumOfBuckets);
+                checkNumOfBuckets,
+                scanManifestParallelism);
         this.rowType = rowType;
         this.fieldStatsConverters =
                 new FieldStatsConverters(sid -> scanTableSchema(sid).fields(), schemaId);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -54,7 +54,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
-            boolean checkNumOfBuckets) {
+            boolean checkNumOfBuckets,
+            Integer scanManifestParallelism) {
         super(
                 partitionType,
                 bucketKeyType,
@@ -63,7 +64,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                 manifestFileFactory,
                 manifestListFactory,
                 numOfBuckets,
-                checkNumOfBuckets);
+                checkNumOfBuckets,
+                scanManifestParallelism);
         this.fieldStatsConverters =
                 new FieldStatsConverters(
                         sid -> keyValueFieldsExtractor.keyFields(scanTableSchema(sid)), schemaId);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -20,7 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.SimpleManifestEntry;
 import org.apache.paimon.partition.PartitionTimeExtractor;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
@@ -112,10 +112,8 @@ public class PartitionExpire {
     }
 
     private List<BinaryRow> readPartitions() {
-        // TODO optimize this to read partition only
-        return scan.plan().files().stream()
-                .map(ManifestEntry::partition)
-                .distinct()
+        return scan.simplePlan().files().stream()
+                .map(SimpleManifestEntry::partition)
                 .collect(Collectors.toList());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.consumer.Consumer;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.operation.FileStoreScan;
@@ -37,6 +38,7 @@ import org.apache.paimon.table.source.snapshot.StaticFromSnapshotStartingScanner
 import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanner;
 import org.apache.paimon.utils.Preconditions;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
@@ -127,5 +129,9 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                 throw new UnsupportedOperationException(
                         "Unknown startup mode " + startupMode.name());
         }
+    }
+
+    public List<Partition> partitions() {
+        return snapshotSplitReader.partitions();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.table.Table;
 
 import java.util.List;
@@ -33,6 +34,9 @@ public interface TableScan {
 
     /** Plan splits, throws {@link EndOfScanException} if the scan is ended. */
     Plan plan();
+
+    /** Get partitions from simple manifest entries. */
+    List<Partition> partitions();
 
     /**
      * Plan of scan.

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotSplitReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotSplitReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.Predicate;
@@ -47,4 +48,7 @@ public interface SnapshotSplitReader {
 
     /** Get splits from an overwrite snapshot. */
     List<DataSplit> overwriteSplits();
+
+    /** Get partitions from a snapshot. */
+    List<Partition> partitions();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotSplitReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotSplitReaderImpl.java
@@ -21,12 +21,15 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.AbstractManifestEntry;
 import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.SimpleManifestEntry;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.Predicate;
@@ -34,7 +37,10 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.SplitGenerator;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.RowDataPartitionComputer;
 import org.apache.paimon.utils.SnapshotManager;
 
 import java.util.ArrayList;
@@ -43,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.predicate.PredicateBuilder.transformFieldMapping;
 
@@ -157,6 +164,34 @@ public class SnapshotSplitReaderImpl implements SnapshotSplitReader {
                 false,
                 splitGenerator,
                 files);
+    }
+
+    @Override
+    public List<Partition> partitions() {
+        List<SimpleManifestEntry> entryList = scan.simplePlan().files();
+        RowType rowType = tableSchema.logicalPartitionType();
+
+        RowDataPartitionComputer rowDataPartitionComputer =
+                new RowDataPartitionComputer(
+                        FileStorePathFactory.PARTITION_DEFAULT_NAME.defaultValue(),
+                        rowType,
+                        rowType.getFieldNames().toArray(new String[0]));
+
+        return entryList.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                AbstractManifestEntry::partition,
+                                LinkedHashMap::new,
+                                Collectors.reducing((a, b) -> b)))
+                .values()
+                .stream()
+                .map(Optional::get)
+                .map(
+                        row ->
+                                Partition.of(
+                                        rowDataPartitionComputer.generatePartValues(
+                                                row.partition())))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.system;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.InternalRow;
@@ -222,6 +223,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         public List<DataSplit> overwriteSplits() {
             return snapshotSplitReader.overwriteSplits();
         }
+
+        @Override
+        public List<Partition> partitions() {
+            return snapshotSplitReader.partitions();
+        }
     }
 
     private class AuditLogBatchScan implements InnerTableScan {
@@ -242,6 +248,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         public Plan plan() {
             return batchScan.plan();
         }
+
+        @Override
+        public List<Partition> partitions() {
+            return batchScan.partitions();
+        }
     }
 
     private class AuditLogStreamScan implements InnerStreamTableScan {
@@ -261,6 +272,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         @Override
         public Plan plan() {
             return streamScan.plan();
+        }
+
+        @Override
+        public List<Partition> partitions() {
+            return streamScan.partitions();
         }
 
         @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
@@ -42,7 +42,6 @@ public class ParallellyExecuteUtils {
         } else if (queueSize <= 0) {
             throw new NegativeArraySizeException("queue size should not be negetive");
         }
-        queueSize = 1;
 
         final Queue<List<U>> stack = new ArrayDeque<>(Lists.partition(input, queueSize));
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * This class is a parallel execution util class, which mainly aim to process tasks parallelly with
+ * memory control.
+ */
+public class ParallellyExecuteUtils {
+
+    // reduce memory usage by batch iterable process, the cached result in memory will be queueSize
+    public static <T, U> Iterable<T> parallelismBatchIterable(
+            Function<List<U>, List<T>> processor, List<U> input, Integer queueSize) {
+        if (queueSize == null) {
+            queueSize = FileUtils.COMMON_IO_FORK_JOIN_POOL.getParallelism();
+        } else if (queueSize <= 0) {
+            throw new NegativeArraySizeException("queue size should not be negetive");
+        }
+
+        final Queue<List<U>> stack = new ArrayDeque<>(Lists.partition(input, queueSize));
+
+        return () ->
+                new Iterator<T>() {
+                    List<T> activeList = null;
+                    private int index = 0;
+
+                    @Override
+                    public boolean hasNext() {
+                        advanceIfNeeded();
+                        return activeList != null && index < activeList.size();
+                    }
+
+                    @Override
+                    public T next() {
+                        advanceIfNeeded();
+                        if (activeList == null || index >= activeList.size()) {
+                            throw new NoSuchElementException();
+                        }
+                        return activeList.get(index++);
+                    }
+
+                    private void advanceIfNeeded() {
+                        if ((activeList == null || index >= activeList.size())
+                                && stack.size() > 0) {
+                            // reset index
+                            index = 0;
+                            try {
+                                activeList =
+                                        CompletableFuture.supplyAsync(
+                                                        () -> processor.apply(stack.poll()),
+                                                        FileUtils.COMMON_IO_FORK_JOIN_POOL)
+                                                .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    }
+                };
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ParallellyExecuteUtils.java
@@ -42,6 +42,7 @@ public class ParallellyExecuteUtils {
         } else if (queueSize <= 0) {
             throw new NegativeArraySizeException("queue size should not be negetive");
         }
+        queueSize = 1;
 
         final Queue<List<U>> stack = new ArrayDeque<>(Lists.partition(input, queueSize));
 
@@ -66,7 +67,7 @@ public class ParallellyExecuteUtils {
                     }
 
                     private void advanceIfNeeded() {
-                        if ((activeList == null || index >= activeList.size())
+                        while ((activeList == null || index >= activeList.size())
                                 && stack.size() > 0) {
                             // reset index
                             index = 0;

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -59,6 +60,18 @@ public abstract class CatalogTestBase {
                             new DataField(2, "col2", DataTypes.STRING())),
                     Collections.emptyList(),
                     Collections.emptyList(),
+                    Maps.newHashMap(),
+                    "");
+
+    protected static final Schema PARTITION_SCHEMA =
+            new Schema(
+                    Lists.newArrayList(
+                            new DataField(0, "pk1", DataTypes.INT()),
+                            new DataField(1, "pk2", DataTypes.STRING()),
+                            new DataField(3, "pk3", DataTypes.STRING()),
+                            new DataField(4, "col", DataTypes.STRING())),
+                    Arrays.asList("pk1", "pk2"),
+                    Arrays.asList("pk1", "pk2", "pk3"),
                     Maps.newHashMap(),
                     "");
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
@@ -18,12 +18,20 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,5 +51,37 @@ public class FileSystemCatalogTest extends CatalogTestBase {
         // List databases returns an empty list when there are no databases
         List<String> databases = catalog.listDatabases();
         assertThat(databases).isEmpty();
+    }
+
+    @Test
+    public void testListPartitions() throws Exception {
+        catalog.createDatabase("test_db", false);
+        // Create table creates a new table when it does not exist
+        Identifier identifier = Identifier.create("test_db", "new_table");
+        catalog.createTable(identifier, PARTITION_SCHEMA, false);
+        Table table = catalog.getTable(identifier);
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        BatchTableWrite write = builder.newWrite();
+
+        for (int i = 0; i < 1000; i++) {
+            InternalRow row =
+                    GenericRow.of(
+                            1,
+                            BinaryString.fromString(String.valueOf(i)),
+                            BinaryString.fromString(String.valueOf(i)),
+                            BinaryString.fromString(String.valueOf(i)));
+            write.write(row);
+        }
+        List<CommitMessage> result = write.prepareCommit();
+        builder.newCommit().commit(result);
+
+        AtomicInteger ai = new AtomicInteger(0);
+        catalog.listPartitions(identifier).stream()
+                .map(Partition::partitionSpec)
+                .forEach(
+                        spec -> {
+                            String.valueOf(ai.get()).equals(spec.get("pk1"));
+                            String.valueOf(ai.getAndIncrement()).equals(spec.get("pk2"));
+                        });
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/SimpleManifestEntrySerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/SimpleManifestEntrySerializerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+
+import org.junit.jupiter.api.Test;
+
+/** Test for {@link SimpleManifestEntrySerializer}. */
+public class SimpleManifestEntrySerializerTest {
+
+    @Test
+    public void testSerializer() {
+        SimpleManifestEntrySerializer simpleManifestEntrySerializer =
+                new SimpleManifestEntrySerializer();
+
+        BinaryRow row = new BinaryRow(1);
+        BinaryRowWriter binaryRowWriter = new BinaryRowWriter(row);
+        binaryRowWriter.writeString(0, BinaryString.fromString("p1"));
+        binaryRowWriter.complete();
+
+        SimpleManifestEntry simpleManifestEntry =
+                new SimpleManifestEntry(FileKind.ADD, row.copy(), 0, 1, "filetest.avro", 0);
+        simpleManifestEntrySerializer
+                .convertFrom(2, simpleManifestEntrySerializer.convertTo(simpleManifestEntry))
+                .equals(simpleManifestEntry);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/SimpleManifestReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/SimpleManifestReaderTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Partition;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileIOFinder;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFileTestDataGenerator;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.RowDataPartitionComputer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.TestKeyValueGenerator.DEFAULT_PART_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** tests for {@link SimpleManifestReader}. */
+public class SimpleManifestReaderTest {
+
+    private final Object[][] partitionValues = {
+        {"a", 1},
+        {"B", 2},
+        {"中国", 4},
+        {"panda", 5}
+    };
+
+    private DataFileTestDataGenerator dgen = DataFileTestDataGenerator.builder().build();
+    private final FileFormat avro = FileFormat.fromIdentifier("avro", new Options());
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private List<ManifestEntry> generateManifestEntriesWithAddOnly() {
+        BinaryRow reuseRow = new BinaryRow(DEFAULT_PART_TYPE.getFieldCount());
+        BinaryRowWriter reuseWriter = new BinaryRowWriter(reuseRow);
+        List<ManifestEntry> entries = new ArrayList<>();
+        for (Object[] td : partitionValues) {
+            reuseWriter.reset();
+            reuseWriter.writeRowKind(RowKind.INSERT);
+            reuseWriter.writeString(0, BinaryString.fromString((String) td[0]));
+            reuseWriter.writeInt(1, (int) td[1]);
+            reuseWriter.complete();
+            DataFileMeta meta = dgen.next().meta;
+            entries.add(new ManifestEntry(FileKind.ADD, reuseRow.copy(), 0, 2, meta));
+        }
+        return entries;
+    }
+
+    private ManifestFile.Factory createManifestFileFactory(String pathStr) {
+        Path path = new Path(pathStr);
+        FileStorePathFactory pathFactory =
+                new FileStorePathFactory(
+                        path,
+                        DEFAULT_PART_TYPE,
+                        "default",
+                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+        int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
+        FileIO fileIO = FileIOFinder.find(path);
+        return new ManifestFile.Factory(
+                fileIO,
+                new SchemaManager(fileIO, path),
+                DEFAULT_PART_TYPE,
+                avro,
+                pathFactory,
+                suggestedFileSize,
+                null);
+    }
+
+    @Test
+    public void testEntry() {
+        List<ManifestEntry> entries = generateManifestEntriesWithAddOnly();
+        ManifestFile.Factory factory = createManifestFileFactory(tempDir.toString());
+        ManifestFile manifestFile = factory.create();
+        List<ManifestFileMeta> actualMetas = manifestFile.write(entries);
+
+        SimpleManifestReader simpleManifestReader = factory.createSimpleManifestReader();
+        List<SimpleManifestEntry> simpleManifestEntryList =
+                actualMetas.stream()
+                        .flatMap(m -> simpleManifestReader.read(m.fileName()).stream())
+                        .collect(Collectors.toList());
+
+        AtomicInteger i = new AtomicInteger(0);
+
+        entries.forEach(
+                entry -> {
+                    assertThat(entry.kind()).isEqualTo(simpleManifestEntryList.get(i.get()).kind());
+                    assertThat(entry.partition())
+                            .isEqualTo(simpleManifestEntryList.get(i.get()).partition());
+                    assertThat(entry.bucket())
+                            .isEqualTo(simpleManifestEntryList.get(i.get()).bucket());
+                    assertThat(entry.file().fileName())
+                            .isEqualTo(simpleManifestEntryList.get(i.getAndIncrement()).fileName());
+                });
+    }
+
+    @Test
+    public void testPartitions() {
+        List<ManifestEntry> entries = generateManifestEntriesWithAddOnly();
+        ManifestFile.Factory factory = createManifestFileFactory(tempDir.toString());
+        ManifestFile manifestFile = factory.create();
+        List<ManifestFileMeta> actualMetas = manifestFile.write(entries);
+
+        SimpleManifestReader simpleManifestReader = factory.createSimpleManifestReader();
+        Collection<SimpleManifestEntry> simpleManifestEntryList =
+                actualMetas.stream()
+                        .flatMap(m -> simpleManifestReader.read(m.fileName()).stream())
+                        .collect(Collectors.toList());
+
+        simpleManifestEntryList = AbstractManifestEntry.mergeEntries(simpleManifestEntryList);
+
+        RowType rowType = simpleManifestReader.getPartitionType();
+
+        RowDataPartitionComputer rowDataPartitionComputer =
+                new RowDataPartitionComputer(
+                        FileStorePathFactory.PARTITION_DEFAULT_NAME.defaultValue(),
+                        rowType,
+                        rowType.getFieldNames().toArray(new String[0]));
+
+        List<Partition> partitions =
+                simpleManifestEntryList.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        SimpleManifestEntry::partition,
+                                        LinkedHashMap::new,
+                                        Collectors.reducing((a, b) -> b)))
+                        .values()
+                        .stream()
+                        .map(Optional::get)
+                        .map(
+                                row ->
+                                        Partition.of(
+                                                rowDataPartitionComputer.generatePartValues(
+                                                        row.partition())))
+                        .collect(Collectors.toList());
+
+        AtomicInteger i = new AtomicInteger(0);
+
+        partitions.stream()
+                .map(Partition::partitionSpec)
+                .map(LinkedHashMap::values)
+                .map(t -> t.toArray(new Object[0]))
+                .map(t -> new Object[] {t[0], Integer.valueOf(t[1].toString())})
+                .forEach(
+                        v -> {
+                            assertThat(v[0]).isEqualTo(partitionValues[i.get()][0]);
+                            assertThat(v[1]).isEqualTo(partitionValues[i.getAndIncrement()][1]);
+                        });
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -143,5 +144,19 @@ public class ParallellyExecuteUtilsTest {
                         Collections.singletonList(1),
                         null);
         re.forEach(i -> Assertions.assertThat(i).isEqualTo(2));
+    }
+
+    @Test
+    public void testDifferentQueueSizeWithFilterElement() {
+        for (int queueSize = 1; queueSize < 20; queueSize++) {
+            Iterable<Integer> re =
+                    ParallellyExecuteUtils.parallelismBatchIterable(
+                            l -> l.parallelStream().filter(i -> i > 5).collect(Collectors.toList()),
+                            Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                            queueSize);
+            Integer[] result = new Integer[]{6, 7, 8, 9, 10};
+
+            Assertions.assertThat(re).hasSameElementsAs(Arrays.asList(result));
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/** This test mainly test for the methods in {@link ParallellyExecuteUtils}. */
+public class ParallellyExecuteUtilsTest {
+
+    @Test
+    public void testParallelismBatchIterable() {
+        List<Integer> nums = new ArrayList<>();
+
+        for (int i = 0; i < 10000; i++) {
+            nums.add(i);
+        }
+
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        nums,
+                        null);
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        re.forEach(
+                i ->
+                        Assertions.assertThat(i)
+                                .isEqualTo(nums.get(atomicInteger.getAndIncrement()) + 1));
+    }
+
+    @Test
+    public void testParallelismBatchIterable2() {
+        List<Integer> nums = new ArrayList<>();
+
+        for (int i = 0; i < 12345; i++) {
+            nums.add(i);
+        }
+
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        nums,
+                        null);
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        re.forEach(
+                i ->
+                        Assertions.assertThat(i)
+                                .isEqualTo(nums.get(atomicInteger.getAndIncrement()) + 1));
+    }
+
+    @Test
+    public void testParallelismBatchIterable3() {
+        List<Integer> nums = new ArrayList<>();
+
+        for (int i = 0; i < 10000; i++) {
+            nums.add(i);
+        }
+
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        nums,
+                        null);
+
+        Iterator<Integer> iterator = re.iterator();
+        for (int i = 0; i < 100; i++) {
+            iterator.hasNext();
+        }
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        while (iterator.hasNext()) {
+            Integer i = iterator.next();
+            Assertions.assertThat(i).isEqualTo(nums.get(atomicInteger.getAndIncrement()) + 1);
+        }
+    }
+
+    @Test
+    public void testParallelismBatchIterable4() {
+        List<Integer> nums = new ArrayList<>();
+
+        for (int i = 0; i < 12345; i++) {
+            nums.add(i);
+        }
+
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        nums,
+                        null);
+
+        Iterator<Integer> iterator = re.iterator();
+        for (int i = 0; i < 123; i++) {
+            iterator.hasNext();
+        }
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        while (iterator.hasNext()) {
+            Integer i = iterator.next();
+            Assertions.assertThat(i).isEqualTo(nums.get(atomicInteger.getAndIncrement()) + 1);
+        }
+    }
+
+    @Test
+    public void testForEmptyInput() {
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        (List<Integer>) Collections.EMPTY_LIST,
+                        null);
+        Assertions.assertThat(!re.iterator().hasNext()).isTrue();
+    }
+
+    @Test
+    public void testForSingletonInput() {
+        Iterable<Integer> re =
+                ParallellyExecuteUtils.parallelismBatchIterable(
+                        l -> l.parallelStream().map(i -> i + 1).collect(Collectors.toList()),
+                        Collections.singletonList(1),
+                        null);
+        re.forEach(i -> Assertions.assertThat(i).isEqualTo(2));
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ParallellyExecuteUtilsTest.java
@@ -154,7 +154,7 @@ public class ParallellyExecuteUtilsTest {
                             l -> l.parallelStream().filter(i -> i > 5).collect(Collectors.toList()),
                             Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
                             queueSize);
-            Integer[] result = new Integer[]{6, 7, 8, 9, 10};
+            Integer[] result = new Integer[] {6, 7, 8, 9, 10};
 
             Assertions.assertThat(re).hasSameElementsAs(Arrays.asList(result));
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
@@ -312,6 +313,11 @@ public class ContinuousFileSplitEnumeratorTest {
                 throw new EndOfScanException();
             }
             return plan;
+        }
+
+        @Override
+        public List<Partition> partitions() {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroBulkFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroBulkFormatTest.java
@@ -128,4 +128,19 @@ class AvroBulkFormatTest {
         reader.forEachRemaining(
                 rowData -> assertThat(rowData).isEqualTo(TEST_DATA.get(i.getAndIncrement())));
     }
+
+    @Test
+    void testReadPartRecord() throws IOException {
+        AvroBulkFormatTestUtils.TestingAvroPartBulkFormat bulkFormat =
+                new AvroBulkFormatTestUtils.TestingAvroPartBulkFormat();
+        RecordReader<InternalRow> reader =
+                bulkFormat.createReader(new LocalFileIO(), new Path(tmpFile.toString()));
+        AtomicInteger i = new AtomicInteger(0);
+        reader.forEachRemaining(
+                rowData ->
+                        assertThat(((GenericRow) rowData).getField(0))
+                                .isEqualTo(
+                                        ((GenericRow) TEST_DATA.get(i.getAndIncrement()))
+                                                .getField(1)));
+    }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroBulkFormatTestUtils.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroBulkFormatTestUtils.java
@@ -40,6 +40,13 @@ public class AvroBulkFormatTestUtils {
                             .build()
                             .notNull();
 
+    public static final RowType SINGLE_ROW_TYPE =
+            (RowType)
+                    RowType.builder()
+                            .fields(new DataType[] {DataTypes.STRING()}, new String[] {"b"})
+                            .build()
+                            .notNull();
+
     /** {@link AbstractAvroBulkFormat} for tests. */
     public static class TestingAvroBulkFormat extends AbstractAvroBulkFormat<GenericRecord> {
 
@@ -56,6 +63,26 @@ public class AvroBulkFormatTestUtils {
         protected Function<GenericRecord, InternalRow> createConverter() {
             AvroToRowDataConverters.AvroToRowDataConverter converter =
                     AvroToRowDataConverters.createRowConverter(ROW_TYPE);
+            return record -> record == null ? null : (InternalRow) converter.convert(record);
+        }
+    }
+
+    /** {@link AbstractAvroBulkFormat} for tests. */
+    public static class TestingAvroPartBulkFormat extends AbstractAvroBulkFormat<GenericRecord> {
+
+        protected TestingAvroPartBulkFormat() {
+            super(AvroSchemaConverter.convertToSchema(SINGLE_ROW_TYPE));
+        }
+
+        @Override
+        protected GenericRecord createReusedAvroRecord() {
+            return new GenericData.Record(readerSchema);
+        }
+
+        @Override
+        protected Function<GenericRecord, InternalRow> createConverter() {
+            AvroToRowDataConverters.AvroToRowDataConverter converter =
+                    AvroToRowDataConverters.createRowConverter(SINGLE_ROW_TYPE);
             return record -> record == null ? null : (InternalRow) converter.convert(record);
         }
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.CatalogLock;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.Partition;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.Lock;
@@ -377,6 +378,18 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public boolean caseSensitive() {
         return false;
+    }
+
+    @Override
+    public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
+        checkNotSystemTable(identifier, "listPartitions");
+        throw new UnsupportedOperationException("not support yet");
+    }
+
+    @Override
+    public void dropPartitions(Identifier identifier, List<Partition> partitions)
+            throws TableNotExistException {
+        throw new UnsupportedOperationException("not support yet");
     }
 
     @Override


### PR DESCRIPTION
[core] add interface listPartitions and dropPartitions to paimon Catalog (#1004)


### Purpose

* add interfaces and realize listPartitions interface by  projection down way ( directly read the avro schema in avro reader)

* add parallelismBatchIterable function in AbstractFileStoreScan to limit memory usage while parallelly reading manifest file

### Tests

add test in test class

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
