### PR TITLE
[flink] Support flink managed memory for writer buffer

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -87,10 +87,22 @@ under the License.
             <td>If no records flow in a partition of a stream for that amount of time, then that partition is considered "idle" and will not hold back the progress of watermarks in downstream operators.</td>
         </tr>
         <tr>
+            <td><h5>sink.managed.writer-buffer-memory</h5></td>
+            <td style="word-wrap: break-word;">256 mb</td>
+            <td>MemorySize</td>
+            <td>Weight of writer buffer in managed memory, Flink will compute the memory size for writer according to the weight, the actual memory used depends on the running environment.</td>
+        </tr>
+        <tr>
             <td><h5>sink.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>Defines a custom parallelism for the sink. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration.</td>
+        </tr>
+        <tr>
+            <td><h5>sink.use-managed-memory-allocator</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, flink sink will use managed memory for merge tree; otherwise, it will create an independent memory allocator.</td>
         </tr>
         <tr>
             <td><h5>streaming-read-atomic</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/memory/AbstractMemorySegmentPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/AbstractMemorySegmentPool.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.memory;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Abstract memory segment pool. */
+public abstract class AbstractMemorySegmentPool implements MemorySegmentPool {
+    private final LinkedList<MemorySegment> segments;
+    private final int maxPages;
+    protected final int pageSize;
+
+    private int numPage;
+
+    public AbstractMemorySegmentPool(long maxMemory, int pageSize) {
+        this.segments = new LinkedList<>();
+        this.maxPages = (int) (maxMemory / pageSize);
+        this.pageSize = pageSize;
+        this.numPage = 0;
+    }
+
+    @Override
+    public MemorySegment nextSegment() {
+        if (this.segments.size() > 0) {
+            return this.segments.poll();
+        } else if (numPage < maxPages) {
+            numPage++;
+            return allocateMemory();
+        }
+
+        return null;
+    }
+
+    protected abstract MemorySegment allocateMemory();
+
+    @Override
+    public int pageSize() {
+        return pageSize;
+    }
+
+    @Override
+    public void returnAll(List<MemorySegment> memory) {
+        segments.addAll(memory);
+    }
+
+    @Override
+    public int freePages() {
+        return segments.size() + maxPages - numPage;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/memory/MemorySegment.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/MemorySegment.java
@@ -92,15 +92,6 @@ public final class MemorySegment {
         return size;
     }
 
-    public void free() {
-        if (this.heapMemory == null) {
-            UNSAFE.freeMemory(this.address);
-        }
-        this.heapMemory = null;
-        this.offHeapBuffer = null;
-        this.address = 0;
-    }
-
     public boolean isOffHeap() {
         return heapMemory == null;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.utils;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -47,12 +46,5 @@ public class ReflectionUtils {
     public static <T> T invokeStaticMethod(Method method, Object... args)
             throws InvocationTargetException, IllegalAccessException {
         return (T) method.invoke(null, args);
-    }
-
-    public static <T, C> T getField(C obj, String field)
-            throws NoSuchFieldException, IllegalAccessException {
-        Field f = obj.getClass().getDeclaredField(field);
-        f.setAccessible(true);
-        return (T) f.get(obj);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -46,5 +47,12 @@ public class ReflectionUtils {
     public static <T> T invokeStaticMethod(Method method, Object... args)
             throws InvocationTargetException, IllegalAccessException {
         return (T) method.invoke(null, args);
+    }
+
+    public static <T, C> T getField(C obj, String field)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field f = obj.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        return (T) f.get(obj);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -23,6 +23,7 @@ import org.apache.paimon.CoreOptions.StreamingReadMode;
 import org.apache.paimon.annotation.Documentation.ExcludeFromDocumentation;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
@@ -180,6 +181,27 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "How many splits should assign to subtask per batch in StaticFileStoreSplitEnumerator "
                                     + "to avoid exceed `akka.framesize` limit.");
+
+    /* Sink writer allocate segments from managed memory. */
+    public static final ConfigOption<Boolean> SINK_USE_MANAGED_MEMORY =
+            ConfigOptions.key("sink.use-managed-memory-allocator")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, flink sink will use managed memory for merge tree; otherwise, "
+                                    + "it will create an independent memory allocator.");
+
+    /**
+     * Weight of writer buffer in managed memory, Flink will compute the memory size for writer
+     * according to the weight, the actual memory used depends on the running environment.
+     */
+    public static final ConfigOption<MemorySize> SINK_MANAGED_WRITER_BUFFER_MEMORY =
+            ConfigOptions.key("sink.managed.writer-buffer-memory")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(256))
+                    .withDescription(
+                            "Weight of writer buffer in managed memory, Flink will compute the memory size "
+                                    + "for writer according to the weight, the actual memory used depends on the running environment.");
 
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/FlinkMemorySegmentPool.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/FlinkMemorySegmentPool.java
@@ -16,17 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.memory;
+package org.apache.paimon.flink.memory;
 
-/** MemorySegment pool from heap. */
-public class HeapMemorySegmentPool extends AbstractMemorySegmentPool {
+import org.apache.paimon.memory.AbstractMemorySegmentPool;
+import org.apache.paimon.memory.MemorySegment;
 
-    public HeapMemorySegmentPool(long maxMemory, int pageSize) {
+/**
+ * Flink memory segment pool allocates segment from flink managed memory for paimon writer buffer.
+ */
+public class FlinkMemorySegmentPool extends AbstractMemorySegmentPool {
+    private final MemorySegmentAllocator allocator;
+
+    public FlinkMemorySegmentPool(long maxMemory, int pageSize, MemorySegmentAllocator allocator) {
         super(maxMemory, pageSize);
+        this.allocator = allocator;
     }
 
     @Override
     protected MemorySegment allocateMemory() {
-        return MemorySegment.allocateHeapMemory(pageSize);
+        return allocator.allocate();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/MemorySegmentAllocator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/MemorySegmentAllocator.java
@@ -47,6 +47,8 @@ public class MemorySegmentAllocator {
             memoryManager.allocatePages(owner, segments, 1);
             org.apache.flink.core.memory.MemorySegment segment = segments.remove(0);
             allocatedSegments.add(segment);
+            // TODO Use getOffHeapBuffer in MemorySegment after
+            // https://issues.apache.org/jira/browse/FLINK-32213
             return MemorySegment.wrapOffHeapMemory(
                     ReflectionUtils.getField(segment, "offHeapBuffer"));
         } catch (Exception e) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/MemorySegmentAllocator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/memory/MemorySegmentAllocator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.memory;
+
+import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.utils.ReflectionUtils;
+
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Allocate memory segment from memory manager in flink for paimon. */
+public class MemorySegmentAllocator {
+    private final Object owner;
+    private final MemoryManager memoryManager;
+    private final List<org.apache.flink.core.memory.MemorySegment> allocatedSegments;
+    private final List<org.apache.flink.core.memory.MemorySegment> segments;
+
+    public MemorySegmentAllocator(Object owner, MemoryManager memoryManager) {
+        this.owner = owner;
+        this.memoryManager = memoryManager;
+        this.allocatedSegments = new ArrayList<>();
+        this.segments = new ArrayList<>(1);
+    }
+
+    /** Allocates a set of memory segments for memory pool. */
+    public MemorySegment allocate() {
+        segments.clear();
+        try {
+            memoryManager.allocatePages(owner, segments, 1);
+            org.apache.flink.core.memory.MemorySegment segment = segments.remove(0);
+            allocatedSegments.add(segment);
+            return MemorySegment.wrapOffHeapMemory(
+                    ReflectionUtils.getField(segment, "offHeapBuffer"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /* Release the segments allocated by the allocator if the task is closed. */
+    public void release() {
+        memoryManager.release(allocatedSegments);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.Preconditions;
@@ -29,6 +30,7 @@ import org.apache.paimon.utils.SerializableFunction;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -45,6 +47,8 @@ import java.util.UUID;
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_LOOKUP_WAIT;
+import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_MANAGED_WRITER_BUFFER_MEMORY;
+import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
 
 /** Abstract sink of paimon. */
 public abstract class FlinkSink<T> implements Serializable {
@@ -87,7 +91,7 @@ public abstract class FlinkSink<T> implements Serializable {
 
             if (changelogProducer == ChangelogProducer.FULL_COMPACTION || deltaCommits >= 0) {
                 int finalDeltaCommits = Math.max(deltaCommits, 1);
-                return (table, commitUser, state, ioManager) ->
+                return (table, commitUser, state, ioManager, memoryPool) ->
                         new GlobalFullCompactionSinkWrite(
                                 table,
                                 commitUser,
@@ -95,13 +99,20 @@ public abstract class FlinkSink<T> implements Serializable {
                                 ioManager,
                                 isOverwrite,
                                 waitCompaction,
-                                finalDeltaCommits);
+                                finalDeltaCommits,
+                                memoryPool);
             }
         }
 
-        return (table, commitUser, state, ioManager) ->
+        return (table, commitUser, state, ioManager, memoryPool) ->
                 new StoreSinkWriteImpl(
-                        table, commitUser, state, ioManager, isOverwrite, waitCompaction);
+                        table,
+                        commitUser,
+                        state,
+                        ioManager,
+                        isOverwrite,
+                        waitCompaction,
+                        memoryPool);
     }
 
     public DataStreamSink<?> sinkFrom(DataStream<T> input) {
@@ -138,6 +149,13 @@ public abstract class FlinkSink<T> implements Serializable {
                                 typeInfo,
                                 createWriteOperator(sinkProvider, isStreaming, commitUser))
                         .setParallelism(input.getParallelism());
+        Options options = Options.fromMap(table.options());
+        if (options.get(SINK_USE_MANAGED_MEMORY)) {
+            MemorySize memorySize = options.get(SINK_MANAGED_WRITER_BUFFER_MEMORY);
+            written.getTransformation()
+                    .declareManagedMemoryUseCaseAtOperatorScope(
+                            ManagedMemoryUseCase.OPERATOR, memorySize.getMebiBytes());
+        }
 
         SingleOutputStreamOperator<?> committed =
                 written.transform(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.utils.SnapshotManager;
@@ -29,6 +30,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,8 +71,9 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
             IOManager ioManager,
             boolean isOverwrite,
             boolean waitCompaction,
-            int deltaCommits) {
-        super(table, commitUser, state, ioManager, isOverwrite, waitCompaction);
+            int deltaCommits,
+            @Nullable MemorySegmentPool memoryPool) {
+        super(table, commitUser, state, ioManager, isOverwrite, waitCompaction, memoryPool);
 
         this.deltaCommits = deltaCommits;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
@@ -18,28 +18,70 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.flink.memory.FlinkMemorySegmentPool;
+import org.apache.paimon.flink.memory.MemorySegmentAllocator;
 import org.apache.paimon.memory.MemorySegmentPool;
+import org.apache.paimon.options.Options;
 
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
+
 /** Prepare commit operator to emit {@link Committable}s. */
 public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
         implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
 
     @Nullable protected transient MemorySegmentPool memoryPool;
+    @Nullable private transient MemorySegmentAllocator memoryAllocator;
+    private final Options options;
     private boolean endOfInput = false;
 
-    public PrepareCommitOperator() {
+    public PrepareCommitOperator(Options options) {
+        this.options = options;
         setChainingStrategy(ChainingStrategy.ALWAYS);
+    }
+
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<OUT>> output) {
+        super.setup(containingTask, config, output);
+        if (options.get(SINK_USE_MANAGED_MEMORY)) {
+            MemoryManager memoryManager = containingTask.getEnvironment().getMemoryManager();
+            memoryAllocator = new MemorySegmentAllocator(containingTask, memoryManager);
+            memoryPool =
+                    new FlinkMemorySegmentPool(
+                            computeMemorySize(), memoryManager.getPageSize(), memoryAllocator);
+        }
+    }
+
+    /** Compute memory size from memory faction. */
+    private long computeMemorySize() {
+        final Environment environment = getContainingTask().getEnvironment();
+        return environment
+                .getMemoryManager()
+                .computeMemorySize(
+                        getOperatorConfig()
+                                .getManagedMemoryFractionOperatorUseCaseOfSlot(
+                                        ManagedMemoryUseCase.OPERATOR,
+                                        environment.getTaskManagerInfo().getConfiguration(),
+                                        environment.getUserCodeClassLoader().asClassLoader()));
     }
 
     @Override
@@ -54,6 +96,14 @@ public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOpera
     public void endInput() throws Exception {
         endOfInput = true;
         emitCommittables(true, Long.MAX_VALUE);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        if (memoryAllocator != null) {
+            memoryAllocator.release();
+        }
     }
 
     private void emitCommittables(boolean doCompaction, long checkpointId) throws IOException {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
@@ -18,11 +18,15 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.memory.MemorySegmentPool;
+
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,6 +35,7 @@ import java.util.List;
 public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
         implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
 
+    @Nullable protected transient MemorySegmentPool memoryPool;
     private boolean endOfInput = false;
 
     public PrepareCommitOperator() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -93,7 +93,8 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
                         table,
                         commitUser,
                         state,
-                        getContainingTask().getEnvironment().getIOManager());
+                        getContainingTask().getEnvironment().getIOManager(),
+                        memoryPool);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.Preconditions;
 
@@ -58,6 +59,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
             StoreSinkWrite.Provider storeSinkWriteProvider,
             boolean isStreaming,
             String initialCommitUser) {
+        super(Options.fromMap(table.options()));
         Preconditions.checkArgument(
                 !table.coreOptions().writeOnly(),
                 CoreOptions.WRITE_ONLY.key() + " should not be true for StoreCompactOperator.");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
@@ -21,11 +21,14 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.table.sink.TableWriteImpl;
 
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -68,6 +71,7 @@ public interface StoreSinkWrite {
                 FileStoreTable table,
                 String commitUser,
                 StoreSinkWriteState state,
-                IOManager ioManager);
+                IOManager ioManager,
+                @Nullable MemorySegmentPool memoryPool);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -122,7 +122,8 @@ public class CdcRecordStoreMultiWriteOperator
                                         table,
                                         commitUser,
                                         state,
-                                        getContainingTask().getEnvironment().getIOManager()));
+                                        getContainingTask().getEnvironment().getIOManager(),
+                                        memoryPool));
 
         Optional<GenericRow> optionalConverted = record.toGenericRow(table.schema().fields());
         if (!optionalConverted.isPresent()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -26,6 +26,7 @@ import org.apache.paimon.flink.sink.PrepareCommitOperator;
 import org.apache.paimon.flink.sink.StateUtils;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -65,7 +66,9 @@ public class CdcRecordStoreMultiWriteOperator
     public CdcRecordStoreMultiWriteOperator(
             Catalog.Loader catalogLoader,
             StoreSinkWrite.Provider storeSinkWriteProvider,
-            String initialCommitUser) {
+            String initialCommitUser,
+            Options options) {
+        super(options);
         this.catalogLoader = catalogLoader;
         this.storeSinkWriteProvider = storeSinkWriteProvider;
         this.initialCommitUser = initialCommitUser;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
@@ -26,6 +26,7 @@ import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -62,6 +63,7 @@ public class CdcRecordStoreWriteOperator extends PrepareCommitOperator<CdcRecord
             FileStoreTable table,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
+        super(Options.fromMap(table.options()));
         this.table = table;
         this.storeSinkWriteProvider = storeSinkWriteProvider;
         this.initialCommitUser = initialCommitUser;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
@@ -95,7 +95,8 @@ public class CdcRecordStoreWriteOperator extends PrepareCommitOperator<CdcRecord
                         table,
                         commitUser,
                         state,
-                        getContainingTask().getEnvironment().getIOManager());
+                        getContainingTask().getEnvironment().getIOManager(),
+                        memoryPool);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
@@ -645,9 +645,9 @@ public class CdcRecordStoreMultiWriteOperatorTest {
         CdcRecordStoreMultiWriteOperator operator =
                 new CdcRecordStoreMultiWriteOperator(
                         catalogLoader,
-                        (t, commitUser, state, ioManager) ->
+                        (t, commitUser, state, ioManager, memoryPool) ->
                                 new StoreSinkWriteImpl(
-                                        t, commitUser, state, ioManager, false, false),
+                                        t, commitUser, state, ioManager, false, false, memoryPool),
                         commitUser);
         TypeSerializer<CdcMultiplexRecord> inputSerializer = new JavaSerializer<>();
         TypeSerializer<MultiTableCommittable> outputSerializer =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
@@ -648,7 +648,8 @@ public class CdcRecordStoreMultiWriteOperatorTest {
                         (t, commitUser, state, ioManager, memoryPool) ->
                                 new StoreSinkWriteImpl(
                                         t, commitUser, state, ioManager, false, false, memoryPool),
-                        commitUser);
+                        commitUser,
+                        Options.fromMap(new HashMap<>()));
         TypeSerializer<CdcMultiplexRecord> inputSerializer = new JavaSerializer<>();
         TypeSerializer<MultiTableCommittable> outputSerializer =
                 new MultiTableCommittableTypeInfo().createSerializer(new ExecutionConfig());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
@@ -255,9 +255,9 @@ public class CdcRecordStoreWriteOperatorTest {
         CdcRecordStoreWriteOperator operator =
                 new CdcRecordStoreWriteOperator(
                         table,
-                        (t, commitUser, state, ioManager) ->
+                        (t, commitUser, state, ioManager, memoryPool) ->
                                 new StoreSinkWriteImpl(
-                                        t, commitUser, state, ioManager, false, false),
+                                        t, commitUser, state, ioManager, false, false, memoryPool),
                         commitUser);
         TypeSerializer<CdcRecord> inputSerializer = new JavaSerializer<>();
         TypeSerializer<Committable> outputSerializer =


### PR DESCRIPTION
### Purpose

Fix #1071 Use flink managed memory for writer buffer in paimon

1. Add options `sink.use-managed-memory-allocator` and `sink.managed.writer-buffer-memory` for flink managed memory
2. Calculate managed memory weight in FlinkSink
3. Create memory pool for paimon writer in RowDataStoreWriteOperator

### Tests

1. Added test case ContinuousFileStoreITCase.testFlinkMemoryPool

### API and Format
no

### Documentation
no
