### PR TITLE
[core] Introduce IntHashSet and Int2ShortHashMap

### DIFF
--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -119,6 +119,12 @@ under the License.
             <version>${antlr4.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.5.12</version>
+        </dependency>
+
         <!-- Test -->
 
         <dependency>
@@ -249,6 +255,7 @@ under the License.
                                 <includes combine.children="append">
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.codehaus.janino:*</include>
+                                    <include>it.unimi.dsi:fastutil</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -274,6 +281,10 @@ under the License.
                                 <relocation>
                                     <pattern>org.codehaus.commons</pattern>
                                     <shadedPattern>org.apache.paimon.shade.org.codehaus.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>it.unimi.dsi.fastutil</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.it.unimi.dsi.fastutil</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/Int2ShortHashMap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Int2ShortHashMap.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import it.unimi.dsi.fastutil.ints.Int2ShortOpenHashMap;
+
+/** Int to short hash map. */
+public class Int2ShortHashMap {
+
+    private final Int2ShortOpenHashMap map;
+
+    public Int2ShortHashMap() {
+        this.map = new Int2ShortOpenHashMap();
+    }
+
+    public void put(int key, short value) {
+        map.put(key, value);
+    }
+
+    public boolean containsKey(int key) {
+        return map.containsKey(key);
+    }
+
+    public short get(int key) {
+        return map.get(key);
+    }
+
+    public int size() {
+        return map.size();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/IntHashSet.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IntHashSet.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+
+/** A hash set for ints. */
+public class IntHashSet {
+
+    private final IntOpenHashSet set;
+
+    public IntHashSet() {
+        this.set = new IntOpenHashSet();
+    }
+
+    public IntHashSet(int expected) {
+        this.set = new IntOpenHashSet(expected);
+    }
+
+    public void add(int value) {
+        set.add(value);
+    }
+
+    public int[] toSortedInts() {
+        int[] ints = set.toIntArray();
+        IntArrays.stableSort(ints);
+        return ints;
+    }
+}

--- a/paimon-common/src/main/resources/META-INF/NOTICE
+++ b/paimon-common/src/main/resources/META-INF/NOTICE
@@ -10,3 +10,4 @@ You find them under licenses/LICENSE.antlr-runtime and licenses/LICENSE.janino.
 - org.antlr:antlr4-runtime:4.7
 - org.codehaus.janino:janino:3.0.11
 - org.codehaus.janino:commons-compiler:3.0.11
+- it.unimi.dsi:fastutil:8.5.12

--- a/paimon-common/src/test/java/org/apache/paimon/utils/Int2ShortHashMapTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/Int2ShortHashMapTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link Int2ShortHashMap}. */
+public class Int2ShortHashMapTest {
+
+    @Test
+    public void testRandom() {
+        Map<Integer, Short> values = new HashMap<>();
+        Random rnd = new Random();
+        for (int i = 0; i < rnd.nextInt(100); i++) {
+            values.put(rnd.nextInt(), (short) rnd.nextInt());
+        }
+        if (rnd.nextBoolean()) {
+            values.put(0, (short) 0);
+            values.put(-1, (short) -1);
+            values.put(1, (short) 1);
+        }
+
+        Int2ShortHashMap map = new Int2ShortHashMap();
+        values.forEach(map::put);
+
+        assertThat(map.size()).isEqualTo(values.size());
+
+        values.forEach(
+                (k, v) -> {
+                    assertThat(map.containsKey(k)).isTrue();
+                    assertThat(map.get(k)).isEqualTo(v);
+                });
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/IntHashSetTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/IntHashSetTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link IntHashSet}. */
+public class IntHashSetTest {
+
+    @Test
+    public void testRandom() {
+        Set<Integer> values = new HashSet<>();
+        Random rnd = new Random();
+        for (int i = 0; i < rnd.nextInt(100); i++) {
+            values.add(rnd.nextInt());
+        }
+        if (rnd.nextBoolean()) {
+            values.add(0);
+            values.add(-1);
+            values.add(1);
+        }
+
+        IntHashSet set = new IntHashSet();
+        values.forEach(set::add);
+
+        int[] expected = values.stream().mapToInt(Integer::intValue).sorted().toArray();
+        assertThat(set.toSortedInts()).containsExactly(expected);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

They are used for dynamic bucket tables.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
