### PR TITLE
[Core]Add skip collect statistics columns config

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/ColumnStatisticsCollectSkipper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/ColumnStatisticsCollectSkipper.java
@@ -1,0 +1,17 @@
+package org.apache.paimon.format;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** the helper class for skip the statistics collect. */
+public class ColumnStatisticsCollectSkipper {
+    private Set<Integer> skipColumnIndexes = new HashSet<>();
+
+    public boolean skipStatistics(int index) {
+        return skipColumnIndexes.contains(index);
+    }
+
+    public void addSkipColumnIndex(int index) {
+        skipColumnIndexes.add(index);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Function;
 
 /**
  * Factory class which creates reader and writer factories for specific file format.
@@ -75,7 +76,8 @@ public abstract class FileFormat {
         return createReaderFactory(rowType, projection, new ArrayList<>());
     }
 
-    public Optional<FileStatsExtractor> createStatsExtractor(RowType type) {
+    public Optional<Function<ColumnStatisticsCollectSkipper, FileStatsExtractor>>
+            createStatsExtractorSupplier(RowType type) {
         return Optional.empty();
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/format/FileStatsExtractorTestBase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/format/FileStatsExtractorTestBase.java
@@ -88,7 +88,8 @@ public abstract class FileStatsExtractorTestBase {
         }
         FieldStats[] expected = collector.extract();
 
-        FileStatsExtractor extractor = format.createStatsExtractor(rowType).get();
+        FileStatsExtractor extractor =
+                format.createStatsExtractorSupplier(rowType).get().apply(null);
         assertThat(extractor).isNotNull();
         FieldStats[] actual = extractor.extract(fileIO, path);
         for (int i = 0; i < expected.length; i++) {

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -95,7 +95,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                 pathFactory(),
                 snapshotManager(),
                 newScan(true).withManifestCacheFilter(manifestFilter),
-                options);
+                options,
+                columnStatisticsCollectSkipper);
     }
 
     private AppendOnlyFileStoreScan newScan(boolean forWrite) {

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -156,6 +156,13 @@ public class CoreOptions implements Serializable {
                             "The default partition name in case the dynamic partition"
                                     + " column value is null/empty string.");
 
+    public static final ConfigOption<String> STATISTICS_SKIP_COLUMNS =
+            key("statistics.skip.columns")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify the column name which skipping the statistics,"
+                                    + "you can use commas to separate multiple columns");
     public static final ConfigOption<Integer> SNAPSHOT_NUM_RETAINED_MIN =
             key("snapshot.num-retained.min")
                     .intType()
@@ -896,6 +903,10 @@ public class CoreOptions implements Serializable {
 
     public boolean writeOnly() {
         return options.get(WRITE_ONLY);
+    }
+
+    public String skipStaticsColumn() {
+        return options.get(STATISTICS_SKIP_COLUMNS);
     }
 
     public boolean streamingReadOverwrite() {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -124,7 +124,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 snapshotManager(),
                 newScan(true).withManifestCacheFilter(manifestFilter),
                 options,
-                keyValueFieldsExtractor);
+                keyValueFieldsExtractor,
+                columnStatisticsCollectSkipper);
     }
 
     private KeyValueFileStoreScan newScan(boolean forWrite) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -21,6 +21,7 @@ package org.apache.paimon.append;
 
 import org.apache.paimon.compact.CompactManager;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.CompactIncrement;
@@ -65,6 +66,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
 
     private RowDataRollingFileWriter writer;
 
+    private ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper;
+
     public AppendOnlyWriter(
             FileIO fileIO,
             long schemaId,
@@ -76,7 +79,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
             boolean forceCompact,
             DataFilePathFactory pathFactory,
             @Nullable CommitIncrement increment,
-            String fileCompression) {
+            String fileCompression,
+            @Nullable ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper) {
         this.fileIO = fileIO;
         this.schemaId = schemaId;
         this.fileFormat = fileFormat;
@@ -98,6 +102,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
             compactBefore.addAll(increment.compactIncrement().compactBefore());
             compactAfter.addAll(increment.compactIncrement().compactAfter());
         }
+        this.columnStatisticsCollectSkipper = columnStatisticsCollectSkipper;
     }
 
     @Override
@@ -173,7 +178,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
                 writeSchema,
                 pathFactory,
                 seqNumCounter,
-                fileCompression);
+                fileCompression,
+                columnStatisticsCollectSkipper);
     }
 
     private void trySyncLatestCompaction(boolean blocking)

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -22,6 +22,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FieldStats;
 import org.apache.paimon.format.FileStatsExtractor;
 import org.apache.paimon.format.FormatWriterFactory;
@@ -73,10 +74,12 @@ public class KeyValueDataFileWriter
             Function<KeyValue, InternalRow> converter,
             RowType keyType,
             RowType valueType,
-            @Nullable FileStatsExtractor fileStatsExtractor,
+            @Nullable
+                    Function<ColumnStatisticsCollectSkipper, FileStatsExtractor> fileStatsExtractor,
             long schemaId,
             int level,
-            String compression) {
+            String compression,
+            ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper) {
         super(
                 fileIO,
                 factory,
@@ -84,7 +87,8 @@ public class KeyValueDataFileWriter
                 converter,
                 KeyValue.schema(keyType, valueType),
                 fileStatsExtractor,
-                compression);
+                compression,
+                columnStatisticsCollectSkipper);
 
         this.keyType = keyType;
         this.valueType = valueType;

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
@@ -20,6 +20,7 @@
 package org.apache.paimon.io;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileStatsExtractor;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
@@ -49,10 +50,12 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
             FormatWriterFactory factory,
             Path path,
             RowType writeSchema,
-            @Nullable FileStatsExtractor fileStatsExtractor,
+            @Nullable
+                    Function<ColumnStatisticsCollectSkipper, FileStatsExtractor> fileStatsExtractor,
             long schemaId,
             LongCounter seqNumCounter,
-            String fileCompression) {
+            String fileCompression,
+            ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper) {
         super(
                 fileIO,
                 factory,
@@ -60,7 +63,8 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
                 Function.identity(),
                 writeSchema,
                 fileStatsExtractor,
-                fileCompression);
+                fileCompression,
+                columnStatisticsCollectSkipper);
         this.schemaId = schemaId;
         this.seqNumCounter = seqNumCounter;
         this.statsArraySerializer = new FieldStatsArraySerializer(writeSchema);

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
@@ -20,6 +20,7 @@
 package org.apache.paimon.io;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.types.RowType;
@@ -36,7 +37,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
             RowType writeSchema,
             DataFilePathFactory pathFactory,
             LongCounter seqNumCounter,
-            String fileCompression) {
+            String fileCompression,
+            ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper) {
         super(
                 () ->
                         new RowDataFileWriter(
@@ -44,10 +46,11 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
                                 fileFormat.createWriterFactory(writeSchema),
                                 pathFactory.newPath(),
                                 writeSchema,
-                                fileFormat.createStatsExtractor(writeSchema).orElse(null),
+                                fileFormat.createStatsExtractorSupplier(writeSchema).orElse(null),
                                 schemaId,
                                 seqNumCounter,
-                                fileCompression),
+                                fileCompression,
+                                columnStatisticsCollectSkipper),
                 targetFileSize);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -27,6 +27,7 @@ import org.apache.paimon.compact.CompactManager;
 import org.apache.paimon.compact.NoopCompactManager;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
@@ -93,7 +94,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             CoreOptions options,
-            KeyValueFieldsExtractor extractor) {
+            KeyValueFieldsExtractor extractor,
+            ColumnStatisticsCollectSkipper columnStatisticsCollectSkipper) {
         super(commitUser, snapshotManager, scan, options);
         this.fileIO = fileIO;
         this.keyType = keyType;
@@ -116,7 +118,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         valueType,
                         options.fileFormat(),
                         pathFactory,
-                        options.targetFileSize());
+                        options.targetFileSize(),
+                        columnStatisticsCollectSkipper);
         this.keyComparatorSupplier = keyComparatorSupplier;
         this.valueEqualiserSupplier = valueEqualiserSupplier;
         this.mfFactory = mfFactory;

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -317,7 +317,8 @@ public class AppendOnlyWriterTest {
                         forceCompact,
                         pathFactory,
                         null,
-                        CoreOptions.FILE_COMPRESSION.defaultValue());
+                        CoreOptions.FILE_COMPRESSION.defaultValue(),
+                        null);
         return Pair.of(writer, compactManager.allFiles());
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -74,7 +74,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         false,
                         dataFilePathFactory,
                         null,
-                        CoreOptions.FILE_COMPRESSION.defaultValue());
+                        CoreOptions.FILE_COMPRESSION.defaultValue(),
+                        null);
         appendOnlyWriter.write(
                 GenericRow.of(1, BinaryString.fromString("aaa"), BinaryString.fromString("1")));
         CommitIncrement increment = appendOnlyWriter.prepareCommit(true);

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileStatsExtractingAvroFormat.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileStatsExtractingAvroFormat.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 /** An avro {@link FileFormat} for test. It provides a {@link FileStatsExtractor}. */
 public class FileStatsExtractingAvroFormat extends FileFormat {
@@ -55,7 +56,8 @@ public class FileStatsExtractingAvroFormat extends FileFormat {
     }
 
     @Override
-    public Optional<FileStatsExtractor> createStatsExtractor(RowType type) {
-        return Optional.of(new TestFileStatsExtractor(this, type));
+    public Optional<Function<ColumnStatisticsCollectSkipper, FileStatsExtractor>>
+            createStatsExtractorSupplier(RowType type) {
+        return Optional.of(statSkip -> new TestFileStatsExtractor(this, type));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -254,7 +254,8 @@ public class KeyValueFileReadWriteTest {
                         // special format which flushes for every added element
                         new FlushingFileFormat(format),
                         pathFactory,
-                        suggestedFileSize)
+                        suggestedFileSize,
+                        null)
                 .build(BinaryRow.EMPTY_ROW, 0, null, null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -73,10 +73,13 @@ public class RollingFileWriterTest {
                                                                 .toString())
                                                 .newPath(),
                                         SCHEMA,
-                                        fileFormat.createStatsExtractor(SCHEMA).orElse(null),
+                                        fileFormat
+                                                .createStatsExtractorSupplier(SCHEMA)
+                                                .orElse(null),
                                         0L,
                                         new LongCounter(0),
-                                        CoreOptions.FILE_COMPRESSION.defaultValue()),
+                                        CoreOptions.FILE_COMPRESSION.defaultValue(),
+                                        null),
                         TARGET_FILE_SIZE);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -233,7 +233,8 @@ public class LookupLevelsTest {
                         rowType,
                         new FlushingFileFormat("avro"),
                         new FileStorePathFactory(path),
-                        TARGET_FILE_SIZE.defaultValue().getBytes())
+                        TARGET_FILE_SIZE.defaultValue().getBytes(),
+                        null)
                 .build(BinaryRow.EMPTY_ROW, 0, null, null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -177,7 +177,8 @@ public abstract class MergeTreeTestBase {
                         valueType,
                         flushingAvro,
                         pathFactory,
-                        options.targetFileSize());
+                        options.targetFileSize(),
+                        null);
         writerFactory =
                 writerFactoryBuilder.build(
                         BinaryRow.EMPTY_ROW,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -186,7 +186,8 @@ public class TestChangelogDataReadWrite {
                                 snapshotManager,
                                 null, // not used, we only create an empty writer
                                 options,
-                                EXTRACTOR)
+                                EXTRACTOR,
+                                null)
                         .createWriterContainer(partition, bucket, true)
                         .writer;
         ((MemoryOwner) writer)

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -20,6 +20,7 @@ package org.apache.paimon.format.orc;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FileStatsExtractor;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.types.DataTypeChecks.getFieldTypes;
@@ -86,8 +88,9 @@ public class OrcFileFormat extends FileFormat {
     }
 
     @Override
-    public Optional<FileStatsExtractor> createStatsExtractor(RowType type) {
-        return Optional.of(new OrcFileStatsExtractor(type));
+    public Optional<Function<ColumnStatisticsCollectSkipper, FileStatsExtractor>>
+            createStatsExtractorSupplier(RowType type) {
+        return Optional.of(statSkipper -> new OrcFileStatsExtractor(type, statSkipper));
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcFileStatsExtractor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcFileStatsExtractor.java
@@ -81,17 +81,16 @@ public class OrcFileStatsExtractor implements FileStatsExtractor {
                                 DataField field = rowType.getFields().get(i);
                                 int fieldIdx = columnNames.indexOf(field.name());
                                 int colId = columnTypes.get(fieldIdx).getId();
-                                return toFieldStats(field, columnStatistics[colId], rowCount, i);
+                                return toFieldStats(field, columnStatistics[colId], rowCount);
                             })
                     .toArray(FieldStats[]::new);
         }
     }
 
-    private FieldStats toFieldStats(
-            DataField field, ColumnStatistics stats, long rowCount, int index) {
+    private FieldStats toFieldStats(DataField field, ColumnStatistics stats, long rowCount) {
         long nullCount = rowCount - stats.getNumberOfValues();
 
-        if (nullCount == rowCount || (skipper != null && skipper.skipStatistics(index))) {
+        if (nullCount == rowCount || (skipper != null && skipper.skipStatistics(field.id()))) {
             // all nulls
             return new FieldStats(null, null, nullCount);
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.format.ColumnStatisticsCollectSkipper;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FileStatsExtractor;
@@ -32,6 +33,7 @@ import org.apache.paimon.utils.Projection;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.apache.paimon.format.parquet.ParquetFileFormatFactory.IDENTIFIER;
 
@@ -72,8 +74,9 @@ public class ParquetFileFormat extends FileFormat {
     }
 
     @Override
-    public Optional<FileStatsExtractor> createStatsExtractor(RowType type) {
-        return Optional.of(new ParquetFileStatsExtractor(type));
+    public Optional<Function<ColumnStatisticsCollectSkipper, FileStatsExtractor>>
+            createStatsExtractorSupplier(RowType type) {
+        return Optional.of(statSkipper -> new ParquetFileStatsExtractor(type));
     }
 
     public static Options getParquetConfiguration(Options options) {


### PR DESCRIPTION
When collecting statistics for a large column in Paimon, it can consume a large amount of memory, especially when dealing with a large number of entries. Therefore, a configuration was added to the PR for collecting statistics on a specific column.

Add a draft for  discusstion 