### PR TITLE
[core] Support to make up the sequence number to nanosecond precision

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -260,6 +260,8 @@ there will be some cases that lead to data disorder. At this time, you can use a
 {{< hint info >}}
 When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged. For example,
 you can use [Mysql Binlog operation time](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#available-metadata) as `sequence.field`.
+If the provided `sequence.field` doesn't meet the precision, you can set `sequence.nanos` as `true` so that the precision of sequence number will be made up to nanosecond by system. 
+Note that only fields of data type `Timestamp` with precision of `second` and `millisecond` can be made up by nanoseconds.
 {{< /hint >}}
 
 {{< tabs "sequence.field" >}}

--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -260,8 +260,8 @@ there will be some cases that lead to data disorder. At this time, you can use a
 {{< hint info >}}
 When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged. For example,
 you can use [Mysql Binlog operation time](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#available-metadata) as `sequence.field`.
-If the provided `sequence.field` doesn't meet the precision, you can set `sequence.nanos` as `true` so that the precision of sequence number will be made up to nanosecond by system. 
-Note that only fields of data type `Timestamp` with precision of `second` and `millisecond` can be made up by nanoseconds.
+If the provided `sequence.field` doesn't meet the precision, like a rough second or millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision of sequence number will be made up to microsecond by system. 
+Note that only fields of data type `Timestamp`, `Integer` and `BigInt` which indicates a `second` or `millisecond` can be padded by microseconds.
 {{< /hint >}}
 
 {{< tabs "sequence.field" >}}

--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -261,7 +261,6 @@ there will be some cases that lead to data disorder. At this time, you can use a
 When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged. For example,
 you can use [Mysql Binlog operation time](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#available-metadata) as `sequence.field`.
 If the provided `sequence.field` doesn't meet the precision, like a rough second or millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision of sequence number will be made up to microsecond by system. 
-Note that only fields of data type `Timestamp`, `Integer` and `BigInt` which indicates a `second` or `millisecond` can be padded by microseconds.
 {{< /hint >}}
 
 {{< tabs "sequence.field" >}}

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -351,16 +351,16 @@ under the License.
             <td>Optional timestamp used in case of "from-timestamp" scan mode.</td>
         </tr>
         <tr>
+            <td><h5>sequence.auto-padding</h5></td>
+            <td style="word-wrap: break-word;">none</td>
+            <td><p>Enum</p></td>
+            <td>Specify the way of padding precision up to micro-second if the provided sequence field is used to indicate "time" but doesn't meet the precise.<br /><br />Possible values:<ul><li>"none": No padding for sequence field.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>sequence.field</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The field that generates the sequence number for primary key table, the sequence number determines which data is the most recent.</td>
-        </tr>
-        <tr>
-            <td><h5>sequence.auto-padding</h5></td>
-            <td style="word-wrap: break-word;">none</td>
-            <td>Enum</td>
-            <td>Specify the way of making up time precision to microsecond for sequence field which indicates a second or millisecond.<br /><br />Possible values:<ul><li>"none": Do not pad to sequence number.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
         </tr>
         <tr>
             <td><h5>snapshot.num-retained.max</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -357,6 +357,12 @@ under the License.
             <td>The field that generates the sequence number for primary key table, the sequence number determines which data is the most recent.</td>
         </tr>
         <tr>
+            <td><h5>sequence.nanos</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Boolean</td>
+            <td>Whether to splice a nano time after sequence number to decide the merge order with higher precision if "sequence.field" of data type "Timestamp" is provided but doesn't meet the precise.</td>
+        </tr>
+        <tr>
             <td><h5>snapshot.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -357,10 +357,10 @@ under the License.
             <td>The field that generates the sequence number for primary key table, the sequence number determines which data is the most recent.</td>
         </tr>
         <tr>
-            <td><h5>sequence.nanos</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Boolean</td>
-            <td>Whether to splice a nano time after sequence number to decide the merge order with higher precision if "sequence.field" of data type "Timestamp" is provided but doesn't meet the precise.</td>
+            <td><h5>sequence.auto-padding</h5></td>
+            <td style="word-wrap: break-word;">none</td>
+            <td>Enum</td>
+            <td>Specify the way of making up time precision to microsecond for sequence field which indicates a second or millisecond.<br /><br />Possible values:<ul><li>"none": Do not pad to sequence number.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
         </tr>
         <tr>
             <td><h5>snapshot.num-retained.max</h5></td>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -375,8 +375,9 @@ public class CoreOptions implements Serializable {
             key("sequence.auto-padding")
                     .enumType(SequenceAutoPadding.class)
                     .defaultValue(SequenceAutoPadding.NONE)
-                    .withDescription("Specify the way of padding precision up to micro-second" +
-                            " if the provided sequence field is used to indicate \"time\" but doesn't meet the precise.");
+                    .withDescription(
+                            "Specify the way of padding precision up to micro-second"
+                                    + " if the provided sequence field is used to indicate \"time\" but doesn't meet the precise.");
 
     public static final ConfigOption<StartupMode> SCAN_MODE =
             key("scan.mode")
@@ -1291,7 +1292,9 @@ public class CoreOptions implements Serializable {
         SECOND_TO_MICRO(
                 "second-to-micro",
                 "Pads the sequence field that indicates time with precision of seconds to micro-second."),
-        MILLS_TO_MICRO("mills-to-micro", "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
+        MILLIS_TO_MICRO(
+                "millis-to-micro",
+                "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -371,14 +371,12 @@ public class CoreOptions implements Serializable {
                             "The field that generates the sequence number for primary key table,"
                                     + " the sequence number determines which data is the most recent.");
 
-    public static final ConfigOption<Boolean> SEQUENCE_NANOS =
-            key("sequence.nanos")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Whether to splice a nano time after sequence number to decide the merge order"
-                                    + " with higher precision if \"sequence.field\" of data type \"Timestamp\" is provided"
-                                    + " but doesn't meet the precise.");
+    public static final ConfigOption<SequenceAutoPadding> SEQUENCE_AUTO_PADDING =
+            key("sequence.auto-padding")
+                    .enumType(SequenceAutoPadding.class)
+                    .defaultValue(SequenceAutoPadding.NONE)
+                    .withDescription("Specify the way of padding precision up to micro-second" +
+                            " if the provided sequence field is used to indicate \"time\" but doesn't meet the precise.");
 
     public static final ConfigOption<StartupMode> SCAN_MODE =
             key("scan.mode")
@@ -892,8 +890,8 @@ public class CoreOptions implements Serializable {
         return options.getOptional(SEQUENCE_FIELD);
     }
 
-    public boolean sequenceNanos() {
-        return options.get(SEQUENCE_NANOS);
+    public SequenceAutoPadding sequenceAutoPadding() {
+        return options.get(SEQUENCE_AUTO_PADDING);
     }
 
     public WriteMode writeMode() {
@@ -1272,6 +1270,33 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         SortEngine(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Specifies the way of making up time precision for sequence field. */
+    public enum SequenceAutoPadding implements DescribedEnum {
+        NONE("none", "No padding for sequence field."),
+        SECOND_TO_MICRO(
+                "second-to-micro",
+                "Pads the sequence field that indicates time with precision of seconds to micro-second."),
+        MILLS_TO_MICRO("mills-to-micro", "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
+
+        private final String value;
+        private final String description;
+
+        SequenceAutoPadding(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -371,6 +371,15 @@ public class CoreOptions implements Serializable {
                             "The field that generates the sequence number for primary key table,"
                                     + " the sequence number determines which data is the most recent.");
 
+    public static final ConfigOption<Boolean> SEQUENCE_NANOS =
+            key("sequence.nanos")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to splice a nano time after sequence number to decide the merge order"
+                                    + " with higher precision if \"sequence.field\" of data type \"Timestamp\" is provided"
+                                    + " but doesn't meet the precise.");
+
     public static final ConfigOption<StartupMode> SCAN_MODE =
             key("scan.mode")
                     .enumType(StartupMode.class)
@@ -881,6 +890,10 @@ public class CoreOptions implements Serializable {
 
     public Optional<String> sequenceField() {
         return options.getOptional(SEQUENCE_FIELD);
+    }
+
+    public boolean sequenceNanos() {
+        return options.get(SEQUENCE_NANOS);
     }
 
     public WriteMode writeMode() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -223,7 +223,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         .sequenceField()
                         .map(field -> new SequenceGenerator(field, schema().logicalRowType()))
                         .orElse(null);
-        final CoreOptions.SequenceAutoPadding sequenceAutoPadding = store().options().sequenceAutoPadding();
+        final CoreOptions.SequenceAutoPadding sequenceAutoPadding =
+                store().options().sequenceAutoPadding();
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 store().newWrite(commitUser, manifestFilter),
@@ -234,7 +235,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                                     ? KeyValue.UNKNOWN_SEQUENCE
                                     : sequenceAutoPadding == CoreOptions.SequenceAutoPadding.NONE
                                             ? sequenceGenerator.generate(record.row())
-                                            : sequenceGenerator.generateWithPadding(record.row(), sequenceAutoPadding);
+                                            : sequenceGenerator.generateWithPadding(
+                                                    record.row(), sequenceAutoPadding);
                     return kv.replace(
                             record.primaryKey(),
                             sequenceNumber,

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -223,6 +223,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         .sequenceField()
                         .map(field -> new SequenceGenerator(field, schema().logicalRowType()))
                         .orElse(null);
+        final boolean sequenceNanos = store().options().sequenceNanos();
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 store().newWrite(commitUser, manifestFilter),
@@ -231,7 +232,9 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                     long sequenceNumber =
                             sequenceGenerator == null
                                     ? KeyValue.UNKNOWN_SEQUENCE
-                                    : sequenceGenerator.generate(record.row());
+                                    : sequenceNanos
+                                            ? sequenceGenerator.generateWithNanos(record.row())
+                                            : sequenceGenerator.generate(record.row());
                     return kv.replace(
                             record.primaryKey(),
                             sequenceNumber,

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -223,7 +223,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         .sequenceField()
                         .map(field -> new SequenceGenerator(field, schema().logicalRowType()))
                         .orElse(null);
-        final boolean sequenceNanos = store().options().sequenceNanos();
+        final CoreOptions.SequenceAutoPadding sequenceAutoPadding = store().options().sequenceAutoPadding();
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 store().newWrite(commitUser, manifestFilter),
@@ -232,9 +232,9 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                     long sequenceNumber =
                             sequenceGenerator == null
                                     ? KeyValue.UNKNOWN_SEQUENCE
-                                    : sequenceNanos
-                                            ? sequenceGenerator.generateWithNanos(record.row())
-                                            : sequenceGenerator.generate(record.row());
+                                    : sequenceAutoPadding == CoreOptions.SequenceAutoPadding.NONE
+                                            ? sequenceGenerator.generate(record.row())
+                                            : sequenceGenerator.generateWithPadding(record.row(), sequenceAutoPadding);
                     return kv.replace(
                             record.primaryKey(),
                             sequenceNumber,

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -92,29 +92,26 @@ public class TableWriteImpl<T>
     }
 
     public SinkRecord writeAndReturn(InternalRow row) throws Exception {
-        keyAndBucketExtractor.setRecord(row);
-        SinkRecord record =
-                new SinkRecord(
-                        keyAndBucketExtractor.partition(),
-                        keyAndBucketExtractor.bucket(),
-                        keyAndBucketExtractor.trimmedPrimaryKey(),
-                        row);
+        SinkRecord record = toSinkRecord(row);
         write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
         return record;
     }
 
     @VisibleForTesting
     public T writeAndReturnData(InternalRow row) throws Exception {
-        keyAndBucketExtractor.setRecord(row);
-        SinkRecord record =
-                new SinkRecord(
-                        keyAndBucketExtractor.partition(),
-                        keyAndBucketExtractor.bucket(),
-                        keyAndBucketExtractor.trimmedPrimaryKey(),
-                        row);
+        SinkRecord record = toSinkRecord(row);
         T data = recordExtractor.extract(record);
         write.write(record.partition(), record.bucket(), data);
         return data;
+    }
+
+    private SinkRecord toSinkRecord(InternalRow row) throws Exception {
+        keyAndBucketExtractor.setRecord(row);
+        return new SinkRecord(
+                keyAndBucketExtractor.partition(),
+                keyAndBucketExtractor.bucket(),
+                keyAndBucketExtractor.trimmedPrimaryKey(),
+                row);
     }
 
     public SinkRecord toLogRecord(SinkRecord record) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.FileStore;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -100,6 +101,20 @@ public class TableWriteImpl<T>
                         row);
         write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
         return record;
+    }
+
+    @VisibleForTesting
+    public T writeAndReturnData(InternalRow row) throws Exception {
+        keyAndBucketExtractor.setRecord(row);
+        SinkRecord record =
+                new SinkRecord(
+                        keyAndBucketExtractor.partition(),
+                        keyAndBucketExtractor.bucket(),
+                        keyAndBucketExtractor.trimmedPrimaryKey(),
+                        row);
+        T data = recordExtractor.extract(record);
+        write.write(record.partition(), record.bucket(), data);
+        return data;
     }
 
     public SinkRecord toLogRecord(SinkRecord record) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -20,10 +20,12 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
+import org.apache.paimon.KeyValue;
 import org.apache.paimon.WriteMode;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.operation.ScanKind;
@@ -42,6 +44,7 @@ import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
+import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
@@ -58,11 +61,13 @@ import org.apache.paimon.utils.CompatibilityTestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -70,6 +75,7 @@ import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.data.DataFormatTestUtil.internalRowToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link ChangelogWithKeyFileStoreTable}. */
 public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
@@ -152,6 +158,155 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         Arrays.asList(
                                 "1|10|200|binary|varbinary|mapKey:mapVal|multiset",
                                 "1|11|101|binary|varbinary|mapKey:mapVal|multiset"));
+    }
+
+    @Test
+    public void testNanosSequenceNumberOnTimestampSecond() throws Exception {
+        Timestamp ts =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 5, 23, 11, 22, 33, 123456000));
+        List<InternalRow> rows = prepareTimestampRows(ts);
+        FileStoreTable table =
+                createFileStoreTable(
+                        conf -> {
+                            conf.set(CoreOptions.SEQUENCE_FIELD, "tm1");
+                            conf.set(CoreOptions.SEQUENCE_NANOS, true);
+                        },
+                        ROW_TYPE_WITH_TIMESTAMP);
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+        long sequenceNumber1 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)).sequenceNumber();
+        long sequenceNumber2 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(1)).sequenceNumber();
+        long sec = ts.getMillisecond() / 1000;
+        assertEquals(sec, TimeUnit.SECONDS.convert(sequenceNumber1, TimeUnit.NANOSECONDS));
+        assertEquals(sec, TimeUnit.SECONDS.convert(sequenceNumber2, TimeUnit.NANOSECONDS));
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        String expectedResult;
+        if (sequenceNumber2 > sequenceNumber1) {
+            expectedResult =
+                    "1|10|101|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456";
+        } else {
+            expectedResult =
+                    "1|10|100|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456";
+        }
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        TableRead read = table.newRead();
+        assertThat(getResult(read, splits, binaryRow(1), 0, ROW_WITH_TIMESTAMP_TO_STRING))
+                .isEqualTo(Arrays.asList(expectedResult));
+    }
+
+    @Test
+    public void testNanosSequenceNumberOnTimestampMilliSecond() throws Exception {
+        Timestamp ts =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 5, 23, 11, 22, 33, 123456000));
+        List<InternalRow> rows = prepareTimestampRows(ts);
+        FileStoreTable table =
+                createFileStoreTable(
+                        conf -> {
+                            conf.set(CoreOptions.SEQUENCE_FIELD, "tm2");
+                            conf.set(CoreOptions.SEQUENCE_NANOS, true);
+                        },
+                        ROW_TYPE_WITH_TIMESTAMP);
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+        long sequenceNumber1 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)).sequenceNumber();
+        long sequenceNumber2 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(1)).sequenceNumber();
+        assertEquals(
+                ts.getMillisecond(),
+                TimeUnit.MILLISECONDS.convert(sequenceNumber1, TimeUnit.NANOSECONDS));
+        assertEquals(
+                ts.getMillisecond(),
+                TimeUnit.MILLISECONDS.convert(sequenceNumber2, TimeUnit.NANOSECONDS));
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        String expectedResult;
+        if (sequenceNumber2 > sequenceNumber1) {
+            expectedResult =
+                    "1|10|101|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456";
+        } else {
+            expectedResult =
+                    "1|10|100|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456";
+        }
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        TableRead read = table.newRead();
+        assertThat(getResult(read, splits, binaryRow(1), 0, ROW_WITH_TIMESTAMP_TO_STRING))
+                .isEqualTo(Arrays.asList(expectedResult));
+    }
+
+    @Test
+    public void testNanosSequenceNumberOnTimestampMicroSecond() throws Exception {
+        Timestamp ts =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 5, 23, 11, 22, 33, 123456000));
+        List<InternalRow> rows = prepareTimestampRows(ts);
+        FileStoreTable table =
+                createFileStoreTable(
+                        conf -> {
+                            conf.set(CoreOptions.SEQUENCE_FIELD, "tm3");
+                            conf.set(CoreOptions.SEQUENCE_NANOS, true);
+                        },
+                        ROW_TYPE_WITH_TIMESTAMP);
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+        long sequenceNumber1 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)).sequenceNumber();
+        long sequenceNumber2 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(1)).sequenceNumber();
+        assertEquals(ts.getMillisecond(), sequenceNumber1);
+        assertEquals(ts.getMillisecond(), sequenceNumber2);
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        TableRead read = table.newRead();
+        assertThat(getResult(read, splits, binaryRow(1), 0, ROW_WITH_TIMESTAMP_TO_STRING))
+                .isEqualTo(
+                        Arrays.asList(
+                                "1|10|101|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456"));
+    }
+
+    @Test
+    public void testNanosSequenceNumberOnNonTimestampField() throws Exception {
+        Timestamp ts =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 5, 23, 11, 22, 33, 123456000));
+        List<InternalRow> rows = prepareTimestampRows(ts);
+        FileStoreTable table =
+                createFileStoreTable(
+                        conf -> {
+                            conf.set(CoreOptions.SEQUENCE_FIELD, "b");
+                            conf.set(CoreOptions.SEQUENCE_NANOS, true);
+                        },
+                        ROW_TYPE_WITH_TIMESTAMP);
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        long sequenceNumber1 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)).sequenceNumber();
+        long sequenceNumber2 =
+                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(1)).sequenceNumber();
+        assertEquals(100, sequenceNumber1);
+        assertEquals(101, sequenceNumber2);
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        TableRead read = table.newRead();
+        assertThat(getResult(read, splits, binaryRow(1), 0, ROW_WITH_TIMESTAMP_TO_STRING))
+                .isEqualTo(
+                        Arrays.asList(
+                                "1|10|101|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456"));
+    }
+
+    private List<InternalRow> prepareTimestampRows(Timestamp ts) {
+        long millis = ts.getMillisecond();
+        long sec = millis / 1000;
+
+        InternalRow row1 =
+                GenericRow.of(1, 10, 100L, Timestamp.fromEpochMillis(sec * 1000), ts, ts);
+        InternalRow row2 =
+                GenericRow.of(1, 10, 101L, Timestamp.fromEpochMillis(sec * 1000), ts, ts);
+        return Arrays.asList(row1, row2);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -76,6 +76,7 @@ import static org.apache.paimon.data.DataFormatTestUtil.internalRowToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link ChangelogWithKeyFileStoreTable}. */
 public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
@@ -188,10 +189,10 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         String expectedResult;
         if (sequenceNumber2 > sequenceNumber1) {
             expectedResult =
-                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|2";
+                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a2";
         } else {
             expectedResult =
-                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|1";
+                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a1";
         }
         List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
         TableRead read = table.newRead();
@@ -230,10 +231,10 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         String expectedResult;
         if (sequenceNumber2 > sequenceNumber1) {
             expectedResult =
-                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|2";
+                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a2";
         } else {
             expectedResult =
-                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|1";
+                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a1";
         }
         List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
         TableRead read = table.newRead();
@@ -269,10 +270,10 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         String expectedResult;
         if (sequenceNumber2 > sequenceNumber1) {
             expectedResult =
-                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|2";
+                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a2";
         } else {
             expectedResult =
-                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|1";
+                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a1";
         }
         List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
         TableRead read = table.newRead();
@@ -312,10 +313,10 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         String expectedResult;
         if (sequenceNumber2 > sequenceNumber1) {
             expectedResult =
-                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|2";
+                    "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a2";
         } else {
             expectedResult =
-                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|1";
+                    "1|10|100|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|a1";
         }
         List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
         TableRead read = table.newRead();
@@ -338,21 +339,9 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         },
                         ROW_TYPE_WITH_TIMESTAMP);
         StreamTableWrite write = table.newWrite(commitUser);
-        StreamTableCommit commit = table.newCommit(commitUser);
-        long sequenceNumber1 =
-                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)).sequenceNumber();
-        long sequenceNumber2 =
-                ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(1)).sequenceNumber();
-        assertEquals(1, sequenceNumber1);
-        assertEquals(2, sequenceNumber2);
-        commit.commit(0, write.prepareCommit(true, 0));
-        write.close();
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
-        TableRead read = table.newRead();
-        assertThat(getResult(read, splits, binaryRow(1), 0, ROW_WITH_TIMESTAMP_TO_STRING))
-                .isEqualTo(
-                        Arrays.asList(
-                                "1|10|101|1685530987|1685530987123|2023-05-23T11:22:33|2023-05-23T11:22:33.123|2023-05-23T11:22:33.123456|2"));
+        assertThrows(
+                NumberFormatException.class,
+                () -> ((TableWriteImpl<KeyValue>) write).writeAndReturnData(rows.get(0)));
     }
 
     private List<InternalRow> prepareSequencePaddingRows(
@@ -370,7 +359,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         Timestamp.fromEpochMillis(sec * 1000),
                         ts,
                         ts,
-                        BinaryString.fromString("1"));
+                        BinaryString.fromString("a1"));
         InternalRow row2 =
                 GenericRow.of(
                         1,
@@ -381,7 +370,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         Timestamp.fromEpochMillis(sec * 1000),
                         ts,
                         ts,
-                        BinaryString.fromString("2"));
+                        BinaryString.fromString("a2"));
         return Arrays.asList(row1, row2);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -122,6 +122,18 @@ public abstract class FileStoreTableTestBase {
                     },
                     new String[] {"pk", "pt0", "pt1", "v"});
 
+    protected static final RowType ROW_TYPE_WITH_TIMESTAMP =
+            RowType.of(
+                    new DataType[] {
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.BIGINT(),
+                        DataTypes.TIMESTAMP(0),
+                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
+                        DataTypes.TIMESTAMP(6)
+                    },
+                    new String[] {"pt", "a", "b", "tm1", "tm2", "tm3"});
+
     protected static final int[] PROJECTION = new int[] {2, 1};
     protected static final Function<InternalRow, String> BATCH_ROW_TO_STRING =
             rowData ->
@@ -154,6 +166,20 @@ public abstract class FileStoreTableTestBase {
     protected static final Function<InternalRow, String> CHANGELOG_ROW_TO_STRING =
             rowData ->
                     rowData.getRowKind().shortString() + " " + BATCH_ROW_TO_STRING.apply(rowData);
+
+    protected static final Function<InternalRow, String> ROW_WITH_TIMESTAMP_TO_STRING =
+            rowData ->
+                    rowData.getInt(0)
+                            + "|"
+                            + rowData.getInt(1)
+                            + "|"
+                            + rowData.getLong(2)
+                            + "|"
+                            + rowData.getTimestamp(3, 0)
+                            + "|"
+                            + rowData.getTimestamp(4, 3)
+                            + "|"
+                            + rowData.getTimestamp(5, 6);
 
     @TempDir java.nio.file.Path tempDir;
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -127,12 +127,15 @@ public abstract class FileStoreTableTestBase {
                     new DataType[] {
                         DataTypes.INT(),
                         DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
                         DataTypes.BIGINT(),
                         DataTypes.TIMESTAMP(0),
                         DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
-                        DataTypes.TIMESTAMP(6)
+                        DataTypes.TIMESTAMP(6),
+                        DataTypes.STRING()
                     },
-                    new String[] {"pt", "a", "b", "tm1", "tm2", "tm3"});
+                    new String[] {"pt", "a", "b", "sec", "mills", "tm0", "tm3", "tm6", "non_time"});
 
     protected static final int[] PROJECTION = new int[] {2, 1};
     protected static final Function<InternalRow, String> BATCH_ROW_TO_STRING =
@@ -173,13 +176,19 @@ public abstract class FileStoreTableTestBase {
                             + "|"
                             + rowData.getInt(1)
                             + "|"
-                            + rowData.getLong(2)
+                            + rowData.getInt(2)
                             + "|"
-                            + rowData.getTimestamp(3, 0)
+                            + rowData.getInt(3)
                             + "|"
-                            + rowData.getTimestamp(4, 3)
+                            + rowData.getLong(4)
                             + "|"
-                            + rowData.getTimestamp(5, 6);
+                            + rowData.getTimestamp(5, 0)
+                            + "|"
+                            + rowData.getTimestamp(6, 3)
+                            + "|"
+                            + rowData.getTimestamp(7, 6)
+                            + "|"
+                            + rowData.getString(8);
 
     @TempDir java.nio.file.Path tempDir;
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -164,22 +164,23 @@ public class SequenceGeneratorTest {
     @Test
     public void testGenerateWithPadding() {
         assertEquals(1, getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_id")));
-        assertEquals(1, generateWithPaddingOnSecond("pt"));
+        assertEquals(1, getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("pt")));
         assertEquals(
                 1685548953,
                 getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_intsecond")));
-        assertEquals(2, generateWithPaddingOnSecond("_tinyint"));
-        assertEquals(3, generateWithPaddingOnSecond("_smallint"));
+        assertEquals(2, getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_tinyint")));
+        assertEquals(
+                3, getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_smallint")));
         assertEquals(
                 4000000000000L,
                 getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigint")));
         assertEquals(
                 1685548953000L,
                 getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigintmillis")));
-        assertEquals(2, generateWithPaddingOnMillis("_float"));
-        assertEquals(3, generateWithPaddingOnMillis("_double"));
-        assertEquals(1, generateWithPaddingOnMillis("_string"));
-        assertEquals(375, generateWithPaddingOnMillis("_date"));
+        assertEquals(2, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_float")));
+        assertEquals(3, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_double")));
+        assertEquals(1, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_string")));
+        assertEquals(375, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_date")));
         assertEquals(
                 1685548953L,
                 getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_timestamp0")));
@@ -189,8 +190,11 @@ public class SequenceGeneratorTest {
         assertEquals(
                 1685548953123L,
                 getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_timestamp6")));
-        assertEquals(3, generateWithPaddingOnMillis("_char"));
-        assertEquals(4, generateWithPaddingOnMillis("_varchar"));
+        assertEquals(3, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_char")));
+        assertEquals(4, getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_varchar")));
+        assertEquals(
+                1685548953L,
+                getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_localtimestamp")));
         assertEquals(
                 1685548953123L,
                 getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_localtimestamp")));

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Test for {@link SequenceGenerator}. */
+public class SequenceGeneratorTest {
+
+    private static final RowType ALL_DATA_TYPE =
+            RowType.of(
+                    new DataType[] {
+                        DataTypes.INT(), // _id
+                        DataTypes.DECIMAL(2, 1), // pt
+                        DataTypes.INT(), // second
+                        DataTypes.BOOLEAN(),
+                        DataTypes.TINYINT(),
+                        DataTypes.SMALLINT(),
+                        DataTypes.BIGINT(),
+                        DataTypes.BIGINT(), // millis
+                        DataTypes.FLOAT(),
+                        DataTypes.DOUBLE(),
+                        DataTypes.STRING(),
+                        DataTypes.DATE(),
+                        DataTypes.TIMESTAMP(0),
+                        DataTypes.TIMESTAMP(3),
+                        DataTypes.TIMESTAMP(6),
+                        DataTypes.CHAR(10),
+                        DataTypes.VARCHAR(20),
+                        DataTypes.BINARY(10),
+                        DataTypes.VARBINARY(20),
+                        DataTypes.BYTES(),
+                        DataTypes.TIME(),
+                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+                        DataTypes.MAP(DataTypes.INT(), DataTypes.INT()),
+                        DataTypes.ARRAY(DataTypes.STRING()),
+                        DataTypes.MULTISET(DataTypes.VARCHAR(8))
+                    },
+                    new String[] {
+                        "_id",
+                        "pt",
+                        "_intsecond",
+                        "_boolean",
+                        "_tinyint",
+                        "_smallint",
+                        "_bigint",
+                        "_bigintmillis",
+                        "_float",
+                        "_double",
+                        "_string",
+                        "_date",
+                        "_timestamp0",
+                        "_timestamp3",
+                        "_timestamp6",
+                        "_char",
+                        "_varchar",
+                        "_binary",
+                        "_varbinary",
+                        "_bytes",
+                        "_time",
+                        "_localtimestamp",
+                        "_map",
+                        "_array",
+                        "_multiset",
+                    });
+    private static final InternalRow row =
+            GenericRow.of(
+                    1,
+                    Decimal.fromUnscaledLong(10, 2, 1),
+                    1685548953,
+                    true,
+                    (byte) 2,
+                    (short) 3,
+                    4000000000000L,
+                    1685548953000L,
+                    2.81f,
+                    3.678008,
+                    BinaryString.fromString("1"),
+                    375, /* 1971-01-11 */
+                    Timestamp.fromEpochMillis(1685548953000L),
+                    Timestamp.fromEpochMillis(1685548953123L),
+                    Timestamp.fromMicros(1685548953123456L),
+                    BinaryString.fromString("3"),
+                    BinaryString.fromString("4"),
+                    "5".getBytes(),
+                    "6".getBytes(),
+                    "7".getBytes(),
+                    123,
+                    Timestamp.fromMicros(1685548953123456L),
+                    new GenericMap(
+                            Collections.singletonMap(
+                                    BinaryString.fromString("mapKey"),
+                                    BinaryString.fromString("mapVal"))),
+                    new GenericArray(
+                            new BinaryString[] {
+                                BinaryString.fromString("a"), BinaryString.fromString("b")
+                            }),
+                    new GenericMap(
+                            Collections.singletonMap(BinaryString.fromString("multiset"), 1)));
+
+    @Test
+    public void testGenerate() {
+        assertEquals(1, getGenerator("_id").generate(row));
+        assertEquals(1, getGenerator("pt").generate(row));
+        assertEquals(1685548953, getGenerator("_intsecond").generate(row));
+        assertEquals(2, getGenerator("_tinyint").generate(row));
+        assertEquals(3, getGenerator("_smallint").generate(row));
+        assertEquals(4000000000000L, getGenerator("_bigint").generate(row));
+        assertEquals(1685548953000L, getGenerator("_bigintmillis").generate(row));
+        assertEquals(2, getGenerator("_float").generate(row));
+        assertEquals(3, getGenerator("_double").generate(row));
+        assertEquals(1, getGenerator("_string").generate(row));
+        assertEquals(375, getGenerator("_date").generate(row));
+        assertEquals(1685548953000L, getGenerator("_timestamp0").generate(row));
+        assertEquals(1685548953123L, getGenerator("_timestamp3").generate(row));
+        assertEquals(1685548953123L, getGenerator("_timestamp6").generate(row));
+        assertEquals(3, getGenerator("_char").generate(row));
+        assertEquals(4, getGenerator("_varchar").generate(row));
+        assertEquals(1685548953123L, getGenerator("_localtimestamp").generate(row));
+        assertUnsupportedDatatype("_boolean");
+        assertUnsupportedDatatype("_binary");
+        assertUnsupportedDatatype("_varbinary");
+        assertUnsupportedDatatype("_bytes");
+        assertUnsupportedDatatype("_time");
+        assertUnsupportedDatatype("_map");
+        assertUnsupportedDatatype("_array");
+        assertUnsupportedDatatype("_multiset");
+    }
+
+    @Test
+    public void testGenerateWithPadding() {
+        assertEquals(1, getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_id")));
+        assertEquals(1, generateWithPaddingOnSecond("pt"));
+        assertEquals(
+                1685548953,
+                getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_intsecond")));
+        assertEquals(2, generateWithPaddingOnSecond("_tinyint"));
+        assertEquals(3, generateWithPaddingOnSecond("_smallint"));
+        assertEquals(
+                4000000000000L,
+                getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigint")));
+        assertEquals(
+                1685548953000L,
+                getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigintmillis")));
+        assertEquals(2, generateWithPaddingOnMillis("_float"));
+        assertEquals(3, generateWithPaddingOnMillis("_double"));
+        assertEquals(1, generateWithPaddingOnMillis("_string"));
+        assertEquals(375, generateWithPaddingOnMillis("_date"));
+        assertEquals(
+                1685548953L,
+                getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_timestamp0")));
+        assertEquals(
+                1685548953123L,
+                getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_timestamp3")));
+        assertEquals(
+                1685548953123L,
+                getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_timestamp6")));
+        assertEquals(3, generateWithPaddingOnMillis("_char"));
+        assertEquals(4, generateWithPaddingOnMillis("_varchar"));
+        assertEquals(
+                1685548953123L,
+                getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_localtimestamp")));
+        assertUnsupportedDatatype("_boolean");
+        assertUnsupportedDatatype("_binary");
+        assertUnsupportedDatatype("_varbinary");
+        assertUnsupportedDatatype("_bytes");
+        assertUnsupportedDatatype("_time");
+        assertUnsupportedDatatype("_map");
+        assertUnsupportedDatatype("_array");
+        assertUnsupportedDatatype("_multiset");
+    }
+
+    private SequenceGenerator getGenerator(String field) {
+        return new SequenceGenerator(field, ALL_DATA_TYPE);
+    }
+
+    private void assertUnsupportedDatatype(String field) {
+        assertThrows(UnsupportedOperationException.class, () -> getGenerator(field).generate(row));
+    }
+
+    private long generateWithPaddingOnSecond(String field) {
+        return getGenerator(field)
+                .generateWithPadding(row, CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO);
+    }
+
+    private long getSecondFromGeneratedWithPadding(long generated) {
+        return TimeUnit.SECONDS.convert(generated, TimeUnit.MICROSECONDS);
+    }
+
+    private long generateWithPaddingOnMillis(String field) {
+        return getGenerator(field)
+                .generateWithPadding(row, CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO);
+    }
+
+    private long getMillisFromGeneratedWithPadding(long generated) {
+        return TimeUnit.MILLISECONDS.convert(generated, TimeUnit.MICROSECONDS);
+    }
+}


### PR DESCRIPTION
### Purpose

fix #1050 

Taking `System.nanotime()` as the time source with high precision, make up to the provided `sequence.field` to nanosecond if it's in`Timestamp` data type and with the precision of second or millisecond.

### Tests

ChangelogWithKeyFileStoreTableTest#testNanosSequenceNumberOnTimestampSecond
ChangelogWithKeyFileStoreTableTest#testNanosSequenceNumberOnTimestampMilliSecond
ChangelogWithKeyFileStoreTableTest#testNanosSequenceNumberOnTimestampMicroSecond
ChangelogWithKeyFileStoreTableTest#testNanosSequenceNumberOnNonTimestampField



