### PR TITLE
fix workflow fail

### DIFF
--- a/.github/workflows/check-licensing.yml
+++ b/.github/workflows/check-licensing.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: 'temurin'
+          distribution: 'adopt'
           cache: 'maven'
 
       - name: Build


### PR DESCRIPTION
the jdk distrbution "Temurin" seem to fail setting up, we can change the  distribution to adopt to work around it.
![image](https://github.com/apache/incubator-paimon/assets/14267759/2f17a9db-9d08-492c-a141-aeae13b4b6f8)


