### PR TITLE
[flink] Default enable scan.infer-parallelism

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td><h5>scan.infer-parallelism</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>If it is false, parallelism of source are set by scan.parallelism. Otherwise, source parallelism is inferred from splits number (batch mode) or bucket number(streaming mode).</td>
         </tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -89,7 +89,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Boolean> INFER_SCAN_PARALLELISM =
             ConfigOptions.key("scan.infer-parallelism")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
                             "If it is false, parallelism of source are set by "
                                     + SCAN_PARALLELISM.key()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -25,7 +25,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ReadBuilder;
-import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.system.BucketsTable;
 import org.apache.paimon.types.RowType;
 
@@ -102,15 +101,13 @@ public class CompactorSourceBuilder {
         } else {
             bucketsTable = bucketsTable.copy(batchCompactOptions());
             ReadBuilder readBuilder = bucketsTable.newReadBuilder().withFilter(partitionPredicate);
-            List<Split> splits = readBuilder.newScan().plan().splits();
             return new StaticFileStoreSource(
                     readBuilder,
                     null,
                     bucketsTable
                             .coreOptions()
                             .toConfiguration()
-                            .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
-                    splits);
+                            .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE));
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -72,7 +72,7 @@ public class DataTableSource extends AbstractDataTableSource implements Supports
             return TableStats.UNKNOWN;
         }
 
-        splitsForScan();
-        return new TableStats(rowCount);
+        scanSplitsForInference();
+        return new TableStats(splitStatistics.totalRowCount());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -30,7 +30,6 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.ReadBuilder;
-import org.apache.paimon.table.source.Split;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -48,7 +47,6 @@ import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.StreamingReadMode.FILE;
@@ -72,7 +70,6 @@ public class FlinkSourceBuilder {
     @Nullable private Integer parallelism;
     @Nullable private Long limit;
     @Nullable private WatermarkStrategy<RowData> watermarkStrategy;
-    @Nullable private List<Split> splits;
 
     public FlinkSourceBuilder(ObjectIdentifier tableIdentifier, Table table) {
         this.tableIdentifier = tableIdentifier;
@@ -121,11 +118,6 @@ public class FlinkSourceBuilder {
         return this;
     }
 
-    public FlinkSourceBuilder withSplits(List<Split> splits) {
-        this.splits = splits;
-        return this;
-    }
-
     private ReadBuilder createReadBuilder() {
         return table.newReadBuilder().withProjection(projectedFields).withFilter(predicate);
     }
@@ -136,8 +128,7 @@ public class FlinkSourceBuilder {
                         createReadBuilder(),
                         limit,
                         Options.fromMap(table.options())
-                                .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
-                        splits));
+                                .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE)));
     }
 
     private DataStream<RowData> buildContinuousFileSource() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.source;
 
 import org.apache.paimon.table.source.ReadBuilder;
-import org.apache.paimon.table.source.Split;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
@@ -36,16 +35,11 @@ public class StaticFileStoreSource extends FlinkSource {
     private static final long serialVersionUID = 3L;
 
     private final int splitBatchSize;
-    private final List<Split> splitList;
 
     public StaticFileStoreSource(
-            ReadBuilder readBuilder,
-            @Nullable Long limit,
-            int splitBatchSize,
-            List<Split> splitList) {
+            ReadBuilder readBuilder, @Nullable Long limit, int splitBatchSize) {
         super(readBuilder, limit);
         this.splitBatchSize = splitBatchSize;
-        this.splitList = splitList;
     }
 
     @Override
@@ -64,10 +58,6 @@ public class StaticFileStoreSource extends FlinkSource {
 
     private List<FileStoreSourceSplit> getSplits() {
         FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
-        if (null != splitList) {
-            return splitGenerator.createSplits(splitList);
-        } else {
-            return splitGenerator.createSplits(readBuilder.newScan().plan());
-        }
+        return splitGenerator.createSplits(readBuilder.newScan().plan());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
@@ -24,7 +24,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.ReadBuilder;
-import org.apache.paimon.table.source.Split;
 
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -33,8 +32,6 @@ import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;
-
-import java.util.List;
 
 /** A {@link FlinkTableSource} for system table. */
 public class SystemTableSource extends FlinkTableSource {
@@ -76,8 +73,7 @@ public class SystemTableSource extends FlinkTableSource {
         if (isStreamingMode && table instanceof DataTable) {
             source = new ContinuousFileStoreSource(readBuilder, table.options(), limit);
         } else {
-            List<Split> splits = readBuilder.newScan().plan().splits();
-            source = new StaticFileStoreSource(readBuilder, limit, splitBatchSize, splits);
+            source = new StaticFileStoreSource(readBuilder, limit, splitBatchSize);
         }
         return SourceProvider.of(source);
     }


### PR DESCRIPTION

### Purpose

Considering that splits have already been scanned during the statistical information inference process, we can default to enabling parallelism inference.

Additionally, we do not need to pass the splits to the runtime, as there may be a risk of OOM when there are many splits.