### PR TITLE
[core][fix] reset the iterator in loserTree to null after releaseBatch.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LoserTree.java
@@ -309,6 +309,7 @@ public class LoserTree<T> implements Closeable {
                 while (!endOfInput) {
                     if (iterator != null) {
                         iterator.releaseBatch();
+                        iterator = null;
                     }
 
                     iterator = reader.readBatch();
@@ -327,6 +328,7 @@ public class LoserTree<T> implements Closeable {
         public void close() throws IOException {
             if (this.iterator != null) {
                 this.iterator.releaseBatch();
+                this.iterator = null;
             }
             this.reader.close();
         }


### PR DESCRIPTION
Fix #833 

### Purpose

When an exception occurs in the `readBatch` of the `RecordReader`,  the `close` of `LoserTree` may be the second time to close the `iterator`. 

solution: reset the `iterator` in `loserTree` to `null` after `releaseBatch`.

### Tests

Added unit test `org.apache.paimon.mergetree.compact#testLoserTreeCloseNormally` to verify that the `close` of `LoserTree` is normal.

### API and Format

No

### Documentation

No
