### PR TITLE
[hive] Hive read paimon table should always build schema from existing Paimon table schema first

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -126,6 +126,8 @@ public class HiveSchema {
                     location);
             checkSchemaMatched(columnNames, typeInfos, tableSchema.get());
             // Use paimon table data types and column comments when the paimon table exists.
+            // Using paimon data types first because hive's TypeInfoFactory.timestampTypeInfo
+            // doesn't contain precision and thus may cause casting problems
             Map<String, DataField> paimonFields =
                     tableSchema.get().fields().stream()
                             .collect(Collectors.toMap(DataField::name, Function.identity()));

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -91,7 +91,7 @@ public class HiveSchema {
         String location = LocationKeyExtractor.getLocation(properties);
         Optional<TableSchema> tableSchema = getExistsSchema(configuration, location);
         String columnProperty = properties.getProperty(serdeConstants.LIST_COLUMNS);
-        // Create hive external table with empty ddl
+        // Create Hive external table with Paimon schema directly when Hive schema is absent
         if (StringUtils.isEmpty(columnProperty)) {
             if (!tableSchema.isPresent()) {
                 throw new IllegalArgumentException(
@@ -103,7 +103,6 @@ public class HiveSchema {
             return new HiveSchema(new RowType(tableSchema.get().fields()));
         }
 
-        // Create hive external table with ddl
         String columnNameDelimiter =
                 properties.getProperty(
                         // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
@@ -112,21 +111,24 @@ public class HiveSchema {
         List<String> columnNames = Arrays.asList(columnProperty.split(columnNameDelimiter));
         String columnTypes = properties.getProperty(serdeConstants.LIST_COLUMN_TYPES);
         List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(columnTypes);
+
+        // If both Paimon table schema and Hive table schema exist, we check whether the schema
+        // matches and still build from Paimon table schema
+        if (tableSchema.isPresent()) {
+            if (columnNames.size() > 0 && typeInfos.size() > 0) {
+                LOG.debug(
+                        "Extract schema with exists DDL and exists paimon table, table location:[{}].",
+                        location);
+                checkSchemaMatched(columnNames, typeInfos, tableSchema.get());
+            }
+
+            return new HiveSchema(new RowType(tableSchema.get().fields()));
+        }
+
+        // Create from Hive schema only when Paimon schema is absent
         List<String> comments =
                 Lists.newArrayList(
                         Splitter.on('\0').split(properties.getProperty("columns.comments")));
-        // Both Paimon table schema and Hive table schema exist
-        if (tableSchema.isPresent() && columnNames.size() > 0 && typeInfos.size() > 0) {
-            LOG.debug(
-                    "Extract schema with exists DDL and exists paimon table, table location:[{}].",
-                    location);
-            checkSchemaMatched(columnNames, typeInfos, tableSchema.get());
-            // Use paimon table column comment when the paimon table exists.
-            comments =
-                    tableSchema.get().fields().stream()
-                            .map(DataField::description)
-                            .collect(Collectors.toList());
-        }
         RowType.Builder builder = RowType.builder();
         for (int i = 0; i < columnNames.size(); i++) {
             builder.field(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -900,14 +900,25 @@ public class PaimonStorageHandlerITCase {
     public void testDateAndTimestamp() throws Exception {
         String path = folder.newFolder().toURI().toString();
         String tablePath = String.format("%s/default.db/hive_test_table", path);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
-        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
+        int randomInt = random.nextInt(3);
+        if (randomInt == 0) {
+            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.ORC);
+        } else if (randomInt == 1) {
+            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.PARQUET);
+        } else {
+            conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
+        }
         Table table =
                 FileStoreTestUtils.createFileStoreTable(
                         conf,
                         RowType.of(
-                                new DataType[] {DataTypes.DATE(), DataTypes.TIMESTAMP(3)},
+                                new DataType[] {
+                                    DataTypes.DATE(),
+                                    DataTypes.TIMESTAMP(random.nextBoolean() ? 3 : 6)
+                                },
                                 new String[] {"dt", "ts"}),
                         Collections.emptyList(),
                         Collections.emptyList());

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -916,8 +916,7 @@ public class PaimonStorageHandlerITCase {
                         conf,
                         RowType.of(
                                 new DataType[] {
-                                    DataTypes.DATE(),
-                                    DataTypes.TIMESTAMP(random.nextBoolean() ? 3 : 6)
+                                    DataTypes.DATE(), DataTypes.TIMESTAMP(random.nextInt(10))
                                 },
                                 new String[] {"dt", "ts"}),
                         Collections.emptyList(),


### PR DESCRIPTION
### Purpose

When reading from Hive, the  current `HiveSchema` maybe constructed from Hive schema infomation even Paimon schema is available. This PR fix it.

This PR can fix #1198 because now the `TIMESTAMP` precision can be set correctly.

### Tests

`PaimonStorageHandlerITCase#testDateAndTimestamp`

### API and Format

no
### Documentation

no