### PR TITLE
[license] Add header to test java files

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/docs/layouts/shortcodes/generated/kafka_log_configuration.html
+++ b/docs/layouts/shortcodes/generated/kafka_log_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 {{ $ref := ref . "maintenance/configurations.md" }}
 <table class="configuration table table-bordered">
     <thead>

--- a/docs/layouts/shortcodes/generated/mysql_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_table.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 {{ $ref := ref . "maintenance/configurations.md" }}
 <table class="configuration table table-bordered">
     <thead>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -1,3 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
 <table class="configuration table table-bordered">
     <thead>
         <tr>

--- a/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeRewriterTestBase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeRewriterTestBase.java
@@ -50,6 +50,10 @@ abstract class CodeRewriterTestBase<R extends CodeRewriter> {
                                                             + filename
                                                             + ".java")
                                             .toURI()));
+
+            // remove apache header
+            code = removeApacheHeader(code);
+
             String expected =
                     FileIOUtils.readFileUtf8(
                             new File(
@@ -62,6 +66,9 @@ abstract class CodeRewriterTestBase<R extends CodeRewriter> {
                                                             + filename
                                                             + ".java")
                                             .toURI()));
+
+            // remove apache header
+            expected = removeApacheHeader(expected);
 
             R rewriter = rewriterProvider.apply(code);
 
@@ -79,5 +86,13 @@ abstract class CodeRewriterTestBase<R extends CodeRewriter> {
             // we reset the counter to ensure the variable names after rewrite are as expected
             CodeSplitUtil.getCounter().set(0L);
         }
+    }
+
+    private String removeApacheHeader(String code) {
+        int headerLen = 807;
+        if (code.length() == headerLen) {
+            return "";
+        }
+        return code.substring(808);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeRewriterTestBase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeRewriterTestBase.java
@@ -22,6 +22,7 @@ import org.apache.paimon.utils.FileIOUtils;
 import java.io.File;
 import java.util.function.Function;
 
+import static org.apache.paimon.codegen.codesplit.CodeSplitTestUtil.removeApacheHeader;
 import static org.apache.paimon.codegen.codesplit.CodeSplitTestUtil.trimLines;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,13 +87,5 @@ abstract class CodeRewriterTestBase<R extends CodeRewriter> {
             // we reset the counter to ensure the variable names after rewrite are as expected
             CodeSplitUtil.getCounter().set(0L);
         }
-    }
-
-    private String removeApacheHeader(String code) {
-        int headerLen = 807;
-        if (code.length() == headerLen) {
-            return "";
-        }
-        return code.substring(808);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeSplitTestUtil.java
+++ b/paimon-common/src/test/java/org/apache/paimon/codegen/codesplit/CodeSplitTestUtil.java
@@ -29,7 +29,9 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -120,5 +122,21 @@ public final class CodeSplitTestUtil {
         SimpleCompiler compiler = new SimpleCompiler();
         compiler.setParentClassLoader(cl);
         compiler.cook(code);
+    }
+
+    public static String removeApacheHeader(String content) {
+        String[] lines = content.trim().split("\n");
+        List<String> removed = new ArrayList<>();
+        int i;
+        for (i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            if (!line.startsWith("/*") && !line.startsWith(" *") && !"".equals(line)) {
+                break;
+            }
+        }
+        for (; i < lines.length; i++) {
+            removed.add(lines[i]);
+        }
+        return String.join("\n", removed);
     }
 }

--- a/paimon-common/src/test/resources/codesplit/add-boolean/code/TestAddBooleanBeforeReturn.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/code/TestAddBooleanBeforeReturn.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestAddBooleanBeforeReturn {
     public void fun1(int a) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/add-boolean/code/TestNotRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/code/TestNotRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewrite {
     public void fun1(int[] a, int[] b) {
         a[0] += b[1];

--- a/paimon-common/src/test/resources/codesplit/add-boolean/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public void fun(int a) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/add-boolean/code/TestSkipAnonymousClassAndLambda.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/code/TestSkipAnonymousClassAndLambda.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSkipAnonymousClassAndLambda {
     public void fun(String a) {
         if (a.length() > 5) {

--- a/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestAddBooleanBeforeReturn.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestAddBooleanBeforeReturn.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestAddBooleanBeforeReturn {
 boolean fun2HasReturned$1;
 boolean fun1HasReturned$0;

--- a/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestNotRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestNotRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewrite {
     public void fun1(int[] a, int[] b) {
         a[0] += b[1];

--- a/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
 boolean funHasReturned$0;
     public void fun(int a) {

--- a/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestSkipAnonymousClassAndLambda.java
+++ b/paimon-common/src/test/resources/codesplit/add-boolean/expected/TestSkipAnonymousClassAndLambda.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSkipAnonymousClassAndLambda {
 boolean funHasReturned$0;
     public void fun(String a) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfInsideWhileLoopRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfInsideWhileLoopRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfInsideWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfMultipleSingleLineStatementRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfMultipleSingleLineStatementRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfMultipleSingleLineStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite1.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite1.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite1 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite2.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite2.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite2 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite3.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestIfStatementRewrite3.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite3 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestNotRewriteIfStatementInFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestNotRewriteIfStatementInFunctionWithReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteIfStatementInFunctionWithReturnValue {
     public int myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public void myFun(int[] a, int[] b) {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/code/TestRewriteTwoStatements.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestRewriteTwoStatements.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfInsideWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/code/TestWhileLoopInsideIfRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestWhileLoopInsideIfRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestWhileLoopInsideIfRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/code/TestWhileLoopRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/code/TestWhileLoopRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfInsideWhileLoopRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfInsideWhileLoopRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfInsideWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfMultipleSingleLineStatementRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfMultipleSingleLineStatementRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfMultipleSingleLineStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite1.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite1.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite1 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite2.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite2.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite2 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite3.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestIfStatementRewrite3.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfStatementRewrite3 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestNotRewriteIfStatementInFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestNotRewriteIfStatementInFunctionWithReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteIfStatementInFunctionWithReturnValue {
     public int myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] == 0) {

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public void myFun(int[] a, int[] b) {
 

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestRewriteTwoStatements.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestRewriteTwoStatements.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestIfInsideWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestWhileLoopInsideIfRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestWhileLoopInsideIfRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestWhileLoopInsideIfRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/block/expected/TestWhileLoopRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/block/expected/TestWhileLoopRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestWhileLoopRewrite {
 
     int counter = 0;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestLocalVariableAndMemberVariableWithSameName.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestLocalVariableAndMemberVariableWithSameName.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestLocalVariableAndMemberVariableWithSameName {
     int local1;
     String local2;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestLocalVariableWithSameName.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestLocalVariableWithSameName.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestLocalVariableWithSameName {
     public void myFun1() {
         int local1;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteLocalVariableInFunctionWithReturnValue {
     public int myFun() {
         int local1;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public void myFun() {
         int local1;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariable.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariable {
     public void myFun() {
         int local1;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariableInForLoop1.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariableInForLoop1.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariableInForLoop1 {
     public void myFun() {
         int sum = 0;

--- a/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariableInForLoop2.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/code/TestRewriteLocalVariableInForLoop2.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariableInForLoop2 {
     public void myFun(int[] arr) {
         int sum = 0;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestLocalVariableAndMemberVariableWithSameName.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestLocalVariableAndMemberVariableWithSameName.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestLocalVariableAndMemberVariableWithSameName {
 int local$0;
 String local$1;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestLocalVariableWithSameName.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestLocalVariableWithSameName.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestLocalVariableWithSameName {
 int local1;
 String local2;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
 int local1;
 String local2;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariable.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariable {
 int local1;
 String local2;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariableInForLoop1.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariableInForLoop1.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariableInForLoop1 {
 int sum;
 int i;

--- a/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariableInForLoop2.java
+++ b/paimon-common/src/test/resources/codesplit/declaration/expected/TestRewriteLocalVariableInForLoop2.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteLocalVariableInForLoop2 {
 int sum;
 int local$0;

--- a/paimon-common/src/test/resources/codesplit/function/code/TestNotSplitFunctionWithOnlyOneStatement.java
+++ b/paimon-common/src/test/resources/codesplit/function/code/TestNotSplitFunctionWithOnlyOneStatement.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitFunctionWithOnlyOneStatement {
     public void myFun(int argumentWithALongName) throws RuntimeException {
         System.out.println(argumentWithALongName);

--- a/paimon-common/src/test/resources/codesplit/function/code/TestNotSplitFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/function/code/TestNotSplitFunctionWithReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitFunctionWithReturnValue {
     public int myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] != 0) {

--- a/paimon-common/src/test/resources/codesplit/function/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/function/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public void myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] != 0) {

--- a/paimon-common/src/test/resources/codesplit/function/code/TestSplitFunction.java
+++ b/paimon-common/src/test/resources/codesplit/function/code/TestSplitFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSplitFunction {
     public void myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] != 0) {

--- a/paimon-common/src/test/resources/codesplit/function/expected/TestNotSplitFunctionWithOnlyOneStatement.java
+++ b/paimon-common/src/test/resources/codesplit/function/expected/TestNotSplitFunctionWithOnlyOneStatement.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitFunctionWithOnlyOneStatement {
     public void myFun(int argumentWithALongName) throws RuntimeException {
         System.out.println(argumentWithALongName);

--- a/paimon-common/src/test/resources/codesplit/function/expected/TestNotSplitFunctionWithReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/function/expected/TestNotSplitFunctionWithReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitFunctionWithReturnValue {
     public int myFun(int[] a, int[] b) throws RuntimeException {
         if (a[0] != 0) {

--- a/paimon-common/src/test/resources/codesplit/function/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/function/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
 boolean myFunHasReturned$0;
     public void myFun(int[] a, int[] b) throws RuntimeException {

--- a/paimon-common/src/test/resources/codesplit/function/expected/TestSplitFunction.java
+++ b/paimon-common/src/test/resources/codesplit/function/expected/TestSplitFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSplitFunction {
 boolean myFunHasReturned$0;
     public void myFun(int[] a, int[] b) throws RuntimeException {

--- a/paimon-common/src/test/resources/codesplit/groups/code/IfInWhile.txt
+++ b/paimon-common/src/test/resources/codesplit/groups/code/IfInWhile.txt
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     a[0] += b[1];
     b[1] += a[1];

--- a/paimon-common/src/test/resources/codesplit/groups/code/WhileInIf.txt
+++ b/paimon-common/src/test/resources/codesplit/groups/code/WhileInIf.txt
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     a[0] += b[1];
     b[1] += a[1];

--- a/paimon-common/src/test/resources/codesplit/groups/expected/IfInWhile.txt
+++ b/paimon-common/src/test/resources/codesplit/groups/expected/IfInWhile.txt
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     myFun_rewriteGroup6(a, b);
 

--- a/paimon-common/src/test/resources/codesplit/groups/expected/WhileInIf.txt
+++ b/paimon-common/src/test/resources/codesplit/groups/expected/WhileInIf.txt
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
   myFun_rewriteGroup8(a, b);
 

--- a/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteFunctionParameter.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteFunctionParameter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteFunctionParameter {
     int a = 1;
     int b;

--- a/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteLocalVariable.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteLocalVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteLocalVariable {
     int a = 1;
     int b = 2;

--- a/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteMember.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestNotRewriteMember.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteMember {
     int a;
     private static int b;

--- a/paimon-common/src/test/resources/codesplit/member/code/TestRewriteGenericType.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestRewriteGenericType.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteGenericType {
     java.util.List<String> a = new java.util.ArrayList<>();
     java.util.List<Integer> b = new java.util.ArrayList<>();

--- a/paimon-common/src/test/resources/codesplit/member/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public int a;
     protected int b = 1;

--- a/paimon-common/src/test/resources/codesplit/member/code/TestRewriteMemberField.java
+++ b/paimon-common/src/test/resources/codesplit/member/code/TestRewriteMemberField.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteMemberField {
     public int a;
     private long b;

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteFunctionParameter.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteFunctionParameter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteFunctionParameter {
 int[] rewrite$0 = new int[3];
 

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteLocalVariable.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteLocalVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteLocalVariable {
 int[] rewrite$0 = new int[3];
 

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteMember.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestNotRewriteMember.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewriteMember {
 int[] rewrite$0 = new int[3];
 

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteGenericType.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteGenericType.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteGenericType {
 java.util.List<Integer>[] rewrite$0 = new java.util.List[1];
 java.util.List<String>[] rewrite$1 = new java.util.List[2];

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
 int[] rewrite$0 = new int[3];
 

--- a/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteMemberField.java
+++ b/paimon-common/src/test/resources/codesplit/member/expected/TestRewriteMemberField.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteMemberField {
 String[] rewrite$0 = new String[3];
 int[] rewrite$1 = new int[3];

--- a/paimon-common/src/test/resources/codesplit/return/code/TestNotRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/return/code/TestNotRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewrite {
     public void fun1(int a) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/return/code/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/return/code/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
     public String fun(int a, String b) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/return/code/TestRewriteReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/return/code/TestRewriteReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteReturnValue {
     public String fun1(int a, String b) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/return/code/TestSkipAnonymousClassAndLambda.java
+++ b/paimon-common/src/test/resources/codesplit/return/code/TestSkipAnonymousClassAndLambda.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSkipAnonymousClassAndLambda {
     public String fun(int a, String b) {
         if (a > 0) {

--- a/paimon-common/src/test/resources/codesplit/return/expected/TestNotRewrite.java
+++ b/paimon-common/src/test/resources/codesplit/return/expected/TestNotRewrite.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotRewrite {
 
     public void fun1(int a) {

--- a/paimon-common/src/test/resources/codesplit/return/expected/TestRewriteInnerClass.java
+++ b/paimon-common/src/test/resources/codesplit/return/expected/TestRewriteInnerClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteInnerClass {
 String funReturnValue$0;
 

--- a/paimon-common/src/test/resources/codesplit/return/expected/TestRewriteReturnValue.java
+++ b/paimon-common/src/test/resources/codesplit/return/expected/TestRewriteReturnValue.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestRewriteReturnValue {
 String fun1ReturnValue$0;
 String fun2ReturnValue$1;

--- a/paimon-common/src/test/resources/codesplit/return/expected/TestSkipAnonymousClassAndLambda.java
+++ b/paimon-common/src/test/resources/codesplit/return/expected/TestSkipAnonymousClassAndLambda.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSkipAnonymousClassAndLambda {
 String funReturnValue$0;
 

--- a/paimon-common/src/test/resources/codesplit/splitter/code/TestNotSplitJavaCode.java
+++ b/paimon-common/src/test/resources/codesplit/splitter/code/TestNotSplitJavaCode.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitJavaCode {
     private int a = 1;
     public final int[] b;

--- a/paimon-common/src/test/resources/codesplit/splitter/code/TestSplitJavaCode.java
+++ b/paimon-common/src/test/resources/codesplit/splitter/code/TestSplitJavaCode.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSplitJavaCode {
     private int a = 1;
     public final int[] b;

--- a/paimon-common/src/test/resources/codesplit/splitter/expected/TestNotSplitJavaCode.java
+++ b/paimon-common/src/test/resources/codesplit/splitter/expected/TestNotSplitJavaCode.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestNotSplitJavaCode {
     private int a = 1;
     public final int[] b;

--- a/paimon-common/src/test/resources/codesplit/splitter/expected/TestSplitJavaCode.java
+++ b/paimon-common/src/test/resources/codesplit/splitter/expected/TestSplitJavaCode.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public class TestSplitJavaCode {
     boolean[] rewrite$16 = new boolean[2];
     int[][] rewrite$17 = new int[1][];

--- a/paimon-docs/src/main/java/org/apache/paimon/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/paimon-docs/src/main/java/org/apache/paimon/docs/configuration/ConfigOptionsDocGenerator.java
@@ -61,6 +61,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.docs.util.Utils.apacheHeaderToHtml;
 import static org.apache.paimon.docs.util.Utils.escapeCharacters;
 import static org.apache.paimon.options.description.TextElement.text;
 
@@ -185,7 +186,8 @@ public class ConfigOptionsDocGenerator {
                     try {
                         Files.write(
                                 Paths.get(outputDirectory, getSectionFileName(section)),
-                                sectionHtmlTable.getBytes(StandardCharsets.UTF_8));
+                                (apacheHeaderToHtml() + sectionHtmlTable)
+                                        .getBytes(StandardCharsets.UTF_8));
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
@@ -245,7 +247,8 @@ public class ConfigOptionsDocGenerator {
                         String outputFile = toSnakeCase(name) + "_configuration.html";
                         Files.write(
                                 Paths.get(outputDirectory, outputFile),
-                                group.getRight().getBytes(StandardCharsets.UTF_8));
+                                (apacheHeaderToHtml() + group.getRight())
+                                        .getBytes(StandardCharsets.UTF_8));
                     }
                 });
     }

--- a/paimon-docs/src/main/java/org/apache/paimon/docs/util/Utils.java
+++ b/paimon-docs/src/main/java/org/apache/paimon/docs/util/Utils.java
@@ -33,4 +33,25 @@ public class Utils {
                 .replaceAll(">", "&gt;")
                 .replaceAll(TEMPORARY_PLACEHOLDER, "<wbr>");
     }
+
+    public static String apacheHeaderToHtml() {
+        return "{{/*\n"
+                + "Licensed to the Apache Software Foundation (ASF) under one\n"
+                + "or more contributor license agreements.  See the NOTICE file\n"
+                + "distributed with this work for additional information\n"
+                + "regarding copyright ownership.  The ASF licenses this file\n"
+                + "to you under the Apache License, Version 2.0 (the\n"
+                + "\"License\"); you may not use this file except in compliance\n"
+                + "with the License.  You may obtain a copy of the License at\n"
+                + "\n"
+                + "  http://www.apache.org/licenses/LICENSE-2.0\n"
+                + "\n"
+                + "Unless required by applicable law or agreed to in writing,\n"
+                + "software distributed under the License is distributed on an\n"
+                + "\"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n"
+                + "KIND, either express or implied.  See the License for the\n"
+                + "specific language governing permissions and limitations\n"
+                + "under the License.\n"
+                + "*/}}\n";
+    }
 }

--- a/paimon-docs/src/test/java/org/apache/paimon/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/paimon-docs/src/test/java/org/apache/paimon/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.docs.util.Utils.apacheHeaderToHtml;
 import static org.apache.paimon.options.description.TextElement.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -527,10 +528,10 @@ class ConfigOptionsDocGeneratorTest {
                 ConfigOptionsDocGenerator.getSectionFileName(TestCommonOptions.SECTION_2);
         assertThat(new File(outputDirectory, fileName1))
                 .content(StandardCharsets.UTF_8)
-                .isEqualTo(expected1);
+                .isEqualTo(apacheHeaderToHtml() + expected1);
         assertThat(new File(outputDirectory, fileName2))
                 .content(StandardCharsets.UTF_8)
-                .isEqualTo(expected2);
+                .isEqualTo(apacheHeaderToHtml() + expected2);
     }
 
     static class TestConfigGroupWithExclusion {

--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,6 @@ under the License.
                         <exclude>release/**</exclude>
                         <!-- antlr grammar files -->
                         <exclude>paimon-common/src/main/antlr4/**</exclude>
-                        <!-- Test files -->
-                        <exclude>paimon-common/src/test/resources/codesplit/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,6 @@ under the License.
                         <exclude>docs/themes/book/**</exclude>
                         <exclude>docs/assets/github.css</exclude>
                         <exclude>docs/static/js/anchor.min.js</exclude>
-                        <exclude>docs/layouts/shortcodes/generated/**</exclude>
                         <exclude>**/*.svg</exclude>
                         <exclude>**/dependency-reduced-pom.xml</exclude>
                         <!-- Bundled license files -->


### PR DESCRIPTION
### Purpose

Even java files in resources, we need to add header to these files.

From https://lists.apache.org/thread/2fdsps5ggllo56oy61cp0gwb8spov1vf

- These files are missing ASF headers [3][4][5] and other files in that directory, and these directories [6][7][8][9][10] and other directories under [11]. Are they ASF files and how are they licensed?