### PR TITLE
[core] add range check of snapshot id during scan to prevent endless waiting

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -114,6 +114,13 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
             }
 
             if (!snapshotManager.snapshotExists(nextSnapshotId)) {
+                Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+                if (earliestSnapshotId != null && earliestSnapshotId > nextSnapshotId) {
+                    throw new OutOfRangeException(
+                            String.format(
+                                    "The snapshot waiting to be consumed is %d, but the earliest snapshot in storage is %d.",
+                                    nextSnapshotId, earliestSnapshotId));
+                }
                 LOG.debug(
                         "Next snapshot id {} does not exist, wait for the snapshot generation.",
                         nextSnapshotId);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -118,8 +118,10 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                 if (earliestSnapshotId != null && earliestSnapshotId > nextSnapshotId) {
                     throw new OutOfRangeException(
                             String.format(
-                                    "The snapshot waiting to be consumed is %d, but the earliest snapshot in storage is %d.",
-                                    nextSnapshotId, earliestSnapshotId));
+                                    "The snapshot with id %d has expired., You can: "
+                                            + "1. increase the snapshot expiration time. "
+                                            + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.",
+                                    nextSnapshotId));
                 }
                 LOG.debug(
                         "Next snapshot id {} does not exist, wait for the snapshot generation.",

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/OutOfRangeException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/OutOfRangeException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+/** Indicates that the snapshot to be consumed has been deleted from storage. */
+public class OutOfRangeException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public OutOfRangeException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
### Purpose

[core] add range check of snapshot id during scan to prevent endless waiting.  This will fix #807 .

### Tests

No.

### API and Format 

No.

### Documentation

No.
