### PR TITLE
[bug] bugfix: packing return one empty list

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinPacking.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinPacking.java
@@ -39,7 +39,9 @@ public class BinPacking {
 
         for (T item : items) {
             long weight = weightFunc.apply(item);
-            if (binWeight + weight > targetWeight) {
+            // when get a much big item or total weight enough, we check the binItems size. If
+            // greater than zero, we pack it
+            if (binWeight + weight > targetWeight && binItems.size() > 0) {
                 packed.add(binItems);
                 binItems = new ArrayList<>();
                 binWeight = 0;

--- a/paimon-common/src/test/java/org/apache/paimon/utils/BinPackingTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/BinPackingTest.java
@@ -37,4 +37,13 @@ public class BinPackingTest {
                 .containsExactlyInAnyOrder(
                         Arrays.asList(1, 3), Arrays.asList(2, 5), Arrays.asList(1, 2, 6));
     }
+
+    @Test
+    public void testExactlyPack() {
+        List<Pair<String, Long>> items =
+                Arrays.asList(Pair.of("a", 1000L), Pair.of("b", 20L), Pair.of("c", 200L));
+        List<List<Pair<String, Long>>> packed =
+                BinPacking.packForOrdered(items, Pair<String, Long>::getRight, 800);
+        assertThat(packed.size()).isEqualTo(2);
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/OrderedPackingTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/OrderedPackingTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Tests for {@link OrderedPacking}. */
+public class OrderedPackingTest {
+    @Test
+    public void testExactlyPack() {
+        List<Pair<String, Long>> items =
+                Arrays.asList(Pair.of("a", 1000L), Pair.of("b", 20L), Pair.of("c", 200L));
+        List<List<Pair<String, Long>>> packed =
+                OrderedPacking.pack(items, Pair<String, Long>::getRight, 800);
+        Assertions.assertEquals(packed.size(), 2);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The packing method will return one empty list while binItems is empty and the next file weight is bigger than targetWeight.
e.g   The first item weight is 500, the target is 400, then this method will pack a redundant empty list.
We need to check binItems' size

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
