### PR TITLE
[flink] make sync action construct method to public

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -109,7 +109,7 @@ public class MySqlSyncDatabaseAction implements Action {
     private final Map<String, String> catalogConfig;
     private final Map<String, String> tableConfig;
 
-    MySqlSyncDatabaseAction(
+    public MySqlSyncDatabaseAction(
             Map<String, String> mySqlConfig,
             String warehouse,
             String database,
@@ -129,7 +129,7 @@ public class MySqlSyncDatabaseAction implements Action {
                 tableConfig);
     }
 
-    MySqlSyncDatabaseAction(
+    public MySqlSyncDatabaseAction(
             Map<String, String> mySqlConfig,
             String warehouse,
             String database,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -98,7 +98,7 @@ public class MySqlSyncTableAction implements Action {
     private final Map<String, String> catalogConfig;
     private final Map<String, String> tableConfig;
 
-    MySqlSyncTableAction(
+    public MySqlSyncTableAction(
             Map<String, String> mySqlConfig,
             String warehouse,
             String database,
@@ -119,7 +119,7 @@ public class MySqlSyncTableAction implements Action {
                 tableConfig);
     }
 
-    MySqlSyncTableAction(
+    public MySqlSyncTableAction(
             Map<String, String> mySqlConfig,
             String warehouse,
             String database,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose


the[ paimon doc](https://paimon.apache.org/docs/master/how-to/cdc-ingestion/#synchronizing-tables) desc that we can use DataStream to use `MySqlSyncTableAction`,  but when we use the action in DataStream, it throw an exception 

`MySqlSyncTableAction(java.util.Map<java.lang.String,java.lang.String>, java.lang.String, java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.util.List<java.lang.String>, java.util.Map<java.lang.String,java.lang.String>, ...)' is not public in 'org.apache.paimon.flink.action.cdc.mysql.MySqlSyncTableAction'. Cannot be accessed from outside package`


so I think we may need to make the construct method to public.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
