### PR TITLE
[docs] Document how to travel to snapshot with mode 'from-snapshot-full'

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -103,8 +103,11 @@ Currently, Paimon supports time travel for Flink and Spark 3 (requires Spark 3.3
 you can use [dynamic table options](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/hints/#dynamic-table-options) to specify scan mode and from where to start:
 
 ```sql
--- travel to snapshot with id 1L
+-- travel to snapshot with id 1L with 'scan.mode'='from-snapshot' by default
 SELECT * FROM t /*+ OPTIONS('scan.snapshot-id' = '1') */;
+
+-- travel to snapshot with id 1L with 'scan.mode'='from-snapshot-full'
+SELECT * FROM t /*+ OPTIONS('scan.mode'='from-snapshot-full','scan.snapshot-id' = '1') */;
 
 -- travel to specified timestamp with a long value in milliseconds
 SELECT * FROM t /*+ OPTIONS('scan.timestamp-millis' = '1678883047356') */;


### PR DESCRIPTION
Document how to travel to snapshot with 'scan.mode'='from-snapshot-full', to describe clear the traveling will be with the mode of 'from-snapshot' by default if use specify the 'scan.snapshot-id'.
