### PR TITLE
[Improve] Support of tencent clound chdfs schema

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/ChdfsFileIOLoader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/ChdfsFileIOLoader.java
@@ -22,7 +22,7 @@ import org.apache.paimon.fs.FileIOLoader;
 import org.apache.paimon.fs.Path;
 
 /**
- *  {@link ChdfsFileIOLoader} to support tencent cloud chdfs scheme.
+ *  {@link ChdfsFileIOLoader} to support tencent cloud chdfs schema.
  *  tencent cloud chdfs product : https://cloud.tencent.com/document/product/1105
  * */
 public class ChdfsFileIOLoader implements FileIOLoader {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/ChdfsFileIOLoader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/ChdfsFileIOLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs.hadoop;
+
+import org.apache.paimon.fs.FileIOLoader;
+import org.apache.paimon.fs.Path;
+
+/**
+ *  {@link ChdfsFileIOLoader} to support tencent cloud chdfs scheme.
+ *  tencent cloud chdfs product : https://cloud.tencent.com/document/product/1105
+ * */
+public class ChdfsFileIOLoader implements FileIOLoader {
+
+    @Override
+    public String getScheme() {
+        return "ofs";
+    }
+
+    @Override
+    public HadoopFileIO load(Path path) {
+        return new HadoopFileIO();
+    }
+}

--- a/paimon-common/src/main/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
+++ b/paimon-common/src/main/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
@@ -16,3 +16,4 @@
 org.apache.paimon.fs.local.LocalFileIOLoader
 org.apache.paimon.fs.hadoop.HadoopFileIOLoader
 org.apache.paimon.fs.hadoop.HadoopViewFsFileIOLoader
+org.apache.paimon.fs.hadoop.ChdfsFileIOLoader

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ChdfsFileIOLoaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ChdfsFileIOLoaderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class ChdfsFileIOLoaderTest {
 
     @Test
-    public void loadFromClasspathByDefault() {
+    public void testOfsSchema() {
         FileIO fileIO = FileIOFinder.find(new Path("ofs://user/warehouse"));
         Assert.assertEquals(HadoopFileIO.class, fileIO.getClass());
     }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ChdfsFileIOLoaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ChdfsFileIOLoaderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import org.apache.paimon.fs.hadoop.HadoopFileIO;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+
+/** tests for {@link org.apache.paimon.fs.hadoop.ChdfsFileIOLoader}. */
+public class ChdfsFileIOLoaderTest {
+
+    @Test
+    public void loadFromClasspathByDefault() {
+        FileIO fileIO = FileIOFinder.find(new Path("ofs://user/warehouse"));
+        Assert.assertEquals(HadoopFileIO.class, fileIO.getClass());
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Cloud HDFS (CHDFS) is a distributed file system of Tencent Cloud that provides standard HDFS access protocols, excellent performance, and hierarchical namespaces. CHDFS mainly solves massive data storage and data analysis in big data scenarios.

It's provides standard HDFS access protocols but file shema is ofs, so this pr offer a ChdfsFileIOLoader to support it.

chdfs product link : https://cloud.tencent.com/document/product/1105

<!-- What is the purpose of the change, or the associated issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
