### PR TITLE
[flink] Avoid FileNotFoundException in snapshot loop

### DIFF
--- a/docs/content/maintenance/read-performance.md
+++ b/docs/content/maintenance/read-performance.md
@@ -31,9 +31,6 @@ under the License.
 Configure 'full-compaction.delta-commits' perform full-compaction periodically in Flink writing.
 And it can ensure that partitions are full compacted before writing ends.
 
-It is not recommended to set a value that exceeds the snapshot expiration time (default 1 hour). For example,
-if your checkpoint interval is 1 minute, it is recommended to set the 'full-compaction.delta-commits' to 30.
-
 ### Primary Key Table
 
 For Primary Key Table, it's a 'MergeOnRead' technology. When reading data, multiple layers of LSM data are merged,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -160,6 +160,10 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
     }
 
     private void checkSuccessfulFullCompaction() {
+        if (commitIdentifiersToCheck.isEmpty()) {
+            return;
+        }
+
         snapshotManager.traversalSnapshotsFromLatestSafely(this::checkSuccessfulFullCompaction);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -172,21 +172,15 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
                 && snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
             long commitIdentifier = snapshot.commitIdentifier();
             if (commitIdentifiersToCheck.contains(commitIdentifier)) {
-                // We found a full compaction snapshot triggered by
-                // `submitFullCompaction`
-                // method.
+                // We found a full compaction snapshot triggered by `submitFullCompaction` method.
                 //
-                // Because `submitFullCompaction` will compact all buckets in
-                // `writtenBuckets`,
-                // thus a successful commit indicates that all previous buckets have
-                // been
-                // compacted.
+                // Because `submitFullCompaction` will compact all buckets in `writtenBuckets`, thus
+                // a successful commit indicates that all previous buckets have been compacted.
                 //
                 // We must make sure that the compact snapshot is triggered by
-                // `submitFullCompaction`, because normal compaction may also trigger
-                // full
-                // compaction, but that only compacts a specific bucket, not all buckets
-                // recorded in `writtenBuckets`.
+                // `submitFullCompaction`, because normal compaction may also trigger full
+                // compaction, but that only compacts a specific bucket, not all buckets recorded in
+                // `writtenBuckets`.
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(
                             "Found full compaction snapshot #{} with identifier {}",

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -160,44 +160,41 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
     }
 
     private void checkSuccessfulFullCompaction() {
-        Long latestId = snapshotManager.latestSnapshotId();
-        if (latestId == null) {
-            return;
-        }
-        Long earliestId = snapshotManager.earliestSnapshotId();
-        if (earliestId == null) {
-            return;
-        }
+        snapshotManager.traversalSnapshotsFromLatestSafely(this::checkSuccessfulFullCompaction);
+    }
 
-        for (long id = latestId; id >= earliestId; id--) {
-            Snapshot snapshot = snapshotManager.snapshot(id);
-            if (snapshot.commitUser().equals(commitUser)
-                    && snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
-                long commitIdentifier = snapshot.commitIdentifier();
-                if (commitIdentifiersToCheck.contains(commitIdentifier)) {
-                    // We found a full compaction snapshot triggered by `submitFullCompaction`
-                    // method.
-                    //
-                    // Because `submitFullCompaction` will compact all buckets in `writtenBuckets`,
-                    // thus a successful commit indicates that all previous buckets have been
-                    // compacted.
-                    //
-                    // We must make sure that the compact snapshot is triggered by
-                    // `submitFullCompaction`, because normal compaction may also trigger full
-                    // compaction, but that only compacts a specific bucket, not all buckets
-                    // recorded in `writtenBuckets`.
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Found full compaction snapshot #{} with identifier {}",
-                                id,
-                                commitIdentifier);
-                    }
-                    writtenBuckets.headMap(commitIdentifier, true).clear();
-                    commitIdentifiersToCheck.headSet(commitIdentifier).clear();
-                    break;
+    private boolean checkSuccessfulFullCompaction(Snapshot snapshot) {
+        if (snapshot.commitUser().equals(commitUser)
+                && snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+            long commitIdentifier = snapshot.commitIdentifier();
+            if (commitIdentifiersToCheck.contains(commitIdentifier)) {
+                // We found a full compaction snapshot triggered by
+                // `submitFullCompaction`
+                // method.
+                //
+                // Because `submitFullCompaction` will compact all buckets in
+                // `writtenBuckets`,
+                // thus a successful commit indicates that all previous buckets have
+                // been
+                // compacted.
+                //
+                // We must make sure that the compact snapshot is triggered by
+                // `submitFullCompaction`, because normal compaction may also trigger
+                // full
+                // compaction, but that only compacts a specific bucket, not all buckets
+                // recorded in `writtenBuckets`.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Found full compaction snapshot #{} with identifier {}",
+                            snapshot.id(),
+                            commitIdentifier);
                 }
+                writtenBuckets.headMap(commitIdentifier, true).clear();
+                commitIdentifiersToCheck.headSet(commitIdentifier).clear();
+                return true;
             }
         }
+        return false;
     }
 
     private void submitFullCompaction(long currentCheckpointId) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1302

After modifying this to safely loop, we can remove limitation in documentation, users can set a free full compaction commits delta.

<!-- What is the purpose of the change -->

### Tests

`SnapshotManagerTest.testTraversalSnapshotsFromLatestSafely`.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
