### PR TITLE
[core]Fix inconsistent format option between read and write

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -22,7 +22,7 @@ import org.apache.paimon.annotation.Documentation.ExcludeFromDocumentation;
 import org.apache.paimon.annotation.Documentation.Immutable;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.format.FileFormat;
-import org.apache.paimon.format.FileFormatFactory.FormatContext;
+import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.MemorySize;
@@ -741,11 +741,8 @@ public class CoreOptions implements Serializable {
 
     public static FileFormat createFileFormat(
             Options options, ConfigOption<FileFormatType> formatOption) {
-        FileFormatType formatIdentifier = options.get(formatOption);
-        int readBatchSize = options.get(READ_BATCH_SIZE);
-        return FileFormat.fromIdentifier(
-                formatIdentifier.toString(),
-                new FormatContext(options.removePrefix(formatIdentifier + "."), readBatchSize));
+        String formatIdentifier = options.get(formatOption).toString();
+        return FileFormatDiscover.getFileFormat(options, formatIdentifier);
     }
 
     public Map<Integer, String> fileCompressionPerLevel() {

--- a/paimon-core/src/main/java/org/apache/paimon/format/FileFormatDiscover.java
+++ b/paimon-core/src/main/java/org/apache/paimon/format/FileFormatDiscover.java
@@ -20,6 +20,7 @@ package org.apache.paimon.format;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
+import org.apache.paimon.options.Options;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,12 +38,20 @@ public interface FileFormatDiscover {
             }
 
             private FileFormat create(String identifier) {
-                return FileFormat.fromIdentifier(
-                        identifier,
-                        new FormatContext(options.toConfiguration(), options.readBatchSize()));
+                return getFileFormat(options.toConfiguration(), identifier);
             }
         };
     }
 
     FileFormat discover(String identifier);
+
+    static FileFormat getFileFormat(Options options, String formatIdentifier) {
+        int readBatchSize = options.get(CoreOptions.READ_BATCH_SIZE);
+        FileFormat fileFormat =
+                FileFormat.fromIdentifier(
+                        formatIdentifier,
+                        new FormatContext(
+                                options.removePrefix(formatIdentifier + "."), readBatchSize));
+        return fileFormat;
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -113,7 +113,8 @@ public class FileFormatTest {
         tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.fromValue(IDENTIFIER));
         tableOptions.set(CoreOptions.READ_BATCH_SIZE, 1024);
         tableOptions.setString(IDENTIFIER + ".hello", "world");
-        FileFormatDiscover fileFormatDiscover = FileFormatDiscover.of(new CoreOptions(tableOptions));
+        FileFormatDiscover fileFormatDiscover =
+                FileFormatDiscover.of(new CoreOptions(tableOptions));
         FileFormat fileFormat = fileFormatDiscover.discover(IDENTIFIER);
         Assertions.assertTrue(fileFormat instanceof OrcFileFormat);
         OrcFileFormat orcFileFormat = (OrcFileFormat) fileFormat;

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.orc.OrcFileFormat;
@@ -101,6 +102,20 @@ public class FileFormatTest {
         FileFormat fileFormat = CoreOptions.createFileFormat(tableOptions, CoreOptions.FILE_FORMAT);
         Assertions.assertTrue(fileFormat instanceof OrcFileFormat);
 
+        OrcFileFormat orcFileFormat = (OrcFileFormat) fileFormat;
+        assertThat(orcFileFormat.formatContext().formatOptions().get("hello")).isEqualTo("world");
+        assertThat(orcFileFormat.formatContext().readBatchSize()).isEqualTo(1024);
+    }
+
+    @Test
+    public void testFileFormatOption() {
+        Options tableOptions = new Options();
+        tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.fromValue(IDENTIFIER));
+        tableOptions.set(CoreOptions.READ_BATCH_SIZE, 1024);
+        tableOptions.setString(IDENTIFIER + ".hello", "world");
+        FileFormatDiscover fileFormatDiscover = FileFormatDiscover.of(new CoreOptions(tableOptions));
+        FileFormat fileFormat = fileFormatDiscover.discover(IDENTIFIER);
+        Assertions.assertTrue(fileFormat instanceof OrcFileFormat);
         OrcFileFormat orcFileFormat = (OrcFileFormat) fileFormat;
         assertThat(orcFileFormat.formatContext().formatOptions().get("hello")).isEqualTo("world");
         assertThat(orcFileFormat.formatContext().readBatchSize()).isEqualTo(1024);


### PR DESCRIPTION
The format options ,such as 'orc.xx','parquet.xx' currently don't work for reading. 
It work for writing

