### PR TITLE
[flink] Introduce Dynamic bucket sink to Flink

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -32,6 +32,17 @@ Primary keys consist of a set of columns that contain unique values for each rec
 
 By [defining primary keys]({{< ref "how-to/creating-tables#tables-with-primary-keys" >}}) on a changelog table, users can access the following features.
 
+## Bucket
+
+A bucket is the smallest storage unit for reads and writes, each bucket directory contains an [LSM tree]({{< ref "concepts/file-layouts#lsm-trees" >}}).
+
+Primary Key Table supports two bucket mode:
+1. Fixed Bucket mode: configure a bucket greater than 0, rescaling buckets can only be done through offline processes, 
+   see [Rescale Bucket]({{< ref "/maintenance/rescale-bucket" >}}). A too large number of buckets leads to too many
+   small files, and a too small number of buckets leads to poor write performance.
+2. Dynamic Bucket mode: configure `'bucket' = '-1'`, Paimon dynamically maintains the index, keeping the data volume
+   in the bucket below `'dynamic-bucket.target-row-num'`. (This is an experimental feature)
+
 ## Merge Engines
 
 When Paimon sink receives two or more records with the same primary keys, it will merge them into one record to keep primary keys unique. By specifying the `merge-engine` table property, users can choose how records are merged together.

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -176,7 +176,7 @@ The command to recover from previous snapshot and add new tables to synchronize 
 
 ```bash
 <FLINK_HOME>/bin/flink run \
-    --fromSavepoint {{< savepointPath >}} \
+    --fromSavepoint savepointPath \
     /path/to/paimon-flink-action-{{< version >}}.jar \
     mysql-sync-database \
     --warehouse hdfs:///path/to/warehouse \

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -111,6 +111,12 @@ under the License.
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
+            <td><h5>dynamic-bucket.target-row-num</h5></td>
+            <td style="word-wrap: break-word;">2000000</td>
+            <td>Long</td>
+            <td>If the bucket is -1, for primary key table, is dynamic bucket mode, this option controls the target row number for one bucket.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-partition-overwrite</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -648,6 +648,14 @@ public class CoreOptions implements Serializable {
                             "The expiration interval of consumer files. A consumer file will be expired if "
                                     + "it's lifetime after last modification is over this value.");
 
+    public static final ConfigOption<Long> DYNAMIC_BUCKET_TARGET_ROW_NUM =
+            key("dynamic-bucket.target-row-num")
+                    .longType()
+                    .defaultValue(2_000_000L)
+                    .withDescription(
+                            "If the bucket is -1, for primary key table, is dynamic bucket mode, "
+                                    + "this option controls the target row number for one bucket.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -835,6 +843,10 @@ public class CoreOptions implements Serializable {
 
     public int maxSortedRunNum() {
         return options.get(COMPACTION_MAX_SORTED_RUN_NUM);
+    }
+
+    public long dynamicBucketTargetRowNum() {
+        return options.get(DYNAMIC_BUCKET_TARGET_ROW_NUM);
     }
 
     public ChangelogProducer changelogProducer() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.DynamicBucketRow;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/** A {@link PrepareCommitOperator} to write {@link RowData} with bucket. Record schema is fixed. */
+public class DynamicBucketRowWriteOperator extends TableWriteOperator<Tuple2<RowData, Integer>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public DynamicBucketRowWriteOperator(
+            FileStoreTable table,
+            StoreSinkWrite.Provider storeSinkWriteProvider,
+            String initialCommitUser) {
+        super(table, storeSinkWriteProvider, initialCommitUser);
+    }
+
+    @Override
+    protected boolean containLogSystem() {
+        return false;
+    }
+
+    @Override
+    public void processElement(StreamRecord<Tuple2<RowData, Integer>> element) throws Exception {
+        FlinkRowWrapper internalRow = new FlinkRowWrapper(element.getValue().f0);
+        DynamicBucketRow row = new DynamicBucketRow(internalRow, element.getValue().f1);
+        write.write(row);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.utils.SerializableFunction;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.createPartitionTransformation;
+
+/** Sink for dynamic bucket table. */
+public abstract class DynamicBucketSink<T> extends FlinkWriteSink<Tuple2<T, Integer>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public DynamicBucketSink(
+            FileStoreTable table,
+            Lock.Factory lockFactory,
+            @Nullable Map<String, String> overwritePartition) {
+        super(table, overwritePartition, lockFactory);
+    }
+
+    protected abstract ChannelComputer<T> channelComputer1();
+
+    protected abstract ChannelComputer<Tuple2<T, Integer>> channelComputer2();
+
+    protected abstract SerializableFunction<TableSchema, PartitionKeyExtractor<T>>
+            extractorFunction();
+
+    public DataStreamSink<?> build(DataStream<T> input, @Nullable Integer parallelism) {
+        String initialCommitUser = UUID.randomUUID().toString();
+
+        // Topology:
+        // input -- shuffle by key hash --> bucket-assigner -- shuffle by bucket --> writer -->
+        // committer
+
+        // 1. shuffle by key hash
+        DataStream<T> partitionByKeyHash =
+                createPartitionTransformation(input, channelComputer1(), parallelism);
+
+        // 2. bucket-assigner
+        HashBucketAssignerOperator<T> assignerOperator =
+                new HashBucketAssignerOperator<>(initialCommitUser, table, extractorFunction());
+        TupleTypeInfo<Tuple2<T, Integer>> rowWithBucketType =
+                new TupleTypeInfo<>(partitionByKeyHash.getType(), BasicTypeInfo.INT_TYPE_INFO);
+        DataStream<Tuple2<T, Integer>> bucketAssigned =
+                partitionByKeyHash.transform(
+                        "dynamic-bucket-assigner", rowWithBucketType, assignerOperator);
+
+        // 3. shuffle by bucket
+        DataStream<Tuple2<T, Integer>> partitionByBucket =
+                createPartitionTransformation(bucketAssigned, channelComputer2(), parallelism);
+
+        // 4. writer and committer
+        return sinkFrom(partitionByBucket, initialCommitUser);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.createPartitionTransformation;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Builder for {@link FileStoreSink}. */
 public class FlinkSinkBuilder {
@@ -78,10 +79,17 @@ public class FlinkSinkBuilder {
             case FIXED:
                 return buildForFixedBucket();
             case DYNAMIC:
+                return buildDynamicBucketSink();
             case UNAWARE:
             default:
                 throw new UnsupportedOperationException("Unsupported bucket mode: " + bucketMode);
         }
+    }
+
+    private DataStreamSink<?> buildDynamicBucketSink() {
+        checkArgument(logSinkFunction == null, "Dynamic bucket mode can not work with log system.");
+        return new RowDynamicBucketSink(table, lockFactory, overwritePartition)
+                .build(input, parallelism);
     }
 
     private DataStreamSink<?> buildForFixedBucket() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.index.HashBucketAssigner;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.AbstractFileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.utils.SerializableFunction;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/** Assign bucket for the input record, output record with bucket. */
+public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2<T, Integer>>
+        implements OneInputStreamOperator<T, Tuple2<T, Integer>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String initialCommitUser;
+
+    private final AbstractFileStoreTable table;
+    private final SerializableFunction<TableSchema, PartitionKeyExtractor<T>> extractorFunction;
+
+    private transient HashBucketAssigner assigner;
+    private transient PartitionKeyExtractor<T> extractor;
+
+    public HashBucketAssignerOperator(
+            String commitUser,
+            Table table,
+            SerializableFunction<TableSchema, PartitionKeyExtractor<T>> extractorFunction) {
+        this.initialCommitUser = commitUser;
+        this.table = (AbstractFileStoreTable) table;
+        this.extractorFunction = extractorFunction;
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        // Each job can only have one user name and this name must be consistent across restarts.
+        // We cannot use job id as commit user name here because user may change job id by creating
+        // a savepoint, stop the job and then resume from savepoint.
+        String commitUser =
+                StateUtils.getSingleValueFromState(
+                        context, "commit_user_state", String.class, initialCommitUser);
+
+        this.assigner =
+                new HashBucketAssigner(
+                        table.snapshotManager(),
+                        commitUser,
+                        table.store().newIndexFileHandler(),
+                        getRuntimeContext().getNumberOfParallelSubtasks(),
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        table.coreOptions().dynamicBucketTargetRowNum());
+        this.extractor = extractorFunction.apply(table.schema());
+    }
+
+    @Override
+    public void processElement(StreamRecord<T> streamRecord) throws Exception {
+        T value = streamRecord.getValue();
+        int bucket =
+                assigner.assign(
+                        extractor.partition(value), extractor.trimmedPrimaryKey(value).hashCode());
+        output.collect(new StreamRecord<>(new Tuple2<>(value, bucket)));
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) {
+        assigner.prepareCommit(checkpointId);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.utils.SerializableFunction;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/** Sink for dynamic bucket table. */
+public class RowDynamicBucketSink extends DynamicBucketSink<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    public RowDynamicBucketSink(
+            FileStoreTable table,
+            Lock.Factory lockFactory,
+            @Nullable Map<String, String> overwritePartition) {
+        super(table, lockFactory, overwritePartition);
+    }
+
+    @Override
+    protected ChannelComputer<RowData> channelComputer1() {
+        return new RowHashKeyChannelComputer(table.schema());
+    }
+
+    @Override
+    protected ChannelComputer<Tuple2<RowData, Integer>> channelComputer2() {
+        return new RowWithBucketChannelComputer(table.schema());
+    }
+
+    @Override
+    protected SerializableFunction<TableSchema, PartitionKeyExtractor<RowData>>
+            extractorFunction() {
+        return RowDataPartitionKeyExtractor::new;
+    }
+
+    @Override
+    protected OneInputStreamOperator<Tuple2<RowData, Integer>, Committable> createWriteOperator(
+            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+        return new DynamicBucketRowWriteOperator(table, writeProvider, commitUser);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.sink.ChannelComputer;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.DynamicBucketSink;
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.utils.SerializableFunction;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+
+/** Sink for dynamic bucket table. */
+public class CdcDynamicBucketSink extends DynamicBucketSink<CdcRecord> {
+
+    private static final long serialVersionUID = 1L;
+
+    public CdcDynamicBucketSink(FileStoreTable table, Lock.Factory lockFactory) {
+        super(table, lockFactory, null);
+    }
+
+    @Override
+    protected ChannelComputer<CdcRecord> channelComputer1() {
+        return new CdcHashKeyChannelComputer(table.schema());
+    }
+
+    @Override
+    protected ChannelComputer<Tuple2<CdcRecord, Integer>> channelComputer2() {
+        return new CdcWithBucketChannelComputer(table.schema());
+    }
+
+    @Override
+    protected SerializableFunction<TableSchema, PartitionKeyExtractor<CdcRecord>>
+            extractorFunction() {
+        return schema -> {
+            CdcRecordKeyAndBucketExtractor extractor = new CdcRecordKeyAndBucketExtractor(schema);
+            return new PartitionKeyExtractor<CdcRecord>() {
+                @Override
+                public BinaryRow partition(CdcRecord record) {
+                    extractor.setRecord(record);
+                    return extractor.partition();
+                }
+
+                @Override
+                public BinaryRow trimmedPrimaryKey(CdcRecord record) {
+                    extractor.setRecord(record);
+                    return extractor.trimmedPrimaryKey();
+                }
+            };
+        };
+    }
+
+    @Override
+    protected OneInputStreamOperator<Tuple2<CdcRecord, Integer>, Committable> createWriteOperator(
+            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+        return new CdcDynamicBucketWriteOperator(table, writeProvider, commitUser);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcHashKeyChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcHashKeyChannelComputer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.flink.sink.ChannelComputer;
+import org.apache.paimon.schema.TableSchema;
+
+/** Hash key of a {@link CdcRecord}. */
+public class CdcHashKeyChannelComputer implements ChannelComputer<CdcRecord> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableSchema schema;
+
+    private transient int numChannels;
+    private transient CdcRecordKeyAndBucketExtractor extractor;
+
+    public CdcHashKeyChannelComputer(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public void setup(int numChannels) {
+        this.numChannels = numChannels;
+        this.extractor = new CdcRecordKeyAndBucketExtractor(schema);
+    }
+
+    @Override
+    public int channel(CdcRecord record) {
+        extractor.setRecord(record);
+        int hash = extractor.trimmedPrimaryKey().hashCode();
+        return Math.abs(hash % numChannels);
+    }
+
+    @Override
+    public String toString() {
+        return "shuffle by key hash";
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcWithBucketChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcWithBucketChannelComputer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.flink.sink.ChannelComputer;
+import org.apache.paimon.schema.TableSchema;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+/** Hash key of a {@link CdcRecord} with bucket. */
+public class CdcWithBucketChannelComputer implements ChannelComputer<Tuple2<CdcRecord, Integer>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableSchema schema;
+
+    private transient int numChannels;
+    private transient CdcRecordKeyAndBucketExtractor extractor;
+
+    public CdcWithBucketChannelComputer(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public void setup(int numChannels) {
+        this.numChannels = numChannels;
+        this.extractor = new CdcRecordKeyAndBucketExtractor(schema);
+    }
+
+    @Override
+    public int channel(Tuple2<CdcRecord, Integer> record) {
+        extractor.setRecord(record.f0);
+        return ChannelComputer.select(extractor.partition(), record.f1, numChannels);
+    }
+
+    @Override
+    public String toString() {
+        return "shuffle by partition & bucket";
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for batch file store. */
+public class DynamicBucketTableITCase extends CatalogITCaseBase {
+
+    @Override
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE IF NOT EXISTS T ("
+                        + "pt INT, "
+                        + "pk INT, "
+                        + "v INT, "
+                        + "PRIMARY KEY (pt, pk) NOT ENFORCED"
+                        + ") PARTITIONED BY (pt) WITH ("
+                        + " 'bucket'='-1', "
+                        + " 'dynamic-bucket.target-row-num'='3' "
+                        + ")");
+    }
+
+    @Test
+    public void testWriteRead() {
+        sql("INSERT INTO T VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, 1, 1),
+                        Row.of(1, 2, 2),
+                        Row.of(1, 3, 3),
+                        Row.of(1, 4, 4),
+                        Row.of(1, 5, 5));
+        sql("INSERT INTO T VALUES (1, 3, 33), (1, 1, 11)");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, 1, 11),
+                        Row.of(1, 2, 2),
+                        Row.of(1, 3, 33),
+                        Row.of(1, 4, 4),
+                        Row.of(1, 5, 5));
+
+        assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
+                .containsExactlyInAnyOrder(Row.of(0), Row.of(1));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -187,6 +187,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
             throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.BUCKET, numBucket);
+        conf.set(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, 100L);
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 /** IT cases for {@link FlinkCdcSyncDatabaseSinkBuilder}. */
 public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
@@ -65,6 +66,16 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
     @Test
     @Timeout(120)
     public void testRandomCdcEvents() throws Exception {
+        innerTestRandomCdcEvents(() -> ThreadLocalRandom.current().nextInt(5) + 1);
+    }
+
+    @Test
+    @Timeout(120)
+    public void testRandomCdcEventsDynamicBucket() throws Exception {
+        innerTestRandomCdcEvents(() -> -1);
+    }
+
+    private void innerTestRandomCdcEvents(Supplier<Integer> bucket) throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         int numTables = random.nextInt(3) + 1;
@@ -74,7 +85,6 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
         int maxSchemaChanges = 10;
         int maxPartitions = 3;
         int maxKeys = 150;
-        int maxBuckets = 5;
 
         String failingName = UUID.randomUUID().toString();
 
@@ -121,7 +131,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
                             testTable.initialRowType(),
                             Collections.singletonList("pt"),
                             Arrays.asList("pt", "k"),
-                            random.nextInt(maxBuckets) + 1);
+                            bucket.get());
             fileStoreTables.add(fileStoreTable);
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -150,6 +150,7 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
             throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.BUCKET, numBucket);
+        conf.set(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, 100L);
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -60,13 +60,22 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
     @Test
     @Timeout(120)
     public void testRandomCdcEvents() throws Exception {
+        innerTestRandomCdcEvents(ThreadLocalRandom.current().nextInt(5) + 1);
+    }
+
+    @Test
+    @Timeout(120)
+    public void testRandomCdcEventsDynamicBucket() throws Exception {
+        innerTestRandomCdcEvents(-1);
+    }
+
+    private void innerTestRandomCdcEvents(int numBucket) throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         int numEvents = random.nextInt(1500) + 1;
         int numSchemaChanges = Math.min(numEvents / 2, random.nextInt(10) + 1);
         int numPartitions = random.nextInt(3) + 1;
         int numKeys = random.nextInt(150) + 1;
-        int numBucket = random.nextInt(5) + 1;
         boolean enableFailure = random.nextBoolean();
 
         TestTable testTable =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
A bucket is the smallest storage unit for reads and writes, each bucket directory contains an [LSM tree].

Primary Key Table supports two bucket mode:
1. Fixed Bucket mode: configure a bucket greater than 0, rescaling buckets can only be done through offline processes, 
   see [Rescale Bucket]. A too large number of buckets leads to too many
   small files, and a too small number of buckets leads to poor write performance.
2. Dynamic Bucket mode: configure `'bucket' = '-1'`, Paimon dynamically maintains the index, keeping the data volume
   in the bucket below `'dynamic-bucket.target-row-num'`. (This is an experimental feature)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
