### PR TITLE
[flink] rm VisibleForTesting annotation from FlinkCatalog#catalog method

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.schema.Schema;
@@ -115,7 +114,6 @@ public class FlinkCatalog extends AbstractCatalog {
         }
     }
 
-    @VisibleForTesting
     public Catalog catalog() {
         return catalog;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When we use flink api to develop some program, we need the `org.apache.paimon.table.Table` object, and we can use the follow code to get the `Table`  directly， it is very convenient，so I think we may remove the `VisibleForTesting` annotation from `FlinkCatalog#catalog` method

```
FlinkCatalog catalog = (FlinkCatalog) tenv.getCatalog(catalogName).get();
Table table = catalog.catalog().getTable(new Identifier(databaseName, tableName));
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
