### PR TITLE
[flink] Fix kafka hybrid restore enumerator

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
@@ -56,10 +56,12 @@ public class LogHybridSourceFactory
     public Source<RowData, ?, ?> create(
             HybridSource.SourceSwitchContext<StaticFileStoreSplitEnumerator> context) {
         StaticFileStoreSplitEnumerator enumerator = context.getPreviousEnumerator();
-        Snapshot snapshot = enumerator.snapshot();
         Map<Integer, Long> logOffsets = null;
-        if (snapshot != null) {
-            logOffsets = snapshot.logOffsets();
+        if (enumerator != null) {
+            Snapshot snapshot = enumerator.snapshot();
+            if (snapshot != null) {
+                logOffsets = snapshot.logOffsets();
+            }
         }
         return provider.createSource(logOffsets);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
@@ -161,7 +161,7 @@ public class KafkaLogTestUtils {
                 origin, new ResolvedSchema(resolvedColumns, Collections.emptyList(), constraint));
     }
 
-    static DynamicTableFactory.Context testContext(
+    public static DynamicTableFactory.Context testContext(
             String servers, LogChangelogMode changelogMode, boolean keyed) {
         return testContext("table", servers, changelogMode, LogConsistency.TRANSACTIONAL, keyed);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/LogHybridSourceFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/LogHybridSourceFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.flink.kafka.KafkaLogSourceProvider;
+import org.apache.paimon.flink.kafka.KafkaLogTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.paimon.flink.kafka.KafkaLogTestUtils.discoverKafkaLogFactory;
+import static org.apache.paimon.flink.kafka.KafkaLogTestUtils.testContext;
+
+/** Test for {@link LogHybridSourceFactory}. */
+public class LogHybridSourceFactoryTest {
+
+    @Test
+    public void testRestoreLogSource() {
+        KafkaLogSourceProvider sourceProvider =
+                discoverKafkaLogFactory()
+                        .createSourceProvider(
+                                testContext("", CoreOptions.LogChangelogMode.UPSERT, true),
+                                KafkaLogTestUtils.SOURCE_CONTEXT,
+                                null);
+        LogHybridSourceFactory sourceFactory = new LogHybridSourceFactory(sourceProvider);
+        sourceFactory.create(() -> null);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change, or the associated issue -->

Restore kafka source should not throw NPE exception.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
