### PR TITLE
[flink][bug] MySQL datetime and timestamp default precision should be 0

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -171,7 +171,9 @@ public class MySqlTypeUtils {
             case DATETIME:
             case TIMESTAMP:
                 if (length == null) {
-                    return DataTypes.TIMESTAMP();
+                    // default precision is 0
+                    // see https://dev.mysql.com/doc/refman/8.0/en/date-and-time-type-syntax.html
+                    return DataTypes.TIMESTAMP(0);
                 } else if (length >= JDBC_TIMESTAMP_BASE_LENGTH) {
                     if (length > JDBC_TIMESTAMP_BASE_LENGTH + 1) {
                         // Timestamp with a fraction of seconds.
@@ -184,7 +186,10 @@ public class MySqlTypeUtils {
                 } else if (length >= 0 && length <= TimestampType.MAX_PRECISION) {
                     return DataTypes.TIMESTAMP(length);
                 } else {
-                    return DataTypes.TIMESTAMP();
+                    throw new UnsupportedOperationException(
+                            "Unsupported length "
+                                    + length
+                                    + " for MySQL DATETIME and TIMESTAMP types");
                 }
             case CHAR:
                 return DataTypes.CHAR(Preconditions.checkNotNull(length));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
@@ -83,17 +83,19 @@ public class MySqlActionITCaseBase extends ActionITCaseBase {
 
         // wait for table schema to become our expected schema
         while (true) {
-            int cnt = 0;
-            for (int i = 0; i < table.schema().fields().size(); i++) {
-                DataField field = table.schema().fields().get(i);
-                boolean sameName = field.name().equals(rowType.getFieldNames().get(i));
-                boolean sameType = field.type().equals(rowType.getFieldTypes().get(i));
-                if (sameName && sameType) {
-                    cnt++;
+            if (rowType.getFieldCount() == table.schema().fields().size()) {
+                int cnt = 0;
+                for (int i = 0; i < table.schema().fields().size(); i++) {
+                    DataField field = table.schema().fields().get(i);
+                    boolean sameName = field.name().equals(rowType.getFieldNames().get(i));
+                    boolean sameType = field.type().equals(rowType.getFieldTypes().get(i));
+                    if (sameName && sameType) {
+                        cnt++;
+                    }
                 }
-            }
-            if (cnt == rowType.getFieldCount()) {
-                break;
+                if (cnt == rowType.getFieldCount()) {
+                    break;
+                }
             }
             table = table.copyWithLatestSchema();
             Thread.sleep(1000);


### PR DESCRIPTION
### Purpose

This PR fixes #1020.

In MySQL, `datetime` and `timestamp` default precision is 0 (see https://dev.mysql.com/doc/refman/8.0/en/date-and-time-type-syntax.html). However in Paimon, `timestamp` default precision is 6.

This PR fixes the conversion between MySQL `datetime` / `timestamp` types with default precision and Paimon `timestamp` type.

### Tests

* `MySqlSyncTableActionITCase#testAllTypes`

### API and Format 

N/A

### Documentation

N/A
