### PR TITLE
[flink] support RowLevelDelete for ChangelogValueCountFileStoreTable.

### DIFF
--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -309,8 +309,8 @@ For more information of 'delete', see
 {{< tab "Flink 1.17+" >}}
 {{< hint info >}}
 Important table properties setting:
-1. Only [primary key table]({{< ref "concepts/primary-key-table" >}}) supports this feature.
-2. [MergeEngine]({{< ref "concepts/primary-key-table#merge-engines" >}}) needs to be [deduplicate]({{< ref "concepts/primary-key-table#deduplicate" >}}) to support this feature.
+1. Only tables whose `write-mode` is set to `change-log` supports this feature.
+2. If the table has primary keys, [MergeEngine]({{< ref "concepts/primary-key-table#merge-engines" >}}) needs to be [deduplicate]({{< ref "concepts/primary-key-table#deduplicate" >}}) to support this feature.
    {{< /hint >}}
 
 {{< hint warning >}}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
@@ -121,8 +121,9 @@ public class FlinkTableSink extends FlinkTableSinkBase
                     String.format(
                             "merge engine '%s' can not support delete, currently only %s can support delete.",
                             options.get(MERGE_ENGINE), MergeEngine.DEDUPLICATE));
-        } else if (table instanceof AppendOnlyFileStoreTable
-                || table instanceof ChangelogValueCountFileStoreTable) {
+        } else if (table instanceof ChangelogValueCountFileStoreTable) {
+            return new RowLevelDeleteInfo() {};
+        } else if (table instanceof AppendOnlyFileStoreTable) {
             throw new UnsupportedOperationException(
                     String.format(
                             "table '%s' can not support delete, because there is no primary key.",


### PR DESCRIPTION

### Purpose

Support `RowLevelDelete` for `ChangelogValueCountFileStoreTable`.  close #1215 

### Tests

Modified `org.apache.paimon.flink.ReadWriteTableITCase#testDeleteWithoutPrimaryKey` to verify correctness.

### API and Format

No.

### Documentation

No.
