### PR TITLE
[core] Do not truncate string and binary for casting

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
@@ -21,18 +21,14 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeChecks;
 
 import java.time.DateTimeException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.paimon.data.BinaryString.fromString;
-import static org.apache.paimon.types.DataTypeRoot.BINARY;
-import static org.apache.paimon.types.DataTypeRoot.CHAR;
 
 /** Util for {@link BinaryString}. */
 public class BinaryStringUtils {
@@ -305,32 +301,14 @@ public class BinaryStringUtils {
     }
 
     public static BinaryString toCharacterString(BinaryString strData, DataType type) {
-        final boolean targetCharType = type.getTypeRoot() == CHAR;
-        final int targetLength = DataTypeChecks.getLength(type);
-        if (strData.numChars() > targetLength) {
-            return strData.substring(0, targetLength);
-        } else if (strData.numChars() < targetLength && targetCharType) {
-            int padLength = targetLength - strData.numChars();
-            BinaryString padString = BinaryString.blankString(padLength);
-            return StringUtils.concat(strData, padString);
-        }
+        // DO NOT Truncate or fill, let the data remain in its original form, even it is not
+        // compatible with the precision.
         return strData;
     }
 
     public static byte[] toBinaryString(byte[] byteArrayTerm, DataType type) {
-        final boolean targetBinaryType = type.getTypeRoot() == BINARY;
-        final int targetLength = DataTypeChecks.getLength(type);
-        if (byteArrayTerm.length == targetLength) {
-            return byteArrayTerm;
-        }
-        if (targetBinaryType) {
-            return Arrays.copyOf(byteArrayTerm, targetLength);
-        } else {
-            if (byteArrayTerm.length <= targetLength) {
-                return byteArrayTerm;
-            } else {
-                return Arrays.copyOf(byteArrayTerm, targetLength);
-            }
-        }
+        // DO NOT Truncate or fill, let the data remain in its original form, even it is not
+        // compatible with the precision.
+        return byteArrayTerm;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
@@ -55,27 +54,12 @@ public class TypeUtils {
         switch (type.getTypeRoot()) {
             case CHAR:
             case VARCHAR:
-                int stringLength = DataTypeChecks.getLength(type);
-                if (s.length() > stringLength) {
-                    throw new IllegalArgumentException(
-                            String.format(
-                                    "Length of type %s is %d, but casting result has a length of %d",
-                                    type, stringLength, s.length()));
-                }
                 return str;
             case BOOLEAN:
                 return BinaryStringUtils.toBoolean(str);
             case BINARY:
             case VARBINARY:
-                int binaryLength = DataTypeChecks.getLength(type);
-                byte[] bytes = s.getBytes();
-                if (bytes.length > binaryLength) {
-                    throw new IllegalArgumentException(
-                            String.format(
-                                    "Length of type %s is %d, but casting result has a length of %d",
-                                    type, binaryLength, bytes.length));
-                }
-                return bytes;
+                return s.getBytes();
             case DECIMAL:
                 DecimalType decimalType = (DecimalType) type;
                 return Decimal.fromBigDecimal(

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimeToStringCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimeToStringCastRule.java
@@ -44,9 +44,8 @@ class TimeToStringCastRule extends AbstractCastRule<Integer, BinaryString> {
 
     @Override
     public CastExecutor<Integer, BinaryString> create(DataType inputType, DataType targetType) {
+        int precision = DataTypeChecks.getPrecision(inputType);
         return value ->
-                BinaryString.fromString(
-                        DateTimeUtils.formatTimestampMillis(
-                                value, DataTypeChecks.getPrecision(inputType)));
+                BinaryString.fromString(DateTimeUtils.formatTimestampMillis(value, precision));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
DO NOT Truncate or fill, let the data remain in its original form, even it is not compatible with the precision.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
