### PR TITLE
[flink] Support nullability change when altering table on flink 1.17

### DIFF
--- a/docs/content/how-to/altering-tables.md
+++ b/docs/content/how-to/altering-tables.md
@@ -288,7 +288,7 @@ ALTER TABLE my_table DROP COLUMN c1;
 
 ## Changing Column Nullability
 
-The following SQL sets column `coupon_info` to be nullable.
+The following SQL changes nullability of column `coupon_info`.
 
 {{< tabs "change-nullability-example" >}}
 
@@ -296,7 +296,14 @@ The following SQL sets column `coupon_info` to be nullable.
 
 ```sql
 CREATE TABLE my_table (id INT PRIMARY KEY NOT ENFORCED, coupon_info FLOAT NOT NULL);
+
+-- Change column `coupon_info` from NOT NULL to nullable
 ALTER TABLE my_table MODIFY coupon_info FLOAT;
+
+-- Change column `coupon_info` from nullable to NOT NULL
+-- If there are NULL values already, set table option as below to drop those records silently before altering table.
+SET 'table.exec.sink.not-null-enforcer' = 'DROP';
+ALTER TABLE my_table MODIFY coupon_info FLOAT NOT NULL;
 ```
 
 {{< /tab >}}
@@ -311,6 +318,12 @@ ALTER TABLE my_table ALTER COLUMN coupon_info DROP NOT NULL;
 {{< /tab >}}
 
 {{< /tabs >}}
+
+{{< hint info >}}
+
+Changing nullable column to NOT NULL is only supported by Flink currently.
+
+{{< /hint >}}
 
 ## Changing Column Comment
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -381,7 +381,7 @@ public class FlinkCatalog extends AbstractCatalog {
         if (null != tableChanges) {
             List<SchemaChange> schemaChanges =
                     tableChanges.stream()
-                            .flatMap(tableChange -> (toSchemaChange(tableChange).stream()))
+                            .flatMap(tableChange -> toSchemaChange(tableChange).stream())
                             .collect(Collectors.toList());
             changes.addAll(schemaChanges);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -256,12 +256,13 @@ public class FlinkCatalog extends AbstractCatalog {
             AddColumn add = (AddColumn) change;
             String comment = add.getColumn().getComment().orElse(null);
             SchemaChange.Move move = getMove(add.getPosition(), add.getColumn().getName());
-            schemaChanges.add(SchemaChange.addColumn(
-                    add.getColumn().getName(),
-                    LogicalTypeConversion.toDataType(
-                            add.getColumn().getDataType().getLogicalType()),
-                    comment,
-                    move));
+            schemaChanges.add(
+                    SchemaChange.addColumn(
+                            add.getColumn().getName(),
+                            LogicalTypeConversion.toDataType(
+                                    add.getColumn().getDataType().getLogicalType()),
+                            comment,
+                            move));
             return schemaChanges;
         } else if (change instanceof DropColumn) {
             DropColumn drop = (DropColumn) change;
@@ -269,16 +270,21 @@ public class FlinkCatalog extends AbstractCatalog {
             return schemaChanges;
         } else if (change instanceof ModifyColumnName) {
             ModifyColumnName modify = (ModifyColumnName) change;
-            schemaChanges.add(SchemaChange.renameColumn(modify.getOldColumnName(), modify.getNewColumnName()));
+            schemaChanges.add(
+                    SchemaChange.renameColumn(
+                            modify.getOldColumnName(), modify.getNewColumnName()));
             return schemaChanges;
         } else if (change instanceof ModifyPhysicalColumnType) {
             ModifyPhysicalColumnType modify = (ModifyPhysicalColumnType) change;
-            schemaChanges.add(SchemaChange.updateColumnNullability(
-                    new String[]{modify.getNewColumn().getName()},
-                    modify.getNewType().getLogicalType().isNullable()));
-            schemaChanges.add(SchemaChange.updateColumnType(
-                    modify.getOldColumn().getName(),
-                    LogicalTypeConversion.toDataType(modify.getNewType().getLogicalType())));
+            schemaChanges.add(
+                    SchemaChange.updateColumnNullability(
+                            new String[] {modify.getNewColumn().getName()},
+                            modify.getNewType().getLogicalType().isNullable()));
+            schemaChanges.add(
+                    SchemaChange.updateColumnType(
+                            modify.getOldColumn().getName(),
+                            LogicalTypeConversion.toDataType(
+                                    modify.getNewType().getLogicalType())));
             return schemaChanges;
         } else if (change instanceof ModifyColumnPosition) {
             ModifyColumnPosition modify = (ModifyColumnPosition) change;
@@ -374,7 +380,9 @@ public class FlinkCatalog extends AbstractCatalog {
         List<SchemaChange> changes = new ArrayList<>();
         if (null != tableChanges) {
             List<SchemaChange> schemaChanges =
-                    tableChanges.stream().flatMap(tableChange -> (toSchemaChange(tableChange).stream())).collect(Collectors.toList());
+                    tableChanges.stream()
+                            .flatMap(tableChange -> (toSchemaChange(tableChange).stream()))
+                            .collect(Collectors.toList());
             changes.addAll(schemaChanges);
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.paimon.testutils.assertj.AssertionUtils;
 
 import org.apache.flink.types.Row;
@@ -283,7 +285,13 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + "  `c` VARCHAR(2147483647),\n"
                                 + "  `d` INT,\n"
                                 + "  `e` FLOAT NOT NULL,");
+        assertThatThrownBy(() -> sql("INSERT INTO T VALUES('aaa', 'bbb', 'ccc', 1, CAST(NULL AS FLOAT))"))
+                .satisfies(
+                        AssertionUtils.anyCauseMatches(
+                                TableException.class,
+                                "Column 'e' is NOT NULL, however, a null value is being written into it."));
 
+        // Not null -> nullable
         sql("ALTER TABLE T MODIFY e FLOAT");
         result = sql("SHOW CREATE TABLE T");
         assertThat(result.toString())
@@ -295,10 +303,34 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + "  `d` INT,\n"
                                 + "  `e` FLOAT");
 
-        assertThatThrownBy(() -> sql("ALTER TABLE T MODIFY c STRING NOT NULL"))
-                .hasMessageContaining(
-                        "Could not execute ALTER TABLE PAIMON.default.T\n"
-                                + "  MODIFY `c` STRING NOT NULL");
+        // Nullable -> not null
+        sql("ALTER TABLE T MODIFY c STRING NOT NULL");
+        result = sql("SHOW CREATE TABLE T");
+        assertThat(result.toString())
+                .contains(
+                        "CREATE TABLE `PAIMON`.`default`.`T` (\n"
+                                + "  `a` VARCHAR(2147483647) NOT NULL,\n"
+                                + "  `b` VARCHAR(2147483647),\n"
+                                + "  `c` VARCHAR(2147483647) NOT NULL,\n"
+                                + "  `d` INT,\n"
+                                + "  `e` FLOAT");
+        assertThatThrownBy(() -> sql("INSERT INTO T VALUES('aaa', 'bbb', CAST(NULL AS STRING), 1, CAST(NULL AS FLOAT))"))
+                .satisfies(
+                        AssertionUtils.anyCauseMatches(
+                                TableException.class,
+                                "Column 'c' is NOT NULL, however, a null value is being written into it."));
+
+        // Insert a null value
+        sql("INSERT INTO T VALUES('aaa', 'bbb', 'ccc', 1, CAST(NULL AS FLOAT))");
+        result = sql("select * from T");
+        assertThat(result.toString()).isEqualTo("[+I[aaa, bbb, ccc, 1, null]]");
+
+        // Then nullable -> not null
+        tEnv.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER, ExecutionConfigOptions.NotNullEnforcer.DROP);
+        sql("ALTER TABLE T MODIFY e FLOAT NOT NULL;\n");
+        sql("INSERT INTO T VALUES('aa2', 'bb2', 'cc2', 2, 2.5)");
+        result = sql("select * from T");
+        assertThat(result.toString()).isEqualTo("[+I[aa2, bb2, cc2, 2, 2.5]]");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -18,10 +18,10 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.paimon.testutils.assertj.AssertionUtils;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 
@@ -285,7 +285,10 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + "  `c` VARCHAR(2147483647),\n"
                                 + "  `d` INT,\n"
                                 + "  `e` FLOAT NOT NULL,");
-        assertThatThrownBy(() -> sql("INSERT INTO T VALUES('aaa', 'bbb', 'ccc', 1, CAST(NULL AS FLOAT))"))
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "INSERT INTO T VALUES('aaa', 'bbb', 'ccc', 1, CAST(NULL AS FLOAT))"))
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
                                 TableException.class,
@@ -314,7 +317,10 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + "  `c` VARCHAR(2147483647) NOT NULL,\n"
                                 + "  `d` INT,\n"
                                 + "  `e` FLOAT");
-        assertThatThrownBy(() -> sql("INSERT INTO T VALUES('aaa', 'bbb', CAST(NULL AS STRING), 1, CAST(NULL AS FLOAT))"))
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "INSERT INTO T VALUES('aaa', 'bbb', CAST(NULL AS STRING), 1, CAST(NULL AS FLOAT))"))
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
                                 TableException.class,
@@ -326,7 +332,10 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         assertThat(result.toString()).isEqualTo("[+I[aaa, bbb, ccc, 1, null]]");
 
         // Then nullable -> not null
-        tEnv.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER, ExecutionConfigOptions.NotNullEnforcer.DROP);
+        tEnv.getConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER,
+                        ExecutionConfigOptions.NotNullEnforcer.DROP);
         sql("ALTER TABLE T MODIFY e FLOAT NOT NULL;\n");
         sql("INSERT INTO T VALUES('aa2', 'bb2', 'cc2', 2, 2.5)");
         result = sql("select * from T");


### PR DESCRIPTION
fix #1111 

Flink is able to modify nullable column to not null column by setting `table.exec.sink.not-null-enforcer` to `DROP` to dropping those null-value records with not-null column silently. 