### PR TITLE
[flink] Support specifying table affix in MySQL CDC action

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -113,6 +113,8 @@ To use this feature through `flink run`, run the following shell command.
     --warehouse <warehouse-path> \
     --database <database-name> \
     [--ignore-incompatible <true/false>] \
+    [--table-prefix <paimon-table-prefix>] \
+    [--table-suffix <paimon-table-suffix>] \
     [--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
     [--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]
@@ -122,6 +124,9 @@ To use this feature through `flink run`, run the following shell command.
 * `--database` is the database name in Paimon catalog.
 * `--ignore-incompatible` is default false, in this case, if MySQL table name exists in Paimon and their schema is incompatible, 
 an exception will be thrown. You can specify it to true explicitly to ignore the incompatible tables and exception.
+* `--table-prefix` is the prefix of all Paimon tables to be synchronized. For example, if you want all synchronized tables 
+to have "ods_" as prefix, you can specify `--table-prefix ods_`.
+* `--table-suffix` is the suffix of all Paimon tables to be synchronized. The usage is same as `--table-prefix`.
 * `--mysql-conf` is the configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format `key=value`. `hostname`, `username`, `password` and `database-name` are required configurations, others are optional. Note that `database-name` should be the exact name of the MySQL databse you want to synchronize. It can't be a regular expression. See its [document](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options) for a complete list of configurations.
 * `--catalog-conf` is the configuration for Paimon catalog. Each configuration should be specified in the format `key=value`. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of catalog configurations.
 * `--table-conf` is the configuration for Paimon table sink. Each configuration should be specified in the format `key=value`. All Paimon sink table will be applied the same set of configurations. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of table configurations.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -62,23 +62,21 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ZoneId serverTimeZone;
     private final boolean caseSensitive;
-    private final String tablePrefix;
-    private final String tableSuffix;
+    private final TableNameConverter tableNameConverter;
 
     private JsonNode payload;
     private Map<String, String> mySqlFieldTypes;
     private Map<String, String> fieldClassNames;
 
     public MySqlDebeziumJsonEventParser(ZoneId serverTimeZone, boolean caseSensitive) {
-        this(serverTimeZone, caseSensitive, "", "");
+        this(serverTimeZone, caseSensitive, new TableNameConverter(caseSensitive));
     }
 
     public MySqlDebeziumJsonEventParser(
-            ZoneId serverTimeZone, boolean caseSensitive, String tablePrefix, String tableSuffix) {
+            ZoneId serverTimeZone, boolean caseSensitive, TableNameConverter tableNameConverter) {
         this.serverTimeZone = serverTimeZone;
         this.caseSensitive = caseSensitive;
-        this.tablePrefix = tablePrefix;
-        this.tableSuffix = tableSuffix;
+        this.tableNameConverter = tableNameConverter;
     }
 
     @Override
@@ -104,8 +102,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     @Override
     public String tableName() {
         String tableName = payload.get("source").get("table").asText();
-        tableName = caseSensitive ? tableName : tableName.toLowerCase();
-        return tablePrefix + tableName + tableSuffix;
+        return tableNameConverter.convert(tableName);
     }
 
     private void updateFieldTypes(JsonNode schema) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -62,14 +62,23 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ZoneId serverTimeZone;
     private final boolean caseSensitive;
+    private final String tablePrefix;
+    private final String tableSuffix;
 
     private JsonNode payload;
     private Map<String, String> mySqlFieldTypes;
     private Map<String, String> fieldClassNames;
 
     public MySqlDebeziumJsonEventParser(ZoneId serverTimeZone, boolean caseSensitive) {
+        this(serverTimeZone, caseSensitive, "", "");
+    }
+
+    public MySqlDebeziumJsonEventParser(
+            ZoneId serverTimeZone, boolean caseSensitive, String tablePrefix, String tableSuffix) {
         this.serverTimeZone = serverTimeZone;
         this.caseSensitive = caseSensitive;
+        this.tablePrefix = tablePrefix;
+        this.tableSuffix = tableSuffix;
     }
 
     @Override
@@ -95,7 +104,8 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     @Override
     public String tableName() {
         String tableName = payload.get("source").get("table").asText();
-        return caseSensitive ? tableName : tableName.toLowerCase();
+        tableName = caseSensitive ? tableName : tableName.toLowerCase();
+        return tablePrefix + tableName + tableSuffix;
     }
 
     private void updateFieldTypes(JsonNode schema) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSchema.java
@@ -33,10 +33,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** Utility class to load MySQL table schema with JDBC. */
 public class MySqlSchema {
 
-    // used for retrieving metadata and throwing error, do not convert to case-insensitive form
     private final String databaseName;
-    private final String originalTableName;
-    // might be converted to case-insensitive form
     private final String tableName;
 
     private final LinkedHashMap<String, DataType> fields;
@@ -46,8 +43,7 @@ public class MySqlSchema {
             DatabaseMetaData metaData, String databaseName, String tableName, boolean caseSensitive)
             throws Exception {
         this.databaseName = databaseName;
-        this.originalTableName = tableName;
-        this.tableName = caseSensitive ? tableName : tableName.toLowerCase();
+        this.tableName = tableName;
 
         fields = new LinkedHashMap<>();
         try (ResultSet rs = metaData.getColumns(databaseName, null, tableName, null)) {
@@ -68,7 +64,7 @@ public class MySqlSchema {
                             !fields.containsKey(fieldName.toLowerCase()),
                             String.format(
                                     "Duplicate key '%s' in table '%s.%s' appears when converting fields map keys to case-insensitive form.",
-                                    fieldName, databaseName, originalTableName));
+                                    fieldName, databaseName, tableName));
                     fieldName = fieldName.toLowerCase();
                 }
                 fields.put(fieldName, MySqlTypeUtils.toDataType(fieldType, precision, scale));
@@ -89,10 +85,6 @@ public class MySqlSchema {
 
     public String databaseName() {
         return databaseName;
-    }
-
-    public String originalTableName() {
-        return originalTableName;
     }
 
     public String tableName() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/TableNameConverter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/TableNameConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.mysql;
+
+import java.io.Serializable;
+
+/** Used to convert a MySQL source table name to corresponding Paimon table name. */
+public class TableNameConverter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean caseSensitive;
+    private final String prefix;
+    private final String suffix;
+
+    TableNameConverter(boolean caseSensitive) {
+        this(caseSensitive, "", "");
+    }
+
+    TableNameConverter(boolean caseSensitive, String prefix, String suffix) {
+        this.caseSensitive = caseSensitive;
+        this.prefix = prefix;
+        this.suffix = suffix;
+    }
+
+    public String convert(String originName) {
+        String tableName = caseSensitive ? originName : originName.toLowerCase();
+        return prefix + tableName + suffix;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
@@ -308,3 +308,23 @@ CREATE TABLE compatible (
     v2 BIGINT,
     PRIMARY KEY (k1, k2)
 );
+
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testTableAffix
+-- ################################################################################
+
+CREATE DATABASE paimon_sync_database_affix;
+USE paimon_sync_database_affix;
+
+CREATE TABLE t1 (
+    k1 INT,
+    v0 VARCHAR(10),
+    PRIMARY KEY (k1)
+);
+
+CREATE TABLE t2 (
+    k2 INT,
+    v0 VARCHAR(10),
+    PRIMARY KEY (k2)
+);
+


### PR DESCRIPTION
### Purpose

Fix #1017 

### Tests

`MySqlSyncDatabaseActionITCase#testTableAffix`

### API and Format 

New args for mysql-sync-database:
--table-prefix
--table-suffix
both are optional

### Documentation

CDC Ingestion # Synchronizing Databases