### PR TITLE
[core] Introduce filterAndCommit method for StreamTableCommit, which merges filterCommitted and commit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamWriteBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamWriteBuilder.java
@@ -32,8 +32,8 @@ import org.apache.paimon.data.InternalRow;
  *   <li>Different applications need to use different commitUsers.
  *   <li>The commitIdentifier of {@link StreamTableWrite} and {@link StreamTableCommit} needs to be
  *       consistent, and the id needs to be incremented for the next committing.
- *   <li>When a failure occurs, if you still have uncommitted {@link CommitMessage}s, please use
- *       {@link StreamTableCommit#filterCommitted} to exclude the committed messages by
+ *   <li>When a failure occurs, if you still have uncommitted {@link CommitMessage}s, please retry
+ *       with {@link StreamTableCommit#filterAndCommit} to exclude the committed messages by
  *       commitIdentifier.
  * </ul>
  *

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -32,16 +32,18 @@ import java.util.Map;
  */
 public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
 
-    /** Find out which global committables need to be retried when recovering from the failure. */
-    List<GlobalCommitT> filterRecoveredCommittables(List<GlobalCommitT> globalCommittables)
-            throws IOException;
-
     /** Compute an aggregated committable from a list of committables. */
     GlobalCommitT combine(long checkpointId, long watermark, List<CommitT> committables)
             throws IOException;
 
     /** Commits the given {@link GlobalCommitT}. */
     void commit(List<GlobalCommitT> globalCommittables) throws IOException, InterruptedException;
+
+    /**
+     * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link
+     * GlobalCommitT}.
+     */
+    int filterAndCommit(List<GlobalCommitT> globalCommittables) throws IOException;
 
     Map<Long, List<CommitT>> groupByCheckpoint(Collection<CommitT> committables);
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
@@ -78,9 +78,8 @@ public class RestoreAndFailCommittableStateManager<GlobalCommitT>
 
     private void recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
             throws Exception {
-        committables = committer.filterRecoveredCommittables(committables);
-        if (!committables.isEmpty()) {
-            committer.commit(committables);
+        int numCommitted = committer.filterAndCommit(committables);
+        if (numCommitted > 0) {
             throw new RuntimeException(
                     "This exception is intentionally thrown "
                             + "after committing the restored checkpoints. "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -29,8 +29,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /** {@link Committer} for dynamic store. */
 public class StoreCommitter implements Committer<Committable, ManifestCommittable> {
@@ -39,19 +37,6 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
 
     public StoreCommitter(TableCommit commit) {
         this.commit = (TableCommitImpl) commit;
-    }
-
-    @Override
-    public List<ManifestCommittable> filterRecoveredCommittables(
-            List<ManifestCommittable> globalCommittables) {
-        Set<Long> identifiers =
-                commit.filterCommitted(
-                        globalCommittables.stream()
-                                .map(ManifestCommittable::identifier)
-                                .collect(Collectors.toSet()));
-        return globalCommittables.stream()
-                .filter(m -> identifiers.contains(m.identifier()))
-                .collect(Collectors.toList());
     }
 
     @Override
@@ -78,6 +63,11 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     public void commit(List<ManifestCommittable> committables)
             throws IOException, InterruptedException {
         commit.commitMultiple(committables);
+    }
+
+    @Override
+    public int filterAndCommit(List<ManifestCommittable> globalCommittables) throws IOException {
+        return commit.filterAndCommitMultiple(globalCommittables);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -31,10 +31,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -45,45 +43,17 @@ import java.util.stream.Collectors;
 public class StoreMultiCommitter
         implements Committer<MultiTableCommittable, WrappedManifestCommittable> {
 
-    private Catalog catalog;
+    private final Catalog catalog;
     private final String commitUser;
     // To make the commit behavior consistent with that of Committer,
     //    StoreMultiCommitter manages multiple committers which are
     //    referenced by table id.
-    private Map<Identifier, StoreCommitter> tableCommitters;
+    private final Map<Identifier, StoreCommitter> tableCommitters;
 
     public StoreMultiCommitter(String commitUser, Catalog.Loader catalogLoader) {
         this.catalog = catalogLoader.load();
         this.commitUser = commitUser;
         this.tableCommitters = new HashMap<>();
-    }
-
-    @Override
-    public List<WrappedManifestCommittable> filterRecoveredCommittables(
-            List<WrappedManifestCommittable> globalCommittables) {
-        // key by table id
-        Map<Identifier, List<ManifestCommittable>> committableMap =
-                groupByTable(globalCommittables);
-
-        Map<Long, WrappedManifestCommittable> result = new TreeMap<>();
-
-        for (Map.Entry<Identifier, List<ManifestCommittable>> entry : committableMap.entrySet()) {
-            Identifier tableId = entry.getKey();
-            List<ManifestCommittable> committableList = entry.getValue();
-            StoreCommitter committer = getStoreCommitter(tableId);
-            List<ManifestCommittable> filteredCommittables =
-                    committer.filterRecoveredCommittables(committableList);
-
-            for (ManifestCommittable filteredCommittable : filteredCommittables) {
-                long identifier = filteredCommittable.identifier();
-                WrappedManifestCommittable wrappedFilteredCommittable =
-                        result.computeIfAbsent(identifier, id -> new WrappedManifestCommittable());
-
-                wrappedFilteredCommittable.putManifestCommittable(tableId, filteredCommittable);
-            }
-        }
-
-        return new LinkedList<>(result.values());
     }
 
     @Override
@@ -126,6 +96,17 @@ public class StoreMultiCommitter
             StoreCommitter committer = getStoreCommitter(tableId);
             committer.commit(committableList);
         }
+    }
+
+    @Override
+    public int filterAndCommit(List<WrappedManifestCommittable> globalCommittables)
+            throws IOException {
+        int result = 0;
+        for (Map.Entry<Identifier, List<ManifestCommittable>> entry :
+                groupByTable(globalCommittables).entrySet()) {
+            result += getStoreCommitter(entry.getKey()).filterAndCommit(entry.getValue());
+        }
+        return result;
     }
 
     private Map<Identifier, List<ManifestCommittable>> groupByTable(


### PR DESCRIPTION
### Purpose

Currently to retry the commit process after failure, the user has to first call `StreamTableCommit#filterCommitted` and then call `StreamTableCommit#commit`. This is kind of cumbersome.

This PR merges the two method calls into one `StreamTableCommit#filterAndCommit`. Users just need to pass all `CommitMessage`s in question into the method and it will automatically choose what to commit.

What's more, we are going to support adding partition into Hive metastore in the future. By adding the `StreamTableCommit#filterAndCommit` method we can check and create our desired partition in this method during retry to ensure consistency.

### Tests

Existing UT/IT should cover this change.

### API and Format

Yes. It changes the public Java API. `StreamTableCommit#filterCommitted` is now deprecated.

### Documentation

No.
