### PR TITLE
[flink] implements SourceReader.pauseOrResumeSplit for flink-1.17

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/RecordsFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/RecordsFunction.java
@@ -26,6 +26,11 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
 
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Set;
+
 /** Records construction and emitter in source. */
 public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreSourceSplitState> {
 
@@ -101,6 +106,27 @@ public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreS
                 output.collect(record.getRecord());
                 state.setPosition(record);
             }
+        }
+    }
+
+    /** Indicates that the {@link FileStoreSourceSplitReader} is paused. */
+    class RecordsWithPausedSplit<T> implements RecordsWithSplitIds<T> {
+
+        @Nullable
+        @Override
+        public String nextSplit() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public T nextRecordFromSplit() {
+            return null;
+        }
+
+        @Override
+        public Set<String> finishedSplits() {
+            return Collections.emptySet();
         }
     }
 }


### PR DESCRIPTION


### Purpose

Implements SourceReader.pauseOrResumeSplit for flink-1.17.  close #788 

### Tests

Add `org.apache.paimon.flink.source.FileStoreSourceSplitReaderTest#testPauseOrResumeSplits` to verify correctness.

### API and Format

No.

### Documentation

No.
