### PR TITLE
[hotfix] fix error format date

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -148,16 +148,16 @@ public class PartitionExpireTest {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         // prepare commits
-        int now =
-                Integer.parseInt(
-                        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")));
         int preparedCommits = random.nextInt(20, 30);
 
         List<List<CommitMessage>> commitMessages = new ArrayList<>();
         Set<Long> notCommitted = new HashSet<>();
         for (int i = 0; i < preparedCommits; i++) {
             // ensure the partition will be expired
-            String f0 = String.valueOf(now - random.nextInt(10));
+            String f0 =
+                    LocalDateTime.now()
+                            .minusDays(random.nextInt(10))
+                            .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
             String f1 = String.valueOf(random.nextInt(25));
             StreamTableWrite write = table.newWrite(commitUser);
             write.write(GenericRow.of(BinaryString.fromString(f0), BinaryString.fromString(f1)));


### PR DESCRIPTION
*(Please specify the module before the PR name: [core] ... or [flink] ...)*

### Purpose

*fix the error format date.*

the error is 

```
org.apache.paimon.operation.PartitionExpireTest
Error:  testFilterCommittedAfterExpiring  Time elapsed: 5.714 s  <<< ERROR!
java.time.format.DateTimeParseException: Text '20230499' could not be parsed: Invalid value for DayOfMonth (valid values 1 - 28/31): 99
	at java.time.format.DateTimeFormatter.createError(DateTimeFormatter.java:1920)
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1855)
	at java.time.LocalDate.parse(LocalDate.java:400)
	at org.apache.paimon.partition.PartitionTimeExtractor.toLocalDateTime(PartitionTimeExtractor.java:112)
	at org.apache.paimon.partition.PartitionTimeExtractor.extract(PartitionTimeExtractor.java:97)
	at org.apache.paimon.operation.PartitionExpire.doExpire(PartitionExpire.java:95)
	at org.apache.paimon.operation.PartitionExpire.expire(PartitionExpire.java:85)
	at org.apache.paimon.operation.PartitionExpire.expire(PartitionExpire.java:74)
	at org.apache.paimon.table.sink.TableCommitImpl.expire(TableCommitImpl.java:145)
	at org.apache.paimon.table.sink.TableCommitImpl.commit(TableCommitImpl.java:105)
	at org.apache.paimon.operation.PartitionExpireTest.testFilterCommittedAfterExpiring(PartitionExpireTest.java:189)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

```


### Tests

*org.apache.paimon.operation.PartitionExpireTest#testFilterCommittedAfterExpiring*

### API and Format 

*(Does this change affect API or storage format)*

### Documentation

*(Does this change introduce a new feature)*
