### PR TITLE
[core] Refactor Lock into FileStoreTable and hide it from connectors

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -21,6 +21,7 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
@@ -80,7 +81,11 @@ public abstract class AbstractCatalog implements Catalog {
 
     private FileStoreTable getDataTable(Identifier identifier) throws TableNotExistException {
         TableSchema tableSchema = getDataTableSchema(identifier);
-        return FileStoreTableFactory.create(fileIO, getDataTableLocation(identifier), tableSchema);
+        return FileStoreTableFactory.create(
+                fileIO,
+                getDataTableLocation(identifier),
+                tableSchema,
+                Lock.factory(lockFactory().orElse(null), identifier));
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -29,6 +29,7 @@ import org.apache.paimon.operation.AppendOnlyFileStoreRead;
 import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.operation.FileStoreScan;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.operation.ReverseReader;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -53,12 +54,17 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     private transient AppendOnlyFileStore lazyStore;
 
     AppendOnlyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        super(fileIO, path, tableSchema);
+        this(fileIO, path, tableSchema, Lock.emptyFactory());
+    }
+
+    AppendOnlyFileStoreTable(
+            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
+        super(fileIO, path, tableSchema, lockFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new AppendOnlyFileStoreTable(fileIO, path, newTableSchema);
+        return new AppendOnlyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
@@ -31,6 +31,7 @@ import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.ValueCountMergeFunction;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.operation.ReverseReader;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -58,16 +59,20 @@ import static org.apache.paimon.schema.SystemColumns.VALUE_COUNT;
 public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
 
     private static final long serialVersionUID = 1L;
-
     private transient KeyValueFileStore lazyStore;
 
     ChangelogValueCountFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        super(fileIO, path, tableSchema);
+        this(fileIO, path, tableSchema, Lock.emptyFactory());
+    }
+
+    ChangelogValueCountFileStoreTable(
+            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
+        super(fileIO, path, tableSchema, lockFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogValueCountFileStoreTable(fileIO, path, newTableSchema);
+        return new ChangelogValueCountFileStoreTable(fileIO, path, newTableSchema, lockFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -34,6 +34,7 @@ import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -66,12 +67,17 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private transient KeyValueFileStore lazyStore;
 
     ChangelogWithKeyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        super(fileIO, path, tableSchema);
+        this(fileIO, path, tableSchema, Lock.emptyFactory());
+    }
+
+    ChangelogWithKeyFileStoreTable(
+            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
+        super(fileIO, path, tableSchema, lockFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogWithKeyFileStoreTable(fileIO, path, newTableSchema);
+        return new ChangelogWithKeyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -23,6 +23,7 @@ import org.apache.paimon.WriteMode;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -62,15 +63,24 @@ public class FileStoreTableFactory {
                                                 "Schema file not found in location "
                                                         + tablePath
                                                         + ". Please create table first."));
-        return create(fileIO, tablePath, tableSchema, options);
+        return create(fileIO, tablePath, tableSchema, options, Lock.emptyFactory());
     }
 
     public static FileStoreTable create(FileIO fileIO, Path tablePath, TableSchema tableSchema) {
-        return create(fileIO, tablePath, tableSchema, new Options());
+        return create(fileIO, tablePath, tableSchema, new Options(), Lock.emptyFactory());
     }
 
     public static FileStoreTable create(
-            FileIO fileIO, Path tablePath, TableSchema tableSchema, Options dynamicOptions) {
+            FileIO fileIO, Path tablePath, TableSchema tableSchema, Lock.Factory lockFactory) {
+        return create(fileIO, tablePath, tableSchema, new Options(), lockFactory);
+    }
+
+    public static FileStoreTable create(
+            FileIO fileIO,
+            Path tablePath,
+            TableSchema tableSchema,
+            Options dynamicOptions,
+            Lock.Factory lockFactory) {
         FileStoreTable table;
         Options coreOptions = Options.fromMap(tableSchema.options());
         WriteMode writeMode = coreOptions.get(CoreOptions.WRITE_MODE);
@@ -82,12 +92,16 @@ public class FileStoreTableFactory {
             coreOptions.set(CoreOptions.WRITE_MODE, writeMode);
         }
         if (writeMode == WriteMode.APPEND_ONLY) {
-            table = new AppendOnlyFileStoreTable(fileIO, tablePath, tableSchema);
+            table = new AppendOnlyFileStoreTable(fileIO, tablePath, tableSchema, lockFactory);
         } else {
             if (tableSchema.primaryKeys().isEmpty()) {
-                table = new ChangelogValueCountFileStoreTable(fileIO, tablePath, tableSchema);
+                table =
+                        new ChangelogValueCountFileStoreTable(
+                                fileIO, tablePath, tableSchema, lockFactory);
             } else {
-                table = new ChangelogWithKeyFileStoreTable(fileIO, tablePath, tableSchema);
+                table =
+                        new ChangelogWithKeyFileStoreTable(
+                                fileIO, tablePath, tableSchema, lockFactory);
             }
         }
         return table.copy(dynamicOptions.toMap());

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.table.sink;
 
-import org.apache.paimon.operation.Lock;
-
 import javax.annotation.Nullable;
 
 import java.util.Map;
@@ -40,8 +38,4 @@ public interface InnerTableCommit extends StreamTableCommit, BatchTableCommit {
      * </ul>
      */
     InnerTableCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
-
-    /** @deprecated lock should pass from table. */
-    @Deprecated
-    InnerTableCommit withLock(Lock lock);
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -142,6 +143,7 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema, conf);
+        return FileStoreTableFactory.create(
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -26,6 +26,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReaderIterator;
@@ -136,7 +137,8 @@ public abstract class ScannerTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema, conf);
+        return FileStoreTableFactory.create(
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
     }
 
     protected List<Split> toSplits(List<DataSplit> dataSplits) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -120,7 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
     @Override
     public Optional<Factory> getFactory() {
-        return Optional.of(new FlinkTableFactory(catalog.lockFactory().orElse(null)));
+        return Optional.of(new FlinkTableFactory());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkTableFactory.java
@@ -19,8 +19,6 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.catalog.CatalogLock;
-import org.apache.paimon.flink.sink.FlinkTableSink;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
@@ -32,23 +30,11 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
-import javax.annotation.Nullable;
-
 import static org.apache.paimon.CoreOptions.AUTO_CREATE;
 import static org.apache.paimon.flink.FlinkCatalogFactory.IDENTIFIER;
 
 /** A paimon {@link DynamicTableFactory} to create source and sink. */
 public class FlinkTableFactory extends AbstractFlinkTableFactory {
-
-    @Nullable private final CatalogLock.Factory lockFactory;
-
-    public FlinkTableFactory() {
-        this(null);
-    }
-
-    public FlinkTableFactory(@Nullable CatalogLock.Factory lockFactory) {
-        this.lockFactory = lockFactory;
-    }
 
     @Override
     public String factoryIdentifier() {
@@ -84,9 +70,7 @@ public class FlinkTableFactory extends AbstractFlinkTableFactory {
                     context.isTemporary());
         }
         createTableIfNeeded(context);
-        FlinkTableSink sink = (FlinkTableSink) super.createDynamicTableSink(context);
-        sink.setLockFactory(lockFactory);
-        return sink;
+        return super.createDynamicTableSink(context);
     }
 
     private void createTableIfNeeded(Context context) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/TableActionBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/TableActionBase.java
@@ -24,7 +24,6 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.LogicalTypeConversion;
 import org.apache.paimon.flink.sink.FlinkSinkBuilder;
 import org.apache.paimon.flink.utils.TableEnvironmentUtils;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.types.DataType;
@@ -116,9 +115,6 @@ public abstract class TableActionBase extends ActionBase {
                 Collections.singletonList(
                         new FlinkSinkBuilder((FileStoreTable) table)
                                 .withInput(dataStream)
-                                .withLockFactory(
-                                        Lock.factory(
-                                                catalog.lockFactory().orElse(null), identifier))
                                 .build()
                                 .getTransformation());
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.manifest.ManifestCommittable;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.SerializableFunction;
 
@@ -31,11 +30,8 @@ public class CompactorSink extends FlinkSink<RowData> {
 
     private static final long serialVersionUID = 1L;
 
-    private final Lock.Factory lockFactory;
-
-    public CompactorSink(FileStoreTable table, Lock.Factory lockFactory) {
+    public CompactorSink(FileStoreTable table) {
         super(table, false);
-        this.lockFactory = lockFactory;
     }
 
     @Override
@@ -47,7 +43,7 @@ public class CompactorSink extends FlinkSink<RowData> {
     @Override
     protected SerializableFunction<String, Committer<Committable, ManifestCommittable>>
             createCommitterFactory(boolean streamingCheckpointEnabled) {
-        return user -> new StoreCommitter(table.newCommit(user).withLock(lockFactory.create()));
+        return user -> new StoreCommitter(table.newCommit(user));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 
@@ -34,7 +33,6 @@ public class CompactorSinkBuilder {
     private final FileStoreTable table;
 
     private DataStream<RowData> input;
-    private Lock.Factory lockFactory = Lock.emptyFactory();
 
     public CompactorSinkBuilder(FileStoreTable table) {
         this.table = table;
@@ -42,11 +40,6 @@ public class CompactorSinkBuilder {
 
     public CompactorSinkBuilder withInput(DataStream<RowData> input) {
         this.input = input;
-        return this;
-    }
-
-    public CompactorSinkBuilder withLockFactory(Lock.Factory lockFactory) {
-        this.lockFactory = lockFactory;
         return this;
     }
 
@@ -64,6 +57,6 @@ public class CompactorSinkBuilder {
 
     private DataStreamSink<?> buildForBucketAware() {
         DataStream<RowData> partitioned = partition(input, new BucketsRowChannelComputer(), null);
-        return new CompactorSink(table, lockFactory).sinkFrom(partitioned);
+        return new CompactorSink(table).sinkFrom(partitioned);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketSink.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
@@ -43,10 +42,8 @@ public abstract class DynamicBucketSink<T> extends FlinkWriteSink<Tuple2<T, Inte
     private static final long serialVersionUID = 1L;
 
     public DynamicBucketSink(
-            FileStoreTable table,
-            Lock.Factory lockFactory,
-            @Nullable Map<String, String> overwritePartition) {
-        super(table, overwritePartition, lockFactory);
+            FileStoreTable table, @Nullable Map<String, String> overwritePartition) {
+        super(table, overwritePartition);
     }
 
     protected abstract ChannelComputer<T> channelComputer1();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -37,10 +36,9 @@ public class FileStoreSink extends FlinkWriteSink<RowData> {
 
     public FileStoreSink(
             FileStoreTable table,
-            Lock.Factory lockFactory,
             @Nullable Map<String, String> overwritePartition,
             @Nullable LogSinkFunction logSinkFunction) {
-        super(table, overwritePartition, lockFactory);
+        super(table, overwritePartition);
         this.logSinkFunction = logSinkFunction;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.flink.VersionedSerializerWrapper;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestCommittableSerializer;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.SerializableFunction;
 
@@ -35,15 +34,10 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
     private static final long serialVersionUID = 1L;
 
     @Nullable private final Map<String, String> overwritePartition;
-    private final Lock.Factory lockFactory;
 
-    public FlinkWriteSink(
-            FileStoreTable table,
-            @Nullable Map<String, String> overwritePartition,
-            Lock.Factory lockFactory) {
+    public FlinkWriteSink(FileStoreTable table, @Nullable Map<String, String> overwritePartition) {
         super(table, overwritePartition != null);
         this.overwritePartition = overwritePartition;
-        this.lockFactory = lockFactory;
     }
 
     @Override
@@ -57,7 +51,6 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
                 new StoreCommitter(
                         table.newCommit(user)
                                 .withOverwrite(overwritePartition)
-                                .withLock(lockFactory.create())
                                 .ignoreEmptyCommit(!streamingCheckpointEnabled));
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
@@ -38,10 +37,8 @@ public class RowDynamicBucketSink extends DynamicBucketSink<RowData> {
     private static final long serialVersionUID = 1L;
 
     public RowDynamicBucketSink(
-            FileStoreTable table,
-            Lock.Factory lockFactory,
-            @Nullable Map<String, String> overwritePartition) {
-        super(table, lockFactory, overwritePartition);
+            FileStoreTable table, @Nullable Map<String, String> overwritePartition) {
+        super(table, overwritePartition);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -22,7 +22,6 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.WrappedManifestCommittable;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 
@@ -52,7 +51,6 @@ public class StoreMultiCommitter
     //    StoreMultiCommitter manages multiple committers which are
     //    referenced by table id.
     private Map<Identifier, StoreCommitter> tableCommitters;
-    private Lock.Factory lockFactory = Lock.emptyFactory();
 
     public StoreMultiCommitter(String commitUser, Catalog.Loader catalogLoader) {
         this.catalog = catalogLoader.load();
@@ -168,11 +166,7 @@ public class StoreMultiCommitter
                                 "Failed to get committer for table %s", tableId.getFullName()),
                         e);
             }
-            committer =
-                    new StoreCommitter(
-                            table.newCommit(commitUser)
-                                    .withLock(lockFactory.create())
-                                    .ignoreEmptyCommit(false));
+            committer = new StoreCommitter(table.newCommit(commitUser).ignoreEmptyCommit(false));
             tableCommitters.put(tableId, committer);
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketWriteSink.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.flink.compact.UnawareBucketCompactionTopoBuilder;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -44,11 +43,10 @@ public class UnawareBucketWriteSink extends FileStoreSink {
 
     public UnawareBucketWriteSink(
             AppendOnlyFileStoreTable table,
-            Lock.Factory lock,
             Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
             Integer parallelism) {
-        super(table, lock, overwritePartitions, logSinkFunction);
+        super(table, overwritePartitions, logSinkFunction);
         this.table = table;
         this.enableCompaction = !table.coreOptions().writeOnly();
         this.parallelism = parallelism;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
@@ -23,7 +23,6 @@ import org.apache.paimon.flink.sink.ChannelComputer;
 import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.DynamicBucketSink;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
@@ -37,8 +36,8 @@ public class CdcDynamicBucketSink extends DynamicBucketSink<CdcRecord> {
 
     private static final long serialVersionUID = 1L;
 
-    public CdcDynamicBucketSink(FileStoreTable table, Lock.Factory lockFactory) {
-        super(table, lockFactory, null);
+    public CdcDynamicBucketSink(FileStoreTable table) {
+        super(table, null);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSink.java
@@ -22,7 +22,6 @@ import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.FlinkSink;
 import org.apache.paimon.flink.sink.FlinkWriteSink;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -34,8 +33,8 @@ public class FlinkCdcSink extends FlinkWriteSink<CdcRecord> {
 
     private static final long serialVersionUID = 1L;
 
-    public FlinkCdcSink(FileStoreTable table, Lock.Factory lockFactory) {
-        super(table, null, lockFactory);
+    public FlinkCdcSink(FileStoreTable table) {
+        super(table, null);
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -100,7 +100,7 @@ public class HiveCatalog extends AbstractCatalog {
     private final IMetaStoreClient client;
     private final String warehouse;
 
-    private LocationHelper locationHelper;
+    private final LocationHelper locationHelper;
 
     public HiveCatalog(FileIO fileIO, HiveConf hiveConf, String clientClassName, String warehouse) {
         this(fileIO, hiveConf, clientClassName, Collections.emptyMap(), warehouse);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -20,7 +20,6 @@ package org.apache.paimon.spark;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
@@ -56,9 +55,7 @@ public class SparkCatalog extends SparkCatalogBase {
         LOG.info("Time travel target snapshot id is {}.", snapshotId);
 
         Options dynamicOptions = new Options().set(CoreOptions.SCAN_SNAPSHOT_ID, snapshotId);
-        return new SparkTable(
-                table.copy(dynamicOptions.toMap()),
-                Lock.factory(catalog.lockFactory().orElse(null), toIdentifier(ident)));
+        return new SparkTable(table.copy(dynamicOptions.toMap()));
     }
 
     /**
@@ -75,9 +72,7 @@ public class SparkCatalog extends SparkCatalogBase {
         LOG.info("Time travel target timestamp is {} milliseconds.", timestamp);
 
         Options option = new Options().set(CoreOptions.SCAN_TIMESTAMP_MILLIS, timestamp);
-        return new SparkTable(
-                table.copy(option.toMap()),
-                Lock.factory(catalog.lockFactory().orElse(null), toIdentifier(ident)));
+        return new SparkTable(table.copy(option.toMap()));
     }
 
     private Table loadAndCheck(Identifier ident) throws NoSuchTableException {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalogBase.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalogBase.java
@@ -21,7 +21,6 @@ package org.apache.paimon.spark;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -204,9 +203,7 @@ public abstract class SparkCatalogBase implements TableCatalog, SupportsNamespac
     @Override
     public SparkTable loadTable(Identifier ident) throws NoSuchTableException {
         try {
-            return new SparkTable(
-                    load(ident),
-                    Lock.factory(catalog.lockFactory().orElse(null), toIdentifier(ident)));
+            return new SparkTable(load(ident));
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkSource.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkSource.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.catalog.CatalogContext;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTableFactory;
 
@@ -70,7 +69,7 @@ public class SparkSource implements DataSourceRegister, SessionConfigSupport {
                 CatalogContext.create(
                         Options.fromMap(options),
                         SparkSession.active().sessionState().newHadoopConf());
-        return new SparkTable(FileStoreTableFactory.create(catalogContext), Lock.emptyFactory());
+        return new SparkTable(FileStoreTableFactory.create(catalogContext));
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTable.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
@@ -53,11 +52,9 @@ public class SparkTable
                 SupportsDelete {
 
     private final Table table;
-    private final Lock.Factory lockFactory;
 
-    public SparkTable(Table table, Lock.Factory lockFactory) {
+    public SparkTable(Table table) {
         this.table = table;
-        this.lockFactory = lockFactory;
     }
 
     @Override
@@ -94,7 +91,7 @@ public class SparkTable
 
     @Override
     public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-        return new SparkWriteBuilder(table, lockFactory);
+        return new SparkWriteBuilder(table);
     }
 
     @Override
@@ -109,7 +106,7 @@ public class SparkTable
             predicates.add(converter.convert(filter));
         }
 
-        TableUtils.deleteWhere(table, predicates, lockFactory);
+        TableUtils.deleteWhere(table, predicates);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkWriteBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkWriteBuilder.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark;
 
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.Table;
 
 import org.apache.spark.sql.connector.write.Write;
@@ -32,15 +31,13 @@ import org.apache.spark.sql.connector.write.WriteBuilder;
 public class SparkWriteBuilder implements WriteBuilder {
 
     private final Table table;
-    private final Lock.Factory lockFactory;
 
-    public SparkWriteBuilder(Table table, Lock.Factory lockFactory) {
+    public SparkWriteBuilder(Table table) {
         this.table = table;
-        this.lockFactory = lockFactory;
     }
 
     @Override
     public Write build() {
-        return new SparkWrite(table, lockFactory);
+        return new SparkWrite(table);
     }
 }


### PR DESCRIPTION
### Purpose

Currently `Lock` is exposed to all connectors such as Flink, Spark, etc. When creating writers in the connectors, we have to keep in mind that we should use a lock if needed. This is sort of cumbersome for connector creators.

This PR refactors `Lock` into `FileStoreTable` and hide it from connectors. Connectors now do not need to concern about locks. They can create `TableCommit` as they want and don't have to check if there is a lock.

### Tests

Existing UT/IT cases should cover this change.

### API and Format

N/A

### Documentation

N/A
