### PR TITLE
[flink] Supports watermark transmitting for consumer-id mode

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -160,6 +160,8 @@ When stream read Paimon tables, the next snapshot id to be recorded into the fil
    resuming from the state. The newly reading will start reading from next snapshot id found in consumer files.
 2. When deciding whether a snapshot has expired, Paimon looks at all the consumers of the table in the file system,
    and if there are consumers that still depend on this snapshot, then this snapshot will not be deleted by expiration.
+3. When there is no watermark definition, the Paimon table will pass the watermark in the snapshot to the downstream
+   Paimon table, which means you can track the progress of the watermark for the entire pipeline.
 
 {{< hint info >}}
 NOTE: The consumer will prevent expiration of the snapshot. You can specify 'consumer.expiration-time' to manage the 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -62,6 +62,9 @@ public interface FileStoreScan {
     /** Result plan of this scan. */
     interface Plan {
 
+        @Nullable
+        Long watermark();
+
         /**
          * Snapshot id of this plan, return null if the table is empty or the manifest list is
          * specified.

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -99,7 +99,7 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public SnapshotReader newSnapshotSplitReader() {
+    public SnapshotReader newSnapshotReader() {
         return new SnapshotReaderImpl(
                 store().newScan(),
                 tableSchema,
@@ -111,14 +111,14 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public InnerTableScan newScan() {
-        return new InnerTableScanImpl(coreOptions(), newSnapshotSplitReader(), snapshotManager());
+        return new InnerTableScanImpl(coreOptions(), newSnapshotReader(), snapshotManager());
     }
 
     @Override
     public InnerStreamTableScan newStreamScan() {
         return new InnerStreamTableScanImpl(
                 coreOptions(),
-                newSnapshotSplitReader(),
+                newSnapshotReader(),
                 snapshotManager(),
                 supportStreamingReadOverwrite());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -40,8 +40,8 @@ import org.apache.paimon.table.source.InnerStreamTableScanImpl;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.InnerTableScanImpl;
 import org.apache.paimon.table.source.SplitGenerator;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReaderImpl;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReaderImpl;
 import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanner;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -99,8 +99,8 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public SnapshotSplitReader newSnapshotSplitReader() {
-        return new SnapshotSplitReaderImpl(
+    public SnapshotReader newSnapshotSplitReader() {
+        return new SnapshotReaderImpl(
                 store().newScan(),
                 tableSchema,
                 coreOptions(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
@@ -27,7 +27,7 @@ import org.apache.paimon.utils.SnapshotManager;
 /** A {@link Table} for data. */
 public interface DataTable extends InnerTable {
 
-    SnapshotReader newSnapshotSplitReader();
+    SnapshotReader newSnapshotReader();
 
     CoreOptions coreOptions();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
@@ -21,13 +21,13 @@ package org.apache.paimon.table;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.utils.SnapshotManager;
 
 /** A {@link Table} for data. */
 public interface DataTable extends InnerTable {
 
-    SnapshotSplitReader newSnapshotSplitReader();
+    SnapshotReader newSnapshotSplitReader();
 
     CoreOptions coreOptions();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -32,7 +32,7 @@ import org.apache.paimon.table.source.snapshot.ContinuousFromTimestampStartingSc
 import org.apache.paimon.table.source.snapshot.ContinuousLatestStartingScanner;
 import org.apache.paimon.table.source.snapshot.FullCompactedStartingScanner;
 import org.apache.paimon.table.source.snapshot.FullStartingScanner;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.StartingScanner;
 import org.apache.paimon.table.source.snapshot.StaticFromSnapshotStartingScanner;
 import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanner;
@@ -47,16 +47,16 @@ import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 public abstract class AbstractInnerTableScan implements InnerTableScan {
 
     private final CoreOptions options;
-    protected final SnapshotSplitReader snapshotSplitReader;
+    protected final SnapshotReader snapshotReader;
 
-    protected AbstractInnerTableScan(CoreOptions options, SnapshotSplitReader snapshotSplitReader) {
+    protected AbstractInnerTableScan(CoreOptions options, SnapshotReader snapshotReader) {
         this.options = options;
-        this.snapshotSplitReader = snapshotSplitReader;
+        this.snapshotReader = snapshotReader;
     }
 
     @VisibleForTesting
     public AbstractInnerTableScan withBucket(int bucket) {
-        snapshotSplitReader.withBucket(bucket);
+        snapshotReader.withBucket(bucket);
         return this;
     }
 
@@ -84,7 +84,7 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
         // read from consumer id
         String consumerId = options.consumerId();
         if (consumerId != null) {
-            ConsumerManager consumerManager = snapshotSplitReader.consumerManager();
+            ConsumerManager consumerManager = snapshotReader.consumerManager();
             Optional<Consumer> consumer = consumerManager.consumer(consumerId);
             if (consumer.isPresent()) {
                 return new ContinuousFromSnapshotStartingScanner(consumer.get().nextSnapshot());
@@ -142,6 +142,6 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
     }
 
     public List<BinaryRow> listPartitions() {
-        return snapshotSplitReader.partitions();
+        return snapshotReader.partitions();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.StartingScanner;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -34,17 +34,15 @@ public class InnerTableScanImpl extends AbstractInnerTableScan {
     private boolean hasNext;
 
     public InnerTableScanImpl(
-            CoreOptions options,
-            SnapshotSplitReader snapshotSplitReader,
-            SnapshotManager snapshotManager) {
-        super(options, snapshotSplitReader);
+            CoreOptions options, SnapshotReader snapshotReader, SnapshotManager snapshotManager) {
+        super(options, snapshotReader);
         this.snapshotManager = snapshotManager;
         this.hasNext = true;
     }
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        snapshotSplitReader.withFilter(predicate);
+        snapshotReader.withFilter(predicate);
         return this;
     }
 
@@ -56,8 +54,7 @@ public class InnerTableScanImpl extends AbstractInnerTableScan {
 
         if (hasNext) {
             hasNext = false;
-            StartingScanner.Result result =
-                    startingScanner.scan(snapshotManager, snapshotSplitReader);
+            StartingScanner.Result result = startingScanner.scan(snapshotManager, snapshotReader);
             return DataFilePlan.fromResult(result);
         } else {
             throw new EndOfScanException();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/StreamTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/StreamTableScan.java
@@ -33,6 +33,10 @@ import javax.annotation.Nullable;
 @Public
 public interface StreamTableScan extends TableScan, Restorable<Long> {
 
+    /** Current watermark for consumed snapshot. */
+    @Nullable
+    Long watermark();
+
     /** Restore from checkpoint next snapshot id. */
     @Override
     void restore(@Nullable Long nextSnapshotId);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -33,7 +33,7 @@ public class CompactedStartingScanner implements StartingScanner {
     private static final Logger LOG = LoggerFactory.getLogger(CompactedStartingScanner.class);
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long startingSnapshotId = pick(snapshotManager);
         if (startingSnapshotId == null) {
             startingSnapshotId = snapshotManager.latestSnapshotId();
@@ -47,12 +47,8 @@ public class CompactedStartingScanner implements StartingScanner {
             }
         }
 
-        return new ScannedResult(
-                startingSnapshotId,
-                snapshotSplitReader
-                        .withKind(ScanKind.ALL)
-                        .withSnapshot(startingSnapshotId)
-                        .splits());
+        return StartingScanner.fromPlan(
+                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshotId).read());
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
@@ -21,8 +21,6 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
-import org.apache.paimon.table.source.DataFilePlan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +48,7 @@ public class CompactionChangelogFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(
-                snapshotSplitReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).splits());
+    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
@@ -20,8 +20,6 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
-import org.apache.paimon.table.source.DataFilePlan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +48,7 @@ public class ContinuousAppendAndCompactFollowUpScanner implements FollowUpScanne
     }
 
     @Override
-    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(
-                snapshotSplitReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).splits());
+    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
@@ -20,8 +20,6 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
-import org.apache.paimon.table.source.DataFilePlan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,8 +44,7 @@ public class ContinuousCompactorFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(
-                snapshotSplitReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).splits());
+    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScanner.java
@@ -31,7 +31,7 @@ public class ContinuousCompactorStartingScanner implements StartingScanner {
             LoggerFactory.getLogger(ContinuousCompactorStartingScanner.class);
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (latestSnapshotId == null || earliestSnapshotId == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -34,7 +34,7 @@ public class ContinuousFromSnapshotStartingScanner implements StartingScanner {
     }
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
         if (earliestSnapshotId == null) {
             return new NoSnapshot();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -40,7 +40,7 @@ public class ContinuousFromTimestampStartingScanner implements StartingScanner {
     }
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long startingSnapshotId = snapshotManager.earlierThanTimeMills(startupMillis);
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
@@ -34,7 +34,7 @@ public class ContinuousLatestStartingScanner implements StartingScanner {
             LoggerFactory.getLogger(ContinuousLatestStartingScanner.class);
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
@@ -21,8 +21,6 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
-import org.apache.paimon.table.source.DataFilePlan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,8 +44,7 @@ public class DeltaFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(
-                snapshotSplitReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).splits());
+    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FollowUpScanner.java
@@ -19,19 +19,17 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.StreamTableScan;
-import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.table.source.snapshot.SnapshotReader.Plan;
 
 /** Helper class for the follow-up planning of {@link StreamTableScan}. */
 public interface FollowUpScanner {
 
     boolean shouldScanSnapshot(Snapshot snapshot);
 
-    TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader);
+    Plan scan(long snapshotId, SnapshotReader snapshotReader);
 
-    default TableScan.Plan getOverwriteChangesPlan(
-            long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(snapshotSplitReader.withSnapshot(snapshotId).overwriteSplits());
+    default Plan getOverwriteChangesPlan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withSnapshot(snapshotId).readOverwrittenChanges();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
@@ -31,17 +31,13 @@ public class FullStartingScanner implements StartingScanner {
     private static final Logger LOG = LoggerFactory.getLogger(FullStartingScanner.class);
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Long startingSnapshotId = snapshotManager.latestSnapshotId();
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
             return new NoSnapshot();
         }
-        return new ScannedResult(
-                startingSnapshotId,
-                snapshotSplitReader
-                        .withKind(ScanKind.ALL)
-                        .withSnapshot(startingSnapshotId)
-                        .splits());
+        return StartingScanner.fromPlan(
+                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshotId).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
@@ -21,8 +21,6 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
-import org.apache.paimon.table.source.DataFilePlan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,8 +44,7 @@ public class InputChangelogFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public TableScan.Plan scan(long snapshotId, SnapshotSplitReader snapshotSplitReader) {
-        return new DataFilePlan(
-                snapshotSplitReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).splits());
+    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
+        return snapshotReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -34,13 +34,12 @@ public class StaticFromSnapshotStartingScanner implements StartingScanner {
     }
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         if (snapshotManager.earliestSnapshotId() == null
                 || snapshotId < snapshotManager.earliestSnapshotId()) {
             return new NoSnapshot();
         }
-        return new ScannedResult(
-                snapshotId,
-                snapshotSplitReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).splits());
+        return StartingScanner.fromPlan(
+                snapshotReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -44,7 +44,7 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
     }
 
     @Override
-    public Result scan(SnapshotManager snapshotManager, SnapshotSplitReader snapshotSplitReader) {
+    public Result scan(SnapshotManager snapshotManager, SnapshotReader snapshotReader) {
         Snapshot startingSnapshot = timeTravelToTimestamp(snapshotManager, startupMillis);
         if (startingSnapshot == null) {
             LOG.debug(
@@ -52,12 +52,8 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
                     startupMillis);
             return new NoSnapshot();
         }
-        return new ScannedResult(
-                startingSnapshot.id(),
-                snapshotSplitReader
-                        .withKind(ScanKind.ALL)
-                        .withSnapshot(startingSnapshot.id())
-                        .splits());
+        return StartingScanner.fromPlan(
+                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshot.id()).read());
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -119,8 +119,8 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
     }
 
     @Override
-    public SnapshotReader newSnapshotSplitReader() {
-        return new AuditLogDataReader(dataTable.newSnapshotSplitReader());
+    public SnapshotReader newSnapshotReader() {
+        return new AuditLogDataReader(dataTable.newSnapshotReader());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -35,7 +35,7 @@ import org.apache.paimon.table.source.InnerStreamTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
@@ -105,7 +105,7 @@ public class BucketsTable implements DataTable, ReadonlyTable {
     }
 
     @Override
-    public SnapshotSplitReader newSnapshotSplitReader() {
+    public SnapshotReader newSnapshotSplitReader() {
         return wrapped.newSnapshotSplitReader();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -105,8 +105,8 @@ public class BucketsTable implements DataTable, ReadonlyTable {
     }
 
     @Override
-    public SnapshotReader newSnapshotSplitReader() {
-        return wrapped.newSnapshotSplitReader();
+    public SnapshotReader newSnapshotReader() {
+        return wrapped.newSnapshotReader();
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -177,11 +177,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("+101|11", "+102|12"));

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -64,7 +64,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -88,7 +88,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .hasSameElementsAs(Arrays.asList("100|10", "101|11", "102|12", "101|11", "102|12"));
@@ -104,7 +104,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
+                toSplits(table.newSnapshotReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -133,7 +133,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         int[] partitions =
                 splits.stream()
                         .map(split -> ((DataSplit) split).partition().getInt(0))
@@ -162,7 +162,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         int[] partitions =
                 splits.stream()
                         .map(split -> ((DataSplit) split).partition().getInt(0))
@@ -178,7 +178,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());
@@ -198,7 +198,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         Predicate predicate = builder.equal(2, 101L);
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
                                 .read()
@@ -257,7 +257,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 new PredicateBuilder(table.schema().logicalRowType()).equal(0, partition);
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withFilter(partitionFilter)
                                 .withBucket(bucket)
                                 .read()

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -64,7 +64,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -88,7 +88,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .hasSameElementsAs(Arrays.asList("100|10", "101|11", "102|12", "101|11", "102|12"));
@@ -104,7 +104,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -133,7 +133,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         int[] partitions =
                 splits.stream()
                         .map(split -> ((DataSplit) split).partition().getInt(0))
@@ -162,7 +162,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         int[] partitions =
                 splits.stream()
                         .map(split -> ((DataSplit) split).partition().getInt(0))
@@ -177,7 +177,11 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("+101|11", "+102|12"));
@@ -197,7 +201,8 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         table.newSnapshotSplitReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
-                                .splits());
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -255,7 +260,8 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         table.newSnapshotSplitReader()
                                 .withFilter(partitionFilter)
                                 .withBucket(bucket)
-                                .splits());
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
 
         assertThat(getResult(read, splits, binaryRow(partition), bucket, STREAMING_ROW_TO_STRING))

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
@@ -109,11 +109,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -134,11 +130,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("-100|10", "+101|11"));
@@ -211,11 +203,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         // check that no data file is produced
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         assertThat(splits).isEmpty();
         // check that no changelog file is produced
         Path bucketPath = DataFilePathFactory.bucketPath(table.location(), "1", 0);

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
@@ -55,7 +55,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -76,7 +76,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("101|11", "101|11", "102|12"));
@@ -92,7 +92,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
+                toSplits(table.newSnapshotReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -110,7 +110,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());
@@ -135,7 +135,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());
@@ -155,7 +155,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
                                 .read()
@@ -212,7 +212,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         // check that no data file is produced
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
@@ -55,7 +55,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -76,7 +76,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("101|11", "101|11", "102|12"));
@@ -92,7 +92,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -109,7 +109,11 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -130,7 +134,11 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("-100|10", "+101|11"));
@@ -150,7 +158,8 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                         table.newSnapshotSplitReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
-                                .splits());
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
@@ -202,7 +211,11 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         // check that no data file is produced
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         assertThat(splits).isEmpty();
         // check that no changelog file is produced
         Path bucketPath = DataFilePathFactory.bucketPath(table.location(), "1", 0);

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
@@ -57,7 +57,11 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                            toSplits(
+                                    table.newSnapshotSplitReader()
+                                            .withFilter(predicate)
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -80,7 +84,8 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())
                                                             .between(6, 200F, 500F))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
@@ -58,7 +58,7 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                                     .between(6, 200L, 500L);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(predicate)
                                             .read()
                                             .dataSplits());
@@ -79,7 +79,7 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                      */
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
@@ -56,7 +56,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));
@@ -76,7 +76,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     /// TODO: changelog with key only supports to filter key
                     splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(builder.equal(3, 1122))
                                             .read()
                                             .dataSplits());
@@ -107,7 +107,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     // scan filter with "kt" = 114 in schema0
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(builder.equal(4, 114L))
                                             .read()
                                             .dataSplits());
@@ -123,7 +123,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     // scan filter with "kt" = 114 in schema1
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(builder.equal(2, 114L))
                                             .read()
                                             .dataSplits());
@@ -133,7 +133,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                                     Collections.singletonList("1|14|114|null|null|null"));
 
                     // read filter with "kt" = 114 in schema1
-                    splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                    splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     TableRead read2 = table.newRead().withFilter(builder.equal(2, 114L));
                     assertThat(getResult(read2, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
@@ -153,7 +153,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -174,7 +174,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -212,7 +212,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -230,7 +230,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
@@ -55,8 +55,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
@@ -55,7 +55,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));
@@ -77,7 +78,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withFilter(builder.equal(3, 1122))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     TableRead read2 = table.newRead().withFilter(builder.equal(3, 1122));
                     assertThat(getResult(read2, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
@@ -107,7 +109,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withFilter(builder.equal(4, 114L))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     TableRead read = table.newRead();
                     assertThat(getResult(read, splits, SCHEMA_0_ROW_TO_STRING))
                             .hasSameElementsAs(Collections.singletonList("S004|1|14|S14|114|S114"));
@@ -122,14 +125,15 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withFilter(builder.equal(2, 114L))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     TableRead read1 = table.newRead();
                     assertThat(getResult(read1, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
                                     Collections.singletonList("1|14|114|null|null|null"));
 
                     // read filter with "kt" = 114 in schema1
-                    splits = toSplits(table.newSnapshotSplitReader().splits());
+                    splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     TableRead read2 = table.newRead().withFilter(builder.equal(2, 114L));
                     assertThat(getResult(read2, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
@@ -151,7 +155,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     // filter with "b" = 15 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(2, 15));
 
@@ -171,7 +176,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
 
                     // filter with "d" = 15 in schema1 which should be mapped to "b" = 15 in schema0
                     /// TODO: changelog with key only supports to filter on key
@@ -208,7 +214,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     // filter with "kt" = 116 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(4, 116));
 
@@ -225,7 +232,8 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
 
                     // filter with "kt" = 120 in schema1
                     TableRead read = table.newRead().withFilter(builder.equal(1, 120));

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -84,10 +84,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(2, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -100,10 +97,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**
@@ -137,10 +131,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -50,7 +50,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -58,7 +58,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**
@@ -84,7 +84,10 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(2, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -97,7 +100,10 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**
@@ -117,7 +123,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -131,7 +137,10 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -50,7 +50,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -58,7 +58,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     /**
@@ -84,7 +84,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(2, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -100,7 +100,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -123,7 +123,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -137,7 +137,7 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -122,7 +122,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.close();
 
         ReadBuilder readBuilder = table.newReadBuilder();
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = readBuilder.newRead();
         assertThat(getResult(read, splits, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -145,7 +145,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(1, write.prepareCommit(true, 1));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -159,7 +159,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -177,7 +177,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("1000|10"));
@@ -193,7 +193,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         Predicate predicate = PredicateBuilder.and(builder.equal(2, 201L), builder.equal(1, 21));
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
+                toSplits(table.newSnapshotReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -212,7 +212,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());
@@ -236,7 +236,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .read()
                                 .dataSplits());
@@ -257,7 +257,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         Predicate predicate = PredicateBuilder.and(builder.equal(2, 201L), builder.equal(1, 21));
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
                                 .read()
@@ -294,7 +294,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.CHANGELOG)
                                 .read()
                                 .dataSplits());
@@ -333,7 +333,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.CHANGELOG)
                                 .read()
                                 .dataSplits());
@@ -359,7 +359,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.CHANGELOG)
                                 .read()
                                 .dataSplits());
@@ -388,7 +388,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withKind(ScanKind.CHANGELOG)
                                 .read()
                                 .dataSplits());
@@ -550,7 +550,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
         // push down key filter a = 30
         TableRead read = table.newRead().withFilter(builder.equal(1, 30));
@@ -589,7 +589,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.close();
 
         // cannot push down value filter b = 600L
-        splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        splits = toSplits(table.newSnapshotReader().read().dataSplits());
         read = table.newRead().withFilter(builder.equal(2, 600L));
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -621,7 +621,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -651,7 +651,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -674,7 +674,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(1, 20, 200L));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        SnapshotReader snapshotReader = table.newSnapshotSplitReader().withKind(ScanKind.DELTA);
+        SnapshotReader snapshotReader = table.newSnapshotReader().withKind(ScanKind.DELTA);
         List<DataSplit> splits0 = snapshotReader.read().dataSplits();
         assertThat(splits0).hasSize(1);
         assertThat(splits0.get(0).files()).hasSize(1);
@@ -726,7 +726,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         PredicateBuilder predicateBuilder = new PredicateBuilder(auditLogTable.rowType());
 
         // Read all
-        SnapshotReader snapshotReader = auditLogTable.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = auditLogTable.newSnapshotReader();
         TableRead read = auditLogTable.newRead();
         List<String> result =
                 getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
@@ -736,7 +736,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         // Read by filter row kind (No effect)
         Predicate rowKindEqual = predicateBuilder.equal(0, BinaryString.fromString("+I"));
-        snapshotReader = auditLogTable.newSnapshotSplitReader().withFilter(rowKindEqual);
+        snapshotReader = auditLogTable.newSnapshotReader().withFilter(rowKindEqual);
         read = auditLogTable.newRead().withFilter(rowKindEqual);
         result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result)
@@ -745,13 +745,13 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         // Read by filter
         snapshotReader =
-                auditLogTable.newSnapshotSplitReader().withFilter(predicateBuilder.equal(2, 10));
+                auditLogTable.newSnapshotReader().withFilter(predicateBuilder.equal(2, 10));
         read = auditLogTable.newRead().withFilter(predicateBuilder.equal(2, 10));
         result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result).containsExactlyInAnyOrder("+I[+I, 1, 10, 100]");
 
         // Read by projection
-        snapshotReader = auditLogTable.newSnapshotSplitReader();
+        snapshotReader = auditLogTable.newSnapshotReader();
         read = auditLogTable.newRead().withProjection(new int[] {2, 0, 1});
         Function<InternalRow, String> projectToString1 =
                 row ->
@@ -764,7 +764,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                 .containsExactlyInAnyOrder("+I[20, +I, 2]", "+I[30, +U, 1]", "+I[10, +I, 1]");
 
         // Read by projection without row kind
-        snapshotReader = auditLogTable.newSnapshotSplitReader();
+        snapshotReader = auditLogTable.newSnapshotReader();
         read = auditLogTable.newRead().withProjection(new int[] {2, 1});
         Function<InternalRow, String> projectToString2 =
                 row -> internalRowToString(row, DataTypes.ROW(DataTypes.INT(), DataTypes.INT()));
@@ -790,7 +790,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         },
                         rowType);
         Function<InternalRow, String> rowToString = row -> internalRowToString(row, rowType);
-        SnapshotReader snapshotReader = table.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = table.newSnapshotReader();
         TableRead read = table.newRead();
         StreamTableWrite write = table.newWrite("");
         StreamTableCommit commit = table.newCommit("");

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -48,7 +48,7 @@ import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.source.TableScan;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.system.AuditLogTable;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
@@ -122,7 +122,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.close();
 
         ReadBuilder readBuilder = table.newReadBuilder();
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = readBuilder.newRead();
         assertThat(getResult(read, splits, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -145,7 +145,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(1, write.prepareCommit(true, 1));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -159,7 +159,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -177,7 +177,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         writeData();
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("1000|10"));
@@ -193,7 +193,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         Predicate predicate = PredicateBuilder.and(builder.equal(2, 201L), builder.equal(1, 21));
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                toSplits(table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
@@ -211,7 +211,11 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -231,7 +235,11 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.DELTA).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.DELTA)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
 
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
@@ -252,7 +260,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         table.newSnapshotSplitReader()
                                 .withKind(ScanKind.DELTA)
                                 .withFilter(predicate)
-                                .splits());
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
@@ -284,7 +293,11 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.close();
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.CHANGELOG).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.CHANGELOG)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -319,7 +332,11 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(0, write.prepareCommit(true, 0));
 
         List<Split> splits =
-                toSplits(table.newSnapshotSplitReader().withKind(ScanKind.CHANGELOG).splits());
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.CHANGELOG)
+                                .read()
+                                .dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -340,7 +357,12 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.compact(binaryRow(2), 0, true);
         commit.commit(2, write.prepareCommit(true, 2));
 
-        splits = toSplits(table.newSnapshotSplitReader().withKind(ScanKind.CHANGELOG).splits());
+        splits =
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.CHANGELOG)
+                                .read()
+                                .dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("+I 1|30|130|binary|varbinary|mapKey:mapVal|multiset");
         assertThat(getResult(read, splits, binaryRow(2), 0, CHANGELOG_ROW_TO_STRING))
@@ -364,7 +386,12 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.compact(binaryRow(2), 0, true);
         commit.commit(4, write.prepareCommit(true, 4));
 
-        splits = toSplits(table.newSnapshotSplitReader().withKind(ScanKind.CHANGELOG).splits());
+        splits =
+                toSplits(
+                        table.newSnapshotSplitReader()
+                                .withKind(ScanKind.CHANGELOG)
+                                .read()
+                                .dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "-D 1|20|120|binary|varbinary|mapKey:mapVal|multiset",
@@ -523,7 +550,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
         // push down key filter a = 30
         TableRead read = table.newRead().withFilter(builder.equal(1, 30));
@@ -562,7 +589,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.close();
 
         // cannot push down value filter b = 600L
-        splits = toSplits(table.newSnapshotSplitReader().splits());
+        splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         read = table.newRead().withFilter(builder.equal(2, 600L));
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -594,7 +621,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -624,7 +651,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
@@ -647,9 +674,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(1, 20, 200L));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        SnapshotSplitReader snapshotSplitReader =
-                table.newSnapshotSplitReader().withKind(ScanKind.DELTA);
-        List<DataSplit> splits0 = snapshotSplitReader.splits();
+        SnapshotReader snapshotReader = table.newSnapshotSplitReader().withKind(ScanKind.DELTA);
+        List<DataSplit> splits0 = snapshotReader.read().dataSplits();
         assertThat(splits0).hasSize(1);
         assertThat(splits0.get(0).files()).hasSize(1);
 
@@ -660,7 +686,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.withOverwrite(overwritePartition);
         commit.commit(1, write.prepareCommit(true, 1));
 
-        List<DataSplit> splits1 = snapshotSplitReader.splits();
+        List<DataSplit> splits1 = snapshotReader.read().dataSplits();
         assertThat(splits1).hasSize(1);
         assertThat(splits1.get(0).files()).hasSize(1);
         assertThat(splits1.get(0).files().get(0).fileName())
@@ -700,32 +726,32 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         PredicateBuilder predicateBuilder = new PredicateBuilder(auditLogTable.rowType());
 
         // Read all
-        SnapshotSplitReader snapshotSplitReader = auditLogTable.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = auditLogTable.newSnapshotSplitReader();
         TableRead read = auditLogTable.newRead();
         List<String> result =
-                getResult(read, toSplits(snapshotSplitReader.splits()), rowDataToString);
+                getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result)
                 .containsExactlyInAnyOrder(
                         "+I[+I, 2, 20, 200]", "+I[+U, 1, 30, 300]", "+I[+I, 1, 10, 100]");
 
         // Read by filter row kind (No effect)
         Predicate rowKindEqual = predicateBuilder.equal(0, BinaryString.fromString("+I"));
-        snapshotSplitReader = auditLogTable.newSnapshotSplitReader().withFilter(rowKindEqual);
+        snapshotReader = auditLogTable.newSnapshotSplitReader().withFilter(rowKindEqual);
         read = auditLogTable.newRead().withFilter(rowKindEqual);
-        result = getResult(read, toSplits(snapshotSplitReader.splits()), rowDataToString);
+        result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result)
                 .containsExactlyInAnyOrder(
                         "+I[+I, 2, 20, 200]", "+I[+U, 1, 30, 300]", "+I[+I, 1, 10, 100]");
 
         // Read by filter
-        snapshotSplitReader =
+        snapshotReader =
                 auditLogTable.newSnapshotSplitReader().withFilter(predicateBuilder.equal(2, 10));
         read = auditLogTable.newRead().withFilter(predicateBuilder.equal(2, 10));
-        result = getResult(read, toSplits(snapshotSplitReader.splits()), rowDataToString);
+        result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result).containsExactlyInAnyOrder("+I[+I, 1, 10, 100]");
 
         // Read by projection
-        snapshotSplitReader = auditLogTable.newSnapshotSplitReader();
+        snapshotReader = auditLogTable.newSnapshotSplitReader();
         read = auditLogTable.newRead().withProjection(new int[] {2, 0, 1});
         Function<InternalRow, String> projectToString1 =
                 row ->
@@ -733,16 +759,16 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 row,
                                 DataTypes.ROW(
                                         DataTypes.INT(), DataTypes.STRING(), DataTypes.INT()));
-        result = getResult(read, toSplits(snapshotSplitReader.splits()), projectToString1);
+        result = getResult(read, toSplits(snapshotReader.read().dataSplits()), projectToString1);
         assertThat(result)
                 .containsExactlyInAnyOrder("+I[20, +I, 2]", "+I[30, +U, 1]", "+I[10, +I, 1]");
 
         // Read by projection without row kind
-        snapshotSplitReader = auditLogTable.newSnapshotSplitReader();
+        snapshotReader = auditLogTable.newSnapshotSplitReader();
         read = auditLogTable.newRead().withProjection(new int[] {2, 1});
         Function<InternalRow, String> projectToString2 =
                 row -> internalRowToString(row, DataTypes.ROW(DataTypes.INT(), DataTypes.INT()));
-        result = getResult(read, toSplits(snapshotSplitReader.splits()), projectToString2);
+        result = getResult(read, toSplits(snapshotReader.read().dataSplits()), projectToString2);
         assertThat(result).containsExactlyInAnyOrder("+I[20, 2]", "+I[30, 1]", "+I[10, 1]");
     }
 
@@ -764,7 +790,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         },
                         rowType);
         Function<InternalRow, String> rowToString = row -> internalRowToString(row, rowType);
-        SnapshotSplitReader snapshotSplitReader = table.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = table.newSnapshotSplitReader();
         TableRead read = table.newRead();
         StreamTableWrite write = table.newWrite("");
         StreamTableCommit commit = table.newCommit("");
@@ -775,7 +801,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(GenericRow.of(1, 1, 2, 2));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        List<String> result = getResult(read, toSplits(snapshotSplitReader.splits()), rowToString);
+        List<String> result =
+                getResult(read, toSplits(snapshotReader.read().dataSplits()), rowToString);
         assertThat(result).containsExactlyInAnyOrder("+I[1, 1, 6, 3]");
 
         // 2. Retracts
@@ -784,7 +811,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(GenericRow.ofKind(RowKind.DELETE, 1, 1, 1, 1));
         commit.commit(1, write.prepareCommit(true, 1));
 
-        result = getResult(read, toSplits(snapshotSplitReader.splits()), rowToString);
+        result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowToString);
         assertThat(result).containsExactlyInAnyOrder("+I[1, 1, 2, 3]");
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -211,11 +211,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -235,11 +231,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
-                                .read()
-                                .dataSplits());
+                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
 
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
@@ -294,10 +286,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.CHANGELOG)
-                                .read()
-                                .dataSplits());
+                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -333,10 +322,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.CHANGELOG)
-                                .read()
-                                .dataSplits());
+                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -359,10 +345,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.CHANGELOG)
-                                .read()
-                                .dataSplits());
+                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("+I 1|30|130|binary|varbinary|mapKey:mapVal|multiset");
         assertThat(getResult(read, splits, binaryRow(2), 0, CHANGELOG_ROW_TO_STRING))
@@ -388,10 +371,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotReader()
-                                .withKind(ScanKind.CHANGELOG)
-                                .read()
-                                .dataSplits());
+                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "-D 1|20|120|binary|varbinary|mapKey:mapVal|multiset",

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
@@ -91,7 +91,10 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -109,7 +112,8 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(6, 200F, 500F))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                 },
                 getPrimaryKeyNames(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
@@ -91,10 +91,7 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
@@ -91,7 +91,7 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -108,7 +108,7 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                      * data. TODO support filter value in future.
                      */
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(6, 200F, 500F))

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
@@ -56,8 +56,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     // scan all data with original column type
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
@@ -69,8 +68,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
@@ -57,7 +57,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     // scan all data with original column type
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
@@ -70,7 +70,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -107,7 +107,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                                     .between(6, 200L, 500L);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(predicate)
                                             .read()
                                             .dataSplits());
@@ -131,7 +131,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                      */
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())
@@ -161,7 +161,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                                     .between(4, (short) 200, (short) 500);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(predicate)
                                             .read()
                                             .dataSplits());
@@ -179,7 +179,7 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                     // bigint to int
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileDataTestBase.java
@@ -56,7 +56,8 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     // scan all data with original column type
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
@@ -68,7 +69,8 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -104,7 +106,11 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                            toSplits(
+                                    table.newSnapshotSplitReader()
+                                            .withFilter(predicate)
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -130,7 +136,8 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())
                                                             .between(6, 200F, 500F))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -153,7 +160,11 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(4, (short) 200, (short) 500);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().withFilter(predicate).splits());
+                            toSplits(
+                                    table.newSnapshotSplitReader()
+                                            .withFilter(predicate)
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
@@ -173,7 +184,8 @@ public abstract class ColumnTypeFileDataTestBase extends SchemaEvolutionTableTes
                                                     new PredicateBuilder(
                                                                     table.schema().logicalRowType())
                                                             .between(4, 200, 500))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     List<InternalRow.FieldGetter> fieldGetterList = getFieldGetterList(table);
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
@@ -123,10 +123,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -185,10 +182,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(4, (short) 200, (short) 500);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
@@ -49,7 +49,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -64,7 +64,8 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .greaterOrEqual(
                                                             1, BinaryString.fromString("0")))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
 
                     List<String> filesName =
@@ -122,7 +123,10 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -146,7 +150,8 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(6, 200F, 500F))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
 
                     List<String> filesName =
@@ -180,7 +185,10 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(4, (short) 200, (short) 500);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -195,7 +203,8 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(4, 200, 500))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
 
                     List<String> filesName =

--- a/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ColumnTypeFileMetaTestBase.java
@@ -49,7 +49,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 3L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -59,7 +59,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                     FileStoreTable table = createFileStoreTable(schemas);
                     // Scan all data files
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .greaterOrEqual(
@@ -123,7 +123,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -146,7 +146,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                      <p>Then we can check the results of the two result files.
                     */
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(6, 200F, 500F))
@@ -185,7 +185,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(4, (short) 200, (short) 500);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -199,7 +199,7 @@ public abstract class ColumnTypeFileMetaTestBase extends SchemaEvolutionTableTes
                     // results of field "e" in [200, 500] in SCHEMA_FIELDS which is updated from
                     // bigint to int
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .between(4, 200, 500))

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
@@ -155,8 +155,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 schemas -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_0_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     // filter with "b" = 15 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(2, 15));
 
@@ -169,8 +168,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "d" = 15 in schema1 which should be mapped to "b" = 15 in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(1, 15));
@@ -198,8 +196,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));
@@ -253,8 +250,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                                             "f",
                                             Collections.emptyList()));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "d" = 21 or "f" is null in schema1 that "f" is not exist in
                     // schema0, read all data
@@ -295,8 +291,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     // project "c", "b", "pt" in schema0
                     TableRead read = table.newRead().withProjection(PROJECTION);
 
@@ -313,8 +308,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits =
-                            toSplits(table.newSnapshotReader().read().dataSplits());
+                    List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // project "a", "kt", "d" in schema1
                     TableRead read = table.newRead().withProjection(PROJECTION);

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
@@ -155,7 +155,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 schemas -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_0_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     // filter with "b" = 15 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(2, 15));
 
@@ -168,7 +169,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
                     // filter with "d" = 15 in schema1 which should be mapped to "b" = 15 in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(1, 15));
@@ -196,7 +198,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));
@@ -217,7 +220,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withFilter(builder.equal(3, 1122))
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     TableRead read2 = table.newRead().withFilter(builder.equal(3, 1122));
                     assertThat(getResult(read2, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
@@ -249,7 +253,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                                             "f",
                                             Collections.emptyList()));
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
                     // filter with "d" = 21 or "f" is null in schema1 that "f" is not exist in
                     // schema0, read all data
@@ -271,7 +276,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                                             "1|17|117|1117|S007|S17",
                                             "1|19|119|1119|S009|S19"));
 
-                    splits = toSplits(table.newSnapshotSplitReader().splits());
+                    splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     // filter with "d" = 21 or "f" is null, read snapshot which contains "d" = 21
                     TableRead read2 =
                             table.newRead().withFilter(PredicateBuilder.and(predicateList));
@@ -290,7 +295,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
                     // project "c", "b", "pt" in schema0
                     TableRead read = table.newRead().withProjection(PROJECTION);
 
@@ -307,7 +313,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+                    List<Split> splits =
+                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
 
                     // project "a", "kt", "d" in schema1
                     TableRead read = table.newRead().withProjection(PROJECTION);
@@ -341,7 +348,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     TableRead read = table.newRead();
 
                     assertThat(getResult(read, splits, STREAMING_SCHEMA_0_ROW_TO_STRING))
@@ -358,7 +366,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
 
                     TableRead read = table.newRead();
                     assertThat(getResult(read, splits, STREAMING_SCHEMA_1_ROW_TO_STRING))
@@ -382,7 +391,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     // project "c", "b", "pt" in schema0
                     TableRead read = table.newRead().withProjection(PROJECTION);
 
@@ -397,7 +407,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
 
                     // project "a", "kt", "d" in schema1
                     TableRead read = table.newRead().withProjection(PROJECTION);
@@ -420,7 +431,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
                     // filter with "b" = 15 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(2, 15));
 
@@ -437,7 +449,8 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                             toSplits(
                                     table.newSnapshotSplitReader()
                                             .withKind(ScanKind.DELTA)
-                                            .splits());
+                                            .read()
+                                            .dataSplits());
 
                     // filter with "d" = 15 in schema1 which should be mapped to "b" = 15 in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(1, 15));

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
@@ -156,7 +156,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_0_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
                     // filter with "b" = 15 in schema0
                     TableRead read = table.newRead().withFilter(builder.equal(2, 15));
 
@@ -170,7 +170,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "d" = 15 in schema1 which should be mapped to "b" = 15 in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(1, 15));
@@ -199,7 +199,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     PredicateBuilder builder = new PredicateBuilder(new RowType(SCHEMA_1_FIELDS));
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "a" = 1122 in schema1 which is not exist in schema0
                     TableRead read1 = table.newRead().withFilter(builder.equal(3, 1122));
@@ -218,7 +218,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     // filter with "a" = 1122 in scan and read
                     splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withFilter(builder.equal(3, 1122))
                                             .read()
                                             .dataSplits());
@@ -254,7 +254,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                                             Collections.emptyList()));
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // filter with "d" = 21 or "f" is null in schema1 that "f" is not exist in
                     // schema0, read all data
@@ -276,7 +276,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                                             "1|17|117|1117|S007|S17",
                                             "1|19|119|1119|S009|S19"));
 
-                    splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                    splits = toSplits(table.newSnapshotReader().read().dataSplits());
                     // filter with "d" = 21 or "f" is null, read snapshot which contains "d" = 21
                     TableRead read2 =
                             table.newRead().withFilter(PredicateBuilder.and(predicateList));
@@ -296,7 +296,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
                     // project "c", "b", "pt" in schema0
                     TableRead read = table.newRead().withProjection(PROJECTION);
 
@@ -314,7 +314,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
-                            toSplits(table.newSnapshotSplitReader().read().dataSplits());
+                            toSplits(table.newSnapshotReader().read().dataSplits());
 
                     // project "a", "kt", "d" in schema1
                     TableRead read = table.newRead().withProjection(PROJECTION);
@@ -346,7 +346,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -364,7 +364,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -389,7 +389,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -405,7 +405,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -429,7 +429,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());
@@ -447,7 +447,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<Split> splits =
                             toSplits(
-                                    table.newSnapshotSplitReader()
+                                    table.newSnapshotReader()
                                             .withKind(ScanKind.DELTA)
                                             .read()
                                             .dataSplits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
@@ -42,7 +42,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -55,7 +55,8 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .greaterOrEqual(1, 0))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
                     List<String> filesName =
@@ -121,7 +122,8 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(2, 14, 19);
                     List<DataFileMeta> files =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits().stream()
+                            table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits()
+                                    .stream()
                                     .flatMap(s -> s.files().stream())
                                     .collect(Collectors.toList());
                     assertThat(files.size()).isGreaterThan(0);
@@ -135,7 +137,10 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     List<DataFileMeta> filterFileMetas =
                             filterSplits.stream()
                                     .flatMap(s -> s.files().stream())
@@ -157,7 +162,8 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     List<DataSplit> filterAllSplits =
                             table.newSnapshotSplitReader()
                                     .withFilter(builder.greaterOrEqual(1, 0))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     assertThat(
                                     filterAllSplits.stream()
                                             .flatMap(
@@ -171,7 +177,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                                             .collect(Collectors.toList()));
 
                     // get all meta files without filter
-                    List<DataSplit> allSplits = table.newSnapshotSplitReader().splits();
+                    List<DataSplit> allSplits = table.newSnapshotSplitReader().read().dataSplits();
                     assertThat(filterAllSplits).isEqualTo(allSplits);
 
                     Set<String> filterFileNames = new HashSet<>();
@@ -201,7 +207,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<DataFileMeta> files =
-                            table.newSnapshotSplitReader().splits().stream()
+                            table.newSnapshotSplitReader().read().dataSplits().stream()
                                     .flatMap(s -> s.files().stream())
                                     .collect(Collectors.toList());
                     assertThat(files.size()).isGreaterThan(0);
@@ -217,7 +223,10 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(filterSplits), 2L);
 
                     List<DataFileMeta> filterFileMetas =
@@ -241,7 +250,8 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     List<DataSplit> allSplits =
                             table.newSnapshotSplitReader()
                                     .withFilter(builder.greaterOrEqual(1, 0))
-                                    .splits();
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(allSplits), 12L);
 
                     Set<String> filterFileNames = new HashSet<>();
@@ -293,7 +303,10 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(4, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return null;
                 },
@@ -303,7 +316,10 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(2, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader().withFilter(predicate).splits();
+                            table.newSnapshotSplitReader()
+                                    .withFilter(predicate)
+                                    .read()
+                                    .dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                 },
                 getPrimaryKeyNames(),
@@ -317,7 +333,10 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
             FileStoreTable table, int index, int value, long expectedRowCount) {
         PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());
         List<DataSplit> splits =
-                table.newSnapshotSplitReader().withFilter(builder.equal(index, value)).splits();
+                table.newSnapshotSplitReader()
+                        .withFilter(builder.equal(index, value))
+                        .read()
+                        .dataSplits();
         checkFilterRowCount(toDataFileMetas(splits), expectedRowCount);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
@@ -137,10 +137,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     List<DataFileMeta> filterFileMetas =
                             filterSplits.stream()
                                     .flatMap(s -> s.files().stream())
@@ -223,10 +220,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(filterSplits), 2L);
 
                     List<DataFileMeta> filterFileMetas =
@@ -303,10 +297,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(4, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return null;
                 },
@@ -316,10 +307,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(2, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotReader()
-                                    .withFilter(predicate)
-                                    .read()
-                                    .dataSplits();
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                 },
                 getPrimaryKeyNames(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileMetaFilterTestBase.java
@@ -42,7 +42,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
         writeAndCheckFileResult(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 6L);
                     return splits.stream()
                             .flatMap(s -> s.files().stream())
@@ -51,7 +51,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(
                                             new PredicateBuilder(table.schema().logicalRowType())
                                                     .greaterOrEqual(1, 0))
@@ -122,7 +122,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(2, 14, 19);
                     List<DataFileMeta> files =
-                            table.newSnapshotSplitReader().withFilter(predicate).read().dataSplits()
+                            table.newSnapshotReader().withFilter(predicate).read().dataSplits()
                                     .stream()
                                     .flatMap(s -> s.files().stream())
                                     .collect(Collectors.toList());
@@ -137,7 +137,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
                     Predicate predicate = builder.between(1, 14, 19);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -160,7 +160,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     builder = new PredicateBuilder(table.schema().logicalRowType());
                     // get all meta files with filter
                     List<DataSplit> filterAllSplits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(builder.greaterOrEqual(1, 0))
                                     .read()
                                     .dataSplits();
@@ -177,7 +177,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                                             .collect(Collectors.toList()));
 
                     // get all meta files without filter
-                    List<DataSplit> allSplits = table.newSnapshotSplitReader().read().dataSplits();
+                    List<DataSplit> allSplits = table.newSnapshotReader().read().dataSplits();
                     assertThat(filterAllSplits).isEqualTo(allSplits);
 
                     Set<String> filterFileNames = new HashSet<>();
@@ -207,7 +207,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
                     List<DataFileMeta> files =
-                            table.newSnapshotSplitReader().read().dataSplits().stream()
+                            table.newSnapshotReader().read().dataSplits().stream()
                                     .flatMap(s -> s.files().stream())
                                     .collect(Collectors.toList());
                     assertThat(files.size()).isGreaterThan(0);
@@ -223,7 +223,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     // SCHEMA_0_FIELDS
                     Predicate predicate = builder.greaterThan(3, 1120);
                     List<DataSplit> filterSplits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -248,7 +248,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                     assertThat(fileNameList).doesNotContainAnyElementsOf(filesName);
 
                     List<DataSplit> allSplits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(builder.greaterOrEqual(1, 0))
                                     .read()
                                     .dataSplits();
@@ -303,7 +303,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(4, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -316,7 +316,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
                             new PredicateBuilder(table.schema().logicalRowType());
                     Predicate predicate = builder.between(2, 115L, 120L);
                     List<DataSplit> splits =
-                            table.newSnapshotSplitReader()
+                            table.newSnapshotReader()
                                     .withFilter(predicate)
                                     .read()
                                     .dataSplits();
@@ -333,7 +333,7 @@ public abstract class FileMetaFilterTestBase extends SchemaEvolutionTableTestBas
             FileStoreTable table, int index, int value, long expectedRowCount) {
         PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());
         List<DataSplit> splits =
-                table.newSnapshotSplitReader()
+                table.newSnapshotReader()
                         .withFilter(builder.equal(index, value))
                         .read()
                         .dataSplits();

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -191,7 +191,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().splits()),
+                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
@@ -211,7 +211,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().splits()),
+                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
@@ -242,7 +242,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().splits()),
+                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyElementsOf(expected);
     }
@@ -291,7 +291,7 @@ public abstract class FileStoreTableTestBase {
         }
 
         // validate
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(
                         getResult(
@@ -322,7 +322,7 @@ public abstract class FileStoreTableTestBase {
         commit.withOverwrite(overwritePartition).commit(1, write.prepareCommit(true, 1));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -356,7 +356,8 @@ public abstract class FileStoreTableTestBase {
                 toSplits(
                         table.newSnapshotSplitReader()
                                 .withFilter(new PredicateBuilder(ROW_TYPE).equal(1, 5))
-                                .splits());
+                                .read()
+                                .dataSplits());
         assertThat(splits.size()).isEqualTo(1);
         assertThat(((DataSplit) splits.get(0)).bucket()).isEqualTo(1);
     }
@@ -401,7 +402,7 @@ public abstract class FileStoreTableTestBase {
         write.close();
 
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead().withFilter(builder.equal(2, 300L));
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -520,7 +521,7 @@ public abstract class FileStoreTableTestBase {
         write.close();
 
         List<DataFileMeta> files =
-                table.newSnapshotSplitReader().splits().stream()
+                table.newSnapshotSplitReader().read().dataSplits().stream()
                         .flatMap(split -> split.files().stream())
                         .collect(Collectors.toList());
         for (DataFileMeta file : files) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -191,7 +191,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
+                                toSplits(table.newSnapshotReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
@@ -211,7 +211,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
+                                toSplits(table.newSnapshotReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
@@ -242,7 +242,7 @@ public abstract class FileStoreTableTestBase {
         assertThat(
                         getResult(
                                 table.newRead(),
-                                toSplits(table.newSnapshotSplitReader().read().dataSplits()),
+                                toSplits(table.newSnapshotReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyElementsOf(expected);
     }
@@ -291,7 +291,7 @@ public abstract class FileStoreTableTestBase {
         }
 
         // validate
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(
                         getResult(
@@ -322,7 +322,7 @@ public abstract class FileStoreTableTestBase {
         commit.withOverwrite(overwritePartition).commit(1, write.prepareCommit(true, 1));
         write.close();
 
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -354,7 +354,7 @@ public abstract class FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotSplitReader()
+                        table.newSnapshotReader()
                                 .withFilter(new PredicateBuilder(ROW_TYPE).equal(1, 5))
                                 .read()
                                 .dataSplits());
@@ -402,7 +402,7 @@ public abstract class FileStoreTableTestBase {
         write.close();
 
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead().withFilter(builder.equal(2, 300L));
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
@@ -521,7 +521,7 @@ public abstract class FileStoreTableTestBase {
         write.close();
 
         List<DataFileMeta> files =
-                table.newSnapshotSplitReader().read().dataSplits().stream()
+                table.newSnapshotReader().read().dataSplits().stream()
                         .flatMap(split -> split.files().stream())
                         .collect(Collectors.toList());
         for (DataFileMeta file : files) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -33,7 +33,7 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReader;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.FloatType;
@@ -359,11 +359,11 @@ public class SchemaEvolutionTest {
     private void forEachRemaining(
             FileStoreTable table, Predicate filter, Consumer<InternalRow> consumer)
             throws IOException {
-        SnapshotSplitReader snapshotSplitReader = table.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = table.newSnapshotSplitReader();
         if (filter != null) {
-            snapshotSplitReader.withFilter(filter);
+            snapshotReader.withFilter(filter);
         }
-        for (Split split : snapshotSplitReader.splits()) {
+        for (Split split : snapshotReader.read().dataSplits()) {
             InnerTableRead read = table.newRead();
             if (filter != null) {
                 read.withFilter(filter);

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -359,7 +359,7 @@ public class SchemaEvolutionTest {
     private void forEachRemaining(
             FileStoreTable table, Predicate filter, Consumer<InternalRow> consumer)
             throws IOException {
-        SnapshotReader snapshotReader = table.newSnapshotSplitReader();
+        SnapshotReader snapshotReader = table.newSnapshotReader();
         if (filter != null) {
             snapshotReader.withFilter(filter);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
@@ -78,7 +78,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         write.close();
 
         // read
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
         List<String> results = new ArrayList<>();
         for (int i = 0; i < 5; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
@@ -78,7 +78,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         write.close();
 
         // read
-        List<Split> splits = toSplits(table.newSnapshotSplitReader().splits());
+        List<Split> splits = toSplits(table.newSnapshotSplitReader().read().dataSplits());
         TableRead read = table.newRead();
         List<String> results = new ArrayList<>();
         for (int i = 0; i < 5; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -229,7 +229,7 @@ public class StartupModeTest extends ScannerTestBase {
             options.set(property.getKey(), property.getValue());
         }
         table = createFileStoreTable(options);
-        snapshotReader = table.newSnapshotSplitReader();
+        snapshotReader = table.newSnapshotReader();
         write = table.newWrite(commitUser);
         commit = table.newCommit(commitUser);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -76,13 +76,13 @@ public class StartupModeTest extends ScannerTestBase {
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
     }
 
     @Test
@@ -96,20 +96,20 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(3).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read());
         assertThat(secondPlan.splits()).isEmpty();
 
         // write next data
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
     }
 
     @Test
@@ -135,13 +135,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = readTable.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(3).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read());
     }
 
     @Test
@@ -159,15 +159,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(5).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(5).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(4).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
     }
 
     @Test
@@ -184,13 +184,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(2).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(2).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
     }
 
     @Test
@@ -205,15 +205,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(2).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(3).withKind(ScanKind.DELTA).splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.DELTA).read());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotSplitReader.withSnapshot(2).withKind(ScanKind.ALL).splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
     }
 
     private void initializeTable(CoreOptions.StartupMode startupMode) throws Exception {
@@ -229,7 +229,7 @@ public class StartupModeTest extends ScannerTestBase {
             options.set(property.getKey(), property.getValue());
         }
         table = createFileStoreTable(options);
-        snapshotSplitReader = table.newSnapshotSplitReader();
+        snapshotReader = table.newSnapshotSplitReader();
         write = table.newWrite(commitUser);
         commit = table.newCommit(commitUser);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -76,13 +76,13 @@ public class StartupModeTest extends ScannerTestBase {
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
     }
 
     @Test
@@ -96,20 +96,20 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read().splits());
         assertThat(secondPlan.splits()).isEmpty();
 
         // write next data
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
     }
 
     @Test
@@ -135,13 +135,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = readTable.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read().splits());
     }
 
     @Test
@@ -159,15 +159,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(5).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(5).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
     }
 
     @Test
@@ -184,13 +184,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
     }
 
     @Test
@@ -205,15 +205,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.DELTA).read());
+                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read());
+                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
     }
 
     private void initializeTable(CoreOptions.StartupMode startupMode) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactedStartingScannerTest.java
@@ -57,7 +57,7 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
 
         CompactedStartingScanner scanner = new CompactedStartingScanner();
         StartingScanner.ScannedResult result =
-                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.currentSnapshotId()).isEqualTo(3);
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
@@ -70,7 +70,7 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         CompactedStartingScanner scanner = new CompactedStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
@@ -91,7 +91,7 @@ public class CompactedStartingScannerTest extends ScannerTestBase {
 
         // No compact snapshot found, reading from the latest snapshot
         StartingScanner.ScannedResult result =
-                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.currentSnapshotId()).isEqualTo(1);
 
         write.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
@@ -64,7 +64,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
 
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(5);
 
-        snapshotSplitReader.withLevelFilter(level -> level == table.coreOptions().numLevels() - 1);
+        snapshotReader.withLevelFilter(level -> level == table.coreOptions().numLevels() - 1);
         TableRead read = table.newRead();
         CompactionChangelogFollowUpScanner scanner = new CompactionChangelogFollowUpScanner();
 
@@ -79,7 +79,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
         snapshot = snapshotManager.snapshot(3);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(3, snapshotSplitReader);
+        TableScan.Plan plan = scanner.scan(3, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|102", "+I 1|20|200", "+I 1|30|300"));
 
@@ -90,7 +90,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
         snapshot = snapshotManager.snapshot(5);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(5, snapshotSplitReader);
+        plan = scanner.scan(5, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(
                         Arrays.asList("-U 1|10|102", "+U 1|10|103", "-D 1|30|300", "+I 1|40|401"));

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -95,21 +95,21 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotSplitReader);
+        TableScan.Plan plan = scanner.scan(1, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|1|0|1", "+I 1|2|0|1"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotSplitReader);
+        plan = scanner.scan(2, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 2|1|0|2", "+I 2|2|0|1"));
 
         snapshot = snapshotManager.snapshot(3);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(3, snapshotSplitReader);
+        plan = scanner.scan(3, snapshotReader);
         assertThat(getResult(read, plan.splits())).hasSameElementsAs(Arrays.asList("+I 3|1|0|1"));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
@@ -85,14 +85,14 @@ public class ContinuousCompactorFollowUpScannerTest extends ScannerTestBase {
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotSplitReader);
+        TableScan.Plan plan = scanner.scan(1, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|1|0|1", "+I 1|2|0|1"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotSplitReader);
+        plan = scanner.scan(2, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Collections.singletonList("+I 2|2|0|1"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
@@ -60,7 +60,7 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
 
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
         StartingScanner.NextSnapshot result =
-                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.nextSnapshotId()).isEqualTo(4);
 
         write.close();
@@ -71,7 +71,7 @@ public class ContinuousCompactorStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -60,7 +60,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.NextSnapshot result =
-                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.nextSnapshotId()).isEqualTo(3);
 
         write.close();
@@ -72,7 +72,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(System.currentTimeMillis());
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
@@ -94,7 +94,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(timestamp);
         StartingScanner.NextSnapshot result =
-                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotReader);
         // next snapshot
         assertThat(result.nextSnapshotId()).isEqualTo(1);
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScannerTest.java
@@ -50,7 +50,7 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
 
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
         StartingScanner.NextSnapshot result =
-                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.nextSnapshotId()).isEqualTo(3);
 
         write.close();
@@ -61,7 +61,7 @@ public class ContinuousLatestStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousLatestStartingScanner scanner = new ContinuousLatestStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScannerTest.java
@@ -61,14 +61,14 @@ public class DeltaFollowUpScannerTest extends ScannerTestBase {
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotSplitReader);
+        TableScan.Plan plan = scanner.scan(1, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|100", "+I 1|20|200", "+I 1|40|400"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotSplitReader);
+        plan = scanner.scan(2, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|102", "+I 1|30|300", "-D 1|40|400"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScannerTest.java
@@ -47,7 +47,7 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
 
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
         StartingScanner.ScannedResult result =
-                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.currentSnapshotId()).isEqualTo(8);
 
         write.close();
@@ -58,7 +58,7 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullCompactedStartingScanner scanner = new FullCompactedStartingScanner(3);
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
@@ -89,7 +89,7 @@ public class FullCompactedStartingScannerTest extends ScannerTestBase {
 
         // No compact snapshot found, reading from the latest snapshot
         StartingScanner.ScannedResult result =
-                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.currentSnapshotId()).isEqualTo(4);
 
         write.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/FullStartingScannerTest.java
@@ -52,7 +52,7 @@ public class FullStartingScannerTest extends ScannerTestBase {
 
         FullStartingScanner scanner = new FullStartingScanner();
         StartingScanner.ScannedResult result =
-                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotSplitReader);
+                (StartingScanner.ScannedResult) scanner.scan(snapshotManager, snapshotReader);
         assertThat(result.currentSnapshotId()).isEqualTo(2);
         assertThat(getResult(table.newRead(), toSplits(result.splits())))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
@@ -65,7 +65,7 @@ public class FullStartingScannerTest extends ScannerTestBase {
     public void testNoSnapshot() {
         SnapshotManager snapshotManager = table.snapshotManager();
         FullStartingScanner scanner = new FullStartingScanner();
-        assertThat(scanner.scan(snapshotManager, snapshotSplitReader))
+        assertThat(scanner.scan(snapshotManager, snapshotReader))
                 .isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScannerTest.java
@@ -64,14 +64,14 @@ public class InputChangelogFollowUpScannerTest extends ScannerTestBase {
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotSplitReader);
+        TableScan.Plan plan = scanner.scan(1, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|100", "+I 1|20|200", "+I 1|40|400"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotSplitReader);
+        plan = scanner.scan(2, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(
                         Arrays.asList("+I 1|10|101", "+I 1|30|300", "+I 1|10|102", "-D 1|40|400"));

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -78,7 +78,7 @@ public abstract class ScannerTestBase {
         fileIO = FileIOFinder.find(tablePath);
         commitUser = UUID.randomUUID().toString();
         table = createFileStoreTable();
-        snapshotReader = table.newSnapshotSplitReader();
+        snapshotReader = table.newSnapshotReader();
     }
 
     protected GenericRow rowData(Object... values) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -70,7 +70,7 @@ public abstract class ScannerTestBase {
     protected FileIO fileIO;
     protected String commitUser;
     protected FileStoreTable table;
-    protected SnapshotSplitReader snapshotSplitReader;
+    protected SnapshotReader snapshotReader;
 
     @BeforeEach
     public void before() throws Exception {
@@ -78,7 +78,7 @@ public abstract class ScannerTestBase {
         fileIO = FileIOFinder.find(tablePath);
         commitUser = UUID.randomUUID().toString();
         table = createFileStoreTable();
-        snapshotSplitReader = table.newSnapshotSplitReader();
+        snapshotReader = table.newSnapshotSplitReader();
     }
 
     protected GenericRow rowData(Object... values) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -211,7 +211,8 @@ public class FlinkSourceBuilder {
                         tableIdentifier.asSummaryString(),
                         produceTypeInfo(),
                         createReadBuilder(),
-                        conf.get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL).toMillis());
+                        conf.get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL).toMillis(),
+                        watermarkStrategy == null);
         if (parallelism != null) {
             dataStream.getTransformation().setParallelism(parallelism);
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
@@ -29,7 +29,9 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
@@ -37,6 +39,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.flink.FlinkConnectorOptions.STREAMING_READ_ATOMIC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +122,30 @@ public class ContinuousFileStoreITCase extends CatalogITCaseBase {
         batchSql("INSERT INTO %s VALUES ('7', '8', '9')", table);
         assertThat(iterator.collect(1)).containsExactlyInAnyOrder(Row.of("7", "8", "9"));
         iterator.close();
+    }
+
+    @TestTemplate
+    @Timeout(120)
+    public void testSnapshotWatermark() throws Exception {
+        streamSqlIter(
+                "CREATE TEMPORARY TABLE gen (a STRING, b STRING, c STRING,"
+                        + " dt AS NOW(), WATERMARK FOR dt AS dt) WITH ('connector'='datagen')");
+        CloseableIterator<Row> insert1 = streamSqlIter("INSERT INTO T2 SELECT a, b, c FROM gen");
+        sql("CREATE TABLE WT (a STRING, b STRING, c STRING, PRIMARY KEY (a) NOT ENFORCED)");
+        CloseableIterator<Row> insert2 =
+                streamSqlIter("INSERT INTO WT SELECT * FROM T2 /*+ OPTIONS('consumer-id'='me') */");
+        while (true) {
+            Set<Long> watermarks =
+                    sql("SELECT `watermark` FROM WT$snapshots").stream()
+                            .map(r -> (Long) r.getField(0))
+                            .collect(Collectors.toSet());
+            if (watermarks.size() > 1) {
+                insert1.close();
+                insert2.close();
+                return;
+            }
+            Thread.sleep(1000);
+        }
     }
 
     private void testSimple(String table) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -108,7 +108,7 @@ public class CompactActionITCase extends ActionITCaseBase {
         Assertions.assertEquals(3, snapshot.id());
         Assertions.assertEquals(Snapshot.CommitKind.COMPACT, snapshot.commitKind());
 
-        List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
+        List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
         Assertions.assertEquals(3, splits.size());
         for (DataSplit split : splits) {
             if (split.partition().getInt(1) == 15) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -108,7 +108,7 @@ public class CompactActionITCase extends ActionITCaseBase {
         Assertions.assertEquals(3, snapshot.id());
         Assertions.assertEquals(Snapshot.CommitKind.COMPACT, snapshot.commitKind());
 
-        List<DataSplit> splits = table.newSnapshotSplitReader().splits();
+        List<DataSplit> splits = table.newSnapshotSplitReader().read().dataSplits();
         Assertions.assertEquals(3, splits.size());
         for (DataSplit split : splits) {
             if (split.partition().getInt(1) == 15) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -328,6 +328,12 @@ public class ContinuousFileSplitEnumeratorTest {
         @Override
         public void notifyCheckpointComplete(@Nullable Long nextSnapshot) {}
 
+        @Nullable
+        @Override
+        public Long watermark() {
+            return null;
+        }
+
         @Override
         public void restore(Long state) {}
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -25,7 +25,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.snapshot.SnapshotSplitReaderImpl;
+import org.apache.paimon.table.source.snapshot.SnapshotReaderImpl;
 
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +47,11 @@ public class FileStoreSourceSplitGeneratorTest {
     public void test() {
         FileStoreScan.Plan plan =
                 new FileStoreScan.Plan() {
+                    @Override
+                    public Long watermark() {
+                        return null;
+                    }
+
                     @Nullable
                     @Override
                     public Long snapshotId() {
@@ -74,7 +79,7 @@ public class FileStoreSourceSplitGeneratorTest {
                     }
                 };
         List<DataSplit> scanSplits =
-                SnapshotSplitReaderImpl.generateSplits(
+                SnapshotReaderImpl.generateSplits(
                         1L,
                         false,
                         false,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -113,7 +113,7 @@ public class OperatorSourceTest {
         // 1. run first
         OperatorSubtaskState snapshot;
         {
-            MonitorFunction function = new MonitorFunction(table.newReadBuilder(), 10);
+            MonitorFunction function = new MonitorFunction(table.newReadBuilder(), 10, false);
             StreamSource<Split, MonitorFunction> src = new StreamSource<>(function);
             AbstractStreamOperatorTestHarness<Split> testHarness =
                     new AbstractStreamOperatorTestHarness<>(src, 1, 1, 0);
@@ -123,7 +123,7 @@ public class OperatorSourceTest {
 
         // 2. restore from state
         {
-            MonitorFunction functionCopy1 = new MonitorFunction(table.newReadBuilder(), 10);
+            MonitorFunction functionCopy1 = new MonitorFunction(table.newReadBuilder(), 10, false);
             StreamSource<Split, MonitorFunction> srcCopy1 = new StreamSource<>(functionCopy1);
             AbstractStreamOperatorTestHarness<Split> testHarnessCopy1 =
                     new AbstractStreamOperatorTestHarness<>(srcCopy1, 1, 1, 0);
@@ -143,7 +143,7 @@ public class OperatorSourceTest {
 
         // 3. restore from consumer id
         {
-            MonitorFunction functionCopy2 = new MonitorFunction(table.newReadBuilder(), 10);
+            MonitorFunction functionCopy2 = new MonitorFunction(table.newReadBuilder(), 10, false);
             StreamSource<Split, MonitorFunction> srcCopy2 = new StreamSource<>(functionCopy2);
             AbstractStreamOperatorTestHarness<Split> testHarnessCopy2 =
                     new AbstractStreamOperatorTestHarness<>(srcCopy2, 1, 1, 0);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For consumer-id mode, when there is no watermark definition, the Paimon table will pass the watermark in the snapshot to the downstream Paimon table, which means you can track the progress of the watermark for the entire pipeline.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
