### PR TITLE
[hive] Fix hive writer memory leak

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonOutputCommitter.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonOutputCommitter.java
@@ -100,6 +100,7 @@ public class PaimonOutputCommitter extends OutputCommitter {
                                 attemptID.getJobID(),
                                 attemptID.getTaskID().getId()),
                         table.fileIO());
+                writer.close(true);
             } catch (Exception e) {
                 LOG.error(
                         "CommitTask prepareCommit error for specific table: {}, attemptID: {}",


### PR DESCRIPTION
### Purpose

Fix hive writer memory leak #1191 
every map task  are not close writer ,it causes more memory required.
 

### Tests

no

### API and Format

no

### Documentation

no
