### PR TITLE
[core] Introduce dynamic-bucket.assigner-parallelism

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -40,8 +40,10 @@ Primary Key Table supports two bucket mode:
 1. Fixed Bucket mode: configure a bucket greater than 0, rescaling buckets can only be done through offline processes, 
    see [Rescale Bucket]({{< ref "/maintenance/rescale-bucket" >}}). A too large number of buckets leads to too many
    small files, and a too small number of buckets leads to poor write performance.
-2. Dynamic Bucket mode: configure `'bucket' = '-1'`, Paimon dynamically maintains the index, keeping the data volume
-   in the bucket below `'dynamic-bucket.target-row-num'`. (This is an experimental feature)
+2. Dynamic Bucket mode: configure `'bucket' = '-1'`, Paimon dynamically maintains the index, automatic expansion of
+   the number of buckets. (This is an experimental feature)
+   - Option1: `'dynamic-bucket.target-row-num'`: controls the target row number for one bucket.
+   - Option2: `'dynamic-bucket.assigner-parallelism'`: Parallelism of assigner operator, controls the number of initialized bucket.
 
 ## Merge Engines
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -111,6 +111,12 @@ under the License.
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
+            <td><h5>dynamic-bucket.assigner-parallelism</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Parallelism of assigner operator for dynamic bucket mode, it is related to the number of initialized bucket, too small will lead to insufficient processing speed of assigner.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.target-row-num</h5></td>
             <td style="word-wrap: break-word;">2000000</td>
             <td>Long</td>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -664,6 +664,15 @@ public class CoreOptions implements Serializable {
                             "If the bucket is -1, for primary key table, is dynamic bucket mode, "
                                     + "this option controls the target row number for one bucket.");
 
+    public static final ConfigOption<Integer> DYNAMIC_BUCKET_ASSIGNER_PARALLELISM =
+            key("dynamic-bucket.assigner-parallelism")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Parallelism of assigner operator for dynamic bucket mode, it is"
+                                    + " related to the number of initialized bucket, too small will lead to"
+                                    + " insufficient processing speed of assigner.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -904,6 +913,10 @@ public class CoreOptions implements Serializable {
 
     public Integer scanManifestParallelism() {
         return options.get(SCAN_MANIFEST_PARALLELISM);
+    }
+
+    public Integer dynamicBucketAssignerParallelism() {
+        return options.get(DYNAMIC_BUCKET_ASSIGNER_PARALLELISM);
     }
 
     public Optional<String> sequenceField() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
@@ -64,7 +64,12 @@ public abstract class DynamicBucketSink<T> extends FlinkWriteSink<Tuple2<T, Inte
         // committer
 
         // 1. shuffle by key hash
-        DataStream<T> partitionByKeyHash = partition(input, channelComputer1(), parallelism);
+        Integer assignerParallelism = table.coreOptions().dynamicBucketAssignerParallelism();
+        if (assignerParallelism == null) {
+            assignerParallelism = parallelism;
+        }
+        DataStream<T> partitionByKeyHash =
+                partition(input, channelComputer1(), assignerParallelism);
 
         // 2. bucket-assigner
         HashBucketAssignerOperator<T> assignerOperator =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
@@ -65,4 +65,13 @@ public class DynamicBucketTableITCase extends CatalogITCaseBase {
         assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
                 .containsExactlyInAnyOrder(Row.of(0), Row.of(1));
     }
+
+    @Test
+    public void testWriteWithAssignerParallelism() {
+        sql(
+                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.assigner-parallelism'='3') */ "
+                        + "VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
+        assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
+                .containsExactlyInAnyOrder(Row.of(0), Row.of(1), Row.of(2));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce dynamic-bucket.assigner-parallelism.
Parallelism of assigner operator for dynamic bucket mode, it is related to the number of initialized bucket, too small will lead to insufficient processing speed of assigner.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
