### PR TITLE
[codegen] Introduce RecordEqualiser for InternalRow to speed up the judgment of equality

### DIFF
--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -53,6 +53,14 @@ public class CodeGeneratorImpl implements CodeGenerator {
                 getAscendingSortSpec(fieldTypes.size()));
     }
 
+    /** Generate a {@link RecordEqualiser}. */
+    @Override
+    public GeneratedClass<RecordEqualiser> generateRecordEqualiser(
+            List<DataType> fieldTypes, String name) {
+        return new EqualiserCodeGenerator(RowType.builder().fields(fieldTypes).build())
+                .generateRecordEqualiser(name);
+    }
+
     private SortSpec getAscendingSortSpec(int numFields) {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
         for (int i = 0; i < numFields; i++) {

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.codegen
+
+import org.apache.paimon.codegen.GenerateUtils._
+import org.apache.paimon.codegen.ScalarOperatorGens.generateEquals
+import org.apache.paimon.types.{BooleanType, DataType, RowType}
+import org.apache.paimon.types.DataTypeChecks.{getFieldTypes, isCompositeType}
+import org.apache.paimon.types.DataTypeRoot._
+import org.apache.paimon.utils.TypeUtils.isPrimitive
+
+import scala.collection.JavaConverters._
+
+class EqualiserCodeGenerator(fieldTypes: Array[DataType]) {
+
+  private val RECORD_EQUALISER = className[RecordEqualiser]
+  private val LEFT_INPUT = "left"
+  private val RIGHT_INPUT = "right"
+
+  def this(rowType: RowType) = {
+    this(rowType.getFieldTypes.asScala.toArray)
+  }
+
+  def generateRecordEqualiser(name: String): GeneratedClass[RecordEqualiser] = {
+    // ignore time zone
+    val ctx = new CodeGeneratorContext
+    val className = newName(name)
+
+    val equalsMethodCodes = for (idx <- fieldTypes.indices) yield generateEqualsMethod(ctx, idx)
+    val equalsMethodCalls = for (idx <- fieldTypes.indices) yield {
+      val methodName = getEqualsMethodName(idx)
+      s"""result = result && $methodName($LEFT_INPUT, $RIGHT_INPUT);"""
+    }
+
+    val classCode =
+      s"""
+        public final class $className implements $RECORD_EQUALISER {
+          ${ctx.reuseMemberCode()}
+
+          public $className(Object[] references) throws Exception {
+            ${ctx.reuseInitCode()}
+          }
+
+          @Override
+          public boolean equals($ROW_DATA $LEFT_INPUT, $ROW_DATA $RIGHT_INPUT) {
+            if ($LEFT_INPUT instanceof $BINARY_ROW && $RIGHT_INPUT instanceof $BINARY_ROW) {
+              return $LEFT_INPUT.equals($RIGHT_INPUT);
+            }
+
+            if ($LEFT_INPUT.getRowKind() != $RIGHT_INPUT.getRowKind()) {
+              return false;
+            }
+
+            boolean result = true;
+            ${equalsMethodCalls.mkString("\n")}
+            return result;
+          }
+
+          ${equalsMethodCodes.mkString("\n")}
+        }
+      """.stripMargin
+
+    new GeneratedClass(className, classCode, ctx.references.toArray)
+  }
+
+  private def getEqualsMethodName(idx: Int) = s"""equalsAtIndex$idx"""
+
+  private def generateEqualsMethod(ctx: CodeGeneratorContext, idx: Int): String = {
+    val methodName = getEqualsMethodName(idx)
+    ctx.startNewLocalVariableStatement(methodName)
+
+    val Seq(leftNullTerm, rightNullTerm) = ctx.addReusableLocalVariables(
+      ("boolean", "isNullLeft"),
+      ("boolean", "isNullRight")
+    )
+
+    val fieldType = fieldTypes(idx)
+    val fieldTypeTerm = primitiveTypeTermForType(fieldType)
+    val Seq(leftFieldTerm, rightFieldTerm) = ctx.addReusableLocalVariables(
+      (fieldTypeTerm, "leftField"),
+      (fieldTypeTerm, "rightField")
+    )
+
+    val leftReadCode = rowFieldReadAccess(idx, LEFT_INPUT, fieldType)
+    val rightReadCode = rowFieldReadAccess(idx, RIGHT_INPUT, fieldType)
+
+    val (equalsCode, equalsResult) =
+      generateEqualsCode(ctx, fieldType, leftFieldTerm, rightFieldTerm, leftNullTerm, rightNullTerm)
+
+    s"""
+       |private boolean $methodName($ROW_DATA $LEFT_INPUT, $ROW_DATA $RIGHT_INPUT) {
+       |  ${ctx.reuseLocalVariableCode(methodName)}
+       |
+       |  $leftNullTerm = $LEFT_INPUT.isNullAt($idx);
+       |  $rightNullTerm = $RIGHT_INPUT.isNullAt($idx);
+       |  if ($leftNullTerm && $rightNullTerm) {
+       |    return true;
+       |  }
+       |
+       |  if ($leftNullTerm || $rightNullTerm) {
+       |    return false;
+       |  }
+       |
+       |  $leftFieldTerm = $leftReadCode;
+       |  $rightFieldTerm = $rightReadCode;
+       |  $equalsCode
+       |
+       |  return $equalsResult;
+       |}
+      """.stripMargin
+  }
+
+  private def generateEqualsCode(
+      ctx: CodeGeneratorContext,
+      fieldType: DataType,
+      leftFieldTerm: String,
+      rightFieldTerm: String,
+      leftNullTerm: String,
+      rightNullTerm: String) = {
+    if (isInternalPrimitive(fieldType)) {
+      ("", s"$leftFieldTerm == $rightFieldTerm")
+    } else if (isCompositeType(fieldType)) {
+      val equaliserGenerator =
+        new EqualiserCodeGenerator(getFieldTypes(fieldType).asScala.toArray)
+      val generatedEqualiser = equaliserGenerator.generateRecordEqualiser("fieldGeneratedEqualiser")
+      val generatedEqualiserTerm =
+        ctx.addReusableObject(generatedEqualiser, "fieldGeneratedEqualiser")
+      val equaliserTypeTerm = classOf[RecordEqualiser].getCanonicalName
+      val equaliserTerm = newName("equaliser")
+      ctx.addReusableMember(s"private $equaliserTypeTerm $equaliserTerm = null;")
+      ctx.addReusableInitStatement(
+        s"""
+           |$equaliserTerm = ($equaliserTypeTerm)
+           |  $generatedEqualiserTerm.newInstance(Thread.currentThread().getContextClassLoader());
+           |""".stripMargin)
+      ("", s"$equaliserTerm.equals($leftFieldTerm, $rightFieldTerm)")
+    } else {
+      val left = GeneratedExpression(leftFieldTerm, leftNullTerm, "", fieldType)
+      val right = GeneratedExpression(rightFieldTerm, rightNullTerm, "", fieldType)
+      val resultType = new BooleanType(fieldType.isNullable)
+      val gen = generateEquals(ctx, left, right, resultType)
+      (gen.code, gen.resultTerm)
+    }
+  }
+
+  private def isInternalPrimitive(t: DataType): Boolean = t.getTypeRoot match {
+    case _ if isPrimitive(t) => true
+
+    case DATE | TIME_WITHOUT_TIME_ZONE => true
+
+    case _ => false
+  }
+}

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.codegen
+
+import org.apache.paimon.codegen.GenerateUtils._
+import org.apache.paimon.data.serializer.InternalMapSerializer
+import org.apache.paimon.types._
+import org.apache.paimon.utils.InternalRowUtils
+import org.apache.paimon.utils.TypeCheckUtils._
+import org.apache.paimon.utils.TypeUtils.isInteroperable
+
+/**
+ * Utilities to generate SQL scalar operators, e.g. arithmetic operator, compare operator, equal
+ * operator, etc.
+ */
+object ScalarOperatorGens {
+
+  def generateEquals(
+      ctx: CodeGeneratorContext,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      resultType: DataType): GeneratedExpression = {
+    // In the current use case, there is no need to support implicit type conversion,
+    // and we temporarily enforce that the compared types are the same.
+    if (left.resultType != right.resultType) {
+      throw new CodeGenException(
+        "implicit type conversion between " +
+          s"${left.resultType.getTypeRoot}" +
+          s" and " +
+          s"${right.resultType.getTypeRoot}" +
+          s" is not supported now")
+    }
+    val canEqual = isInteroperable(left.resultType, right.resultType)
+    if (isCharacterString(left.resultType) && isCharacterString(right.resultType)) {
+      generateOperatorIfNotNull(ctx, resultType, left, right)(
+        (leftTerm, rightTerm) => s"$leftTerm.equals($rightTerm)")
+    }
+    // numeric types
+    else if (isNumeric(left.resultType) && isNumeric(right.resultType)) {
+      generateComparison(ctx, "==", left, right, resultType)
+    }
+    // array types
+    else if (isArray(left.resultType) && canEqual) {
+      generateArrayComparison(ctx, left, right, resultType)
+    }
+    // map types
+    else if (isMap(left.resultType) && canEqual) {
+      val mapType = left.resultType.asInstanceOf[MapType]
+      generateMapComparison(ctx, left, right, mapType.getKeyType, mapType.getValueType, resultType)
+    }
+    // multiset types
+    else if (isMultiset(left.resultType) && canEqual) {
+      val multisetType = left.resultType.asInstanceOf[MultisetType]
+      generateMapComparison(
+        ctx,
+        left,
+        right,
+        multisetType.getElementType,
+        new IntType(false),
+        resultType)
+    }
+    // comparable types of same type
+    else if (isComparable(left.resultType) && canEqual) {
+      generateComparison(ctx, "==", left, right, resultType)
+    }
+    // non comparable types
+    else {
+      generateOperatorIfNotNull(ctx, resultType, left, right) {
+        if (isReference(left.resultType)) {
+          (leftTerm, rightTerm) => s"$leftTerm.equals($rightTerm)"
+        } else if (isReference(right.resultType)) {
+          (leftTerm, rightTerm) => s"$rightTerm.equals($leftTerm)"
+        } else {
+          throw new CodeGenException(
+            s"Incomparable types: ${left.resultType} and " +
+              s"${right.resultType}")
+        }
+      }
+    }
+  }
+
+  /** Generates comparison code for numeric types and comparable types of same type. */
+  def generateComparison(
+      ctx: CodeGeneratorContext,
+      operator: String,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      resultType: DataType): GeneratedExpression = {
+    generateOperatorIfNotNull(ctx, resultType, left, right) {
+      // either side is decimal
+      if (isDecimal(left.resultType) || isDecimal(right.resultType)) {
+        (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0"
+      }
+      // both sides are numeric
+      else if (isNumeric(left.resultType) && isNumeric(right.resultType)) {
+        (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+      }
+
+      // both sides are timestamp
+      else if (isTimestamp(left.resultType) && isTimestamp(right.resultType)) {
+        (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0"
+      }
+
+      // both sides are timestamp with local zone
+      else if (
+        isTimestampWithLocalZone(left.resultType) &&
+        isTimestampWithLocalZone(right.resultType)
+      ) { (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0" }
+
+      // both sides are temporal of same type
+      else if (
+        isTemporal(left.resultType) &&
+        isInteroperable(left.resultType, right.resultType)
+      ) { (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm" }
+      // both sides are boolean
+      else if (
+        isBoolean(left.resultType) &&
+        isInteroperable(left.resultType, right.resultType)
+      ) {
+        operator match {
+          case "==" | "!=" => (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+          case ">" | "<" | "<=" | ">=" =>
+            (leftTerm, rightTerm) => s"java.lang.Boolean.compare($leftTerm, $rightTerm) $operator 0"
+          case _ => throw new CodeGenException(s"Unsupported boolean comparison '$operator'.")
+        }
+      }
+      // both sides are binary type
+      else if (
+        isBinaryString(left.resultType) &&
+        isInteroperable(left.resultType, right.resultType)
+      ) {
+        val utilName = classOf[InternalRowUtils].getCanonicalName
+        val dataTypeRootName = classOf[DataTypeRoot].getCanonicalName
+        (leftTerm, rightTerm) =>
+          s"$utilName.compare($leftTerm, $rightTerm, $dataTypeRootName.${left.resultType.getTypeRoot}) $operator 0"
+      }
+      // both sides are same comparable type
+      else if (
+        isComparable(left.resultType) &&
+        isInteroperable(left.resultType, right.resultType)
+      ) {
+        (leftTerm, rightTerm) =>
+          s"(($leftTerm == null) ? (($rightTerm == null) ? 0 : -1) : (($rightTerm == null) ? " +
+            s"1 : ($leftTerm.compareTo($rightTerm)))) $operator 0"
+      } else {
+        throw new CodeGenException(
+          s"Incomparable types: ${left.resultType} and " +
+            s"${right.resultType}")
+      }
+    }
+  }
+
+  private def generateArrayComparison(
+      ctx: CodeGeneratorContext,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      resultType: DataType): GeneratedExpression = {
+    generateCallWithStmtIfArgsNotNull(ctx, resultType, Seq(left, right)) {
+      args =>
+        val leftTerm = args.head
+        val rightTerm = args(1)
+
+        val resultTerm = newName("compareResult")
+
+        val elementType = left.resultType.asInstanceOf[ArrayType].getElementType
+        val elementCls = primitiveTypeTermForType(elementType)
+        val elementDefault = primitiveDefaultValue(elementType)
+
+        val leftElementTerm = newName("leftElement")
+        val leftElementNullTerm = newName("leftElementIsNull")
+        val leftElementExpr =
+          GeneratedExpression(leftElementTerm, leftElementNullTerm, "", elementType)
+
+        val rightElementTerm = newName("rightElement")
+        val rightElementNullTerm = newName("rightElementIsNull")
+        val rightElementExpr =
+          GeneratedExpression(rightElementTerm, rightElementNullTerm, "", elementType)
+
+        val indexTerm = newName("index")
+        val elementEqualsExpr = generateEquals(
+          ctx,
+          leftElementExpr,
+          rightElementExpr,
+          new BooleanType(elementType.isNullable))
+
+        val stmt =
+          s"""
+             |boolean $resultTerm;
+             |if ($leftTerm instanceof $BINARY_ARRAY && $rightTerm instanceof $BINARY_ARRAY) {
+             |  $resultTerm = $leftTerm.equals($rightTerm);
+             |} else {
+             |  if ($leftTerm.size() == $rightTerm.size()) {
+             |    $resultTerm = true;
+             |    for (int $indexTerm = 0; $indexTerm < $leftTerm.size(); $indexTerm++) {
+             |      $elementCls $leftElementTerm = $elementDefault;
+             |      boolean $leftElementNullTerm = $leftTerm.isNullAt($indexTerm);
+             |      if (!$leftElementNullTerm) {
+             |        $leftElementTerm =
+             |          ${rowFieldReadAccess(indexTerm, leftTerm, elementType)};
+             |      }
+             |
+             |      $elementCls $rightElementTerm = $elementDefault;
+             |      boolean $rightElementNullTerm = $rightTerm.isNullAt($indexTerm);
+             |      if (!$rightElementNullTerm) {
+             |        $rightElementTerm =
+             |          ${rowFieldReadAccess(indexTerm, rightTerm, elementType)};
+             |      }
+             |
+             |      ${elementEqualsExpr.code}
+             |      if (!${elementEqualsExpr.resultTerm}) {
+             |        $resultTerm = false;
+             |        break;
+             |      }
+             |    }
+             |  } else {
+             |    $resultTerm = false;
+             |  }
+             |}
+             """.stripMargin
+        (stmt, resultTerm)
+    }
+  }
+
+  private def generateMapComparison(
+      ctx: CodeGeneratorContext,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      keyType: DataType,
+      valueType: DataType,
+      resultType: DataType): GeneratedExpression =
+    generateCallWithStmtIfArgsNotNull(ctx, resultType, Seq(left, right)) {
+      args =>
+        val leftTerm = args.head
+        val rightTerm = args(1)
+
+        val resultTerm = newName("compareResult")
+
+        val mapCls = className[java.util.Map[_, _]]
+        val keyCls = boxedTypeTermForType(keyType)
+        val valueCls = boxedTypeTermForType(valueType)
+
+        val leftMapTerm = newName("leftMap")
+        val leftKeyTerm = newName("leftKey")
+        val leftValueTerm = newName("leftValue")
+        val leftValueNullTerm = newName("leftValueIsNull")
+        val leftValueExpr =
+          GeneratedExpression(leftValueTerm, leftValueNullTerm, "", valueType)
+
+        val rightMapTerm = newName("rightMap")
+        val rightValueTerm = newName("rightValue")
+        val rightValueNullTerm = newName("rightValueIsNull")
+        val rightValueExpr =
+          GeneratedExpression(rightValueTerm, rightValueNullTerm, "", valueType)
+
+        val entryTerm = newName("entry")
+        val entryCls = classOf[java.util.Map.Entry[AnyRef, AnyRef]].getCanonicalName
+        val valueEqualsExpr =
+          generateEquals(ctx, leftValueExpr, rightValueExpr, new BooleanType(valueType.isNullable))
+
+        val internalTypeCls = classOf[DataType].getCanonicalName
+        val keyTypeTerm = ctx.addReusableObject(keyType, "keyType", internalTypeCls)
+        val valueTypeTerm = ctx.addReusableObject(valueType, "valueType", internalTypeCls)
+        val mapDataUtil = className[InternalMapSerializer]
+
+        val stmt =
+          s"""
+             |boolean $resultTerm;
+             |if ($leftTerm.size() == $rightTerm.size()) {
+             |  $resultTerm = true;
+             |  $mapCls $leftMapTerm = $mapDataUtil
+             |      .convertToJavaMap($leftTerm, $keyTypeTerm, $valueTypeTerm);
+             |  $mapCls $rightMapTerm = $mapDataUtil
+             |      .convertToJavaMap($rightTerm, $keyTypeTerm, $valueTypeTerm);
+             |
+             |  for ($entryCls $entryTerm : $leftMapTerm.entrySet()) {
+             |    $keyCls $leftKeyTerm = ($keyCls) $entryTerm.getKey();
+             |    if ($rightMapTerm.containsKey($leftKeyTerm)) {
+             |      $valueCls $leftValueTerm = ($valueCls) $entryTerm.getValue();
+             |      $valueCls $rightValueTerm = ($valueCls) $rightMapTerm.get($leftKeyTerm);
+             |      boolean $leftValueNullTerm = ($leftValueTerm == null);
+             |      boolean $rightValueNullTerm = ($rightValueTerm == null);
+             |
+             |      ${valueEqualsExpr.code}
+             |      if (!${valueEqualsExpr.resultTerm}) {
+             |        $resultTerm = false;
+             |        break;
+             |      }
+             |    } else {
+             |      $resultTerm = false;
+             |      break;
+             |    }
+             |  }
+             |} else {
+             |  $resultTerm = false;
+             |}
+             """.stripMargin
+        (stmt, resultTerm)
+    }
+
+  // ----------------------------------------------------------------------------------------
+  // private generate utils
+  // ----------------------------------------------------------------------------------------
+
+  private def generateOperatorIfNotNull(
+      ctx: CodeGeneratorContext,
+      returnType: DataType,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      resultNullable: Boolean = false)(expr: (String, String) => String): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, Seq(left, right), resultNullable) {
+      args => expr(args.head, args(1))
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------
+}

--- a/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
+++ b/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.codegen;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.BinaryWriter;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.serializer.InternalArraySerializer;
+import org.apache.paimon.data.serializer.InternalMapSerializer;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.Pair;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+import static org.apache.paimon.utils.TypeUtils.castFromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link EqualiserCodeGenerator}. */
+public class EqualiserCodeGeneratorTest {
+
+    private static final Map<DataTypeRoot, GeneratedData> TEST_DATA = new HashMap<>();
+
+    static {
+        TEST_DATA.put(
+                DataTypeRoot.CHAR,
+                new GeneratedData(
+                        DataTypes.CHAR(1),
+                        Pair.of(BinaryString.fromString("1"), BinaryString.fromString("2"))));
+        TEST_DATA.put(
+                DataTypeRoot.VARCHAR,
+                new GeneratedData(
+                        DataTypes.VARCHAR(1),
+                        Pair.of(BinaryString.fromString("3"), BinaryString.fromString("4"))));
+        TEST_DATA.put(
+                DataTypeRoot.BOOLEAN, new GeneratedData(DataTypes.BOOLEAN(), Pair.of(true, false)));
+        TEST_DATA.put(
+                DataTypeRoot.BINARY,
+                new GeneratedData(DataTypes.BINARY(1), Pair.of("5".getBytes(), "6".getBytes())));
+        TEST_DATA.put(
+                DataTypeRoot.VARBINARY,
+                new GeneratedData(DataTypes.VARBINARY(1), Pair.of("7".getBytes(), "8".getBytes())));
+        TEST_DATA.put(
+                DataTypeRoot.DECIMAL,
+                new GeneratedData(
+                        DataTypes.DECIMAL(10, 0),
+                        Pair.of(
+                                Decimal.fromUnscaledLong(9, 10, 0),
+                                Decimal.fromUnscaledLong(10, 10, 0))));
+        TEST_DATA.put(
+                DataTypeRoot.TINYINT,
+                new GeneratedData(DataTypes.TINYINT(), Pair.of((byte) 11, (byte) 12)));
+        TEST_DATA.put(
+                DataTypeRoot.SMALLINT,
+                new GeneratedData(DataTypes.SMALLINT(), Pair.of((short) 13, (short) 14)));
+        TEST_DATA.put(DataTypeRoot.INTEGER, new GeneratedData(DataTypes.INT(), Pair.of(15, 16)));
+        TEST_DATA.put(
+                DataTypeRoot.BIGINT, new GeneratedData(DataTypes.BIGINT(), Pair.of(17L, 18L)));
+        TEST_DATA.put(
+                DataTypeRoot.FLOAT, new GeneratedData(DataTypes.FLOAT(), Pair.of(19.0f, 20.0f)));
+        TEST_DATA.put(
+                DataTypeRoot.DOUBLE, new GeneratedData(DataTypes.DOUBLE(), Pair.of(21.0d, 22.0d)));
+        TEST_DATA.put(
+                DataTypeRoot.DATE,
+                new GeneratedData(
+                        DataTypes.DATE(),
+                        Pair.of(
+                                castFromString("2023-05-23 09:30:00.0", DataTypes.DATE()),
+                                castFromString("2023-05-24 09:30:00.0", DataTypes.DATE()))));
+        TEST_DATA.put(
+                DataTypeRoot.TIME_WITHOUT_TIME_ZONE,
+                new GeneratedData(
+                        DataTypes.TIME(),
+                        Pair.of(
+                                castFromString("09:30:00.0", DataTypes.TIME()),
+                                castFromString("10:30:00.0", DataTypes.TIME()))));
+        TEST_DATA.put(
+                DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+                new GeneratedData(
+                        DataTypes.TIMESTAMP_MILLIS(),
+                        Pair.of(
+                                Timestamp.fromEpochMillis(1684814400000L),
+                                Timestamp.fromEpochMillis(1684814500000L))));
+        TEST_DATA.put(
+                DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                new GeneratedData(
+                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+                        Pair.of(
+                                Timestamp.fromEpochMillis(1684814600000L),
+                                Timestamp.fromEpochMillis(1684814700000L))));
+        TEST_DATA.put(
+                DataTypeRoot.ARRAY,
+                new GeneratedData(
+                        DataTypes.ARRAY(new VarCharType(1)),
+                        Pair.of(
+                                castFromString("[1,2,3]", DataTypes.ARRAY(new VarCharType())),
+                                castFromString("[4,5,6]", DataTypes.ARRAY(new VarCharType()))),
+                        new InternalArraySerializer(DataTypes.VARCHAR(1))));
+        TEST_DATA.put(
+                DataTypeRoot.MULTISET,
+                new GeneratedData(
+                        DataTypes.MULTISET(new IntType()),
+                        Pair.of(
+                                new GenericMap(
+                                        new HashMap<Integer, Integer>() {
+                                            {
+                                                put(23, 23);
+                                                put(24, 24);
+                                            }
+                                        }),
+                                new GenericMap(
+                                        new HashMap<Integer, Integer>() {
+                                            {
+                                                put(23, 23);
+                                                put(25, 25);
+                                            }
+                                        })),
+                        new InternalMapSerializer(DataTypes.INT(), DataTypes.INT())));
+        TEST_DATA.put(
+                DataTypeRoot.MAP,
+                new GeneratedData(
+                        DataTypes.MAP(new IntType(), new IntType()),
+                        Pair.of(
+                                new GenericMap(
+                                        new HashMap<Integer, Integer>() {
+                                            {
+                                                put(26, 27);
+                                                put(28, 29);
+                                            }
+                                        }),
+                                new GenericMap(
+                                        new HashMap<Integer, Integer>() {
+                                            {
+                                                put(26, 27);
+                                                put(28, 30);
+                                            }
+                                        })),
+                        new InternalMapSerializer(DataTypes.INT(), DataTypes.INT())));
+        TEST_DATA.put(
+                DataTypeRoot.ROW,
+                new GeneratedData(
+                        DataTypes.ROW(DataTypes.INT(), DataTypes.VARCHAR(2)),
+                        Pair.of(
+                                GenericRow.of(31, BinaryString.fromString("32")),
+                                GenericRow.of(31, BinaryString.fromString("33"))),
+                        new InternalRowSerializer(DataTypes.INT(), DataTypes.VARCHAR(2))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(DataTypeRoot.class)
+    public void testSingleField(DataTypeRoot dataTypeRoot) {
+        GeneratedData testData = TEST_DATA.get(dataTypeRoot);
+        if (testData == null) {
+            throw new UnsupportedOperationException("Unsupported type: " + dataTypeRoot);
+        }
+
+        RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(new DataType[] {testData.dataType})
+                        .generateRecordEqualiser("singleFieldEquals")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+        Function<Object, BinaryRow> func =
+                o -> {
+                    BinaryRow row = new BinaryRow(1);
+                    BinaryRowWriter writer = new BinaryRowWriter(row);
+                    BinaryWriter.write(writer, 0, o, testData.dataType, testData.serializer);
+                    writer.complete();
+                    return row;
+                };
+        assertBoolean(equaliser, func, testData.left(), testData.left(), true);
+        assertBoolean(equaliser, func, testData.left(), testData.right(), false);
+    }
+
+    @RepeatedTest(100)
+    public void testManyFields() {
+        int size = 499;
+        GeneratedData[] generatedData = new GeneratedData[size];
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        DataTypeRoot[] dataTypeRoots = DataTypeRoot.values();
+        for (int i = 0; i < size; i++) {
+            int index = random.nextInt(0, dataTypeRoots.length);
+            GeneratedData testData = TEST_DATA.get(dataTypeRoots[index]);
+            if (testData == null) {
+                throw new UnsupportedOperationException(
+                        "Unsupported type: " + dataTypeRoots[index]);
+            }
+            generatedData[i] = testData;
+        }
+
+        final RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(
+                                Arrays.stream(generatedData)
+                                        .map(d -> d.dataType)
+                                        .toArray(DataType[]::new))
+                        .generateRecordEqualiser("ManyFields")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+
+        Object[] fields1 = new Object[size];
+        Object[] fields2 = new Object[size];
+        boolean equal = true;
+        for (int i = 0; i < size; i++) {
+            boolean randomEqual = random.nextBoolean();
+            fields1[i] = generatedData[i].left();
+            fields2[i] = randomEqual ? generatedData[i].left() : generatedData[i].right();
+            equal &= randomEqual;
+        }
+        assertThat(equaliser.equals(GenericRow.of(fields1), GenericRow.of(fields1))).isTrue();
+        assertThat(equaliser.equals(GenericRow.of(fields1), GenericRow.of(fields2)))
+                .isEqualTo(equal);
+    }
+
+    private static <T> void assertBoolean(
+            RecordEqualiser equaliser,
+            Function<T, BinaryRow> toBinaryRow,
+            T o1,
+            T o2,
+            boolean bool) {
+        assertThat(equaliser.equals(GenericRow.of(o1), GenericRow.of(o2))).isEqualTo(bool);
+        assertThat(equaliser.equals(toBinaryRow.apply(o1), GenericRow.of(o2))).isEqualTo(bool);
+        assertThat(equaliser.equals(GenericRow.of(o1), toBinaryRow.apply(o2))).isEqualTo(bool);
+        assertThat(equaliser.equals(toBinaryRow.apply(o1), toBinaryRow.apply(o2))).isEqualTo(bool);
+    }
+
+    private static class GeneratedData {
+        public final DataType dataType;
+        public final Pair<Object, Object> data;
+        public final Serializer<?> serializer;
+
+        public GeneratedData(DataType dataType, Pair<Object, Object> data) {
+            this(dataType, data, null);
+        }
+
+        public GeneratedData(
+                DataType dataType, Pair<Object, Object> data, Serializer<?> serializer) {
+            this.dataType = dataType;
+            this.data = data;
+            this.serializer = serializer;
+        }
+
+        public Object left() {
+            return data.getLeft();
+        }
+
+        public Object right() {
+            return data.getRight();
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
@@ -48,4 +48,13 @@ public interface CodeGenerator {
      */
     GeneratedClass<RecordComparator> generateRecordComparator(
             List<DataType> fieldTypes, String name);
+
+    /**
+     * Generate a {@link RecordEqualiser}.
+     *
+     * @param fieldTypes Both the input row field types and the sort key field types. Records are *
+     *     compared by the first field, then the second field, then the third field and so on. All *
+     *     fields are compared in ascending order.
+     */
+    GeneratedClass<RecordEqualiser> generateRecordEqualiser(List<DataType> fieldTypes, String name);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/RecordEqualiser.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/RecordEqualiser.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.codegen;
+
+import org.apache.paimon.data.InternalRow;
+
+import java.io.Serializable;
+
+/**
+ * Record equaliser for RowData which can compare two RowData and returns whether they are equal.
+ */
+public interface RecordEqualiser extends Serializable {
+
+    /** Returns {@code true} if the rows are equal to each other and {@code false} otherwise. */
+    boolean equals(InternalRow row1, InternalRow row2);
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
@@ -274,9 +274,24 @@ public class InternalRowUtils {
                 Timestamp yDD1 = (Timestamp) y;
                 ret = xDD1.compareTo(yDD1);
                 break;
+            case BINARY:
+            case VARBINARY:
+                ret = byteArrayCompare((byte[]) x, (byte[]) y);
+                break;
             default:
                 throw new IllegalArgumentException();
         }
         return ret;
+    }
+
+    private static int byteArrayCompare(byte[] array1, byte[] array2) {
+        for (int i = 0, j = 0; i < array1.length && j < array2.length; i++, j++) {
+            int a = (array1[i] & 0xff);
+            int b = (array2[j] & 0xff);
+            if (a != b) {
+                return a - b;
+            }
+        }
+        return array1.length - array2.length;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeCheckUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeCheckUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeFamily;
+
+import static org.apache.paimon.types.DataTypeRoot.ARRAY;
+import static org.apache.paimon.types.DataTypeRoot.BIGINT;
+import static org.apache.paimon.types.DataTypeRoot.BOOLEAN;
+import static org.apache.paimon.types.DataTypeRoot.DECIMAL;
+import static org.apache.paimon.types.DataTypeRoot.INTEGER;
+import static org.apache.paimon.types.DataTypeRoot.MAP;
+import static org.apache.paimon.types.DataTypeRoot.MULTISET;
+import static org.apache.paimon.types.DataTypeRoot.ROW;
+import static org.apache.paimon.types.DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.paimon.types.DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+
+/** Utils for type. */
+public class TypeCheckUtils {
+
+    public static boolean isNumeric(DataType type) {
+        return type.getTypeRoot().getFamilies().contains(DataTypeFamily.NUMERIC);
+    }
+
+    public static boolean isTemporal(DataType type) {
+        return isTimePoint(type);
+    }
+
+    public static boolean isTimePoint(DataType type) {
+        return type.getTypeRoot().getFamilies().contains(DataTypeFamily.DATETIME);
+    }
+
+    public static boolean isCharacterString(DataType type) {
+        return type.getTypeRoot().getFamilies().contains(DataTypeFamily.CHARACTER_STRING);
+    }
+
+    public static boolean isBinaryString(DataType type) {
+        return type.getTypeRoot().getFamilies().contains(DataTypeFamily.BINARY_STRING);
+    }
+
+    public static boolean isTimestamp(DataType type) {
+        return type.getTypeRoot() == TIMESTAMP_WITHOUT_TIME_ZONE;
+    }
+
+    public static boolean isTimestampWithLocalZone(DataType type) {
+        return type.getTypeRoot() == TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+    }
+
+    public static boolean isBoolean(DataType type) {
+        return type.getTypeRoot() == BOOLEAN;
+    }
+
+    public static boolean isDecimal(DataType type) {
+        return type.getTypeRoot() == DECIMAL;
+    }
+
+    public static boolean isInteger(DataType type) {
+        return type.getTypeRoot() == INTEGER;
+    }
+
+    public static boolean isLong(DataType type) {
+        return type.getTypeRoot() == BIGINT;
+    }
+
+    public static boolean isArray(DataType type) {
+        return type.getTypeRoot() == ARRAY;
+    }
+
+    public static boolean isMap(DataType type) {
+        return type.getTypeRoot() == MAP;
+    }
+
+    public static boolean isMultiset(DataType type) {
+        return type.getTypeRoot() == MULTISET;
+    }
+
+    public static boolean isRow(DataType type) {
+        return type.getTypeRoot() == ROW;
+    }
+
+    public static boolean isComparable(DataType type) {
+        return !isMap(type) && !isMultiset(type) && !isRow(type) && !isArray(type);
+    }
+
+    public static boolean isMutable(DataType type) {
+        // ordered by type root definition
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR: // the internal representation of String is BinaryString which is mutable
+            case ARRAY:
+            case MULTISET:
+            case MAP:
+            case ROW:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static boolean isReference(DataType type) {
+        // ordered by type root definition
+        switch (type.getTypeRoot()) {
+            case BOOLEAN:
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return false;
+            default:
+                return true;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -51,6 +51,11 @@ public class CodeGenUtils {
         return CodeGenLoader.getCodeGenerator().generateRecordComparator(fieldTypes, name);
     }
 
+    public static GeneratedClass<RecordEqualiser> generateRecordEqualiser(
+            List<DataType> fieldTypes, String name) {
+        return CodeGenLoader.getCodeGenerator().generateRecordEqualiser(fieldTypes, name);
+    }
+
     public static RecordComparator newRecordComparator(List<DataType> fieldTypes, String name) {
         return generateRecordComparator(fieldTypes, name)
                 .newInstance(CodeGenUtils.class.getClassLoader());


### PR DESCRIPTION
### Purpose

Introduce RecordEqualiser for InternalRow to speed up the judgment of equality. close #1102 

Almost all the codes come from `Flink`, and I removed the related codes for unsupported types in `Paimon` (such as `INTERVAL_YEAR_MONTH`, `RAW`, etc.). At the same time, since the two types currently involved in the comparison in `Paimon` are the same, I removed the relevant code for casting the type.

### Tests

Add unit test to verify the correctness of `EqualiserCodeGenerator`.

- org.apache.paimon.codegen.EqualiserCodeGeneratorTest#testSingleField
- org.apache.paimon.codegen.EqualiserCodeGeneratorTest#ttestManyFields


### API and Format

No.

### Documentation

No.
