### PR TITLE
[hotfix] Fix that Maven 3.2.5 cannot build paimon-core

### DIFF
--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -160,6 +160,14 @@ under the License.
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-storage-api</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

Use Maven 3.2.5 to build paimon-core will throw error: cannot find org.apache.hadoop.hive.ql.exec.vector.
This PR fix it.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
