### PR TITLE
[flink] Introduce API to Synchronizing Table

### DIFF
--- a/docs/content/api/flink-api.md
+++ b/docs/content/api/flink-api.md
@@ -142,3 +142,107 @@ public class ReadFromTable {
     }
 }
 ```
+
+## Cdc ingestion Table
+
+Paimon supports ingest data into Paimon tables with schema evolution.
+- You can use Java API to write cdc records into Paimon Tables.
+- You can write records to Paimon's partial-update table with adding columns dynamically.
+
+Here is an example to use `CdcSinkBuilder` API:
+
+```java
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.sink.cdc.CdcRecord;
+import org.apache.paimon.flink.sink.cdc.CdcSinkBuilder;
+import org.apache.paimon.flink.sink.cdc.EventParser;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.List;
+import java.util.Optional;
+
+public class WriteCdcToTable {
+
+    public static void writeTo() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // create a Cdc DataStream
+        DataStream<String> dataStream =
+                env.fromElements(
+                        "INSERT INTO T VALUES (1, 1)",
+                        "INSERT INTO T VALUES (2, 2)",
+                        "ALTER TABLE T ADD (c INT)",
+                        "INSERT INTO T VALUES (3, 3, 3)",
+                        "INSERT INTO T VALUES (4, 4, 4)");
+
+        CdcSinkBuilder<String> builder = new CdcSinkBuilder<>();
+        builder.withInput(dataStream);
+        builder.withTable(createTableIfNotExists());
+        builder.withParserFactory(new EventParserFactory());
+        builder.build();
+
+        env.execute();
+    }
+
+    private static Table createTableIfNotExists() throws Exception {
+        CatalogContext context = CatalogContext.create(new Path("..."));
+        Catalog catalog = CatalogFactory.createCatalog(context);
+
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.primaryKey("a");
+        schemaBuilder.column("a", DataTypes.INT());
+        schemaBuilder.column("b", DataTypes.INT());
+        Schema schema = schemaBuilder.build();
+        Identifier identifier = Identifier.create("my_db", "T");
+        try {
+            catalog.createTable(identifier, schema, false);
+        } catch (Catalog.TableAlreadyExistException e) {
+            // do something
+        }
+        return catalog.getTable(identifier);
+    }
+
+    private static class EventParserFactory implements EventParser.Factory<String> {
+
+        @Override
+        public EventParser<String> create() {
+            return new EventParser<String>() {
+
+                private String event;
+
+                @Override
+                public void setRawEvent(String rawEvent) {
+                    event = rawEvent;
+                }
+
+                @Override
+                public boolean isSchemaChange() {
+                    return event.startsWith("ALTER");
+                }
+
+                @Override
+                public Optional<List<DataField>> parseNewSchema() {
+                    // parse from ADD (c INT)
+                    return ...;
+                }
+
+                @Override
+                public List<CdcRecord> parseRecords() {
+                    // parse from VALUES (1, 1)
+                    return ...;
+                }
+            };
+        }
+    }
+}
+```

--- a/docs/content/api/flink-api.md
+++ b/docs/content/api/flink-api.md
@@ -226,12 +226,7 @@ public class WriteCdcToTable {
                 }
 
                 @Override
-                public boolean isSchemaChange() {
-                    return event.startsWith("ALTER");
-                }
-
-                @Override
-                public Optional<List<DataField>> parseNewSchema() {
+                public List<DataField> parseSchemaChange() {
                     // parse from ADD (c INT)
                     return ...;
                 }

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -26,9 +26,18 @@ under the License.
 
 # CDC Ingestion
 
-Paimon supports synchronizing changes from different databases using change data capture (CDC). This feature requires Flink and its [CDC connectors](https://ververica.github.io/flink-cdc-connectors/).
+Paimon supports a variety of ways to ingest data into Paimon tables with schema evolution. This means that the added
+columns are synchronized to the Paimon table in real time and the synchronization job is not restarted for this purpose.
+
+We currently support the following sync ways:
+
+1. MySQL Synchronizing Table: synchronize one or multiple tables from MySQL into one Paimon table.
+2. MySQL Synchronizing Database: synchronize the whole MySQL database into one Paimon database.
+3. [API Synchronizing Table]({{< ref "/api/flink-api#cdc-ingestion-table" >}}): synchronize your custom DataStream input into one Paimon table.
 
 ## MySQL
+
+Paimon supports synchronizing changes from different databases using change data capture (CDC). This feature requires Flink and its [CDC connectors](https://ververica.github.io/flink-cdc-connectors/).
 
 ### Prepare CDC Bundled Jar
 

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -27,7 +27,7 @@ under the License.
 # CDC Ingestion
 
 Paimon supports a variety of ways to ingest data into Paimon tables with schema evolution. This means that the added
-columns are synchronized to the Paimon table in real time and the synchronization job is not restarted for this purpose.
+columns are synchronized to the Paimon table in real time and the synchronization job will not restarted for this purpose.
 
 We currently support the following sync ways:
 

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ObjectUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ObjectUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Utils for objects. */
+public class ObjectUtils {
+
+    /** @return first non-null value. */
+    public static <T> T coalesce(T v1, T v2) {
+        return v1 != null ? v1 : checkNotNull(v2);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/canal/CanalJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/canal/CanalJsonEventParser.java
@@ -46,8 +46,6 @@ import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlAlterTableChangeColumn;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlAlterTableModifyColumn;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -57,7 +55,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -65,15 +62,12 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** {@link EventParser} for Canal-json. */
 public class CanalJsonEventParser implements EventParser<String> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CanalJsonEventParser.class);
-
     private static final String FIELD_DATA = "data";
     private static final String FIELD_OLD = "old";
     private static final String TYPE = "type";
     private static final String OP_INSERT = "INSERT";
     private static final String OP_UPDATE = "UPDATE";
     private static final String OP_DELETE = "DELETE";
-    private static final String OP_CREATE = "CREATE";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -138,8 +132,7 @@ public class CanalJsonEventParser implements EventParser<String> {
         }
     }
 
-    @Override
-    public boolean isSchemaChange() {
+    private boolean isSchemaChange() {
         if (root.get("isDdl") == null) {
             return false;
         } else {
@@ -148,11 +141,15 @@ public class CanalJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public Optional<List<DataField>> parseNewSchema() {
+    public List<DataField> parseSchemaChange() {
+        if (!isSchemaChange()) {
+            return Collections.emptyList();
+        }
+
         String sql = root.get("sql").asText();
 
         if (StringUtils.isEmpty(sql)) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
 
         List<DataField> result = new ArrayList<>();
@@ -272,11 +269,15 @@ public class CanalJsonEventParser implements EventParser<String> {
             }
         }
 
-        return Optional.of(result);
+        return result;
     }
 
     @Override
     public List<CdcRecord> parseRecords() {
+        if (isSchemaChange()) {
+            return Collections.emptyList();
+        }
+
         List<CdcRecord> records = new ArrayList<>();
         String type = root.get(TYPE).asText();
         if (OP_UPDATE.equals(type)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/canal/CanalJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/canal/CanalJsonEventParser.java
@@ -112,7 +112,7 @@ public class CanalJsonEventParser implements EventParser<String> {
                             + "please make sure that your topic's format is accurate.");
             JsonNode mysqlType = root.get("mysqlType");
 
-            if (!isUpdatedDataFields()) {
+            if (!isSchemaChange()) {
                 updateFieldTypes(mysqlType);
             }
         } catch (Exception e) {
@@ -121,7 +121,7 @@ public class CanalJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public String tableName() {
+    public String parseTableName() {
         String tableName = root.get("table").asText();
         return tableNameConverter.convert(tableName);
     }
@@ -139,7 +139,7 @@ public class CanalJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public boolean isUpdatedDataFields() {
+    public boolean isSchemaChange() {
         if (root.get("isDdl") == null) {
             return false;
         } else {
@@ -148,7 +148,7 @@ public class CanalJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public Optional<List<DataField>> getUpdatedDataFields() {
+    public Optional<List<DataField>> parseNewSchema() {
         String sql = root.get("sql").asText();
 
         if (StringUtils.isEmpty(sql)) {
@@ -276,7 +276,7 @@ public class CanalJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public List<CdcRecord> getRecords() {
+    public List<CdcRecord> parseRecords() {
         List<CdcRecord> records = new ArrayList<>();
         String type = root.get(TYPE).asText();
         if (OP_UPDATE.equals(type)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -104,7 +104,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
                                     + "in the JsonDebeziumDeserializationSchema you created");
             payload = root.get("payload");
 
-            if (!isUpdatedDataFields()) {
+            if (!isSchemaChange()) {
                 updateFieldTypes(schema);
             }
         } catch (Exception e) {
@@ -113,7 +113,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public String tableName() {
+    public String parseTableName() {
         String tableName = payload.get("source").get("table").asText();
         return tableNameConverter.convert(tableName);
     }
@@ -142,12 +142,12 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public boolean isUpdatedDataFields() {
+    public boolean isSchemaChange() {
         return payload.get("op") == null;
     }
 
     @Override
-    public Optional<List<DataField>> getUpdatedDataFields() {
+    public Optional<List<DataField>> parseNewSchema() {
         JsonNode historyRecord = payload.get("historyRecord");
         if (historyRecord == null) {
             return Optional.empty();
@@ -194,7 +194,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public List<CdcRecord> getRecords() {
+    public List<CdcRecord> parseRecords() {
         List<CdcRecord> records = new ArrayList<>();
 
         Map<String, String> before = extractRow(payload.get("before"));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -141,16 +140,19 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
         }
     }
 
-    @Override
-    public boolean isSchemaChange() {
+    private boolean isSchemaChange() {
         return payload.get("op") == null;
     }
 
     @Override
-    public Optional<List<DataField>> parseNewSchema() {
+    public List<DataField> parseSchemaChange() {
+        if (!isSchemaChange()) {
+            return Collections.emptyList();
+        }
+
         JsonNode historyRecord = payload.get("historyRecord");
         if (historyRecord == null) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
 
         JsonNode columns;
@@ -165,10 +167,10 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             columns = tableChanges.get(0).get("table").get("columns");
         } catch (Exception e) {
             LOG.info("Failed to parse history record for schema changes", e);
-            return Optional.empty();
+            return Collections.emptyList();
         }
         if (columns == null) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
 
         List<DataField> result = new ArrayList<>();
@@ -190,11 +192,15 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             String fieldName = column.get("name").asText();
             result.add(new DataField(i, caseSensitive ? fieldName : fieldName.toLowerCase(), type));
         }
-        return Optional.of(result);
+        return result;
     }
 
     @Override
     public List<CdcRecord> parseRecords() {
+        if (isSchemaChange()) {
+            return Collections.emptyList();
+        }
+
         List<CdcRecord> records = new ArrayList<>();
 
         Map<String, String> before = extractRow(payload.get("before"));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -24,8 +24,8 @@ import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionBase;
 import org.apache.paimon.flink.action.cdc.ComputedColumn;
+import org.apache.paimon.flink.sink.cdc.CdcSinkBuilder;
 import org.apache.paimon.flink.sink.cdc.EventParser;
-import org.apache.paimon.flink.sink.cdc.FlinkCdcSyncTableSinkBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 
@@ -184,8 +184,8 @@ public class MySqlSyncTableAction extends ActionBase {
         EventParser.Factory<String> parserFactory =
                 () -> new MySqlDebeziumJsonEventParser(zoneId, caseSensitive, computedColumns);
 
-        FlinkCdcSyncTableSinkBuilder<String> sinkBuilder =
-                new FlinkCdcSyncTableSinkBuilder<String>()
+        CdcSinkBuilder<String> sinkBuilder =
+                new CdcSinkBuilder<String>()
                         .withInput(
                                 env.fromSource(
                                         source, WatermarkStrategy.noWatermarks(), "MySQL Source"))

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiTableParsingProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiTableParsingProcessFunction.java
@@ -61,13 +61,13 @@ public class CdcMultiTableParsingProcessFunction<T> extends ProcessFunction<T, V
     @Override
     public void processElement(T raw, Context context, Collector<Void> collector) throws Exception {
         parser.setRawEvent(raw);
-        String tableName = parser.tableName();
+        String tableName = parser.parseTableName();
 
-        if (parser.isUpdatedDataFields()) {
-            parser.getUpdatedDataFields()
+        if (parser.isSchemaChange()) {
+            parser.parseNewSchema()
                     .ifPresent(t -> context.output(getUpdatedDataFieldsOutputTag(tableName), t));
         } else {
-            for (CdcRecord record : parser.getRecords()) {
+            for (CdcRecord record : parser.parseRecords()) {
                 context.output(getRecordOutputTag(tableName), record);
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiTableParsingProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiTableParsingProcessFunction.java
@@ -62,15 +62,12 @@ public class CdcMultiTableParsingProcessFunction<T> extends ProcessFunction<T, V
     public void processElement(T raw, Context context, Collector<Void> collector) throws Exception {
         parser.setRawEvent(raw);
         String tableName = parser.parseTableName();
-
-        if (parser.isSchemaChange()) {
-            parser.parseNewSchema()
-                    .ifPresent(t -> context.output(getUpdatedDataFieldsOutputTag(tableName), t));
-        } else {
-            for (CdcRecord record : parser.parseRecords()) {
-                context.output(getRecordOutputTag(tableName), record);
-            }
+        List<DataField> schemaChange = parser.parseSchemaChange();
+        if (schemaChange.size() > 0) {
+            context.output(getUpdatedDataFieldsOutputTag(tableName), schemaChange);
         }
+        parser.parseRecords()
+                .forEach(record -> context.output(getRecordOutputTag(tableName), record));
     }
 
     private OutputTag<List<DataField>> getUpdatedDataFieldsOutputTag(String tableName) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecord.java
@@ -18,16 +18,8 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
-import org.apache.paimon.data.GenericRow;
-import org.apache.paimon.types.DataField;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A data change message from the CDC source. Compared to {@link CdcRecord}, MultiplexCdcRecord
@@ -35,8 +27,6 @@ import java.util.Optional;
  */
 public class CdcMultiplexRecord implements Serializable {
     private static final long serialVersionUID = 1L;
-
-    private static final Logger LOG = LoggerFactory.getLogger(CdcMultiplexRecord.class);
 
     private final String databaseName;
     private final String tableName;
@@ -53,20 +43,16 @@ public class CdcMultiplexRecord implements Serializable {
         return new CdcMultiplexRecord(databaseName, tableName, record);
     }
 
-    public GenericRow projectAsInsert(List<DataField> dataFields) {
-        return record.projectAsInsert(dataFields);
-    }
-
-    public Optional<GenericRow> toGenericRow(List<DataField> dataFields) {
-        return record.toGenericRow(dataFields);
-    }
-
-    public String getDatabaseName() {
+    public String databaseName() {
         return databaseName;
     }
 
-    public String getTableName() {
+    public String tableName() {
         return tableName;
+    }
+
+    public CdcRecord record() {
+        return record;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcParsingProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcParsingProcessFunction.java
@@ -59,13 +59,10 @@ public class CdcParsingProcessFunction<T> extends ProcessFunction<T, CdcRecord> 
     public void processElement(T raw, Context context, Collector<CdcRecord> collector)
             throws Exception {
         parser.setRawEvent(raw);
-        if (parser.isSchemaChange()) {
-            parser.parseNewSchema()
-                    .ifPresent(t -> context.output(NEW_DATA_FIELD_LIST_OUTPUT_TAG, t));
-        } else {
-            for (CdcRecord record : parser.parseRecords()) {
-                collector.collect(record);
-            }
+        List<DataField> schemaChange = parser.parseSchemaChange();
+        if (schemaChange.size() > 0) {
+            context.output(NEW_DATA_FIELD_LIST_OUTPUT_TAG, schemaChange);
         }
+        parser.parseRecords().forEach(collector::collect);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcParsingProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcParsingProcessFunction.java
@@ -59,11 +59,11 @@ public class CdcParsingProcessFunction<T> extends ProcessFunction<T, CdcRecord> 
     public void processElement(T raw, Context context, Collector<CdcRecord> collector)
             throws Exception {
         parser.setRawEvent(raw);
-        if (parser.isUpdatedDataFields()) {
-            parser.getUpdatedDataFields()
+        if (parser.isSchemaChange()) {
+            parser.parseNewSchema()
                     .ifPresent(t -> context.output(NEW_DATA_FIELD_LIST_OUTPUT_TAG, t));
         } else {
-            for (CdcRecord record : parser.getRecords()) {
+            for (CdcRecord record : parser.parseRecords()) {
                 collector.collect(record);
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
@@ -18,28 +18,18 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
-import org.apache.paimon.data.GenericRow;
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataType;
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.types.RowKind;
-import org.apache.paimon.utils.TypeUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /** A data change message from the CDC source. */
+@Experimental
 public class CdcRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
-    private static final Logger LOG = LoggerFactory.getLogger(CdcRecord.class);
 
     private final RowKind kind;
     private final Map<String, String> fields;
@@ -49,82 +39,12 @@ public class CdcRecord implements Serializable {
         this.fields = fields;
     }
 
-    /**
-     * Project {@code fields} to a {@link GenericRow}. The fields of row are specified by the given
-     * {@code dataFields} and its {@link RowKind} will always be {@link RowKind#INSERT}.
-     *
-     * <p>NOTE: This method will always return a {@link GenericRow} even if some keys of {@code
-     * fields} are not in {@code dataFields}. If you want to make sure all field names of {@code
-     * dataFields} existed in keys of {@code fields}, use {@link CdcRecord#toGenericRow} instead.
-     *
-     * @param dataFields {@link DataField}s of the converted {@link GenericRow}.
-     * @return the projected {@link GenericRow}.
-     */
-    public GenericRow projectAsInsert(List<DataField> dataFields) {
-        GenericRow genericRow = new GenericRow(dataFields.size());
-        for (int i = 0; i < dataFields.size(); i++) {
-            DataField dataField = dataFields.get(i);
-            genericRow.setField(
-                    i, TypeUtils.castFromString(fields.get(dataField.name()), dataField.type()));
-        }
-        return genericRow;
-    }
-
-    /**
-     * Convert {@code fields} to a {@link GenericRow}. The fields of row are specified by the given
-     * {@code dataFields} and its {@link RowKind} is determined by {@code kind} of this {@link
-     * CdcRecord}.
-     *
-     * <p>NOTE: This method requires all field names of {@code dataFields} existed in keys of {@code
-     * fields}. If you only want to convert some {@code fields}, use {@link
-     * CdcRecord#projectAsInsert} instead.
-     *
-     * @param dataFields {@link DataField}s of the converted {@link GenericRow}.
-     * @return if all field names of {@code dataFields} existed in keys of {@code fields} and all
-     *     values of {@code fields} can be correctly converted to the specified type, an {@code
-     *     Optional#of(GenericRow)} will be returned, otherwise an {@code Optional#empty()} will be
-     *     returned
-     */
-    public Optional<GenericRow> toGenericRow(List<DataField> dataFields) {
-        GenericRow genericRow = new GenericRow(this.kind, dataFields.size());
-        List<String> fieldNames =
-                dataFields.stream().map(DataField::name).collect(Collectors.toList());
-
-        for (Map.Entry<String, String> field : fields.entrySet()) {
-            String key = field.getKey();
-            String value = field.getValue();
-
-            int idx = fieldNames.indexOf(key);
-            if (idx < 0) {
-                LOG.info("Field " + key + " not found. Waiting for schema update.");
-                return Optional.empty();
-            }
-
-            if (value == null) {
-                continue;
-            }
-
-            DataType type = dataFields.get(idx).type();
-            // TODO TypeUtils.castFromString cannot deal with complex types like arrays and
-            //  maps. Change type of CdcRecord#field if needed.
-            try {
-                genericRow.setField(idx, TypeUtils.castFromString(value, type));
-            } catch (Exception e) {
-                LOG.info(
-                        "Failed to convert value "
-                                + value
-                                + " to type "
-                                + type
-                                + ". Waiting for schema update.",
-                        e);
-                return Optional.empty();
-            }
-        }
-        return Optional.of(genericRow);
-    }
-
-    public RowKind getKind() {
+    public RowKind kind() {
         return kind;
+    }
+
+    public Map<String, String> fields() {
+        return fields;
     }
 
     @Override
@@ -140,9 +60,5 @@ public class CdcRecord implements Serializable {
     @Override
     public String toString() {
         return kind.shortString() + " " + fields;
-    }
-
-    public Map<String, String> getFields() {
-        return fields;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordKeyAndBucketExtractor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordKeyAndBucketExtractor.java
@@ -30,6 +30,8 @@ import org.apache.paimon.types.RowType;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.paimon.flink.sink.cdc.CdcRecordUtils.projectAsInsert;
+
 /** {@link KeyAndBucketExtractor} for {@link CdcRecord}. */
 public class CdcRecordKeyAndBucketExtractor implements KeyAndBucketExtractor<CdcRecord> {
 
@@ -74,7 +76,7 @@ public class CdcRecordKeyAndBucketExtractor implements KeyAndBucketExtractor<Cdc
     @Override
     public BinaryRow partition() {
         if (partition == null) {
-            partition = partitionProjection.apply(record.projectAsInsert(partitionFields));
+            partition = partitionProjection.apply(projectAsInsert(record, partitionFields));
         }
         return partition;
     }
@@ -82,7 +84,7 @@ public class CdcRecordKeyAndBucketExtractor implements KeyAndBucketExtractor<Cdc
     @Override
     public int bucket() {
         if (bucketKey == null) {
-            bucketKey = bucketKeyProjection.apply(record.projectAsInsert(bucketKeyFields));
+            bucketKey = bucketKeyProjection.apply(projectAsInsert(record, bucketKeyFields));
         }
         if (bucket == null) {
             bucket =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java
@@ -37,6 +37,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.paimon.flink.sink.cdc.CdcRecordUtils.toGenericRow;
+
 /**
  * A {@link PrepareCommitOperator} to write {@link CdcRecord}. Record schema may change. If current
  * known schema does not fit record schema, this operator will wait for schema changes.
@@ -101,11 +103,11 @@ public class CdcRecordStoreWriteOperator extends PrepareCommitOperator<CdcRecord
     @Override
     public void processElement(StreamRecord<CdcRecord> element) throws Exception {
         CdcRecord record = element.getValue();
-        Optional<GenericRow> optionalConverted = record.toGenericRow(table.schema().fields());
+        Optional<GenericRow> optionalConverted = toGenericRow(record, table.schema().fields());
         if (!optionalConverted.isPresent()) {
             while (true) {
                 table = table.copyWithLatestSchema();
-                optionalConverted = record.toGenericRow(table.schema().fields());
+                optionalConverted = toGenericRow(record, table.schema().fields());
                 if (optionalConverted.isPresent()) {
                     break;
                 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.utils.TypeUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Utils for {@link CdcRecord}. */
+public class CdcRecordUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CdcRecordUtils.class);
+
+    /**
+     * Project {@code fields} to a {@link GenericRow}. The fields of row are specified by the given
+     * {@code dataFields} and its {@link RowKind} will always be {@link RowKind#INSERT}.
+     *
+     * <p>NOTE: This method will always return a {@link GenericRow} even if some keys of {@code
+     * fields} are not in {@code dataFields}. If you want to make sure all field names of {@code
+     * dataFields} existed in keys of {@code fields}, use {@link CdcRecordUtils#toGenericRow}
+     * instead.
+     *
+     * @param dataFields {@link DataField}s of the converted {@link GenericRow}.
+     * @return the projected {@link GenericRow}.
+     */
+    public static GenericRow projectAsInsert(CdcRecord record, List<DataField> dataFields) {
+        GenericRow genericRow = new GenericRow(dataFields.size());
+        for (int i = 0; i < dataFields.size(); i++) {
+            DataField dataField = dataFields.get(i);
+            genericRow.setField(
+                    i,
+                    TypeUtils.castFromString(
+                            record.fields().get(dataField.name()), dataField.type()));
+        }
+        return genericRow;
+    }
+
+    /**
+     * Convert {@code fields} to a {@link GenericRow}. The fields of row are specified by the given
+     * {@code dataFields} and its {@link RowKind} is determined by {@code kind} of this {@link
+     * CdcRecord}.
+     *
+     * <p>NOTE: This method requires all field names of {@code dataFields} existed in keys of {@code
+     * fields}. If you only want to convert some {@code fields}, use {@link
+     * CdcRecordUtils#projectAsInsert} instead.
+     *
+     * @param dataFields {@link DataField}s of the converted {@link GenericRow}.
+     * @return if all field names of {@code dataFields} existed in keys of {@code fields} and all
+     *     values of {@code fields} can be correctly converted to the specified type, an {@code
+     *     Optional#of(GenericRow)} will be returned, otherwise an {@code Optional#empty()} will be
+     *     returned
+     */
+    public static Optional<GenericRow> toGenericRow(CdcRecord record, List<DataField> dataFields) {
+        GenericRow genericRow = new GenericRow(record.kind(), dataFields.size());
+        List<String> fieldNames =
+                dataFields.stream().map(DataField::name).collect(Collectors.toList());
+
+        for (Map.Entry<String, String> field : record.fields().entrySet()) {
+            String key = field.getKey();
+            String value = field.getValue();
+
+            int idx = fieldNames.indexOf(key);
+            if (idx < 0) {
+                LOG.info("Field " + key + " not found. Waiting for schema update.");
+                return Optional.empty();
+            }
+
+            if (value == null) {
+                continue;
+            }
+
+            DataType type = dataFields.get(idx).type();
+            // TODO TypeUtils.castFromString cannot deal with complex types like arrays and
+            //  maps. Change type of CdcRecord#field if needed.
+            try {
+                genericRow.setField(idx, TypeUtils.castFromString(value, type));
+            } catch (Exception e) {
+                LOG.info(
+                        "Failed to convert value "
+                                + value
+                                + " to type "
+                                + type
+                                + ". Waiting for schema update.",
+                        e);
+                return Optional.empty();
+            }
+        }
+        return Optional.of(genericRow);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -18,11 +18,13 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.flink.sink.BucketingStreamPartitioner;
 import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -34,48 +36,56 @@ import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import javax.annotation.Nullable;
 
 /**
- * Builder for {@link FlinkCdcSink} when syncing multiple database tables into one Paimon table.
+ * Builder for sink when syncing records into one Paimon table.
  *
  * @param <T> CDC change event type
  */
-public class FlinkCdcSyncTableSinkBuilder<T> {
+@Experimental
+public class CdcSinkBuilder<T> {
 
     private DataStream<T> input = null;
     private EventParser.Factory<T> parserFactory = null;
-    private FileStoreTable table = null;
+    private Table table = null;
     private Lock.Factory lockFactory = Lock.emptyFactory();
 
     @Nullable private Integer parallelism;
 
-    public FlinkCdcSyncTableSinkBuilder<T> withInput(DataStream<T> input) {
+    public CdcSinkBuilder<T> withInput(DataStream<T> input) {
         this.input = input;
         return this;
     }
 
-    public FlinkCdcSyncTableSinkBuilder<T> withParserFactory(EventParser.Factory<T> parserFactory) {
+    public CdcSinkBuilder<T> withParserFactory(EventParser.Factory<T> parserFactory) {
         this.parserFactory = parserFactory;
         return this;
     }
 
-    public FlinkCdcSyncTableSinkBuilder<T> withTable(FileStoreTable table) {
+    public CdcSinkBuilder<T> withTable(Table table) {
         this.table = table;
         return this;
     }
 
-    public FlinkCdcSyncTableSinkBuilder<T> withLockFactory(Lock.Factory lockFactory) {
+    public CdcSinkBuilder<T> withLockFactory(Lock.Factory lockFactory) {
         this.lockFactory = lockFactory;
         return this;
     }
 
-    public FlinkCdcSyncTableSinkBuilder<T> withParallelism(@Nullable Integer parallelism) {
+    public CdcSinkBuilder<T> withParallelism(@Nullable Integer parallelism) {
         this.parallelism = parallelism;
         return this;
     }
 
     public DataStreamSink<?> build() {
-        Preconditions.checkNotNull(input);
-        Preconditions.checkNotNull(parserFactory);
-        Preconditions.checkNotNull(table);
+        Preconditions.checkNotNull(input, "Input DataStream can not be null.");
+        Preconditions.checkNotNull(parserFactory, "Event ParserFactory can not be null.");
+        Preconditions.checkNotNull(table, "Paimon Table can not be null.");
+
+        if (!(table instanceof FileStoreTable)) {
+            throw new IllegalArgumentException(
+                    "Table should be a data table, but is: " + table.getClass().getName());
+        }
+
+        FileStoreTable dataTable = (FileStoreTable) table;
 
         SingleOutputStreamOperator<CdcRecord> parsed =
                 input.forward()
@@ -87,12 +97,13 @@ public class FlinkCdcSyncTableSinkBuilder<T> {
                                 parsed, CdcParsingProcessFunction.NEW_DATA_FIELD_LIST_OUTPUT_TAG)
                         .process(
                                 new UpdatedDataFieldsProcessFunction(
-                                        new SchemaManager(table.fileIO(), table.location())));
+                                        new SchemaManager(
+                                                dataTable.fileIO(), dataTable.location())));
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
         BucketingStreamPartitioner<CdcRecord> partitioner =
-                new BucketingStreamPartitioner<>(new CdcRecordChannelComputer(table.schema()));
+                new BucketingStreamPartitioner<>(new CdcRecordChannelComputer(dataTable.schema()));
         PartitionTransformation<CdcRecord> partitioned =
                 new PartitionTransformation<>(parsed.getTransformation(), partitioner);
         if (parallelism != null) {
@@ -100,7 +111,7 @@ public class FlinkCdcSyncTableSinkBuilder<T> {
         }
 
         StreamExecutionEnvironment env = input.getExecutionEnvironment();
-        FlinkCdcSink sink = new FlinkCdcSink(table, lockFactory);
+        FlinkCdcSink sink = new FlinkCdcSink(dataTable, lockFactory);
         return sink.sinkFrom(new DataStream<>(env, partitioned));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.types.DataField;
 
 import java.io.Serializable;
@@ -29,17 +30,29 @@ import java.util.Optional;
  *
  * @param <T> CDC change event type
  */
+@Experimental
 public interface EventParser<T> {
 
+    /** Set current raw event to the parser. */
     void setRawEvent(T rawEvent);
 
-    String tableName();
+    /** Parse the table name from raw event. */
+    default String parseTableName() {
+        throw new UnsupportedOperationException("Table name is not supported in this parser.");
+    }
 
-    boolean isUpdatedDataFields();
+    /** Is this event schema change. */
+    boolean isSchemaChange();
 
-    Optional<List<DataField>> getUpdatedDataFields();
+    /**
+     * Parse new schema if this event is schema change.
+     *
+     * @return none if this schema change can be ignored.
+     */
+    Optional<List<DataField>> parseNewSchema();
 
-    List<CdcRecord> getRecords();
+    /** Parse records from event if this event is not a schema change. */
+    List<CdcRecord> parseRecords();
 
     /** Factory to create an {@link EventParser}. */
     interface Factory<T> extends Serializable {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -23,7 +23,6 @@ import org.apache.paimon.types.DataField;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Parse a CDC change event to a list of {@link DataField}s or {@link CdcRecord}.
@@ -41,17 +40,18 @@ public interface EventParser<T> {
         throw new UnsupportedOperationException("Table name is not supported in this parser.");
     }
 
-    /** Is this event schema change. */
-    boolean isSchemaChange();
+    /**
+     * Parse new schema if this event contains schema change.
+     *
+     * @return empty if there is no schema change
+     */
+    List<DataField> parseSchemaChange();
 
     /**
-     * Parse new schema if this event is schema change.
+     * Parse records from event.
      *
-     * @return none if this schema change can be ignored.
+     * @return empty if there is no records
      */
-    Optional<List<DataField>> parseNewSchema();
-
-    /** Parse records from event if this event is not a schema change. */
     List<CdcRecord> parseRecords();
 
     /** Factory to create an {@link EventParser}. */

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
@@ -278,8 +278,7 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parser.parseSchemaChange();
-        assert updatedDataFields == null;
+        assertThat(parser.parseSchemaChange()).isEmpty();
         List<GenericRow> result =
                 parser.parseRecords().stream()
                         .map(record -> toGenericRow(record, dataFields).get())

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
@@ -117,8 +117,7 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
-        assert updatedDataFields == null;
+        assertThat(parser.parseSchemaChange()).isEmpty();
         List<GenericRow> result =
                 parser.parseRecords().stream()
                         .map(record -> toGenericRow(record, dataFields).get())
@@ -154,16 +153,15 @@ public class KafkaEventParserTest {
         expectDataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         expectDataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
         expectDataFields.add(new DataField(6, "v2", DataTypes.INT()));
-        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
-        assert updatedDataFields == null;
+        assertThat(parser.parseSchemaChange()).isEmpty();
         parser.setRawEvent(CANAL_JSON_DDL_ADD_EVENT);
-        List<DataField> updatedDataFieldsAdd = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFieldsAdd = parser.parseSchemaChange();
         assertThat(updatedDataFieldsAdd).isEqualTo(expectDataFields);
 
         expectDataFields.remove(2);
         expectDataFields.add(2, new DataField(2, "v1", DataTypes.VARCHAR(20)));
         parser.setRawEvent(CANAL_JSON_DDL_MODIFY_EVENT);
-        List<DataField> updatedDataFieldsModify = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFieldsModify = parser.parseSchemaChange();
         assertThat(updatedDataFieldsModify).isEqualTo(expectDataFields);
         expectDataFields.remove(2);
         expectDataFields.add(2, new DataField(2, "v1", DataTypes.VARCHAR(30)));
@@ -175,10 +173,10 @@ public class KafkaEventParserTest {
         expectDataFields.add(new DataField(9, "v6", DataTypes.DECIMAL(5, 3)));
         expectDataFields.add(new DataField(10, "$% ^,& *(", DataTypes.VARCHAR(10)));
         parser.setRawEvent(CANAL_JSON_DDL_MULTI_ADD_EVENT);
-        List<DataField> updatedDataFieldsMulti = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFieldsMulti = parser.parseSchemaChange();
         assertThat(updatedDataFieldsMulti).isEqualTo(expectDataFields);
         parser.setRawEvent(CANAL_JSON_DDL_DROP_EVENT);
-        List<DataField> updatedDataFieldsDrop = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFieldsDrop = parser.parseSchemaChange();
         for (int i = 0; i < expectDataFields.size(); i++) {
             expectDataFields.set(
                     i,
@@ -188,7 +186,7 @@ public class KafkaEventParserTest {
         expectDataFields.remove(2);
         assertThat(updatedDataFieldsDrop).isEqualTo(expectDataFields);
         parser.setRawEvent(CANAL_JSON_DDL_CHANGE_EVENT);
-        List<DataField> updatedDataFieldsChange = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFieldsChange = parser.parseSchemaChange();
         expectDataFields.remove(9);
         for (int i = 0; i < expectDataFields.size(); i++) {
             expectDataFields.set(
@@ -218,11 +216,10 @@ public class KafkaEventParserTest {
 
     @Test
     public void testCaseSensitive() {
-        boolean caseSensitive = false;
         EventParser<String> parserCaseInsensitive =
-                new CanalJsonEventParser(caseSensitive, new TableNameConverter(caseSensitive));
+                new CanalJsonEventParser(false, new TableNameConverter(false));
         EventParser<String> parserCaseSensitive =
-                new CanalJsonEventParser(!caseSensitive, new TableNameConverter(!caseSensitive));
+                new CanalJsonEventParser(true, new TableNameConverter(true));
         parserCaseInsensitive.setRawEvent(CANAL_JSON_EVENT);
         List<DataField> dataFields = new ArrayList<>();
         dataFields.add(new DataField(0, "pt", DataTypes.INT()));
@@ -231,8 +228,7 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parserCaseInsensitive.parseNewSchema().orElse(null);
-        assert updatedDataFields == null;
+        assertThat(parserCaseInsensitive.parseSchemaChange()).isEmpty();
         List<GenericRow> result =
                 parserCaseInsensitive.parseRecords().stream()
                         .map(record -> toGenericRow(record, dataFields).get())
@@ -282,7 +278,7 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
+        List<DataField> updatedDataFields = parser.parseSchemaChange();
         assert updatedDataFields == null;
         List<GenericRow> result =
                 parser.parseRecords().stream()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaEventParserTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.flink.sink.cdc.CdcRecordUtils.toGenericRow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -116,11 +117,11 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
         assert updatedDataFields == null;
         List<GenericRow> result =
-                parser.getRecords().stream()
-                        .map(record -> record.toGenericRow(dataFields).get())
+                parser.parseRecords().stream()
+                        .map(record -> toGenericRow(record, dataFields).get())
                         .collect(Collectors.toList());
         BinaryString[] binaryStrings =
                 new BinaryString[] {BinaryString.fromString("a"), BinaryString.fromString("b")};
@@ -153,16 +154,16 @@ public class KafkaEventParserTest {
         expectDataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         expectDataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
         expectDataFields.add(new DataField(6, "v2", DataTypes.INT()));
-        List<DataField> updatedDataFields = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
         assert updatedDataFields == null;
         parser.setRawEvent(CANAL_JSON_DDL_ADD_EVENT);
-        List<DataField> updatedDataFieldsAdd = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFieldsAdd = parser.parseNewSchema().orElse(null);
         assertThat(updatedDataFieldsAdd).isEqualTo(expectDataFields);
 
         expectDataFields.remove(2);
         expectDataFields.add(2, new DataField(2, "v1", DataTypes.VARCHAR(20)));
         parser.setRawEvent(CANAL_JSON_DDL_MODIFY_EVENT);
-        List<DataField> updatedDataFieldsModify = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFieldsModify = parser.parseNewSchema().orElse(null);
         assertThat(updatedDataFieldsModify).isEqualTo(expectDataFields);
         expectDataFields.remove(2);
         expectDataFields.add(2, new DataField(2, "v1", DataTypes.VARCHAR(30)));
@@ -174,10 +175,10 @@ public class KafkaEventParserTest {
         expectDataFields.add(new DataField(9, "v6", DataTypes.DECIMAL(5, 3)));
         expectDataFields.add(new DataField(10, "$% ^,& *(", DataTypes.VARCHAR(10)));
         parser.setRawEvent(CANAL_JSON_DDL_MULTI_ADD_EVENT);
-        List<DataField> updatedDataFieldsMulti = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFieldsMulti = parser.parseNewSchema().orElse(null);
         assertThat(updatedDataFieldsMulti).isEqualTo(expectDataFields);
         parser.setRawEvent(CANAL_JSON_DDL_DROP_EVENT);
-        List<DataField> updatedDataFieldsDrop = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFieldsDrop = parser.parseNewSchema().orElse(null);
         for (int i = 0; i < expectDataFields.size(); i++) {
             expectDataFields.set(
                     i,
@@ -187,7 +188,7 @@ public class KafkaEventParserTest {
         expectDataFields.remove(2);
         assertThat(updatedDataFieldsDrop).isEqualTo(expectDataFields);
         parser.setRawEvent(CANAL_JSON_DDL_CHANGE_EVENT);
-        List<DataField> updatedDataFieldsChange = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFieldsChange = parser.parseNewSchema().orElse(null);
         expectDataFields.remove(9);
         for (int i = 0; i < expectDataFields.size(); i++) {
             expectDataFields.set(
@@ -230,12 +231,11 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields =
-                parserCaseInsensitive.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFields = parserCaseInsensitive.parseNewSchema().orElse(null);
         assert updatedDataFields == null;
         List<GenericRow> result =
-                parserCaseInsensitive.getRecords().stream()
-                        .map(record -> record.toGenericRow(dataFields).get())
+                parserCaseInsensitive.parseRecords().stream()
+                        .map(record -> toGenericRow(record, dataFields).get())
                         .collect(Collectors.toList());
         BinaryString[] binaryStrings =
                 new BinaryString[] {BinaryString.fromString("a"), BinaryString.fromString("b")};
@@ -254,13 +254,13 @@ public class KafkaEventParserTest {
         assertThat(result).isEqualTo(expect);
         parserCaseSensitive.setRawEvent(CANAL_JSON_EVENT);
         Optional<GenericRow> genericRow =
-                parserCaseSensitive.getRecords().get(0).toGenericRow(dataFields);
+                toGenericRow(parserCaseSensitive.parseRecords().get(0), dataFields);
         assert !genericRow.isPresent();
         dataFields.remove(1);
         dataFields.add(1, new DataField(1, "_ID", DataTypes.INT()));
         List<GenericRow> resultCaseSensitive =
-                parserCaseSensitive.getRecords().stream()
-                        .map(record -> record.toGenericRow(dataFields).get())
+                parserCaseSensitive.parseRecords().stream()
+                        .map(record -> toGenericRow(record, dataFields).get())
                         .collect(Collectors.toList());
         assertThat(resultCaseSensitive).isEqualTo(expect);
     }
@@ -282,11 +282,11 @@ public class KafkaEventParserTest {
         dataFields.add(new DataField(3, "_geometrycollection", DataTypes.STRING()));
         dataFields.add(new DataField(4, "_set", DataTypes.ARRAY(DataTypes.STRING())));
         dataFields.add(new DataField(5, "_enum", DataTypes.STRING()));
-        List<DataField> updatedDataFields = parser.getUpdatedDataFields().orElse(null);
+        List<DataField> updatedDataFields = parser.parseNewSchema().orElse(null);
         assert updatedDataFields == null;
         List<GenericRow> result =
-                parser.getRecords().stream()
-                        .map(record -> record.toGenericRow(dataFields).get())
+                parser.parseRecords().stream()
+                        .map(record -> toGenericRow(record, dataFields).get())
                         .collect(Collectors.toList());
         BinaryString[] binaryStrings =
                 new BinaryString[] {BinaryString.fromString("a"), BinaryString.fromString("b")};

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-/** IT cases for {@link FlinkCdcSyncTableSinkBuilder}. */
+/** IT cases for {@link CdcSinkBuilder}. */
 public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
 
     @TempDir java.nio.file.Path tempDir;
@@ -104,7 +104,7 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         TestCdcSourceFunction sourceFunction = new TestCdcSourceFunction(testTable.events());
         DataStreamSource<TestCdcEvent> source = env.addSource(sourceFunction);
         source.setParallelism(2);
-        new FlinkCdcSyncTableSinkBuilder<TestCdcEvent>()
+        new CdcSinkBuilder<TestCdcEvent>()
                 .withInput(source)
                 .withParserFactory(TestCdcEventParser::new)
                 .withTable(table)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
@@ -34,22 +34,22 @@ public class TestCdcEventParser implements EventParser<TestCdcEvent> {
     }
 
     @Override
-    public String tableName() {
+    public String parseTableName() {
         return raw.tableName();
     }
 
     @Override
-    public boolean isUpdatedDataFields() {
+    public boolean isSchemaChange() {
         return raw.updatedDataFields() != null;
     }
 
     @Override
-    public Optional<List<DataField>> getUpdatedDataFields() {
+    public Optional<List<DataField>> parseNewSchema() {
         return Optional.ofNullable(raw.updatedDataFields());
     }
 
     @Override
-    public List<CdcRecord> getRecords() {
+    public List<CdcRecord> parseRecords() {
         return raw.records();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
@@ -19,8 +19,7 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.types.DataField;
-
-import com.google.common.base.Objects;
+import org.apache.paimon.utils.ObjectUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -42,11 +41,11 @@ public class TestCdcEventParser implements EventParser<TestCdcEvent> {
 
     @Override
     public List<DataField> parseSchemaChange() {
-        return Objects.firstNonNull(raw.updatedDataFields(), Collections.emptyList());
+        return ObjectUtils.coalesce(raw.updatedDataFields(), Collections.emptyList());
     }
 
     @Override
     public List<CdcRecord> parseRecords() {
-        return Objects.firstNonNull(raw.records(), Collections.emptyList());
+        return ObjectUtils.coalesce(raw.records(), Collections.emptyList());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
@@ -20,8 +20,10 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.types.DataField;
 
+import com.google.common.base.Objects;
+
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /** Testing {@link EventParser} for {@link TestCdcEvent}. */
 public class TestCdcEventParser implements EventParser<TestCdcEvent> {
@@ -39,17 +41,12 @@ public class TestCdcEventParser implements EventParser<TestCdcEvent> {
     }
 
     @Override
-    public boolean isSchemaChange() {
-        return raw.updatedDataFields() != null;
-    }
-
-    @Override
-    public Optional<List<DataField>> parseNewSchema() {
-        return Optional.ofNullable(raw.updatedDataFields());
+    public List<DataField> parseSchemaChange() {
+        return Objects.firstNonNull(raw.updatedDataFields(), Collections.emptyList());
     }
 
     @Override
     public List<CdcRecord> parseRecords() {
-        return raw.records();
+        return Objects.firstNonNull(raw.records(), Collections.emptyList());
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Paimon supports a variety of ways to ingest data into Paimon tables with schema evolution. This means that the added
columns are synchronized to the Paimon table in real time and the synchronization job is not restarted for this purpose.

We currently support the following sync ways:

1. MySQL Synchronizing Table: synchronize one or multiple tables from MySQL into one Paimon table.
2. MySQL Synchronizing Database: synchronize the whole MySQL database into one Paimon database.
3. [API Synchronizing Table]({{< ref "/api/flink-api#cdc-ingestion-table" >}}): synchronize your custom DataStream input into one Paimon table.

This PR aims to introduce API for Synchronizing Table, Many users have various customization needs, and we provide APIs for them to meet their specific business needs

<!-- What is the purpose of the change, or the associated issue -->

### Tests

No

<!-- List UT and IT cases to verify this change -->

### API and Format

Yes

<!-- Does this change affect API or storage format -->

### Documentation

Yes

<!-- Does this change introduce a new feature -->
