### PR TITLE
[docs] Fix ref link with secondary titles

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -59,7 +59,7 @@ Produces the latest snapshot on the table upon first startup, and continues to r
 <tr>
 <td>compacted-full</td>
 <td>
-Produces the snapshot after the latest <a href="{{< ref "concepts/file-layouts#lsm-trees#compactions" >}}">compaction</a>.
+Produces the snapshot after the latest <a href="{{< ref "concepts/file-layouts#compaction" >}}">compaction</a>.
 </td>
 <td>
 Produces the snapshot after the latest compaction on the table upon first startup, and continues to read the following changes.

--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -63,9 +63,9 @@ the read manifest data to accelerate initialization.
 
 ### Number of Sorted Runs to Trigger Compaction
 
-Paimon uses [LSM tree]({{< ref "concepts/file-layouts#lsm-trees" >}}) which supports a large number of updates. LSM organizes files in several [sorted runs]({{< ref "concepts/file-layouts#lsm-trees#sorted-runs" >}}). When querying records from an LSM tree, all sorted runs must be combined to produce a complete view of all records.
+Paimon uses [LSM tree]({{< ref "concepts/file-layouts#lsm-trees" >}}) which supports a large number of updates. LSM organizes files in several [sorted runs]({{< ref "concepts/file-layouts#sorted-runs" >}}). When querying records from an LSM tree, all sorted runs must be combined to produce a complete view of all records.
 
-One can easily see that too many sorted runs will result in poor query performance. To keep the number of sorted runs in a reasonable range, Paimon writers will automatically perform [compactions]({{< ref "concepts/file-layouts#lsm-trees#compactions" >}}). The following table property determines the minimum number of sorted runs to trigger a compaction.
+One can easily see that too many sorted runs will result in poor query performance. To keep the number of sorted runs in a reasonable range, Paimon writers will automatically perform [compactions]({{< ref "concepts/file-layouts#compaction" >}}). The following table property determines the minimum number of sorted runs to trigger a compaction.
 
 <table class="table table-bordered">
     <thead>


### PR DESCRIPTION
Fix the ref link with secondary titles and typo, which couldn't find the exact resource.
1. 'compactions' -> 'compaction'
2. Remove the h1 headings in the ref link.
