### PR TITLE
[bug] bugfix: packing return one empty list

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinPacking.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinPacking.java
@@ -39,7 +39,9 @@ public class BinPacking {
 
         for (T item : items) {
             long weight = weightFunc.apply(item);
-            if (binWeight + weight > targetWeight) {
+            // when get a much big item or total weight enough, we check the binItems size. If
+            // greater than zero, we pack it
+            if (binWeight + weight > targetWeight && binItems.size() > 0) {
                 packed.add(binItems);
                 binItems = new ArrayList<>();
                 binWeight = 0;

--- a/paimon-common/src/test/java/org/apache/paimon/utils/BinPackingTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/BinPackingTest.java
@@ -37,4 +37,13 @@ public class BinPackingTest {
                 .containsExactlyInAnyOrder(
                         Arrays.asList(1, 3), Arrays.asList(2, 5), Arrays.asList(1, 2, 6));
     }
+
+    @Test
+    public void testExactlyPack() {
+        List<Pair<String, Long>> items =
+                Arrays.asList(Pair.of("a", 1000L), Pair.of("b", 20L), Pair.of("c", 200L));
+        List<List<Pair<String, Long>>> packed =
+                BinPacking.packForOrdered(items, Pair<String, Long>::getRight, 800);
+        assertThat(packed.size()).isEqualTo(2);
+    }
 }


### PR DESCRIPTION

### Purpose

The packing method will return one empty list while binItems is empty and the next file weight is bigger than targetWeight.
e.g The first item weight is 500, the target is 400, then this method will pack a redundant empty list.
We need to check binItems' size


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
