### PR TITLE
[core] Introduce sequence group to partial update

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/RowKind.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowKind.java
@@ -97,6 +97,16 @@ public enum RowKind {
         return value;
     }
 
+    /** Is {@link #UPDATE_BEFORE} or {@link #DELETE}. */
+    public boolean isRetract() {
+        return this == RowKind.UPDATE_BEFORE || this == RowKind.DELETE;
+    }
+
+    /** Is {@link #INSERT} or {@link #UPDATE_AFTER}. */
+    public boolean isAdd() {
+        return this == RowKind.INSERT || this == RowKind.UPDATE_AFTER;
+    }
+
     /**
      * Creates a {@link RowKind} from the given byte value. Each {@link RowKind} has a byte value
      * representation.

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
@@ -73,6 +73,11 @@ public class KeyValue {
         return this;
     }
 
+    public KeyValue replaceValue(InternalRow value) {
+        this.value = value;
+        return this;
+    }
+
     public KeyValue replaceValueKind(RowKind valueKind) {
         this.valueKind = valueKind;
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
@@ -36,6 +36,7 @@ public interface MergeFunctionFactory<T> extends Serializable {
         return new AdjustedProjection(projection, null);
     }
 
+    /** Result of adjusted projection. */
     class AdjustedProjection {
 
         @Nullable public final int[][] pushdownProjection;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
@@ -31,4 +31,20 @@ public interface MergeFunctionFactory<T> extends Serializable {
     }
 
     MergeFunction<T> create(@Nullable int[][] projection);
+
+    default AdjustedProjection adjustProjection(@Nullable int[][] projection) {
+        return new AdjustedProjection(projection, null);
+    }
+
+    class AdjustedProjection {
+
+        @Nullable public final int[][] pushdownProjection;
+
+        @Nullable public final int[][] outerProjection;
+
+        public AdjustedProjection(int[][] pushdownProjection, int[][] outerProjection) {
+            this.pushdownProjection = pushdownProjection;
+            this.outerProjection = outerProjection;
+        }
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -18,16 +18,23 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.sink.SequenceGenerator;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Projection;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.paimon.utils.InternalRowUtils.createFieldGetters;
 
@@ -37,16 +44,24 @@ import static org.apache.paimon.utils.InternalRowUtils.createFieldGetters;
  */
 public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
 
+    public static final String FIELDS = "fields";
+    public static final String SEQUENCE_GROUP = "sequence-group";
+
     private final InternalRow.FieldGetter[] getters;
     private final boolean ignoreDelete;
+    private final Map<Integer, SequenceGenerator> fieldSequences;
 
     private KeyValue latestKv;
     private GenericRow row;
     private KeyValue reused;
 
-    protected PartialUpdateMergeFunction(InternalRow.FieldGetter[] getters, boolean ignoreDelete) {
+    protected PartialUpdateMergeFunction(
+            InternalRow.FieldGetter[] getters,
+            boolean ignoreDelete,
+            Map<Integer, SequenceGenerator> fieldSequences) {
         this.getters = getters;
         this.ignoreDelete = ignoreDelete;
+        this.fieldSequences = fieldSequences;
     }
 
     @Override
@@ -72,10 +87,38 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
         }
 
         latestKv = kv;
+        if (fieldSequences.isEmpty()) {
+            updateNonNullFields(kv);
+        } else {
+            updateWithSequenceGroup(kv);
+        }
+    }
+
+    private void updateNonNullFields(KeyValue kv) {
         for (int i = 0; i < getters.length; i++) {
             Object field = getters[i].getFieldOrNull(kv.value());
             if (field != null) {
                 row.setField(i, field);
+            }
+        }
+    }
+
+    private void updateWithSequenceGroup(KeyValue kv) {
+        for (int i = 0; i < getters.length; i++) {
+            Object field = getters[i].getFieldOrNull(kv.value());
+            SequenceGenerator sequenceGen = fieldSequences.get(i);
+            if (sequenceGen == null) {
+                if (field != null) {
+                    row.setField(i, field);
+                }
+            } else {
+                Long currentSeq = sequenceGen.generateNullable(kv.value());
+                if (currentSeq != null) {
+                    Long previousSeq = sequenceGen.generateNullable(row);
+                    if (previousSeq == null || currentSeq >= previousSeq) {
+                        row.setField(i, field);
+                    }
+                }
             }
         }
     }
@@ -98,9 +141,8 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
         return reused.replace(latestKv.key(), latestKv.sequenceNumber(), RowKind.INSERT, row);
     }
 
-    public static MergeFunctionFactory<KeyValue> factory(
-            boolean ignoreDelete, List<DataType> tableTypes) {
-        return new Factory(ignoreDelete, tableTypes);
+    public static MergeFunctionFactory<KeyValue> factory(Options options, RowType rowType) {
+        return new Factory(options, rowType);
     }
 
     private static class Factory implements MergeFunctionFactory<KeyValue> {
@@ -109,10 +151,40 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
 
         private final boolean ignoreDelete;
         private final List<DataType> tableTypes;
+        private final Map<Integer, SequenceGenerator> fieldSequences;
 
-        private Factory(boolean ignoreDelete, List<DataType> tableTypes) {
-            this.ignoreDelete = ignoreDelete;
-            this.tableTypes = tableTypes;
+        private Factory(Options options, RowType rowType) {
+            this.ignoreDelete = options.get(CoreOptions.PARTIAL_UPDATE_IGNORE_DELETE);
+            this.tableTypes = rowType.getFieldTypes();
+
+            List<String> fieldNames = rowType.getFieldNames();
+            this.fieldSequences = new HashMap<>();
+            for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+                String k = entry.getKey();
+                String v = entry.getValue();
+                if (k.startsWith(FIELDS) && k.endsWith(SEQUENCE_GROUP)) {
+                    String sequenceFieldName =
+                            k.substring(
+                                    FIELDS.length() + 1, k.length() - SEQUENCE_GROUP.length() - 1);
+                    SequenceGenerator sequenceGen =
+                            new SequenceGenerator(sequenceFieldName, rowType);
+                    Arrays.stream(v.split(","))
+                            .map(fieldNames::indexOf)
+                            .forEach(
+                                    field -> {
+                                        if (fieldSequences.containsKey(field)) {
+                                            throw new IllegalArgumentException(
+                                                    String.format(
+                                                            "Field %s is defined repeatedly by multiple groups: %s",
+                                                            fieldNames.get(field), k));
+                                        }
+                                        fieldSequences.put(field, sequenceGen);
+                                    });
+
+                    // add self
+                    fieldSequences.put(sequenceGen.index(), sequenceGen);
+                }
+            }
         }
 
         @Override
@@ -121,7 +193,15 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
             if (projection != null) {
                 fieldTypes = Projection.of(projection).project(tableTypes);
             }
-            return new PartialUpdateMergeFunction(createFieldGetters(fieldTypes), ignoreDelete);
+            InternalRow.FieldGetter[] fieldGetters = createFieldGetters(fieldTypes);
+
+            return new PartialUpdateMergeFunction(fieldGetters, ignoreDelete, fieldSequences);
+        }
+
+        @Override
+        public AdjustedProjection adjustProjection(@Nullable int[][] projection) {
+            // TODO implement this, just keep required fields and adjust fieldSequences too.
+            return new AdjustedProjection(null, projection);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -88,10 +88,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                     mfFactory = DeduplicateMergeFunction.factory();
                     break;
                 case PARTIAL_UPDATE:
-                    mfFactory =
-                            PartialUpdateMergeFunction.factory(
-                                    conf.get(CoreOptions.PARTIAL_UPDATE_IGNORE_DELETE),
-                                    rowType.getFieldTypes());
+                    mfFactory = PartialUpdateMergeFunction.factory(conf, rowType);
                     break;
                 case AGGREGATE:
                     mfFactory =

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/SequenceGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/SequenceGenerator.java
@@ -36,6 +36,8 @@ import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.InternalRowUtils;
 
+import javax.annotation.Nullable;
+
 /** Generate sequence number. */
 public class SequenceGenerator {
 
@@ -53,12 +55,29 @@ public class SequenceGenerator {
         generator = rowType.getTypeAt(index).accept(new SequenceGeneratorVisitor());
     }
 
+    public int index() {
+        return index;
+    }
+
+    @Nullable
+    public Long generateNullable(InternalRow row) {
+        return generator.generateNullable(row, index);
+    }
+
     public long generate(InternalRow row) {
         return generator.generate(row, index);
     }
 
     private interface Generator {
         long generate(InternalRow row, int i);
+
+        @Nullable
+        default Long generateNullable(InternalRow row, int i) {
+            if (row.isNullAt(i)) {
+                return null;
+            }
+            return generate(row, i);
+        }
     }
 
     private static class SequenceGeneratorVisitor extends DataTypeDefaultVisitor<Generator> {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link PartialUpdateMergeFunction}. */
+public class PartialUpdateMergeFunctionTest {
+
+    private long sequence = 0;
+
+    @Test
+    public void testUpdateNonNull() {
+        Options options = new Options();
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        MergeFunction<KeyValue> func =
+                PartialUpdateMergeFunction.factory(options, rowType).create();
+        func.reset();
+        add(func, 1, 1, 1, 1, 1, 1, 1);
+        add(func, 1, 2, 2, 2, 2, 2, null);
+        validate(func, 1, 2, 2, 2, 2, 2, 1);
+    }
+
+    @Test
+    public void testSequenceGroup() {
+        Options options = new Options();
+        options.set("fields.f3.sequence-group", "f1,f2");
+        options.set("fields.f6.sequence-group", "f4,f5");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        MergeFunction<KeyValue> func =
+                PartialUpdateMergeFunction.factory(options, rowType).create();
+        func.reset();
+        add(func, 1, 1, 1, 1, 1, 1, 1);
+        add(func, 1, 2, 2, 2, 2, 2, null);
+        validate(func, 1, 2, 2, 2, 1, 1, 1);
+        add(func, 1, 3, 3, 1, 3, 3, 3);
+        validate(func, 1, 2, 2, 2, 3, 3, 3);
+    }
+
+    @Test
+    public void testSequenceGroupRepeatDefine() {
+        Options options = new Options();
+        options.set("fields.f3.sequence-group", "f1,f2");
+        options.set("fields.f4.sequence-group", "f1,f2");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        assertThatThrownBy(() -> PartialUpdateMergeFunction.factory(options, rowType))
+                .hasMessageContaining("is defined repeatedly by multiple groups");
+    }
+
+    private void add(
+            MergeFunction<KeyValue> function,
+            Integer f0,
+            Integer f1,
+            Integer f2,
+            Integer f3,
+            Integer f4,
+            Integer f5,
+            Integer f6) {
+        function.add(
+                new KeyValue()
+                        .replace(
+                                GenericRow.of(1),
+                                sequence++,
+                                RowKind.INSERT,
+                                GenericRow.of(f0, f1, f2, f3, f4, f5, f6)));
+    }
+
+    private void validate(
+            MergeFunction<KeyValue> function,
+            Integer f0,
+            Integer f1,
+            Integer f2,
+            Integer f3,
+            Integer f4,
+            Integer f5,
+            Integer f6) {
+        assertThat(function.getResult().value())
+                .isEqualTo(GenericRow.of(f0, f1, f2, f3, f4, f5, f6));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change, or the associated issue -->

A sequence-field may not solve the disorder problem of partial-update tables with multiple stream updates, because the sequence-field may be overwritten by the latest data of another stream during multi-stream update.

So we introduce sequence group mechanism for partial-update tables. It can solve:

1. Disorder during multi-stream update. Each stream defines its own sequence-groups.
2. A true partial-update, not just a non-null update.


### Tests

Both UT & IT

<!-- List UT and IT cases to verify this change -->

### API and Format

```
CREATE TABLE T (
    k INT,
    a INT,
    b INT,
    g_1 INT,
    c INT,
    d INT,
    g_2 INT,
    PRIMARY KEY (k) NOT ENFORCED
) WITH (
    'merge-engine'='partial-update',
    'fields.g_1.sequence-group'='a,b',
    'fields.g_2.sequence-group'='c,d'
);
```
<!-- Does this change affect API or storage format -->

### Documentation

Yes

<!-- Does this change introduce a new feature -->
