### PR TITLE
[core] The default value of continuous.discovery-interval can be 10 s

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -82,7 +82,7 @@
         </tr>
         <tr>
             <td><h5>continuous.discovery-interval</h5></td>
-            <td style="word-wrap: break-word;">1 s</td>
+            <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>
             <td>The discovery interval of continuous reading.</td>
         </tr>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -170,7 +170,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Duration> CONTINUOUS_DISCOVERY_INTERVAL =
             key("continuous.discovery-interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(1))
+                    .defaultValue(Duration.ofSeconds(10))
                     .withDescription("The discovery interval of continuous reading.");
 
     @Immutable


### PR DESCRIPTION
### Purpose

At present, the default value for `continuous.discovery-interval` is 1 second, which is too short and can cause frequent access to the file system, causing significant pressure.

We can modify its default value to 10 seconds, as our current recommended stream read delay is 30 seconds to 1 minute, which does not have a significant impact.

### Tests

No

### API and Format

No

### Documentation

Yes
