### PR TITLE
[core] add scan type for non-bucket compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -611,13 +611,12 @@ public class CoreOptions implements Serializable {
                             "Full compaction will be constantly triggered after delta commits.");
 
     @ExcludeFromDocumentation("Internal use only")
-    public static final ConfigOption<Boolean> STREAMING_COMPACT =
+    public static final ConfigOption<StreamingCompactionType> STREAMING_COMPACT =
             key("streaming-compact")
-                    .booleanType()
-                    .defaultValue(false)
+                    .enumType(StreamingCompactionType.class)
+                    .defaultValue(StreamingCompactionType.NONE)
                     .withDescription(
-                            "Only used to force TableScan to construct 'ContinuousCompactorStartingScanner' and "
-                                    + "'ContinuousCompactorFollowUpScanner' for dedicated streaming compaction job.");
+                            "Only used to force TableScan to construct suitable 'StartingUpScanner' and 'FollowUpScanner' dedicated streaming compaction job.");
 
     public static final ConfigOption<StreamingReadMode> STREAMING_READ_MODE =
             key("streaming-read-mode")
@@ -1199,6 +1198,51 @@ public class CoreOptions implements Serializable {
                             value,
                             StringUtils.join(
                                     Arrays.stream(StreamingReadMode.values()).iterator(), ",")));
+        }
+    }
+
+    /** Compaction type when trigger a compaction action. */
+    public enum StreamingCompactionType implements DescribedEnum {
+        NONE("none", "not a streaming compaction."),
+        NORMAL("normal", "Traditional bucket table compaction."),
+        NON_BUCKET("non-bucket", "Compaction for non-bucket table.");
+
+        private final String value;
+        private final String description;
+
+        StreamingCompactionType(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @VisibleForTesting
+        public static StreamingCompactionType fromValue(String value) {
+            for (StreamingCompactionType formatType : StreamingCompactionType.values()) {
+                if (formatType.value.equals(value)) {
+                    return formatType;
+                }
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Invalid format type %s, only support [%s]",
+                            value,
+                            StringUtils.join(
+                                    Arrays.stream(StreamingCompactionType.values()).iterator(),
+                                    ",")));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -65,14 +65,20 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
     }
 
     protected StartingScanner createStartingScanner(boolean isStreaming) {
-        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
-                == CoreOptions.StreamingCompactionType.NORMAL) {
-            Preconditions.checkArgument(
-                    isStreaming, "Set 'streaming-compact' in batch mode. This is unexpected.");
-            return new ContinuousCompactorStartingScanner();
-        } else if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
-                == CoreOptions.StreamingCompactionType.NON_BUCKET) {
-            return new FullStartingScanner();
+        CoreOptions.StreamingCompactionType type =
+                options.toConfiguration().get(CoreOptions.STREAMING_COMPACT);
+        switch (type) {
+            case NORMAL:
+                {
+                    Preconditions.checkArgument(
+                            isStreaming,
+                            "Set 'streaming-compact' in batch mode. This is unexpected.");
+                    return new ContinuousCompactorStartingScanner();
+                }
+            case NON_BUCKET:
+                {
+                    return new FullStartingScanner();
+                }
         }
 
         // read from consumer id

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -65,10 +65,14 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
     }
 
     protected StartingScanner createStartingScanner(boolean isStreaming) {
-        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)) {
+        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
+                == CoreOptions.StreamingCompactionType.NORMAL) {
             Preconditions.checkArgument(
                     isStreaming, "Set 'streaming-compact' in batch mode. This is unexpected.");
             return new ContinuousCompactorStartingScanner();
+        } else if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
+                == CoreOptions.StreamingCompactionType.NON_BUCKET) {
+            return new FullStartingScanner();
         }
 
         // read from consumer id

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -158,12 +158,17 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
     }
 
     private FollowUpScanner createFollowUpScanner() {
-        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
-                == CoreOptions.StreamingCompactionType.NORMAL) {
-            return new ContinuousCompactorFollowUpScanner();
-        } else if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
-                == CoreOptions.StreamingCompactionType.NON_BUCKET) {
-            return new ContinuousAppendAndCompactFollowUpScanner();
+        CoreOptions.StreamingCompactionType type =
+                options.toConfiguration().get(CoreOptions.STREAMING_COMPACT);
+        switch (type) {
+            case NORMAL:
+                {
+                    return new ContinuousCompactorFollowUpScanner();
+                }
+            case NON_BUCKET:
+                {
+                    return new ContinuousAppendAndCompactFollowUpScanner();
+                }
         }
 
         CoreOptions.ChangelogProducer changelogProducer = options.changelogProducer();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -24,6 +24,7 @@ import org.apache.paimon.consumer.Consumer;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.source.snapshot.BoundedChecker;
 import org.apache.paimon.table.source.snapshot.CompactionChangelogFollowUpScanner;
+import org.apache.paimon.table.source.snapshot.ContinuousAppendAndCompactFollowUpScanner;
 import org.apache.paimon.table.source.snapshot.ContinuousCompactorFollowUpScanner;
 import org.apache.paimon.table.source.snapshot.DeltaFollowUpScanner;
 import org.apache.paimon.table.source.snapshot.FollowUpScanner;
@@ -157,8 +158,12 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
     }
 
     private FollowUpScanner createFollowUpScanner() {
-        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)) {
+        if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
+                == CoreOptions.StreamingCompactionType.NORMAL) {
             return new ContinuousCompactorFollowUpScanner();
+        } else if (options.toConfiguration().get(CoreOptions.STREAMING_COMPACT)
+                == CoreOptions.StreamingCompactionType.NON_BUCKET) {
+            return new ContinuousAppendAndCompactFollowUpScanner();
         }
 
         CoreOptions.ChangelogProducer changelogProducer = options.changelogProducer();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source.snapshot;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.DataFilePlan;
+import org.apache.paimon.table.source.TableScan;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link FollowUpScanner} used internally for stand-alone streaming compact job sources when table
+ * is non-bucket.
+ */
+public class ContinuousAppendAndCompactFollowUpScanner implements FollowUpScanner {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ContinuousAppendAndCompactFollowUpScanner.class);
+
+    @Override
+    public boolean shouldScanSnapshot(Snapshot snapshot) {
+        if (snapshot.commitKind() == Snapshot.CommitKind.APPEND
+                || snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+            return true;
+        }
+
+        LOG.debug(
+                "Next snapshot id {} is not APPEND or COMPACT, but is {}, check next one.",
+                snapshot.id(),
+                snapshot.commitKind());
+        return false;
+    }
+
+    @Override
+    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
+        return new DataFilePlan(
+                snapshotSplitReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).splits());
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ContinuousAppendAndCompactFollowUpScanner}. */
 public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBase {
+    
     private static final RowType ROW_TYPE =
             RowType.of(
                     new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ContinuousAppendAndCompactFollowUpScanner}. */
 public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBase {
-    
+
     private static final RowType ROW_TYPE =
             RowType.of(
                     new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -50,7 +50,7 @@ import java.util.List;
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link ContinuousCompactorFollowUpScanner}. */
+/** Tests for {@link ContinuousAppendAndCompactFollowUpScanner}. */
 public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBase {
     private static final RowType ROW_TYPE =
             RowType.of(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source.snapshot;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.StreamTableCommit;
+import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ContinuousCompactorFollowUpScanner}. */
+public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBase {
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
+                    new String[] {"a", "b", "c"});
+
+    private final DataFileMetaSerializer dataFileMetaSerializer = new DataFileMetaSerializer();
+
+    @Test
+    public void testScan() throws Exception {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(1, 20, 200L));
+        write.write(rowData(2, 40, 400L));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        List<CommitMessage> messageList = new ArrayList<>();
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(1, 20, 200L));
+        write.write(rowData(2, 40, 400L));
+        messageList.addAll(write.prepareCommit(true, 1));
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(1, 20, 200L));
+        messageList.addAll(write.prepareCommit(true, 1));
+        commit.commit(1, messageList);
+
+        write.compact(binaryRow(1), 0, true);
+        commit.commit(2, write.prepareCommit(true, 2));
+
+        write.close();
+        commit.close();
+
+        BucketsTable bucketsTable = new BucketsTable(table, true);
+        TableRead read = bucketsTable.newRead();
+        ContinuousAppendAndCompactFollowUpScanner scanner =
+                new ContinuousAppendAndCompactFollowUpScanner();
+
+        Snapshot snapshot = snapshotManager.snapshot(1);
+        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+        assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
+        TableScan.Plan plan = scanner.scan(1, snapshotSplitReader);
+        assertThat(getResult(read, plan.splits()))
+                .hasSameElementsAs(Arrays.asList("+I 1|1|0|1", "+I 1|2|0|1"));
+
+        snapshot = snapshotManager.snapshot(2);
+        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+        assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
+        plan = scanner.scan(2, snapshotSplitReader);
+        assertThat(getResult(read, plan.splits()))
+                .hasSameElementsAs(Arrays.asList("+I 2|1|0|2", "+I 2|2|0|1"));
+
+        snapshot = snapshotManager.snapshot(3);
+        assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
+        assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
+        plan = scanner.scan(3, snapshotSplitReader);
+        assertThat(getResult(read, plan.splits())).hasSameElementsAs(Arrays.asList("+I 3|1|0|1"));
+    }
+
+    @Override
+    protected String rowDataToString(InternalRow rowData) {
+        int numFiles;
+        try {
+            numFiles = dataFileMetaSerializer.deserializeList(rowData.getBinary(3)).size();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return String.format(
+                "%s %d|%d|%d|%d",
+                rowData.getRowKind().shortString(),
+                rowData.getLong(0),
+                deserializeBinaryRow(rowData.getBinary(1)).getInt(0),
+                rowData.getInt(2),
+                numFiles);
+    }
+
+    @Override
+    protected FileStoreTable createFileStoreTable(Options conf) throws Exception {
+        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
+        TableSchema tableSchema =
+                schemaManager.createTable(
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Collections.singletonList("a"),
+                                Collections.emptyList(),
+                                conf.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema, conf);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -129,7 +129,7 @@ public class CompactorSourceBuilder {
         // set 'streaming-compact' and remove 'scan.bounded.watermark'
         return new HashMap<String, String>() {
             {
-                put(CoreOptions.STREAMING_COMPACT.key(), "true");
+                put(CoreOptions.STREAMING_COMPACT.key(), "normal");
                 put(CoreOptions.SCAN_BOUNDED_WATERMARK.key(), null);
             }
         };


### PR DESCRIPTION
Add Scan Type "non-bucket" which is used for non-bucket compaction.

When we assigned "non-bucket", we will use 'FullStartingUpScanner' and 'ContinuousAppendAndCompactScanner' to invoke streaming scan. 