### PR TITLE
[core] Introduce index metadata

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/IntFileUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IntFileUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+
+import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
+import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/** File to store ints. */
+public class IntFileUtils {
+
+    public static IntIterator readInts(FileIO fileIO, Path path) throws IOException {
+        FastBufferedInputStream in = new FastBufferedInputStream(fileIO.newInputStream(path));
+        return new IntIterator() {
+
+            @Override
+            public int next() throws IOException {
+                return readInt(in);
+            }
+
+            @Override
+            public void close() throws IOException {
+                in.close();
+            }
+        };
+    }
+
+    public static void writeInts(FileIO fileIO, Path path, IntIterator input) throws IOException {
+        try (FastBufferedOutputStream out =
+                        new FastBufferedOutputStream(fileIO.newOutputStream(path, false));
+                IntIterator iterator = input) {
+            while (true) {
+                try {
+                    writeInt(out, iterator.next());
+                } catch (EOFException ignored) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private static int readInt(FastBufferedInputStream in) throws IOException {
+        int ch1 = in.read();
+        int ch2 = in.read();
+        int ch3 = in.read();
+        int ch4 = in.read();
+        if ((ch1 | ch2 | ch3 | ch4) < 0) {
+            throw new EOFException();
+        }
+        return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + ch4);
+    }
+
+    private static void writeInt(FastBufferedOutputStream out, int v) throws IOException {
+        out.write((v >>> 24) & 0xFF);
+        out.write((v >>> 16) & 0xFF);
+        out.write((v >>> 8) & 0xFF);
+        out.write(v & 0xFF);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/IntHashSetTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/IntHashSetTest.java
@@ -46,6 +46,6 @@ public class IntHashSetTest {
         values.forEach(set::add);
 
         int[] expected = values.stream().mapToInt(Integer::intValue).sorted().toArray();
-        assertThat(set.toSortedInts()).containsExactly(expected);
+        assertThat(set.toInts()).containsExactlyInAnyOrder(expected);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -125,10 +125,10 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
 
     @Override
     public IndexFileHandler newIndexFileHandler() {
-        HashIndexFile hashIndex =
-                new HashIndexFile.Factory(fileIO, options.fileFormat(), pathFactory()).create();
         return new IndexFileHandler(
-                snapshotManager(), indexManifestFileFactory().create(), hashIndex);
+                snapshotManager(),
+                indexManifestFileFactory().create(),
+                new HashIndexFile(fileIO, pathFactory().indexFileFactory()));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon;
 
+import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreExpire;
@@ -50,6 +51,8 @@ public interface FileStore<T> extends Serializable {
     BucketMode bucketMode();
 
     FileStoreScan newScan();
+
+    IndexFileHandler newIndexFileHandler();
 
     FileStoreRead<T> newRead();
 

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -73,6 +73,7 @@ public class Snapshot {
     private static final String FIELD_BASE_MANIFEST_LIST = "baseManifestList";
     private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
     private static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
+    private static final String FIELD_INDEX_MANIFEST = "indexManifest";
     private static final String FIELD_COMMIT_USER = "commitUser";
     private static final String FIELD_COMMIT_IDENTIFIER = "commitIdentifier";
     private static final String FIELD_COMMIT_KIND = "commitKind";
@@ -109,6 +110,12 @@ public class Snapshot {
     @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST)
     @Nullable
     private final String changelogManifestList;
+
+    // a manifest recording all index files of this table
+    // null if no index file
+    @JsonProperty(FIELD_INDEX_MANIFEST)
+    @Nullable
+    private final String indexManifest;
 
     @JsonProperty(FIELD_COMMIT_USER)
     private final String commitUser;
@@ -164,6 +171,7 @@ public class Snapshot {
             String baseManifestList,
             String deltaManifestList,
             @Nullable String changelogManifestList,
+            @Nullable String indexManifest,
             String commitUser,
             long commitIdentifier,
             CommitKind commitKind,
@@ -180,6 +188,7 @@ public class Snapshot {
                 baseManifestList,
                 deltaManifestList,
                 changelogManifestList,
+                indexManifest,
                 commitUser,
                 commitIdentifier,
                 commitKind,
@@ -199,6 +208,7 @@ public class Snapshot {
             @JsonProperty(FIELD_BASE_MANIFEST_LIST) String baseManifestList,
             @JsonProperty(FIELD_DELTA_MANIFEST_LIST) String deltaManifestList,
             @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST) @Nullable String changelogManifestList,
+            @JsonProperty(FIELD_INDEX_MANIFEST) @Nullable String indexManifest,
             @JsonProperty(FIELD_COMMIT_USER) String commitUser,
             @JsonProperty(FIELD_COMMIT_IDENTIFIER) long commitIdentifier,
             @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
@@ -214,6 +224,7 @@ public class Snapshot {
         this.baseManifestList = baseManifestList;
         this.deltaManifestList = deltaManifestList;
         this.changelogManifestList = changelogManifestList;
+        this.indexManifest = indexManifest;
         this.commitUser = commitUser;
         this.commitIdentifier = commitIdentifier;
         this.commitKind = commitKind;
@@ -255,6 +266,12 @@ public class Snapshot {
     @Nullable
     public String changelogManifestList() {
         return changelogManifestList;
+    }
+
+    @JsonGetter(FIELD_INDEX_MANIFEST)
+    @Nullable
+    public String indexManifest() {
+        return indexManifest;
     }
 
     @JsonGetter(FIELD_COMMIT_USER)
@@ -397,6 +414,7 @@ public class Snapshot {
                 baseManifestList,
                 deltaManifestList,
                 changelogManifestList,
+                indexManifest,
                 commitUser,
                 commitIdentifier,
                 commitKind,
@@ -420,6 +438,7 @@ public class Snapshot {
                 && Objects.equals(baseManifestList, that.baseManifestList)
                 && Objects.equals(deltaManifestList, that.deltaManifestList)
                 && Objects.equals(changelogManifestList, that.changelogManifestList)
+                && Objects.equals(indexManifest, that.indexManifest)
                 && Objects.equals(commitUser, that.commitUser)
                 && commitIdentifier == that.commitIdentifier
                 && commitKind == that.commitKind

--- a/paimon-core/src/main/java/org/apache/paimon/index/HashIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashIndexFile.java
@@ -23,11 +23,11 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.utils.IntIterator;
 import org.apache.paimon.utils.PathFactory;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+
+import static org.apache.paimon.utils.IntFileUtils.readInts;
+import static org.apache.paimon.utils.IntFileUtils.writeInts;
 
 /** Hash index file contains ints. */
 public class HashIndexFile {
@@ -51,53 +51,12 @@ public class HashIndexFile {
     }
 
     public IntIterator read(String fileName) throws IOException {
-        Path path = pathFactory.toPath(fileName);
-        BufferedInputStream in = new BufferedInputStream(fileIO.newInputStream(path));
-        return new IntIterator() {
-
-            @Override
-            public int next() throws IOException {
-                return readInt(in);
-            }
-
-            @Override
-            public void close() throws IOException {
-                in.close();
-            }
-        };
+        return readInts(fileIO, pathFactory.toPath(fileName));
     }
 
     public String write(IntIterator input) throws IOException {
         Path path = pathFactory.newPath();
-        try (BufferedOutputStream out =
-                        new BufferedOutputStream(fileIO.newOutputStream(path, false));
-                IntIterator iterator = input) {
-            while (true) {
-                try {
-                    writeInt(out, iterator.next());
-                } catch (EOFException ignored) {
-                    break;
-                }
-            }
-        }
+        writeInts(fileIO, path, input);
         return path.getName();
-    }
-
-    private int readInt(BufferedInputStream in) throws IOException {
-        int ch1 = in.read();
-        int ch2 = in.read();
-        int ch3 = in.read();
-        int ch4 = in.read();
-        if ((ch1 | ch2 | ch3 | ch4) < 0) {
-            throw new EOFException();
-        }
-        return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + ch4);
-    }
-
-    private void writeInt(BufferedOutputStream out, int v) throws IOException {
-        out.write((v >>> 24) & 0xFF);
-        out.write((v >>> 16) & 0xFF);
-        out.write((v >>> 8) & 0xFF);
-        out.write(v & 0xFF);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/HashIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashIndexFile.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.format.FormatWriterFactory;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.IntObjectSerializer;
+import org.apache.paimon.utils.ObjectsFile;
+import org.apache.paimon.utils.PathFactory;
+
+/** Hash index file contains ints. */
+public class HashIndexFile extends ObjectsFile<Integer> {
+
+    public static final String HASH_INDEX = "HASH";
+
+    private HashIndexFile(
+            FileIO fileIO,
+            FormatReaderFactory readerFactory,
+            FormatWriterFactory writerFactory,
+            PathFactory pathFactory) {
+        super(fileIO, new IntObjectSerializer(), readerFactory, writerFactory, pathFactory, null);
+    }
+
+    private static RowType schema() {
+        return RowType.of(DataTypes.INT());
+    }
+
+    /** Creator of {@link HashIndexFile}. */
+    public static class Factory {
+
+        private final FileIO fileIO;
+        private final FileFormat fileFormat;
+        private final FileStorePathFactory pathFactory;
+
+        public Factory(FileIO fileIO, FileFormat fileFormat, FileStorePathFactory pathFactory) {
+            this.fileIO = fileIO;
+            this.fileFormat = fileFormat;
+            this.pathFactory = pathFactory;
+        }
+
+        public HashIndexFile create() {
+            return new HashIndexFile(
+                    fileIO,
+                    fileFormat.createReaderFactory(schema()),
+                    fileFormat.createWriterFactory(schema()),
+                    pathFactory.indexFileFactory());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.IndexManifestFile;
+import org.apache.paimon.utils.SnapshotManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.apache.paimon.index.HashIndexFile.HASH_INDEX;
+
+/** Handle index files. */
+public class IndexFileHandler {
+
+    private final SnapshotManager snapshotManager;
+    private final IndexManifestFile indexManifestFile;
+    private final HashIndexFile hashIndex;
+
+    public IndexFileHandler(
+            SnapshotManager snapshotManager,
+            IndexManifestFile indexManifestFile,
+            HashIndexFile hashIndex) {
+        this.snapshotManager = snapshotManager;
+        this.indexManifestFile = indexManifestFile;
+        this.hashIndex = hashIndex;
+    }
+
+    public Optional<IndexFileMeta> scan(
+            long snapshotId, String indexType, BinaryRow partition, int bucket) {
+        List<IndexManifestEntry> entries = scan(snapshotId, indexType, partition);
+        List<IndexManifestEntry> result = new ArrayList<>();
+        for (IndexManifestEntry file : entries) {
+            if (file.bucket() == bucket) {
+                result.add(file);
+            }
+        }
+        if (result.size() > 1) {
+            throw new IllegalArgumentException(
+                    "Find multiple index files for one bucket: " + result);
+        }
+        return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0).indexFile());
+    }
+
+    public List<IndexManifestEntry> scan(String indexType, BinaryRow partition) {
+        Long snapshot = snapshotManager.latestSnapshotId();
+        if (snapshot == null) {
+            return Collections.emptyList();
+        }
+
+        return scan(snapshot, indexType, partition);
+    }
+
+    public List<IndexManifestEntry> scan(long snapshotId, String indexType, BinaryRow partition) {
+        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
+        String indexManifest = snapshot.indexManifest();
+        if (indexManifest == null) {
+            throw new IllegalArgumentException("Index manifest is null in snapshot: " + snapshot);
+        }
+
+        List<IndexManifestEntry> allFiles = indexManifestFile.read(indexManifest);
+        List<IndexManifestEntry> result = new ArrayList<>();
+        for (IndexManifestEntry file : allFiles) {
+            if (file.indexFile().indexType().equals(indexType)
+                    && file.partition().equals(partition)) {
+                result.add(file);
+            }
+        }
+
+        return result;
+    }
+
+    public List<Integer> readHashIndex(IndexFileMeta file) {
+        if (!file.indexType().equals(HASH_INDEX)) {
+            throw new IllegalArgumentException("Input file is not hash index: " + file.indexType());
+        }
+
+        return hashIndex.read(file.fileName());
+    }
+
+    public IndexFileMeta writeHashIndex(int[] ints) {
+        Iterator<Integer> iterator = IntStream.of(ints).boxed().iterator();
+        String file = hashIndex.writeWithoutRolling(iterator);
+        return new IndexFileMeta(HASH_INDEX, file, hashIndex.fileSize(file), ints.length);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.utils.SerializationUtils.newStringType;
+
+/** Metadata of index file. */
+public class IndexFileMeta {
+
+    private final String indexType;
+    private final String fileName;
+    private final long fileSize;
+    private final long rowCount;
+
+    public IndexFileMeta(String indexType, String fileName, long fileSize, long rowCount) {
+        this.indexType = indexType;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.rowCount = rowCount;
+    }
+
+    public String indexType() {
+        return indexType;
+    }
+
+    public String fileName() {
+        return fileName;
+    }
+
+    public long fileSize() {
+        return fileSize;
+    }
+
+    public long rowCount() {
+        return rowCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexFileMeta that = (IndexFileMeta) o;
+        return Objects.equals(indexType, that.indexType)
+                && Objects.equals(fileName, that.fileName)
+                && fileSize == that.fileSize
+                && rowCount == that.rowCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexType, fileName, fileSize, rowCount);
+    }
+
+    @Override
+    public String toString() {
+        return "IndexManifestEntry{"
+                + "indexType="
+                + indexType
+                + ", fileName='"
+                + fileName
+                + '\''
+                + ", fileSize="
+                + fileSize
+                + ", rowCount="
+                + rowCount
+                + '}';
+    }
+
+    public static RowType schema() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "_INDEX_TYPE", newStringType(false)));
+        fields.add(new DataField(1, "_FILE_NAME", newStringType(false)));
+        fields.add(new DataField(2, "_FILE_SIZE", new BigIntType(false)));
+        fields.add(new DataField(3, "_ROW_COUNT", new BigIntType(false)));
+        return new RowType(fields);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.utils.ObjectSerializer;
+import org.apache.paimon.utils.VersionedObjectSerializer;
+
+/** A {@link VersionedObjectSerializer} for {@link IndexFileMeta}. */
+public class IndexFileMetaSerializer extends ObjectSerializer<IndexFileMeta> {
+
+    public IndexFileMetaSerializer() {
+        super(IndexFileMeta.schema());
+    }
+
+    @Override
+    public InternalRow toRow(IndexFileMeta record) {
+        return GenericRow.of(
+                BinaryString.fromString(record.indexType()),
+                BinaryString.fromString(record.fileName()),
+                record.fileSize(),
+                record.rowCount());
+    }
+
+    @Override
+    public IndexFileMeta fromRow(InternalRow row) {
+        return new IndexFileMeta(
+                row.getString(0).toString(),
+                row.getString(1).toString(),
+                row.getLong(2),
+                row.getLong(3));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/IndexIncrement.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/IndexIncrement.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.index.IndexFileMeta;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Incremental index files. */
+public class IndexIncrement {
+
+    private final List<IndexFileMeta> newIndexFiles;
+
+    public IndexIncrement(List<IndexFileMeta> newIndexFiles) {
+        this.newIndexFiles = newIndexFiles;
+    }
+
+    public List<IndexFileMeta> newIndexFiles() {
+        return newIndexFiles;
+    }
+
+    public boolean isEmpty() {
+        return newIndexFiles.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexIncrement that = (IndexIncrement) o;
+        return Objects.equals(newIndexFiles, that.newIndexFiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(newIndexFiles);
+    }
+
+    @Override
+    public String toString() {
+        return "IndexIncrement{" + "newIndexFiles=" + newIndexFiles + '}';
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TinyIntType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.SerializationUtils.newBytesType;
+import static org.apache.paimon.utils.SerializationUtils.newStringType;
+
+/** Manifest entry for index file. */
+public class IndexManifestEntry {
+
+    private final FileKind kind;
+    private final BinaryRow partition;
+    private final int bucket;
+    private final IndexFileMeta indexFile;
+
+    public IndexManifestEntry(
+            FileKind kind, BinaryRow partition, int bucket, IndexFileMeta indexFile) {
+        this.kind = kind;
+        this.partition = partition;
+        this.bucket = bucket;
+        this.indexFile = indexFile;
+    }
+
+    public IndexManifestEntry toDeleteEntry() {
+        checkArgument(kind == FileKind.ADD);
+        return new IndexManifestEntry(FileKind.DELETE, partition, bucket, indexFile);
+    }
+
+    public FileKind kind() {
+        return kind;
+    }
+
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    public int bucket() {
+        return bucket;
+    }
+
+    public IndexFileMeta indexFile() {
+        return indexFile;
+    }
+
+    public static RowType schema() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "_KIND", new TinyIntType(false)));
+        fields.add(new DataField(1, "_PARTITION", newBytesType(false)));
+        fields.add(new DataField(2, "_BUCKET", new IntType(false)));
+        fields.add(new DataField(3, "_INDEX_TYPE", newStringType(false)));
+        fields.add(new DataField(4, "_FILE_NAME", newStringType(false)));
+        fields.add(new DataField(5, "_FILE_SIZE", new BigIntType(false)));
+        fields.add(new DataField(6, "_ROW_COUNT", new BigIntType(false)));
+        return new RowType(fields);
+    }
+
+    public Identifier identifier() {
+        return new Identifier(partition, bucket, indexFile.indexType());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexManifestEntry entry = (IndexManifestEntry) o;
+        return bucket == entry.bucket
+                && kind == entry.kind
+                && Objects.equals(partition, entry.partition)
+                && Objects.equals(indexFile, entry.indexFile);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, partition, bucket, indexFile);
+    }
+
+    @Override
+    public String toString() {
+        return "IndexManifestEntry{"
+                + "kind="
+                + kind
+                + ", partition="
+                + partition
+                + ", bucket="
+                + bucket
+                + ", indexFile="
+                + indexFile
+                + '}';
+    }
+
+    /** The {@link Identifier} of a {@link IndexFileMeta}. */
+    public static class Identifier {
+
+        public final BinaryRow partition;
+        public final int bucket;
+        public final String indexType;
+
+        private Integer hash;
+
+        private Identifier(BinaryRow partition, int bucket, String indexType) {
+            this.partition = partition;
+            this.bucket = bucket;
+            this.indexType = indexType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Identifier that = (Identifier) o;
+            return bucket == that.bucket
+                    && Objects.equals(partition, that.partition)
+                    && Objects.equals(indexType, that.indexType);
+        }
+
+        @Override
+        public int hashCode() {
+            if (hash == null) {
+                hash = Objects.hash(partition, bucket, indexType);
+            }
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "Identifier{"
+                    + "partition="
+                    + partition
+                    + ", bucket="
+                    + bucket
+                    + ", indexType='"
+                    + indexType
+                    + '\''
+                    + '}';
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.utils.VersionedObjectSerializer;
+
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** A {@link VersionedObjectSerializer} for {@link IndexManifestEntry}. */
+public class IndexManifestEntrySerializer extends VersionedObjectSerializer<IndexManifestEntry> {
+
+    public IndexManifestEntrySerializer() {
+        super(IndexManifestEntry.schema());
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public InternalRow convertTo(IndexManifestEntry record) {
+        IndexFileMeta indexFile = record.indexFile();
+        return GenericRow.of(
+                record.kind().toByteValue(),
+                serializeBinaryRow(record.partition()),
+                record.bucket(),
+                BinaryString.fromString(indexFile.indexType()),
+                BinaryString.fromString(indexFile.fileName()),
+                indexFile.fileSize(),
+                indexFile.rowCount());
+    }
+
+    @Override
+    public IndexManifestEntry convertFrom(int version, InternalRow row) {
+        if (version != 1) {
+            throw new UnsupportedOperationException("Unsupported version: " + version);
+        }
+
+        return new IndexManifestEntry(
+                FileKind.fromByteValue(row.getByte(0)),
+                deserializeBinaryRow(row.getBinary(1)),
+                row.getInt(2),
+                new IndexFileMeta(
+                        row.getString(3).toString(),
+                        row.getString(4).toString(),
+                        row.getLong(5),
+                        row.getLong(6)));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.format.FormatWriterFactory;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.manifest.IndexManifestEntry.Identifier;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.ObjectsFile;
+import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.VersionedObjectSerializer;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Index manifest file. */
+public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
+
+    private IndexManifestFile(
+            FileIO fileIO,
+            FormatReaderFactory readerFactory,
+            FormatWriterFactory writerFactory,
+            PathFactory pathFactory) {
+        super(
+                fileIO,
+                new IndexManifestEntrySerializer(),
+                readerFactory,
+                writerFactory,
+                pathFactory,
+                null);
+    }
+
+    /** Merge new index files to index manifest. */
+    @Nullable
+    public String merge(
+            @Nullable String previousIndexManifest, List<IndexManifestEntry> newIndexFiles) {
+        String indexManifest = previousIndexManifest;
+        if (newIndexFiles.size() > 0) {
+            Map<Identifier, IndexManifestEntry> indexEntries = new LinkedHashMap<>();
+            List<IndexManifestEntry> entries =
+                    indexManifest == null ? new ArrayList<>() : read(indexManifest);
+            entries.addAll(newIndexFiles);
+            for (IndexManifestEntry file : entries) {
+                if (file.kind() == FileKind.ADD) {
+                    indexEntries.put(file.identifier(), file);
+                    if (file.indexFile().rowCount() == 0) {
+                        indexEntries.remove(file.identifier());
+                        fileIO.deleteQuietly(pathFactory.toPath(file.indexFile().fileName()));
+                    }
+                } else {
+                    indexEntries.remove(file.identifier());
+                }
+            }
+            indexManifest = writeWithoutRolling(indexEntries.values());
+        }
+
+        return indexManifest;
+    }
+
+    /** Creator of {@link IndexManifestFile}. */
+    public static class Factory {
+
+        private final FileIO fileIO;
+        private final FileFormat fileFormat;
+        private final FileStorePathFactory pathFactory;
+
+        public Factory(FileIO fileIO, FileFormat fileFormat, FileStorePathFactory pathFactory) {
+            this.fileIO = fileIO;
+            this.fileFormat = fileFormat;
+            this.pathFactory = pathFactory;
+        }
+
+        public IndexManifestFile create() {
+            RowType schema = VersionedObjectSerializer.versionType(IndexManifestEntry.schema());
+            return new IndexManifestFile(
+                    fileIO,
+                    fileFormat.createReaderFactory(schema),
+                    fileFormat.createWriterFactory(schema),
+                    pathFactory.indexManifestFileFactory());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -54,6 +54,8 @@ public class FileStorePathFactory {
 
     private final AtomicInteger manifestFileCount;
     private final AtomicInteger manifestListCount;
+    private final AtomicInteger indexManifestCount;
+    private final AtomicInteger indexFileCount;
 
     public FileStorePathFactory(Path root) {
         this(
@@ -74,6 +76,8 @@ public class FileStorePathFactory {
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
+        this.indexManifestCount = new AtomicInteger(0);
+        this.indexFileCount = new AtomicInteger(0);
     }
 
     public Path root() {
@@ -166,6 +170,40 @@ public class FileStorePathFactory {
             @Override
             public Path toPath(String fileName) {
                 return toManifestListPath(fileName);
+            }
+        };
+    }
+
+    public PathFactory indexManifestFileFactory() {
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return new Path(
+                        root
+                                + "/manifest/index-manifest-"
+                                + uuid
+                                + "-"
+                                + indexManifestCount.getAndIncrement());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(root + "/manifest/" + fileName);
+            }
+        };
+    }
+
+    public PathFactory indexFileFactory() {
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return new Path(
+                        root + "/index/index-" + uuid + "-" + indexFileCount.getAndIncrement());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(root + "/index/" + fileName);
             }
         };
     }

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashIndexFileTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.IntIterator;
+import org.apache.paimon.utils.PathFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link HashIndexFile}. */
+public class HashIndexFileTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    public void test() throws IOException {
+        Path dir = new Path(tempPath.toUri());
+        PathFactory pathFactory =
+                new PathFactory() {
+                    @Override
+                    public Path newPath() {
+                        return new Path(dir, UUID.randomUUID().toString());
+                    }
+
+                    @Override
+                    public Path toPath(String fileName) {
+                        return new Path(dir, fileName);
+                    }
+                };
+
+        HashIndexFile file = new HashIndexFile(LocalFileIO.create(), pathFactory);
+
+        Random rnd = new Random();
+        List<Integer> random = new ArrayList<>();
+        for (int i = 0; i < rnd.nextInt(100_000); i++) {
+            random.add(rnd.nextInt());
+        }
+
+        String name =
+                file.write(
+                        IntIterator.create(random.stream().mapToInt(Integer::intValue).toArray()));
+
+        List<Integer> result = IntIterator.toIntList(file.read(name));
+        assertThat(result).containsExactlyInAnyOrderElementsOf(random);
+
+        assertThat(file.fileSize(name)).isEqualTo(random.size() * 4L);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/IndexFileMetaSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/IndexFileMetaSerializerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.utils.ObjectSerializer;
+import org.apache.paimon.utils.ObjectSerializerTestBase;
+
+import java.util.Random;
+
+/** Test for {@link org.apache.paimon.index.IndexFileMetaSerializer}. */
+public class IndexFileMetaSerializerTest extends ObjectSerializerTestBase<IndexFileMeta> {
+
+    @Override
+    protected ObjectSerializer<IndexFileMeta> serializer() {
+        return new IndexFileMetaSerializer();
+    }
+
+    @Override
+    protected IndexFileMeta object() {
+        return randomIndexFile();
+    }
+
+    public static IndexFileMeta randomIndexFile() {
+        Random rnd = new Random();
+        return new IndexFileMeta(
+                HashIndexFile.HASH_INDEX,
+                "my_file_name" + rnd.nextLong(),
+                rnd.nextInt(),
+                rnd.nextInt());
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestEntrySerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestEntrySerializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.index.HashIndexFile;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.utils.ObjectSerializer;
+import org.apache.paimon.utils.ObjectSerializerTestBase;
+
+import java.util.Random;
+
+import static org.apache.paimon.io.DataFileTestUtils.row;
+
+/** Test for {@link IndexManifestEntrySerializer}. */
+public class IndexManifestEntrySerializerTest extends ObjectSerializerTestBase<IndexManifestEntry> {
+
+    @Override
+    protected ObjectSerializer<IndexManifestEntry> serializer() {
+        return new IndexManifestEntrySerializer();
+    }
+
+    @Override
+    protected IndexManifestEntry object() {
+        return randomIndexEntry();
+    }
+
+    public static IndexManifestEntry randomIndexEntry() {
+        Random rnd = new Random();
+        return new IndexManifestEntry(
+                rnd.nextBoolean() ? FileKind.ADD : FileKind.DELETE,
+                row(rnd.nextInt()),
+                rnd.nextInt(),
+                new IndexFileMeta(
+                        HashIndexFile.HASH_INDEX,
+                        "my_file_name" + rnd.nextLong(),
+                        rnd.nextInt(),
+                        rnd.nextInt()));
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -434,6 +434,7 @@ public class FileDeletionTest {
                 .tryCommitOnce(
                         delete,
                         Collections.emptyList(),
+                        Collections.emptyList(),
                         commitIdentifier++,
                         null,
                         Collections.emptyMap(),

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -720,20 +720,20 @@ public class FileStoreCommitTest {
         assertThat(part1Index.size()).isEqualTo(2);
 
         assertThat(part1Index.get(0).bucket()).isEqualTo(0);
-        assertThat(indexFileHandler.readHashIndex(part1Index.get(0).indexFile()))
-                .containsExactly(1, 2, 5);
+        assertThat(indexFileHandler.readHashIndexList(part1Index.get(0).indexFile()))
+                .containsExactlyInAnyOrder(1, 2, 5);
 
         assertThat(part1Index.get(1).bucket()).isEqualTo(1);
-        assertThat(indexFileHandler.readHashIndex(part1Index.get(1).indexFile()))
-                .containsExactly(6, 8);
+        assertThat(indexFileHandler.readHashIndexList(part1Index.get(1).indexFile()))
+                .containsExactlyInAnyOrder(6, 8);
 
         // assert part2
         List<IndexManifestEntry> part2Index =
                 indexFileHandler.scan(snapshot.id(), HASH_INDEX, part2);
         assertThat(part2Index.size()).isEqualTo(1);
         assertThat(part2Index.get(0).bucket()).isEqualTo(2);
-        assertThat(indexFileHandler.readHashIndex(part2Index.get(0).indexFile()))
-                .containsExactly(3, 5);
+        assertThat(indexFileHandler.readHashIndexList(part2Index.get(0).indexFile()))
+                .containsExactlyInAnyOrder(3, 5);
 
         // update part1
         store.commitDataIndex(
@@ -745,17 +745,17 @@ public class FileStoreCommitTest {
         assertThat(part1Index.size()).isEqualTo(2);
 
         assertThat(part1Index.get(0).bucket()).isEqualTo(0);
-        assertThat(indexFileHandler.readHashIndex(part1Index.get(0).indexFile()))
-                .containsExactly(1, 4);
+        assertThat(indexFileHandler.readHashIndexList(part1Index.get(0).indexFile()))
+                .containsExactlyInAnyOrder(1, 4);
 
         assertThat(part1Index.get(1).bucket()).isEqualTo(1);
-        assertThat(indexFileHandler.readHashIndex(part1Index.get(1).indexFile()))
-                .containsExactly(6, 8);
+        assertThat(indexFileHandler.readHashIndexList(part1Index.get(1).indexFile()))
+                .containsExactlyInAnyOrder(6, 8);
 
         // assert scan one bucket
         Optional<IndexFileMeta> file = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1, 0);
         assertThat(file).isPresent();
-        assertThat(indexFileHandler.readHashIndex(file.get())).containsExactly(1, 4);
+        assertThat(indexFileHandler.readHashIndexList(file.get())).containsExactlyInAnyOrder(1, 4);
 
         // overwrite one partition
         store.options().toConfiguration().set(CoreOptions.DYNAMIC_PARTITION_OVERWRITE, true);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -26,6 +26,9 @@ import org.apache.paimon.TestKeyValueGenerator;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -56,12 +59,14 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.index.HashIndexFile.HASH_INDEX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -501,6 +506,7 @@ public class FileStoreCommitTest {
                 false,
                 null,
                 null,
+                Collections.emptyList(),
                 (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
         assertThat(store.snapshotManager().latestSnapshotId()).isEqualTo(snapshot.id());
 
@@ -512,6 +518,7 @@ public class FileStoreCommitTest {
                 false,
                 null,
                 null,
+                Collections.emptyList(),
                 (commit, committable) -> {
                     commit.ignoreEmptyCommit(false);
                     commit.commit(committable, Collections.emptyMap());
@@ -533,6 +540,7 @@ public class FileStoreCommitTest {
                     false,
                     (long) i,
                     null,
+                    Collections.emptyList(),
                     (commit, committable) -> {
                         commit.commit(committable, Collections.emptyMap());
                         committables.add(committable);
@@ -677,6 +685,95 @@ public class FileStoreCommitTest {
                         AssertionUtils.anyCauseMatches(
                                 IllegalArgumentException.class,
                                 "Partitions list cannot be empty."));
+    }
+
+    @Test
+    public void testIndexFiles() throws Exception {
+        TestFileStore store = createStore(false, 2);
+        IndexFileHandler indexFileHandler = store.newIndexFileHandler();
+
+        KeyValue record1 = gen.next();
+        BinaryRow part1 = gen.getPartition(record1);
+        KeyValue record2 = record1;
+        BinaryRow part2 = part1;
+        while (part1.equals(part2)) {
+            record2 = gen.next();
+            part2 = gen.getPartition(record2);
+        }
+
+        // init write
+        store.commitDataIndex(
+                record1,
+                gen::getPartition,
+                0,
+                indexFileHandler.writeHashIndex(new int[] {1, 2, 5}));
+        store.commitDataIndex(
+                record1, gen::getPartition, 1, indexFileHandler.writeHashIndex(new int[] {6, 8}));
+        store.commitDataIndex(
+                record2, gen::getPartition, 2, indexFileHandler.writeHashIndex(new int[] {3, 5}));
+
+        Snapshot snapshot = store.snapshotManager().latestSnapshot();
+
+        // assert part1
+        List<IndexManifestEntry> part1Index =
+                indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1);
+        assertThat(part1Index.size()).isEqualTo(2);
+
+        assertThat(part1Index.get(0).bucket()).isEqualTo(0);
+        assertThat(indexFileHandler.readHashIndex(part1Index.get(0).indexFile()))
+                .containsExactly(1, 2, 5);
+
+        assertThat(part1Index.get(1).bucket()).isEqualTo(1);
+        assertThat(indexFileHandler.readHashIndex(part1Index.get(1).indexFile()))
+                .containsExactly(6, 8);
+
+        // assert part2
+        List<IndexManifestEntry> part2Index =
+                indexFileHandler.scan(snapshot.id(), HASH_INDEX, part2);
+        assertThat(part2Index.size()).isEqualTo(1);
+        assertThat(part2Index.get(0).bucket()).isEqualTo(2);
+        assertThat(indexFileHandler.readHashIndex(part2Index.get(0).indexFile()))
+                .containsExactly(3, 5);
+
+        // update part1
+        store.commitDataIndex(
+                record1, gen::getPartition, 0, indexFileHandler.writeHashIndex(new int[] {1, 4}));
+        snapshot = store.snapshotManager().latestSnapshot();
+
+        // assert update part1
+        part1Index = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1);
+        assertThat(part1Index.size()).isEqualTo(2);
+
+        assertThat(part1Index.get(0).bucket()).isEqualTo(0);
+        assertThat(indexFileHandler.readHashIndex(part1Index.get(0).indexFile()))
+                .containsExactly(1, 4);
+
+        assertThat(part1Index.get(1).bucket()).isEqualTo(1);
+        assertThat(indexFileHandler.readHashIndex(part1Index.get(1).indexFile()))
+                .containsExactly(6, 8);
+
+        // assert scan one bucket
+        Optional<IndexFileMeta> file = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1, 0);
+        assertThat(file).isPresent();
+        assertThat(indexFileHandler.readHashIndex(file.get())).containsExactly(1, 4);
+
+        // overwrite one partition
+        store.options().toConfiguration().set(CoreOptions.DYNAMIC_PARTITION_OVERWRITE, true);
+        store.overwriteData(
+                Collections.singletonList(record1), gen::getPartition, kv -> 0, new HashMap<>());
+        snapshot = store.snapshotManager().latestSnapshot();
+        file = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1, 0);
+        assertThat(file).isEmpty();
+        file = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part2, 2);
+        assertThat(file).isPresent();
+
+        // overwrite all partitions
+        store.options().toConfiguration().set(CoreOptions.DYNAMIC_PARTITION_OVERWRITE, false);
+        store.overwriteData(
+                Collections.singletonList(record1), gen::getPartition, kv -> 0, new HashMap<>());
+        snapshot = store.snapshotManager().latestSnapshot();
+        file = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part2, 2);
+        assertThat(file).isEmpty();
     }
 
     private TestFileStore createStore(boolean failing) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -66,6 +66,7 @@ public class SnapshotManagerTest {
                             null,
                             null,
                             null,
+                            null,
                             0L,
                             Snapshot.CommitKind.APPEND,
                             millis + i * 1000,
@@ -98,6 +99,7 @@ public class SnapshotManagerTest {
                     new Snapshot(
                             i,
                             0L,
+                            null,
                             null,
                             null,
                             null,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

The index file is partition + bucket granularity.

This is the pre work of dynamic buckets, which allows for saving which keys are contained in a bucket in dynamic bucket mode, in order to locate the bucket of the key.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
