### PR TITLE
[core] Add withMemoryPool for TableWrite

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.utils.CommitIncrement;
@@ -80,6 +81,11 @@ public abstract class AbstractFileStoreWrite<T>
     @Override
     public FileStoreWrite<T> withIOManager(IOManager ioManager) {
         this.ioManager = ioManager;
+        return this;
+    }
+
+    @Override
+    public FileStoreWrite<T> withMemoryPool(MemorySegmentPool memoryPool) {
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -22,6 +22,7 @@ import org.apache.paimon.FileStore;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.utils.RecordWriter;
@@ -37,6 +38,13 @@ import java.util.List;
 public interface FileStoreWrite<T> {
 
     FileStoreWrite<T> withIOManager(IOManager ioManager);
+
+    /**
+     * With memory pool for the current file store write.
+     *
+     * @param memoryPool the given memory pool.
+     */
+    FileStoreWrite<T> withMemoryPool(MemorySegmentPool memoryPool);
 
     /**
      * If overwrite is true, the writer will overwrite the store, otherwise it won't.

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.Table;
 
 /**
@@ -34,6 +35,9 @@ public interface TableWrite extends AutoCloseable {
 
     /** With {@link IOManager}, this is needed if 'write-buffer-spillable' is set to true. */
     TableWrite withIOManager(IOManager ioManager);
+
+    /** With {@link MemorySegmentPool} for the current table write. */
+    TableWrite withMemoryPool(MemorySegmentPool memoryPool);
 
     /** Calculate which partition {@code row} belongs to. */
     BinaryRow getPartition(InternalRow row);

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.utils.Restorable;
@@ -63,6 +64,12 @@ public class TableWriteImpl<T>
     @Override
     public TableWriteImpl<T> withIOManager(IOManager ioManager) {
         write.withIOManager(ioManager);
+        return this;
+    }
+
+    @Override
+    public TableWriteImpl<T> withMemoryPool(MemorySegmentPool memoryPool) {
+        write.withMemoryPool(memoryPool);
         return this;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -70,6 +71,10 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                         (part, bucket) ->
                                 state.stateValueFilter().filter(table.name(), part, bucket))
                 .withIOManager(new IOManagerImpl(ioManager.getSpillingDirectoriesPaths()))
+                .withMemoryPool(
+                        new HeapMemorySegmentPool(
+                                table.coreOptions().writeBufferSize(),
+                                table.coreOptions().pageSize()))
                 .withOverwrite(isOverwrite);
     }
 


### PR DESCRIPTION
### Purpose

Add withMemoryPool for TableWrite and different engines can create memory pool for paimon writer buffer
Fix #1070 

### Tests

Existing tests can cover this feature

### API and Format 

1. Add withMemoryPool in TableWrite

### Documentation
