### PR TITLE
[core] replace ValueComparatorSupplier with ValueEqualiserSupplier.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon;
 
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.fs.FileIO;
@@ -30,7 +31,7 @@ import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.KeyComparatorSupplier;
-import org.apache.paimon.utils.ValueComparatorSupplier;
+import org.apache.paimon.utils.ValueEqualiserSupplier;
 
 import java.util.Comparator;
 import java.util.function.Supplier;
@@ -45,7 +46,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final RowType valueType;
     private final KeyValueFieldsExtractor keyValueFieldsExtractor;
     private final Supplier<Comparator<InternalRow>> keyComparatorSupplier;
-    private final Supplier<Comparator<InternalRow>> valueComparatorSupplier;
+    private final Supplier<RecordEqualiser> valueEqualiserSupplier;
     private final MergeFunctionFactory<KeyValue> mfFactory;
 
     public KeyValueFileStore(
@@ -66,7 +67,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         this.keyValueFieldsExtractor = keyValueFieldsExtractor;
         this.mfFactory = mfFactory;
         this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
-        this.valueComparatorSupplier = new ValueComparatorSupplier(valueType);
+        this.valueEqualiserSupplier = new ValueEqualiserSupplier(valueType);
     }
 
     @Override
@@ -104,7 +105,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 keyType,
                 valueType,
                 keyComparatorSupplier,
-                valueComparatorSupplier,
+                valueEqualiserSupplier,
                 mfFactory,
                 pathFactory(),
                 snapshotManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -20,6 +20,7 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
@@ -39,7 +40,7 @@ import java.util.List;
 /** A {@link MergeTreeCompactRewriter} which produces changelog files for the compaction. */
 public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewriter {
 
-    protected final Comparator<InternalRow> valueComparator;
+    protected final RecordEqualiser valueEqualiser;
     protected final boolean changelogRowDeduplicate;
 
     public ChangelogMergeTreeRewriter(
@@ -48,10 +49,10 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             Comparator<InternalRow> keyComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
             SortEngine sortEngine,
-            Comparator<InternalRow> valueComparator,
+            RecordEqualiser valueEqualiser,
             boolean changelogRowDeduplicate) {
         super(readerFactory, writerFactory, keyComparator, mfFactory, sortEngine);
-        this.valueComparator = valueComparator;
+        this.valueEqualiser = valueEqualiser;
         this.changelogRowDeduplicate = changelogRowDeduplicate;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -20,6 +20,7 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
@@ -43,7 +44,7 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
             Comparator<InternalRow> keyComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
             SortEngine sortEngine,
-            Comparator<InternalRow> valueComparator,
+            RecordEqualiser valueComparator,
             boolean changelogRowDeduplicate) {
         super(
                 readerFactory,
@@ -76,7 +77,7 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
     @Override
     protected MergeFunctionWrapper<ChangelogResult> createMergeWrapper(int outputLevel) {
         return new FullChangelogMergeFunctionWrapper(
-                mfFactory.create(), maxLevel, valueComparator, changelogRowDeduplicate);
+                mfFactory.create(), maxLevel, valueEqualiser, changelogRowDeduplicate);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -20,6 +20,7 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
@@ -47,7 +48,7 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
             Comparator<InternalRow> keyComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
             SortEngine sortEngine,
-            Comparator<InternalRow> valueComparator,
+            RecordEqualiser valueEqualiser,
             boolean changelogRowDeduplicate) {
         super(
                 readerFactory,
@@ -55,7 +56,7 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
                 keyComparator,
                 mfFactory,
                 sortEngine,
-                valueComparator,
+                valueEqualiser,
                 changelogRowDeduplicate);
         this.lookupLevels = lookupLevels;
     }
@@ -95,7 +96,7 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
                         throw new UncheckedIOException(e);
                     }
                 },
-                valueComparator,
+                valueEqualiser,
                 changelogRowDeduplicate);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ValueEqualiserSupplier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ValueEqualiserSupplier.java
@@ -20,27 +20,25 @@ package org.apache.paimon.utils;
 
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.GeneratedClass;
-import org.apache.paimon.codegen.RecordComparator;
-import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.types.RowType;
 
-import java.util.Comparator;
 import java.util.function.Supplier;
 
-/** A {@link Supplier} that returns the comparator for the file store value. */
-public class ValueComparatorSupplier implements SerializableSupplier<Comparator<InternalRow>> {
+/** A {@link Supplier} that returns the equaliser for the file store value. */
+public class ValueEqualiserSupplier implements SerializableSupplier<RecordEqualiser> {
 
     private static final long serialVersionUID = 1L;
 
-    private final GeneratedClass<RecordComparator> genRecordComparator;
+    private final GeneratedClass<RecordEqualiser> genRecordEqualiser;
 
-    public ValueComparatorSupplier(RowType keyType) {
-        genRecordComparator =
-                CodeGenUtils.generateRecordComparator(keyType.getFieldTypes(), "valueComparator");
+    public ValueEqualiserSupplier(RowType keyType) {
+        genRecordEqualiser =
+                CodeGenUtils.generateRecordEqualiser(keyType.getFieldTypes(), "valueEqualiser");
     }
 
     @Override
-    public RecordComparator get() {
-        return genRecordComparator.newInstance(ValueComparatorSupplier.class.getClassLoader());
+    public RecordEqualiser get() {
+        return genRecordEqualiser.newInstance(ValueEqualiserSupplier.class.getClassLoader());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapperTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapperTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.KeyValue;
-import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.types.RowKind;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import static org.apache.paimon.io.DataFileTestUtils.row;
@@ -38,8 +37,8 @@ public abstract class FullChangelogMergeFunctionWrapperTestBase {
 
     private static final int MAX_LEVEL = 3;
 
-    private static final Comparator<InternalRow> COMPARATOR =
-            Comparator.comparingInt(o -> o.getInt(0));
+    private static final RecordEqualiser EQUALISER =
+            (RecordEqualiser) (row1, row2) -> row1.getInt(0) == row2.getInt(0);
 
     protected FullChangelogMergeFunctionWrapper wrapper;
 
@@ -51,7 +50,7 @@ public abstract class FullChangelogMergeFunctionWrapperTestBase {
     public void beforeEach() {
         wrapper =
                 new FullChangelogMergeFunctionWrapper(
-                        createMergeFunction(), MAX_LEVEL, COMPARATOR, changelogRowDeduplicate());
+                        createMergeFunction(), MAX_LEVEL, EQUALISER, changelogRowDeduplicate());
     }
 
     private static final List<List<KeyValue>> INPUT_KVS =

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
@@ -29,7 +30,6 @@ import org.apache.paimon.types.DataTypes;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,8 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link LookupChangelogMergeFunctionWrapper}. */
 public class LookupChangelogMergeFunctionWrapperTest {
 
-    private static final Comparator<InternalRow> COMPARATOR =
-            Comparator.comparingInt(o -> o.getInt(0));
+    private static final RecordEqualiser EQUALISER =
+            (RecordEqualiser) (row1, row2) -> row1.getInt(0) == row2.getInt(0);
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -55,7 +55,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                 new LookupChangelogMergeFunctionWrapper(
                         LookupMergeFunction.wrap(DeduplicateMergeFunction.factory()),
                         highLevel::get,
-                        COMPARATOR,
+                        EQUALISER,
                         changelogRowDeduplicate);
 
         // Without level-0
@@ -209,7 +209,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                                     new FieldSumAgg(DataTypes.INT())
                                                 })),
                         key -> null,
-                        COMPARATOR,
+                        EQUALISER,
                         changlogRowDeduplicate);
 
         // Without level-0

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -71,6 +72,8 @@ public class TestChangelogDataReadWrite {
             new RowType(singletonList(new DataField(0, "v", new BigIntType())));
     private static final Comparator<InternalRow> COMPARATOR =
             Comparator.comparingLong(o -> o.getLong(0));
+    private static final RecordEqualiser EQUALISER =
+            (RecordEqualiser) (row1, row2) -> row1.getLong(0) == row2.getLong(0);
     private static final KeyValueFieldsExtractor EXTRACTOR =
             new KeyValueFieldsExtractor() {
                 @Override
@@ -177,7 +180,7 @@ public class TestChangelogDataReadWrite {
                                 KEY_TYPE,
                                 VALUE_TYPE,
                                 () -> COMPARATOR,
-                                () -> COMPARATOR,
+                                () -> EQUALISER,
                                 DeduplicateMergeFunction.factory(),
                                 pathFactory,
                                 snapshotManager,


### PR DESCRIPTION


### Purpose

Replace ValueComparatorSupplier with ValueEqualiserSupplier.  fix #1100 

### Tests

Modify the existing unit tests to verify correctness:

- `org.apache.paimon.mergetree.compact.FullChangelogMergeFunctionWrapperTestBase`
- `org.apache.paimon.mergetree.compact.LookupChangelogMergeFunctionWrapperTest`

### API and Format

No.

### Documentation

No.
