### PR TITLE
[flink] Provide a preemptive mode in StaticFileStoreSplitEnumerator

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -57,6 +57,12 @@ under the License.
             <td>How many splits should assign to subtask per batch in StaticFileStoreSplitEnumerator to avoid exceed `akka.framesize` limit.</td>
         </tr>
         <tr>
+            <td><h5>scan.split-enumerator.mode</h5></td>
+            <td style="word-wrap: break-word;">fair</td>
+            <td>Enum</td>
+            <td>The mode used by StaticFileStoreSplitEnumerator to assign splits.<br /><br />Possible values:<ul><li>"fair": Distribute splits evenly when batch reading to prevent a few tasks from reading all.</li><li>"preemptive": Distribute splits preemptively according to the consumption speed of the task.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>scan.watermark.alignment.group</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -182,6 +182,13 @@ public class FlinkConnectorOptions {
                             "How many splits should assign to subtask per batch in StaticFileStoreSplitEnumerator "
                                     + "to avoid exceed `akka.framesize` limit.");
 
+    public static final ConfigOption<SplitAssignMode> SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE =
+            key("scan.split-enumerator.mode")
+                    .enumType(SplitAssignMode.class)
+                    .defaultValue(SplitAssignMode.FAIR)
+                    .withDescription(
+                            "The mode used by StaticFileStoreSplitEnumerator to assign splits.");
+
     /* Sink writer allocate segments from managed memory. */
     public static final ConfigOption<Boolean> SINK_USE_MANAGED_MEMORY =
             ConfigOptions.key("sink.use-managed-memory-allocator")
@@ -230,6 +237,36 @@ public class FlinkConnectorOptions {
         private final String description;
 
         WatermarkEmitStrategy(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /**
+     * Split assign mode for {@link org.apache.paimon.flink.source.StaticFileStoreSplitEnumerator}.
+     */
+    public enum SplitAssignMode implements DescribedEnum {
+        FAIR(
+                "fair",
+                "Distribute splits evenly when batch reading to prevent a few tasks from reading all."),
+        PREEMPTIVE(
+                "preemptive",
+                "Distribute splits preemptively according to the consumption speed of the task.");
+
+        private final String value;
+        private final String description;
+
+        SplitAssignMode(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.source;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.LogicalTypeConversion;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
@@ -101,13 +102,12 @@ public class CompactorSourceBuilder {
         } else {
             bucketsTable = bucketsTable.copy(batchCompactOptions());
             ReadBuilder readBuilder = bucketsTable.newReadBuilder().withFilter(partitionPredicate);
+            Options options = bucketsTable.coreOptions().toConfiguration();
             return new StaticFileStoreSource(
                     readBuilder,
                     null,
-                    bucketsTable
-                            .coreOptions()
-                            .toConfiguration()
-                            .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE));
+                    options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
+                    options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE));
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -123,12 +123,13 @@ public class FlinkSourceBuilder {
     }
 
     private DataStream<RowData> buildStaticFileSource() {
+        Options options = Options.fromMap(table.options());
         return toDataStream(
                 new StaticFileStoreSource(
                         createReadBuilder(),
                         limit,
-                        Options.fromMap(table.options())
-                                .get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE)));
+                        options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
+                        options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE)));
     }
 
     private DataStream<RowData> buildContinuousFileSource() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
@@ -128,8 +128,11 @@ public class LogHybridSourceFactory
             return new StaticFileStoreSplitEnumerator(
                     context,
                     snapshot,
-                    splits,
-                    options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE));
+                    StaticFileStoreSource.createSplitAssigner(
+                            context,
+                            options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
+                            options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE),
+                            splits));
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import static org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
 
@@ -97,11 +96,12 @@ public class StaticFileStoreSource extends FlinkSource {
         }
     }
 
-    private static Map<Integer, Queue<FileStoreSourceSplit>> createSplitAssignment(
+    private static Map<Integer, LinkedList<FileStoreSourceSplit>> createSplitAssignment(
             Collection<FileStoreSourceSplit> splits, int numReaders) {
         List<List<FileStoreSourceSplit>> assignmentList =
-                BinPacking.packForFixedBinNumber(splits, split -> split.split().rowCount(), numReaders);
-        Map<Integer, Queue<FileStoreSourceSplit>> assignment = new HashMap<>();
+                BinPacking.packForFixedBinNumber(
+                        splits, split -> split.split().rowCount(), numReaders);
+        Map<Integer, LinkedList<FileStoreSourceSplit>> assignment = new HashMap<>();
         for (int i = 0; i < assignmentList.size(); i++) {
             assignment.put(i, new LinkedList<>(assignmentList.get(i)));
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -18,7 +18,11 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.flink.source.assigners.FairSplitAssigner;
+import org.apache.paimon.flink.source.assigners.PreemptiveSplitAssigner;
+import org.apache.paimon.flink.source.assigners.SplitAssigner;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.utils.BinPacking;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
@@ -27,7 +31,13 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
 
 /** Bounded {@link FlinkSource} for reading records. It does not monitor new snapshots. */
 public class StaticFileStoreSource extends FlinkSource {
@@ -36,10 +46,16 @@ public class StaticFileStoreSource extends FlinkSource {
 
     private final int splitBatchSize;
 
+    private final SplitAssignMode splitAssignMode;
+
     public StaticFileStoreSource(
-            ReadBuilder readBuilder, @Nullable Long limit, int splitBatchSize) {
+            ReadBuilder readBuilder,
+            @Nullable Long limit,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode) {
         super(readBuilder, limit);
         this.splitBatchSize = splitBatchSize;
+        this.splitAssignMode = splitAssignMode;
     }
 
     @Override
@@ -53,11 +69,42 @@ public class StaticFileStoreSource extends FlinkSource {
             PendingSplitsCheckpoint checkpoint) {
         Collection<FileStoreSourceSplit> splits =
                 checkpoint == null ? getSplits() : checkpoint.splits();
-        return new StaticFileStoreSplitEnumerator(context, null, splits, splitBatchSize);
+        SplitAssigner splitAssigner =
+                createSplitAssigner(context, splitBatchSize, splitAssignMode, splits);
+        return new StaticFileStoreSplitEnumerator(context, null, splitAssigner);
     }
 
     private List<FileStoreSourceSplit> getSplits() {
         FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
         return splitGenerator.createSplits(readBuilder.newScan().plan());
+    }
+
+    public static SplitAssigner createSplitAssigner(
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            Collection<FileStoreSourceSplit> splits) {
+        switch (splitAssignMode) {
+            case FAIR:
+                return new FairSplitAssigner(
+                        splitBatchSize,
+                        createSplitAssignment(splits, context.currentParallelism()));
+            case PREEMPTIVE:
+                return new PreemptiveSplitAssigner(new LinkedList<>(splits));
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported assign mode " + splitAssignMode.toString());
+        }
+    }
+
+    private static Map<Integer, Queue<FileStoreSourceSplit>> createSplitAssignment(
+            Collection<FileStoreSourceSplit> splits, int numReaders) {
+        List<List<FileStoreSourceSplit>> assignmentList =
+                BinPacking.packForFixedBinNumber(splits, split -> split.split().rowCount(), numReaders);
+        Map<Integer, Queue<FileStoreSourceSplit>> assignment = new HashMap<>();
+        for (int i = 0; i < assignmentList.size(); i++) {
+            assignment.put(i, new LinkedList<>(assignmentList.get(i)));
+        }
+        return assignment;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.source;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.utils.BinPacking;
+import org.apache.paimon.flink.source.assigners.SplitAssigner;
 
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
@@ -27,14 +27,8 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Queue;
 
 /** A {@link SplitEnumerator} implementation for {@link StaticFileStoreSource} input. */
 public class StaticFileStoreSplitEnumerator
@@ -44,32 +38,15 @@ public class StaticFileStoreSplitEnumerator
 
     @Nullable private final Snapshot snapshot;
 
-    /** Default batch splits size to avoid exceed `akka.framesize`. */
-    private final int splitBatchSize;
-
-    private final Map<Integer, Queue<FileStoreSourceSplit>> pendingSplitAssignment;
+    private final SplitAssigner splitAssigner;
 
     public StaticFileStoreSplitEnumerator(
             SplitEnumeratorContext<FileStoreSourceSplit> context,
             @Nullable Snapshot snapshot,
-            Collection<FileStoreSourceSplit> splits,
-            int splitBatchSize) {
+            SplitAssigner splitAssigner) {
         this.context = context;
         this.snapshot = snapshot;
-        this.pendingSplitAssignment = createSplitAssignment(splits, context.currentParallelism());
-        this.splitBatchSize = splitBatchSize;
-    }
-
-    private static Map<Integer, Queue<FileStoreSourceSplit>> createSplitAssignment(
-            Collection<FileStoreSourceSplit> splits, int numReaders) {
-        List<List<FileStoreSourceSplit>> assignmentList =
-                BinPacking.packForFixedBinNumber(
-                        splits, split -> split.split().rowCount(), numReaders);
-        Map<Integer, Queue<FileStoreSourceSplit>> assignment = new HashMap<>();
-        for (int i = 0; i < assignmentList.size(); i++) {
-            assignment.put(i, new LinkedList<>(assignmentList.get(i)));
-        }
-        return assignment;
+        this.splitAssigner = splitAssigner;
     }
 
     @Override
@@ -84,14 +61,7 @@ public class StaticFileStoreSplitEnumerator
             return;
         }
 
-        // The following batch assignment operation is for two purposes:
-        // To distribute splits evenly when batch reading to prevent a few tasks from reading all
-        // the data (for example, the current resource can only schedule part of the tasks).
-        Queue<FileStoreSourceSplit> taskSplits = pendingSplitAssignment.get(subtask);
-        List<FileStoreSourceSplit> assignment = new ArrayList<>();
-        while (taskSplits != null && !taskSplits.isEmpty() && assignment.size() < splitBatchSize) {
-            assignment.add(taskSplits.poll());
-        }
+        List<FileStoreSourceSplit> assignment = splitAssigner.getNext(subtask, hostname);
         if (assignment.size() > 0) {
             context.assignSplits(
                     new SplitsAssignment<>(Collections.singletonMap(subtask, assignment)));
@@ -102,9 +72,7 @@ public class StaticFileStoreSplitEnumerator
 
     @Override
     public void addSplitsBack(List<FileStoreSourceSplit> backSplits, int subtaskId) {
-        pendingSplitAssignment
-                .computeIfAbsent(subtaskId, k -> new LinkedList<>())
-                .addAll(backSplits);
+        splitAssigner.addSplits(subtaskId, backSplits);
     }
 
     @Override
@@ -114,9 +82,8 @@ public class StaticFileStoreSplitEnumerator
 
     @Override
     public PendingSplitsCheckpoint snapshotState(long checkpointId) {
-        List<FileStoreSourceSplit> splits = new ArrayList<>();
-        pendingSplitAssignment.values().forEach(splits::addAll);
-        return new PendingSplitsCheckpoint(splits, snapshot == null ? null : snapshot.id());
+        return new PendingSplitsCheckpoint(
+                splitAssigner.remainingSplits(), snapshot == null ? null : snapshot.id());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/FairSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/FairSplitAssigner.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.assigners;
+
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+/**
+ * Pre-calculate which splits each task should process according to the weight, and then distribute
+ * the splits fairly.
+ */
+public class FairSplitAssigner implements SplitAssigner {
+
+    /** Default batch splits size to avoid exceed `akka.framesize`. */
+    private final int splitBatchSize;
+
+    private final Map<Integer, Queue<FileStoreSourceSplit>> pendingSplitAssignment;
+
+    public FairSplitAssigner(
+            int splitBatchSize, Map<Integer, Queue<FileStoreSourceSplit>> pendingSplitAssignment) {
+        this.splitBatchSize = splitBatchSize;
+        this.pendingSplitAssignment = pendingSplitAssignment;
+    }
+
+    @Override
+    public List<FileStoreSourceSplit> getNext(int subtask, @Nullable String hostname) {
+        // The following batch assignment operation is for two purposes:
+        // To distribute splits evenly when batch reading to prevent a few tasks from reading all
+        // the data (for example, the current resource can only schedule part of the tasks).
+        Queue<FileStoreSourceSplit> taskSplits = pendingSplitAssignment.get(subtask);
+        List<FileStoreSourceSplit> assignment = new ArrayList<>();
+        while (taskSplits != null && !taskSplits.isEmpty() && assignment.size() < splitBatchSize) {
+            assignment.add(taskSplits.poll());
+        }
+        return assignment;
+    }
+
+    @Override
+    public void addSplits(int subtask, List<FileStoreSourceSplit> splits) {
+        pendingSplitAssignment.computeIfAbsent(subtask, k -> new LinkedList<>()).addAll(splits);
+    }
+
+    @Override
+    public Collection<FileStoreSourceSplit> remainingSplits() {
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        pendingSplitAssignment.values().forEach(splits::addAll);
+        return splits;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreemptiveSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreemptiveSplitAssigner.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.assigners;
+
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Queue;
+
+/**
+ * Splits are assigned preemptively in the order requested by the task. Only one split is assigned
+ * to the task at a time.
+ */
+public class PreemptiveSplitAssigner implements SplitAssigner {
+
+    private final LinkedList<FileStoreSourceSplit> pendingSplitAssignment;
+
+    public PreemptiveSplitAssigner(Queue<FileStoreSourceSplit> splits) {
+        this.pendingSplitAssignment = new LinkedList<>(splits);
+    }
+
+    @Override
+    public List<FileStoreSourceSplit> getNext(int subtask, @Nullable String hostname) {
+        FileStoreSourceSplit split = pendingSplitAssignment.poll();
+        return split == null ? Collections.emptyList() : Collections.singletonList(split);
+    }
+
+    @Override
+    public void addSplits(int subtask, List<FileStoreSourceSplit> splits) {
+        ListIterator<FileStoreSourceSplit> iterator = splits.listIterator(splits.size());
+        while (iterator.hasPrevious()) {
+            pendingSplitAssignment.addFirst(iterator.previous());
+        }
+    }
+
+    @Override
+    public Collection<FileStoreSourceSplit> remainingSplits() {
+        return new ArrayList<>(pendingSplitAssignment);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/SplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/SplitAssigner.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.assigners;
+
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The {@code SplitAssigner} is responsible for deciding what splits should be processed next by
+ * which node. It determines split processing order and locality.
+ */
+public interface SplitAssigner {
+
+    /**
+     * Gets the next split.
+     *
+     * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
+     * be done and the source will finish once the readers finished their current splits.
+     */
+    List<FileStoreSourceSplit> getNext(int subtask, @Nullable String hostname);
+
+    /**
+     * Adds a set of splits to this assigner. This happens for example when some split processing
+     * failed and the splits need to be re-added, or when new splits got discovered.
+     */
+    void addSplits(int subtask, List<FileStoreSourceSplit> splits);
+
+    /** Gets the remaining splits that this assigner has pending. */
+    Collection<FileStoreSourceSplit> remainingSplits();
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/PreemptiveAssignModeTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/PreemptiveAssignModeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
+import static org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
+import static org.apache.paimon.flink.source.ContinuousFileSplitEnumeratorTest.createSnapshotSplit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link StaticFileStoreSplitEnumerator} with {@link SplitAssignMode#PREEMPTIVE}. */
+public class PreemptiveAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
+
+    @Test
+    public void testSplitAllocation() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(2);
+
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+        StaticFileStoreSplitEnumerator enumerator = getSplitEnumerator(context, splits);
+
+        // test assign
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(0, 1);
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(0));
+        assertThat(assignments.get(1).getAssignedSplits()).containsExactly(splits.get(1));
+        assertThat(enumerator.snapshotState(1L).splits())
+                .containsExactly(splits.get(2), splits.get(3));
+
+        // test addSplitsBack
+        enumerator.addSplitsBack(assignments.get(0).getAssignedSplits(), 0);
+        context.getSplitAssignments().clear();
+        assertThat(context.getSplitAssignments()).isEmpty();
+        assertThat(enumerator.snapshotState(2L).splits())
+                .containsExactly(splits.get(0), splits.get(2), splits.get(3));
+        enumerator.handleSplitRequest(0, "test-host");
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(0));
+
+        // test preemptive assign
+        context.getSplitAssignments().clear();
+        enumerator.handleSplitRequest(0, "test-host");
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(2));
+        assertThat(enumerator.snapshotState(3L).splits()).containsExactly(splits.get(3));
+        context.getSplitAssignments().clear();
+        enumerator.handleSplitRequest(0, "test-host");
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(3));
+        assertThat(enumerator.snapshotState(4L).splits()).isEmpty();
+    }
+
+    @Override
+    protected SplitAssignMode splitAssignMode() {
+        return SplitAssignMode.PREEMPTIVE;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumeratorTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumeratorTestBase.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.flink.FlinkConnectorOptions;
+
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+
+import java.util.List;
+
+import static org.apache.paimon.flink.source.StaticFileStoreSource.createSplitAssigner;
+
+/** Base test class of {@link StaticFileStoreSplitEnumerator}. */
+public abstract class StaticFileStoreSplitEnumeratorTestBase {
+
+    protected TestingSplitEnumeratorContext<FileStoreSourceSplit> getSplitEnumeratorContext(
+            int parallelism) {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(parallelism);
+        for (int i = 0; i < parallelism; i++) {
+            context.registerReader(i, "test-host");
+        }
+        return context;
+    }
+
+    protected StaticFileStoreSplitEnumerator getSplitEnumerator(
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            List<FileStoreSourceSplit> splits) {
+        return new StaticFileStoreSplitEnumerator(
+                context, null, createSplitAssigner(context, 10, splitAssignMode(), splits));
+    }
+
+    protected abstract FlinkConnectorOptions.SplitAssignMode splitAssignMode();
+}


### PR DESCRIPTION


### Purpose

Provide a mode to fall back to the previous preemptive mode in `StaticFileStoreSplitEnumerator`. closes #851 

### Tests

Added `org.apache.paimon.flink.source.PreemptiveAssignModeTest` to verify the correctness of preemptive mode.

### API and Format

No.

### Documentation

No.
