### PR TITLE
[core] rename withOverwrite to fromEmptyWriter

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -67,7 +67,7 @@ public abstract class AbstractFileStoreWrite<T>
     protected final Map<BinaryRow, Map<Integer, WriterContainer<T>>> writers;
 
     private ExecutorService lazyCompactExecutor;
-    private boolean overwrite = false;
+    private boolean emptyWriter = false;
 
     protected AbstractFileStoreWrite(
             String commitUser, SnapshotManager snapshotManager, FileStoreScan scan) {
@@ -89,8 +89,9 @@ public abstract class AbstractFileStoreWrite<T>
         return this;
     }
 
-    public void withOverwrite(boolean overwrite) {
-        this.overwrite = overwrite;
+    @Override
+    public void fromEmptyWriter(boolean emptyWriter) {
+        this.emptyWriter = emptyWriter;
     }
 
     @Override
@@ -286,7 +287,7 @@ public abstract class AbstractFileStoreWrite<T>
             writers.put(partition.copy(), buckets);
         }
         return buckets.computeIfAbsent(
-                bucket, k -> createWriterContainer(partition.copy(), bucket, overwrite));
+                bucket, k -> createWriterContainer(partition.copy(), bucket, emptyWriter));
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -47,11 +47,11 @@ public interface FileStoreWrite<T> {
     FileStoreWrite<T> withMemoryPool(MemorySegmentPool memoryPool);
 
     /**
-     * If overwrite is true, the writer will overwrite the store, otherwise it won't.
+     * Set writer to be empty, the writer will not search restored files.
      *
-     * @param overwrite the overwrite flag
+     * @param emptyWriter set flag to tag the writer is empty.
      */
-    void withOverwrite(boolean overwrite);
+    void fromEmptyWriter(boolean emptyWriter);
 
     /**
      * Write the data to the store according to the partition and bucket.

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
@@ -58,7 +58,7 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
 
     @Override
     public BatchTableWrite newWrite() {
-        return table.newWrite(commitUser).withOverwrite(staticPartition != null);
+        return table.newWrite(commitUser).fromEmptyWriter(staticPartition != null);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
@@ -21,5 +21,5 @@ package org.apache.paimon.table.sink;
 /** Inner {@link TableWrite} contains overwrite setter. */
 public interface InnerTableWrite extends StreamTableWrite, BatchTableWrite {
 
-    InnerTableWrite withOverwrite(boolean overwrite);
+    InnerTableWrite fromEmptyWriter(boolean emptyWriter);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -56,8 +56,8 @@ public class TableWriteImpl<T>
     }
 
     @Override
-    public TableWriteImpl<T> withOverwrite(boolean overwrite) {
-        write.withOverwrite(overwrite);
+    public TableWriteImpl<T> fromEmptyWriter(boolean emptyWriter) {
+        write.fromEmptyWriter(emptyWriter);
         return this;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -281,7 +281,7 @@ public abstract class FileStoreTableTestBase {
         }
 
         // overwrite data
-        try (StreamTableWrite write = table.newWrite(commitUser).withOverwrite(true);
+        try (StreamTableWrite write = table.newWrite(commitUser).fromEmptyWriter(true);
                 InnerTableCommit commit = table.newCommit(commitUser)) {
             for (InternalRow row : overwriteData) {
                 write.write(row);
@@ -313,7 +313,7 @@ public abstract class FileStoreTableTestBase {
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
 
-        write = table.newWrite(commitUser).withOverwrite(true);
+        write = table.newWrite(commitUser).fromEmptyWriter(true);
         commit = table.newCommit(commitUser);
         write.write(rowData(2, 21, 201L));
         Map<String, String> overwritePartition = new HashMap<>();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
@@ -67,7 +67,7 @@ public class ContinuousCompactorFollowUpScannerTest extends ScannerTestBase {
 
         Map<String, String> overwritePartition = new HashMap<>();
         overwritePartition.put("pt", "1");
-        write = table.newWrite(commitUser).withOverwrite(true);
+        write = table.newWrite(commitUser).fromEmptyWriter(true);
         commit = table.newCommit(commitUser).withOverwrite(overwritePartition);
         write.write(rowData(1, 10, 101L));
         write.write(rowData(1, 20, 201L));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -48,7 +48,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
     protected final String commitUser;
     protected final StoreSinkWriteState state;
     private final IOManager ioManager;
-    private final boolean isOverwrite;
+    private final boolean emptyWriter;
     private final boolean waitCompaction;
     @Nullable private final MemorySegmentPool memoryPool;
 
@@ -59,13 +59,13 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
             String commitUser,
             StoreSinkWriteState state,
             IOManager ioManager,
-            boolean isOverwrite,
+            boolean emptyWriter,
             boolean waitCompaction,
             @Nullable MemorySegmentPool memoryPool) {
         this.commitUser = commitUser;
         this.state = state;
         this.ioManager = ioManager;
-        this.isOverwrite = isOverwrite;
+        this.emptyWriter = emptyWriter;
         this.waitCompaction = waitCompaction;
         this.memoryPool = memoryPool;
         this.write = newTableWrite(table);
@@ -83,7 +83,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                                 : new HeapMemorySegmentPool(
                                         table.coreOptions().writeBufferSize(),
                                         table.coreOptions().pageSize()))
-                .withOverwrite(isOverwrite);
+                .fromEmptyWriter(emptyWriter);
     }
 
     @Override


### PR DESCRIPTION
In writers, the overwrite flag does not overwrite actually. It just don't scan restored files, so empty writer is a more suitable name maybe. 

This pull request shift name withOverWrite to fromEmptyWriter.

