### PR TITLE
[flink][bug] MySqlSyncDatabaseActionITCase doesn't need to handle incompatible table

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -192,13 +192,14 @@ public class MySqlSyncDatabaseAction extends ActionBase {
                         incompatibleMessage(table.schema(), mySqlSchema, identifier);
                 if (shouldMonitorTable(table.schema(), fromMySql, errMsg)) {
                     monitoredTables.add(mySqlSchema.tableName());
+                    fileStoreTables.add(table);
                 }
             } catch (Catalog.TableNotExistException e) {
                 catalog.createTable(identifier, fromMySql, false);
                 table = (FileStoreTable) catalog.getTable(identifier);
                 monitoredTables.add(mySqlSchema.tableName());
+                fileStoreTables.add(table);
             }
-            fileStoreTables.add(table);
         }
 
         Preconditions.checkState(


### PR DESCRIPTION
### Purpose
In `MySqlSyncDatabaseAction`, if user has specified `ignoreIncompatible = true`, and the table is not compatible, we should ignore it. However, current implementation still add the ignored table to `fileStoreTables`, then in `FlinkCdcSyncDatabaseSinkBuilder` a `DataStream<Void> schemaChangeProcessFunction` will be created, which is unnecessary.
So this PR remove the ignored table.

### Tests

Original tests.
### API and Format

no

### Documentation

no
