### PR TITLE
[hotfix] Fix failed test PartialUpdateITCase#testForeignKeyJoin

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
@@ -46,8 +46,8 @@ public class PartialUpdateITCase extends CatalogITCaseBase {
                 "CREATE TABLE IF NOT EXISTS dwd_orders ("
                         + "OrderID INT, OrderNumber INT, PersonID INT, LastName STRING, FirstName STRING, Age INT, PRIMARY KEY (OrderID) NOT ENFORCED)"
                         + " WITH ('merge-engine'='partial-update', 'partial-update.ignore-delete'='true');",
-                "CREATE TABLE IF NOT EXISTS ods_orders (OrderID INT, OrderNumber INT, PersonID INT, PRIMARY KEY (OrderID) NOT ENFORCED) WITH ('changelog-producer'='input');",
-                "CREATE TABLE IF NOT EXISTS dim_persons (PersonID INT, LastName STRING, FirstName STRING, Age INT, PRIMARY KEY (PersonID) NOT ENFORCED) WITH ('changelog-producer'='input');");
+                "CREATE TABLE IF NOT EXISTS ods_orders (OrderID INT, OrderNumber INT, PersonID INT, PRIMARY KEY (OrderID) NOT ENFORCED) WITH ('changelog-producer'='input', 'continuous.discovery-interval'='1s');",
+                "CREATE TABLE IF NOT EXISTS dim_persons (PersonID INT, LastName STRING, FirstName STRING, Age INT, PRIMARY KEY (PersonID) NOT ENFORCED) WITH ('changelog-producer'='input', 'continuous.discovery-interval'='1s');");
     }
 
     @Test


### PR DESCRIPTION
### Purpose
This commit (31ce2f87a8d9c1ae15584b606007a52b243b34f8) changed default value of `continuous.discovery-interval` from 1s to 10s. So the `testForeignKeyJoin` maybe failed because the data of dim table are not discovered.

Add `continuous.discovery-interval=1s` for table properties in `PartialUpdateITCase `

### Tests

`PartialUpdateITCase#testForeignKeyJoin`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
