### PR TITLE
[flink] Support specifying including or excluding source tables in MySQL CDC action

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -115,8 +115,8 @@ To use this feature through `flink run`, run the following shell command.
     [--ignore-incompatible <true/false>] \
     [--table-prefix <paimon-table-prefix>] \
     [--table-suffix <paimon-table-suffix>] \
-    [--including-table <mysql-table-name|name-regular-expr>] \
-    [--excluding-table <mysql-table-name|name-regular-expr>] \
+    [--including-tables <mysql-table-name|name-regular-expr>] \
+    [--excluding-tables <mysql-table-name|name-regular-expr>] \
     [--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
     [--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]
@@ -129,10 +129,10 @@ an exception will be thrown. You can specify it to true explicitly to ignore the
 * `--table-prefix` is the prefix of all Paimon tables to be synchronized. For example, if you want all synchronized tables 
 to have "ods_" as prefix, you can specify `--table-prefix ods_`.
 * `--table-suffix` is the suffix of all Paimon tables to be synchronized. The usage is same as `--table-prefix`.
-* `--including-table` is used to specify which source tables are to be synchronized. You must use '|' to separate multiple
-tables. Regular expression is supported, for example, specifying `--including-table test|paimon.*` means to synchronize
-table 'test' and all tables start with 'paimon'. This argument can not be used with `--excluding-table` at the same time.
-* `--excluding-table` is used to specify which source tables are not to be synchronized. The usage is same as `--including-table`.
+* `--including-tables` is used to specify which source tables are to be synchronized. You must use '|' to separate multiple
+tables. Regular expression is supported, for example, specifying `--including-tables test|paimon.*` means to synchronize
+table 'test' and all tables start with 'paimon'. This argument can not be used with `--excluding-tables` at the same time.
+* `--excluding-tables` is used to specify which source tables are not to be synchronized. The usage is same as `--including-tables`.
 * `--mysql-conf` is the configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format `key=value`. `hostname`, `username`, `password` and `database-name` are required configurations, others are optional. Note that `database-name` should be the exact name of the MySQL databse you want to synchronize. It can't be a regular expression. See its [document](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options) for a complete list of configurations.
 * `--catalog-conf` is the configuration for Paimon catalog. Each configuration should be specified in the format `key=value`. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of catalog configurations.
 * `--table-conf` is the configuration for Paimon table sink. Each configuration should be specified in the format `key=value`. All Paimon sink table will be applied the same set of configurations. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of table configurations.

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -131,8 +131,9 @@ to have "ods_" as prefix, you can specify `--table-prefix ods_`.
 * `--table-suffix` is the suffix of all Paimon tables to be synchronized. The usage is same as `--table-prefix`.
 * `--including-tables` is used to specify which source tables are to be synchronized. You must use '|' to separate multiple
 tables. Regular expression is supported, for example, specifying `--including-tables test|paimon.*` means to synchronize
-table 'test' and all tables start with 'paimon'. This argument can not be used with `--excluding-tables` at the same time.
+table 'test' and all tables start with 'paimon'.
 * `--excluding-tables` is used to specify which source tables are not to be synchronized. The usage is same as `--including-tables`.
+`--excluding-tables` has higher priority than `--including-tables` if you specified both.
 * `--mysql-conf` is the configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format `key=value`. `hostname`, `username`, `password` and `database-name` are required configurations, others are optional. Note that `database-name` should be the exact name of the MySQL databse you want to synchronize. It can't be a regular expression. See its [document](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options) for a complete list of configurations.
 * `--catalog-conf` is the configuration for Paimon catalog. Each configuration should be specified in the format `key=value`. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of catalog configurations.
 * `--table-conf` is the configuration for Paimon table sink. Each configuration should be specified in the format `key=value`. All Paimon sink table will be applied the same set of configurations. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of table configurations.

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -115,6 +115,8 @@ To use this feature through `flink run`, run the following shell command.
     [--ignore-incompatible <true/false>] \
     [--table-prefix <paimon-table-prefix>] \
     [--table-suffix <paimon-table-suffix>] \
+    [--including-table <mysql-table-name|name-regular-expr>] \
+    [--excluding-table <mysql-table-name|name-regular-expr>] \
     [--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
     [--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]
@@ -127,6 +129,10 @@ an exception will be thrown. You can specify it to true explicitly to ignore the
 * `--table-prefix` is the prefix of all Paimon tables to be synchronized. For example, if you want all synchronized tables 
 to have "ods_" as prefix, you can specify `--table-prefix ods_`.
 * `--table-suffix` is the suffix of all Paimon tables to be synchronized. The usage is same as `--table-prefix`.
+* `--including-table` is used to specify which source tables are to be synchronized. You must use '|' to separate multiple
+tables. Regular expression is supported, for example, specifying `--including-table test|paimon.*` means to synchronize
+table 'test' and all tables start with 'paimon'. This argument can not be used with `--excluding-table` at the same time.
+* `--excluding-table` is used to specify which source tables are not to be synchronized. The usage is same as `--including-table`.
 * `--mysql-conf` is the configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format `key=value`. `hostname`, `username`, `password` and `database-name` are required configurations, others are optional. Note that `database-name` should be the exact name of the MySQL databse you want to synchronize. It can't be a regular expression. See its [document](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options) for a complete list of configurations.
 * `--catalog-conf` is the configuration for Paimon catalog. Each configuration should be specified in the format `key=value`. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of catalog configurations.
 * `--table-conf` is the configuration for Paimon table sink. Each configuration should be specified in the format `key=value`. All Paimon sink table will be applied the same set of configurations. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of table configurations.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -136,8 +136,8 @@ public class MySqlSyncDatabaseAction implements Action {
             boolean ignoreIncompatible,
             @Nullable String tablePrefix,
             @Nullable String tableSuffix,
-            @Nullable String includingTable,
-            @Nullable String excludingTable,
+            @Nullable String includingTables,
+            @Nullable String excludingTables,
             Map<String, String> catalogConfig,
             Map<String, String> tableConfig) {
         this.mySqlConfig = Configuration.fromMap(mySqlConfig);
@@ -148,10 +148,10 @@ public class MySqlSyncDatabaseAction implements Action {
         this.tableSuffix = tableSuffix == null ? "" : tableSuffix;
 
         checkArgument(
-                includingTable == null || excludingTable == null,
+                includingTables == null || excludingTables == null,
                 "Cannot specify including tables and excluding tables at the same time.");
-        this.includingPattern = includingTable == null ? null : Pattern.compile(includingTable);
-        this.excludingPattern = excludingTable == null ? null : Pattern.compile(excludingTable);
+        this.includingPattern = includingTables == null ? null : Pattern.compile(includingTables);
+        this.excludingPattern = excludingTables == null ? null : Pattern.compile(excludingTables);
 
         this.catalogConfig = catalogConfig;
         this.tableConfig = tableConfig;
@@ -340,10 +340,10 @@ public class MySqlSyncDatabaseAction implements Action {
         boolean ignoreIncompatible = Boolean.parseBoolean(params.get("ignore-incompatible"));
         String tablePrefix = params.get("table-prefix");
         String tableSuffix = params.get("table-suffix");
-        String includingTable = params.get("including-table");
-        String excludingTable = params.get("excluding-table");
+        String includingTables = params.get("including-tables");
+        String excludingTables = params.get("excluding-tables");
 
-        if (includingTable != null && excludingTable != null) {
+        if (includingTables != null && excludingTables != null) {
             System.err.println(
                     "Cannot specify including tables and excluding tables at the same time.");
             return Optional.empty();
@@ -364,8 +364,8 @@ public class MySqlSyncDatabaseAction implements Action {
                         ignoreIncompatible,
                         tablePrefix,
                         tableSuffix,
-                        includingTable,
-                        excludingTable,
+                        includingTables,
+                        excludingTables,
                         catalogConfig == null ? Collections.emptyMap() : catalogConfig,
                         tableConfig == null ? Collections.emptyMap() : tableConfig));
     }
@@ -405,8 +405,8 @@ public class MySqlSyncDatabaseAction implements Action {
                         + "[--ignore-incompatible <true/false>] "
                         + "[--table-prefix <paimon-table-prefix>] "
                         + "[--table-suffix <paimon-table-suffix>] "
-                        + "[--including-table <mysql-table-name|name-regular-expr>] "
-                        + "[--excluding-table <mysql-table-name|name-regular-expr>] "
+                        + "[--including-tables <mysql-table-name|name-regular-expr>] "
+                        + "[--excluding-tables <mysql-table-name|name-regular-expr>] "
                         + "[--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] "
                         + "[--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] "
                         + "[--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]");
@@ -425,11 +425,11 @@ public class MySqlSyncDatabaseAction implements Action {
         System.out.println();
 
         System.out.println(
-                "--including-table is used to specify which source tables are to be synchronized. "
+                "--including-tables is used to specify which source tables are to be synchronized. "
                         + "You must use '|' to separate multiple tables. Regular expression is supported.");
         System.out.println(
-                "--excluding-table is used to specify which source tables are not to be synchronized. "
-                        + "The usage is same as --including-table.");
+                "--excluding-tables is used to specify which source tables are not to be synchronized. "
+                        + "The usage is same as --including-tables.");
         System.out.println(
                 "You cannot use --including-table and --excluding-table at the same time.");
         System.out.println();

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
@@ -329,7 +329,7 @@ CREATE TABLE t2 (
 );
 
 -- ################################################################################
---  MySqlSyncDatabaseActionITCase#testIncludingTable
+--  MySqlSyncDatabaseActionITCase#testIncludingTables
 -- ################################################################################
 
 CREATE DATABASE paimon_sync_database_including;
@@ -356,7 +356,7 @@ CREATE TABLE ignored (
 );
 
 -- ################################################################################
---  MySqlSyncDatabaseActionITCase#testExcludingTable
+--  MySqlSyncDatabaseActionITCase#testExcludingTables
 -- ################################################################################
 
 CREATE DATABASE paimon_sync_database_excluding;
@@ -378,6 +378,33 @@ CREATE TABLE flink (
 );
 
 CREATE TABLE sync (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testIncludingAndExcludingTables
+-- ################################################################################
+
+CREATE DATABASE paimon_sync_database_in_excluding;
+USE paimon_sync_database_in_excluding;
+
+CREATE TABLE paimon_1 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE paimon_2 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE flink (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE test (
     k INT,
     PRIMARY KEY (k)
 );

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/setup.sql
@@ -328,3 +328,56 @@ CREATE TABLE t2 (
     PRIMARY KEY (k2)
 );
 
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testIncludingTable
+-- ################################################################################
+
+CREATE DATABASE paimon_sync_database_including;
+USE paimon_sync_database_including;
+
+CREATE TABLE paimon_1 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE paimon_2 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE flink (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE ignored (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testExcludingTable
+-- ################################################################################
+
+CREATE DATABASE paimon_sync_database_excluding;
+USE paimon_sync_database_excluding;
+
+CREATE TABLE paimon_1 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE paimon_2 (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE flink (
+    k INT,
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE sync (
+    k INT,
+    PRIMARY KEY (k)
+);


### PR DESCRIPTION
### Purpose

As title.

### Tests

`MySqlSyncDatabaseActionITCase#testIncludingTable`
`MySqlSyncDatabaseActionITCase#testExcludingTable`

### API and Format 

New args of mysql-sync-database:
`--including-table`
`--excluding-table`

### Documentation
CDC Ingestion # Synchronizing Databases

*(Does this change introduce a new feature)*
