### PR TITLE
[flink] set spillable default on for batch mode

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -794,8 +794,9 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_SIZE).getBytes();
     }
 
-    public boolean writeBufferSpillable(boolean usingObjectStore) {
-        return options.getOptional(WRITE_BUFFER_SPILLABLE).orElse(usingObjectStore);
+    public boolean writeBufferSpillable(boolean usingObjectStore, boolean isStreaming) {
+        // if not streaming mode, we turn spillable on by default.
+        return options.getOptional(WRITE_BUFFER_SPILLABLE).orElse(usingObjectStore || !isStreaming);
     }
 
     public Duration continuousDiscoveryInterval() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -71,6 +71,7 @@ public abstract class AbstractFileStoreWrite<T>
 
     private ExecutorService lazyCompactExecutor;
     private boolean ignorePreviousFiles = false;
+    protected boolean isStreamingMode = false;
 
     protected AbstractFileStoreWrite(
             String commitUser,
@@ -326,6 +327,11 @@ public abstract class AbstractFileStoreWrite<T>
                 createWriter(partition.copy(), bucket, restoreFiles, null, compactExecutor());
         notifyNewWriter(writer);
         return new WriterContainer<>(writer, indexMaintainer, latestSnapshotId);
+    }
+
+    @Override
+    public void isStreamingMode(boolean isStreamingMode) {
+        this.isStreamingMode = isStreamingMode;
     }
 
     private List<DataFileMeta> scanExistingFileMetas(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -101,11 +101,9 @@ public interface FileStoreWrite<T> {
     /**
      * We detect whether it is in batch mode, if so, we do some optimization.
      *
-     * @param isBatch whether in batch mode
+     * @param isStreamingMode whether in streaming mode
      */
-    default void isStreamingMode(boolean isBatch) {
-        // default do no optimization
-    }
+    void isStreamingMode(boolean isStreamingMode);
 
     /**
      * Close the writer.

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -103,7 +103,7 @@ public interface FileStoreWrite<T> {
      *
      * @param isBatch whether in batch mode
      */
-    default void optimizeForBatch(boolean isBatch) {
+    default void isStreamingMode(boolean isBatch) {
         // default do no optimization
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -99,6 +99,15 @@ public interface FileStoreWrite<T> {
             throws Exception;
 
     /**
+     * We detect whether it is in batch mode, if so, we do some optimization.
+     *
+     * @param isBatch whether in batch mode
+     */
+    default void optimizeForBatch(boolean isBatch) {
+        // default do no optimization
+    }
+
+    /**
      * Close the writer.
      *
      * @throws Exception the thrown exception

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -163,7 +163,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
         CompactManager compactManager =
                 createCompactManager(partition, bucket, compactStrategy, compactExecutor, levels);
         return new MergeTreeWriter(
-                bufferSpillable() || isStreamingMode,
+                bufferSpillable(),
                 options.localSortMaxNumFileHandles(),
                 ioManager,
                 compactManager,
@@ -174,11 +174,6 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 options.commitForceCompact(),
                 options.changelogProducer(),
                 restoreIncrement);
-    }
-
-    @Override
-    public void isStreamingMode(boolean isStreaming) {
-        isStreamingMode = isStreaming;
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -80,7 +80,6 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     private final FileIO fileIO;
     private final RowType keyType;
     private final RowType valueType;
-    private boolean isStreamingMode = false;
 
     public KeyValueFileStoreWrite(
             FileIO fileIO,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -79,6 +79,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     private final FileIO fileIO;
     private final RowType keyType;
     private final RowType valueType;
+    private boolean forceSpillable = false;
 
     public KeyValueFileStoreWrite(
             FileIO fileIO,
@@ -161,7 +162,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
         CompactManager compactManager =
                 createCompactManager(partition, bucket, compactStrategy, compactExecutor, levels);
         return new MergeTreeWriter(
-                bufferSpillable(),
+                bufferSpillable() || forceSpillable,
                 options.localSortMaxNumFileHandles(),
                 ioManager,
                 compactManager,
@@ -172,6 +173,11 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 options.commitForceCompact(),
                 options.changelogProducer(),
                 restoreIncrement);
+    }
+
+    @Override
+    public void optimizeForBatch(boolean isBatch) {
+        forceSpillable = true;
     }
 
     private boolean bufferSpillable() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
@@ -22,4 +22,7 @@ package org.apache.paimon.table.sink;
 public interface InnerTableWrite extends StreamTableWrite, BatchTableWrite {
 
     InnerTableWrite withIgnorePreviousFiles(boolean ignorePreviousFiles);
+
+    // do something to speed up in batch mode
+    InnerTableWrite optimizeForBatch(boolean isBatch);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
@@ -23,6 +23,6 @@ public interface InnerTableWrite extends StreamTableWrite, BatchTableWrite {
 
     InnerTableWrite withIgnorePreviousFiles(boolean ignorePreviousFiles);
 
-    // do something to speed up in batch mode
-    InnerTableWrite optimizeForBatch(boolean isBatch);
+    // we detect whether in streaming mode, and do some optimization
+    InnerTableWrite isStreamingMode(boolean isStreamingMode);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -63,8 +63,8 @@ public class TableWriteImpl<T>
     }
 
     @Override
-    public TableWriteImpl<T> optimizeForBatch(boolean isBatch) {
-        write.optimizeForBatch(isBatch);
+    public TableWriteImpl<T> isStreamingMode(boolean isStreamingMode) {
+        write.isStreamingMode(isStreamingMode);
         return this;
     }
 
@@ -171,6 +171,11 @@ public class TableWriteImpl<T>
     @Override
     public void restore(List<AbstractFileStoreWrite.State<T>> state) {
         write.restore(state);
+    }
+
+    @VisibleForTesting
+    public AbstractFileStoreWrite<T> getWrite() {
+        return write;
     }
 
     /** Extractor to extract {@link T} from the {@link SinkRecord}. */

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -63,6 +63,12 @@ public class TableWriteImpl<T>
     }
 
     @Override
+    public TableWriteImpl<T> optimizeForBatch(boolean isBatch) {
+        write.optimizeForBatch(isBatch);
+        return this;
+    }
+
+    @Override
     public TableWriteImpl<T> withIOManager(IOManager ioManager) {
         write.withIOManager(ioManager);
         return this;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -40,8 +40,8 @@ public class CompactorSink extends FlinkSink<RowData> {
 
     @Override
     protected OneInputStreamOperator<RowData, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
-        return new StoreCompactOperator(table, writeProvider, isStreaming, commitUser);
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
+        return new StoreCompactOperator(table, writeProvider, commitUser);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
@@ -46,7 +46,7 @@ public class FileStoreSink extends FlinkWriteSink<RowData> {
 
     @Override
     protected OneInputStreamOperator<RowData, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -66,7 +66,8 @@ public abstract class FlinkSink<T> implements Serializable {
         this.ignorePreviousFiles = ignorePreviousFiles;
     }
 
-    private StoreSinkWrite.Provider createWriteProvider(CheckpointConfig checkpointConfig) {
+    private StoreSinkWrite.Provider createWriteProvider(
+            CheckpointConfig checkpointConfig, boolean isStreaming) {
         boolean waitCompaction;
         if (table.coreOptions().writeOnly()) {
             waitCompaction = false;
@@ -100,6 +101,7 @@ public abstract class FlinkSink<T> implements Serializable {
                                 ignorePreviousFiles,
                                 waitCompaction,
                                 finalDeltaCommits,
+                                isStreaming,
                                 memoryPool);
             }
         }
@@ -112,6 +114,7 @@ public abstract class FlinkSink<T> implements Serializable {
                         ioManager,
                         ignorePreviousFiles,
                         waitCompaction,
+                        isStreaming,
                         memoryPool);
     }
 
@@ -148,8 +151,8 @@ public abstract class FlinkSink<T> implements Serializable {
                                 createWriteOperator(
                                         createWriteProvider(
                                                 input.getExecutionEnvironment()
-                                                        .getCheckpointConfig()),
-                                        isStreaming,
+                                                        .getCheckpointConfig(),
+                                                isStreaming),
                                         commitUser))
                         .setParallelism(parallelism == null ? input.getParallelism() : parallelism);
         Options options = Options.fromMap(table.options());
@@ -202,7 +205,7 @@ public abstract class FlinkSink<T> implements Serializable {
     }
 
     protected abstract OneInputStreamOperator<T, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser);
+            StoreSinkWrite.Provider writeProvider, String commitUser);
 
     protected abstract SerializableFunction<String, Committer<Committable, ManifestCommittable>>
             createCommitterFactory(boolean streamingCheckpointEnabled);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -72,8 +72,17 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
             boolean ignorePreviousFiles,
             boolean waitCompaction,
             int deltaCommits,
+            boolean isStreaming,
             @Nullable MemorySegmentPool memoryPool) {
-        super(table, commitUser, state, ioManager, ignorePreviousFiles, waitCompaction, memoryPool);
+        super(
+                table,
+                commitUser,
+                state,
+                ioManager,
+                ignorePreviousFiles,
+                waitCompaction,
+                isStreaming,
+                memoryPool);
 
         this.deltaCommits = deltaCommits;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -62,7 +62,7 @@ public class RowDynamicBucketSink extends DynamicBucketSink<RowData> {
 
     @Override
     protected OneInputStreamOperator<Tuple2<RowData, Integer>, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new DynamicBucketRowWriteOperator(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -47,7 +47,6 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
 
     private final FileStoreTable table;
     private final StoreSinkWrite.Provider storeSinkWriteProvider;
-    private final boolean isStreaming;
     private final String initialCommitUser;
 
     private transient StoreSinkWriteState state;
@@ -57,7 +56,6 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
     public StoreCompactOperator(
             FileStoreTable table,
             StoreSinkWrite.Provider storeSinkWriteProvider,
-            boolean isStreaming,
             String initialCommitUser) {
         super(Options.fromMap(table.options()));
         Preconditions.checkArgument(
@@ -65,7 +63,6 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
                 CoreOptions.WRITE_ONLY.key() + " should not be true for StoreCompactOperator.");
         this.table = table;
         this.storeSinkWriteProvider = storeSinkWriteProvider;
-        this.isStreaming = isStreaming;
         this.initialCommitUser = initialCommitUser;
     }
 
@@ -115,7 +112,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
         byte[] serializedFiles = record.getBinary(3);
         List<DataFileMeta> files = dataFileMetaSerializer.deserializeList(serializedFiles);
 
-        if (isStreaming) {
+        if (write.streamingMode()) {
             write.notifyNewFiles(snapshotId, partition, bucket, files);
             write.compact(partition, bucket, false);
         } else {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
@@ -49,6 +49,8 @@ public interface StoreSinkWrite {
 
     void snapshotState() throws Exception;
 
+    boolean streamingMode();
+
     void close() throws Exception;
 
     /**

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -87,7 +87,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                                         table.coreOptions().writeBufferSize(),
                                         table.coreOptions().pageSize()))
                 .withIgnorePreviousFiles(ignorePreviousFiles)
-                .optimizeForBatch(!isStreamingMode);
+                .isStreamingMode(isStreamingMode);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -50,6 +50,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
     private final IOManager ioManager;
     private final boolean ignorePreviousFiles;
     private final boolean waitCompaction;
+    private final boolean isStreamingMode;
     @Nullable private final MemorySegmentPool memoryPool;
 
     protected TableWriteImpl<?> write;
@@ -61,12 +62,14 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
             IOManager ioManager,
             boolean ignorePreviousFiles,
             boolean waitCompaction,
+            boolean isStreamingMode,
             @Nullable MemorySegmentPool memoryPool) {
         this.commitUser = commitUser;
         this.state = state;
         this.ioManager = ioManager;
         this.ignorePreviousFiles = ignorePreviousFiles;
         this.waitCompaction = waitCompaction;
+        this.isStreamingMode = isStreamingMode;
         this.memoryPool = memoryPool;
         this.write = newTableWrite(table);
     }
@@ -83,7 +86,8 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                                 : new HeapMemorySegmentPool(
                                         table.coreOptions().writeBufferSize(),
                                         table.coreOptions().pageSize()))
-                .withIgnorePreviousFiles(ignorePreviousFiles);
+                .withIgnorePreviousFiles(ignorePreviousFiles)
+                .optimizeForBatch(!isStreamingMode);
     }
 
     @Override
@@ -136,6 +140,11 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
     @Override
     public void snapshotState() throws Exception {
         // do nothing
+    }
+
+    @Override
+    public boolean streamingMode() {
+        return isStreamingMode;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -44,7 +44,7 @@ public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionT
 
     @Override
     protected OneInputStreamOperator<AppendOnlyCompactionTask, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new AppendOnlyTableCompactionWorkerOperator(table, commitUser);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
@@ -74,7 +74,7 @@ public class CdcDynamicBucketSink extends DynamicBucketSink<CdcRecord> {
 
     @Override
     protected OneInputStreamOperator<Tuple2<CdcRecord, Integer>, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new CdcDynamicBucketWriteOperator(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSink.java
@@ -40,7 +40,7 @@ public class FlinkCdcSink extends FlinkWriteSink<CdcRecord> {
 
     @Override
     protected OneInputStreamOperator<CdcRecord, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, boolean isStreaming, String commitUser) {
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new CdcRecordStoreWriteOperator(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.fs.FileIOFinder;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.operation.KeyValueFileStoreWrite;
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.state.StateInitializationContextImpl;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorStateStore;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.table.data.RowData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+/** Test class for {@link FlinkSink}. */
+public class FlinkSinkTest {
+
+    @TempDir Path tempPath;
+
+    @Test
+    public void testOptimizeKeyValueWriterForBatch() throws Exception {
+        // test for batch mode auto enable spillable
+        FileStoreTable fileStoreTable = createFileStoreTable();
+        StreamExecutionEnvironment streamExecutionEnvironment =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // set this when batch executing
+        streamExecutionEnvironment.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        Assertions.assertTrue(testSpillable(streamExecutionEnvironment, fileStoreTable));
+
+        // set this to streaming, we should get a false then
+        streamExecutionEnvironment.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        Assertions.assertFalse(testSpillable(streamExecutionEnvironment, fileStoreTable));
+    }
+
+    private boolean testSpillable(
+            StreamExecutionEnvironment streamExecutionEnvironment, FileStoreTable fileStoreTable)
+            throws Exception {
+        DataStreamSource<RowData> source =
+                streamExecutionEnvironment.fromCollection(
+                        Collections.singletonList(new FlinkRowData(GenericRow.of(1, 1))));
+        FlinkSink<RowData> flinkSink =
+                new FileStoreSink(fileStoreTable, Lock.emptyFactory(), null, null);
+        SingleOutputStreamOperator<Committable> written = flinkSink.doWrite(source, "123", 1);
+        RowDataStoreWriteOperator operator =
+                ((RowDataStoreWriteOperator)
+                        ((SimpleOperatorFactory)
+                                        ((OneInputTransformation) written.getTransformation())
+                                                .getOperatorFactory())
+                                .getOperator());
+        StateInitializationContextImpl context =
+                new StateInitializationContextImpl(
+                        null,
+                        new MockOperatorStateStore() {
+                            @Override
+                            public <S> ListState<S> getUnionListState(
+                                    ListStateDescriptor<S> stateDescriptor) throws Exception {
+                                return getListState(stateDescriptor);
+                            }
+                        },
+                        null,
+                        null,
+                        null);
+        operator.initStateAndWriter(context, (a, b, c) -> true, new IOManagerAsync(), "123");
+        return ((KeyValueFileStoreWrite) ((StoreSinkWriteImpl) operator.write).write.getWrite())
+                .bufferSpillable();
+    }
+
+    protected static final RowType ROW_TYPE =
+            RowType.of(
+                    new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"pk", "pt0"});
+
+    private FileStoreTable createFileStoreTable() throws Exception {
+        org.apache.paimon.fs.Path tablePath = new org.apache.paimon.fs.Path(tempPath.toString());
+        Options conf = new Options();
+        conf.set(CoreOptions.PATH, tablePath.toString());
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), tablePath),
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Collections.emptyList(),
+                                Arrays.asList("pk"),
+                                conf.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(
+                FileIOFinder.find(tablePath), tablePath, tableSchema, conf);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
@@ -647,7 +647,14 @@ public class CdcRecordStoreMultiWriteOperatorTest {
                         catalogLoader,
                         (t, commitUser, state, ioManager, memoryPool) ->
                                 new StoreSinkWriteImpl(
-                                        t, commitUser, state, ioManager, false, false, memoryPool),
+                                        t,
+                                        commitUser,
+                                        state,
+                                        ioManager,
+                                        false,
+                                        false,
+                                        true,
+                                        memoryPool),
                         commitUser,
                         Options.fromMap(new HashMap<>()));
         TypeSerializer<CdcMultiplexRecord> inputSerializer = new JavaSerializer<>();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
@@ -257,7 +257,14 @@ public class CdcRecordStoreWriteOperatorTest {
                         table,
                         (t, commitUser, state, ioManager, memoryPool) ->
                                 new StoreSinkWriteImpl(
-                                        t, commitUser, state, ioManager, false, false, memoryPool),
+                                        t,
+                                        commitUser,
+                                        state,
+                                        ioManager,
+                                        false,
+                                        false,
+                                        true,
+                                        memoryPool),
                         commitUser);
         TypeSerializer<CdcRecord> inputSerializer = new JavaSerializer<>();
         TypeSerializer<Committable> outputSerializer =


### PR DESCRIPTION
KeyValueFileStoreWrite could enable spillable in batch mode by default.

We add optimizeForBatch interface to invoke this.

close https://github.com/apache/incubator-paimon/issues/1369
