### PR TITLE
[flink] integrate DELETE filter pushdown for flink-1.17

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownFunctionVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownFunctionVisitor.java
@@ -105,7 +105,7 @@ public class DeletePushDownFunctionVisitor implements FunctionVisitor<Boolean> {
     @Override
     public Boolean visitAnd(List<Boolean> children) {
         if (children.size() != 2) {
-            throw new RuntimeException("Illegal children size: " + children.size());
+            return false;
         }
         if (children.get(0) && children.get(1)) {
             return true;
@@ -116,7 +116,7 @@ public class DeletePushDownFunctionVisitor implements FunctionVisitor<Boolean> {
     @Override
     public Boolean visitOr(List<Boolean> children) {
         if (children.size() != 2) {
-            throw new RuntimeException("Illegal children size: " + children.size());
+            return false;
         }
 
         if (children.get(0) || children.get(1)) {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownFunctionVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownFunctionVisitor.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import java.util.List;
+import java.util.Optional;
+
+/** DeletePushDownFunctionVisitor visit the predicate and check if it can be push down. */
+public class DeletePushDownFunctionVisitor implements FunctionVisitor<Optional<Long>> {
+
+    private final List<String> primaryKeys;
+
+    private final List<String> partitionKeys;
+
+    private final int predicatesSize;
+
+    public DeletePushDownFunctionVisitor(
+            List<String> primaryKeys, List<String> partitionKeys, int size) {
+        this.primaryKeys = primaryKeys;
+        this.partitionKeys = partitionKeys;
+        this.predicatesSize = size;
+    }
+
+    @Override
+    public Optional<Long> visitIsNotNull(FieldRef fieldRef) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitIsNull(FieldRef fieldRef) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitStartsWith(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitLessThan(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitNotEqual(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitEqual(FieldRef fieldRef, Object literal) {
+        if (partitionKeys.contains(fieldRef.name())) {
+            if (predicatesSize == 1) {
+                return Optional.empty();
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Not support delete pushdown for field %s because partition predicate is mixed with others",
+                                fieldRef.name()));
+            }
+        }
+
+        if (!primaryKeys.contains(fieldRef.name())) {
+            throw new IllegalArgumentException(
+                    String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Long> visitGreaterThan(FieldRef fieldRef, Object literal) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitIn(FieldRef fieldRef, List<Object> literals) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitNotIn(FieldRef fieldRef, List<Object> literals) {
+        throw new IllegalArgumentException(
+                String.format("Not support delete pushdown for field %s.", fieldRef.name()));
+    }
+
+    @Override
+    public Optional<Long> visitAnd(List<Optional<Long>> children) {
+        throw new IllegalArgumentException(String.format("Not support delete pushdown."));
+    }
+
+    @Override
+    public Optional<Long> visitOr(List<Optional<Long>> children) {
+        if (children.size() != 2) {
+            throw new RuntimeException("Illegal or children: " + children.size());
+        }
+
+        if (children.get(0).isPresent() || children.get(1).isPresent()) {
+            throw new RuntimeException("Illegal children");
+        }
+
+        return Optional.empty();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
@@ -20,6 +20,10 @@ package org.apache.paimon.predicate;
 
 import java.util.List;
 
+/**
+ * DeletePushDownPartitionKeyVisitor visit the predicate and check if it only contains partition
+ * keys and can be push down.
+ */
 public class DeletePushDownPartitionKeyVisitor implements FunctionVisitor<Boolean> {
 
     private final List<String> partitionKeys;

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.paimon.predicate;
 
 import java.util.List;

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPartitionKeyVisitor.java
@@ -1,0 +1,77 @@
+package org.apache.paimon.predicate;
+
+import java.util.List;
+
+public class DeletePushDownPartitionKeyVisitor implements FunctionVisitor<Boolean> {
+
+    private final List<String> partitionKeys;
+
+    public DeletePushDownPartitionKeyVisitor(List<String> partitionKeys) {
+        this.partitionKeys = partitionKeys;
+    }
+
+    @Override
+    public Boolean visitIsNotNull(FieldRef fieldRef) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIsNull(FieldRef fieldRef) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitNotEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
+        return partitionKeys.contains(fieldRef.name());
+    }
+
+    @Override
+    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitNotIn(FieldRef fieldRef, List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitAnd(List<Boolean> children) {
+        return children.stream().reduce((first, second) -> first && second).get();
+    }
+
+    @Override
+    public Boolean visitOr(List<Boolean> children) {
+        return false;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPrimaryKeyVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/DeletePushDownPrimaryKeyVisitor.java
@@ -20,7 +20,10 @@ package org.apache.paimon.predicate;
 
 import java.util.List;
 
-/** DeletePushDownFunctionVisitor visit the predicate and check if it can be push down. */
+/**
+ * DeletePushDownPrimaryKeyVisitor visit the predicate and check if it only contains primary keys
+ * and can be push down.
+ */
 public class DeletePushDownPrimaryKeyVisitor implements FunctionVisitor<Boolean> {
 
     private final List<String> primaryKeys;

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/DeletePushDownVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/DeletePushDownVisitorTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/* test cases for DeleteFilter Push Down, suppose primaryKeys = (a,b,c,d), partitionKeys=(b,c,d), other fields = (e,f),
+ * the following cases are tested:
+ *
+ * 1. where a=1 and b=2 and c=3 and d=4, push down
+ * 2. where a=1 and b=2 and c=3 and d=4 and e is not null, push down
+ * 3. where a=1 and b=2 and c=3 and d=4 and f=6, push down
+ * 4. where a=1 and b=2 and c=3 and d=4 and e is not null and f=6, push down
+ * 5. where a in (1,2) and b=2 and c=3 and d=4, push down
+ * 6. where a=1 and b=1 and c is not null and d=4, do not push down
+ * 7. where a=1, do not push down
+ * 8. where a=1 and b=2 and d=4, do not push down
+ * 9. where a=1 and c=3 and d=4, do not push down
+ * 10. where b=2 and c=3 and d=4 and f=6, not push down
+ *
+ * 11. where b=2 and c=3 and d=4, push down
+ * 12. where b=2 and c=3, push down
+ * 13. where b=2 and d=4, push down
+ * 14. where b=2 and c=3 and d=4 and e=5, do not push down
+ * 15. where b=2 and c=3 or d=4, do not push down
+ * 16. where b=2 and c=3 and d>5, do not push down
+ */
+/** DeletePushDownVisitorTest tests the DeletePushDownVisitor. */
+public class DeletePushDownVisitorTest {
+
+    @Test
+    public void testPrimaryKeyPushDown() {
+        List<String> primaryKeys = Arrays.asList("a", "b", "c", "d");
+
+        Predicate predicateA =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 1, "a", Collections.singletonList(1));
+
+        Predicate predicateA1 =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 1, "a", Collections.singletonList(2));
+
+        Predicate predicateB =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 2, "b", Collections.singletonList(2));
+
+        Predicate predicateC =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 3, "c", Collections.singletonList(3));
+
+        Predicate predicateCIsNotNull =
+                new LeafPredicate(
+                        IsNotNull.INSTANCE, DataTypes.INT(), 3, "c", Collections.singletonList(3));
+
+        Predicate predicateD =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 4, "d", Collections.singletonList(4));
+
+        // non-primary key's isNotNull filter
+        Predicate predicateE =
+                new LeafPredicate(
+                        IsNotNull.INSTANCE, DataTypes.INT(), 5, "e", Collections.singletonList(5));
+
+        Predicate predicateF =
+                new LeafPredicate(
+                        IsNotNull.INSTANCE, DataTypes.INT(), 6, "f", Collections.singletonList(6));
+
+        /** filters contain all the primary keys with AND of Equal *********** */
+
+        // where a=1 and b=2 and c=3 and d=4, push down
+        DeletePushDownPrimaryKeyVisitor visitor = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate compoundPredicate =
+                PredicateBuilder.and(Arrays.asList(predicateA, predicateB, predicateC, predicateD));
+        Boolean visitResult = compoundPredicate.visit(visitor);
+        Boolean hit = visitor.isHitAll();
+        assertThat(visitResult).isTrue();
+        assertThat(hit).isTrue();
+
+        // where a=1 and b=2 and c=3 and d=4 and e is not null, push down
+        DeletePushDownPrimaryKeyVisitor visitor1 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate predicateABCDE =
+                PredicateBuilder.and(
+                        Arrays.asList(predicateA, predicateB, predicateC, predicateD, predicateE));
+        assertThat(predicateABCDE.visit(visitor1)).isTrue();
+        assertThat(visitor1.isHitAll()).isTrue();
+
+        // where a=1 and b=2 and c=3 and d=4 and f=6, push down
+        DeletePushDownPrimaryKeyVisitor visitor2 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate predicateABCDF =
+                PredicateBuilder.and(
+                        Arrays.asList(predicateA, predicateB, predicateC, predicateD, predicateF));
+        assertThat(predicateABCDF.visit(visitor2)).isTrue();
+        assertThat(visitor2.isHitAll()).isTrue();
+
+        // where a=1 and b=2 and c=3 and d=4 and e is not null and f=6, push down
+        DeletePushDownPrimaryKeyVisitor visitor3 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate predicateABCDEF =
+                PredicateBuilder.and(
+                        Arrays.asList(
+                                predicateA,
+                                predicateB,
+                                predicateC,
+                                predicateD,
+                                predicateE,
+                                predicateF));
+        assertThat(predicateABCDEF.visit(visitor3)).isTrue();
+        assertThat(visitor3.isHitAll()).isTrue();
+
+        // where a in (1,2) and b=2 and c=3 and d=4, push down
+        DeletePushDownPrimaryKeyVisitor visitor4 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate predicateAABCD =
+                PredicateBuilder.and(
+                        Arrays.asList(
+                                PredicateBuilder.or(predicateA, predicateA1),
+                                predicateB,
+                                predicateC,
+                                predicateD,
+                                predicateE));
+        assertThat(predicateAABCD.visit(visitor4)).isTrue();
+        assertThat(visitor4.isHitAll()).isTrue();
+
+        /** not all the primary keys filters are of Equal func ************* */
+
+        // where a=1 and b=1 and c is not null and d=4, do not push down
+        DeletePushDownPrimaryKeyVisitor visitor5 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        Predicate predicateABCNotNull =
+                PredicateBuilder.and(
+                        Arrays.asList(predicateA, predicateB, predicateCIsNotNull, predicateD));
+        assertThat(predicateABCNotNull.visit(visitor5)).isFalse();
+        assertThat(visitor5.isHitAll()).isFalse();
+
+        /** filters not contain all the primary keys ****************** */
+
+        // where a=1, do not push down
+        DeletePushDownPrimaryKeyVisitor visitor6 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        PredicateBuilder.and(Arrays.asList(predicateA)).visit(visitor6);
+        assertThat(visitor6.isHitAll()).isFalse();
+
+        // where a=1 and b=2 and d=4, do not push down
+        DeletePushDownPrimaryKeyVisitor visitor7 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        PredicateBuilder.and(Arrays.asList(predicateA, predicateB, predicateD)).visit(visitor7);
+        assertThat(visitor7.isHitAll()).isFalse();
+
+        // where a=1 and c=3 and d=4, do not push down
+        DeletePushDownPrimaryKeyVisitor visitor8 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        PredicateBuilder.and(Arrays.asList(predicateA, predicateC, predicateD)).visit(visitor8);
+        assertThat(visitor8.isHitAll()).isFalse();
+
+        // where b=2 and c=3 and d=4 and f=6, not push down
+        DeletePushDownPrimaryKeyVisitor visitor9 = new DeletePushDownPrimaryKeyVisitor(primaryKeys);
+        PredicateBuilder.and(Arrays.asList(predicateB, predicateC, predicateD, predicateF))
+                .visit(visitor9);
+        assertThat(visitor9.isHitAll()).isFalse();
+    }
+
+    @Test
+    public void testPartitionKeyNotPushDown() {
+        List<String> partitionKeys = Arrays.asList("b", "c", "d");
+
+        Predicate predicateB =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 2, "b", Collections.singletonList(2));
+
+        Predicate predicateC =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 3, "c", Collections.singletonList(3));
+
+        Predicate predicateD =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 4, "d", Collections.singletonList(4));
+
+        Predicate predicateDgreater =
+                new LeafPredicate(
+                        GreaterThan.INSTANCE,
+                        DataTypes.INT(),
+                        4,
+                        "d",
+                        Collections.singletonList(5));
+
+        Predicate predicateE =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 5, "e", Collections.singletonList(5));
+
+        /** filters only contain partition keys with func Equal ****************** */
+
+        // where b=2 and c=3 and d=4, push down
+        DeletePushDownPartitionKeyVisitor visitor =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(
+                        PredicateBuilder.and(Arrays.asList(predicateB, predicateC, predicateD))
+                                .visit(visitor))
+                .isTrue();
+
+        // where b=2 and c=3, push down
+        DeletePushDownPartitionKeyVisitor visitor1 =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(PredicateBuilder.and(Arrays.asList(predicateB, predicateC)).visit(visitor1))
+                .isTrue();
+
+        // where b=2 and d=4, push down
+        DeletePushDownPartitionKeyVisitor visitor2 =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(PredicateBuilder.and(Arrays.asList(predicateB, predicateD)).visit(visitor2))
+                .isTrue();
+
+        // where b=2 and c=3 and d=4 and e=5, do not push down
+        DeletePushDownPartitionKeyVisitor visitor3 =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(
+                        PredicateBuilder.and(
+                                        Arrays.asList(
+                                                predicateB, predicateC, predicateD, predicateE))
+                                .visit(visitor3))
+                .isFalse();
+
+        // where b=2 and c=3 or d=4, do not push down
+        DeletePushDownPartitionKeyVisitor visitor4 =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(
+                        PredicateBuilder.and(
+                                        Arrays.asList(
+                                                PredicateBuilder.or(predicateB, predicateD),
+                                                PredicateBuilder.or(predicateC, predicateD)))
+                                .visit(visitor4))
+                .isFalse();
+
+        // where b=2 and c=3 and d>5, do not push down
+        DeletePushDownPartitionKeyVisitor visitor5 =
+                new DeletePushDownPartitionKeyVisitor(partitionKeys);
+        assertThat(
+                        PredicateBuilder.and(
+                                        Arrays.asList(predicateB, predicateC, predicateDgreater))
+                                .visit(visitor5))
+                .isFalse();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
@@ -39,6 +39,8 @@ public class TableUtils {
      * Delete according to filters.
      *
      * <p>NOTE: This method is only suitable for deletion of small amount of data.
+     *
+     * @return the number of deleted records
      */
     public static long deleteWhere(Table table, List<Predicate> filters) {
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(filters);

--- a/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
@@ -40,10 +40,11 @@ public class TableUtils {
      *
      * <p>NOTE: This method is only suitable for deletion of small amount of data.
      */
-    public static void deleteWhere(Table table, List<Predicate> filters) {
+    public static long deleteWhere(Table table, List<Predicate> filters) {
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(filters);
         BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
         List<Split> splits = readBuilder.newScan().plan().splits();
+        long hit = 0;
         try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits);
                 BatchTableWrite write = writeBuilder.newWrite();
                 BatchTableCommit commit = writeBuilder.newCommit()) {
@@ -52,12 +53,14 @@ public class TableUtils {
             while (iterator.hasNext()) {
                 InternalRow row = iterator.next();
                 if (filter.test(row)) {
+                    hit++;
                     row.setRowKind(RowKind.DELETE);
                     write.write(row);
                 }
             }
 
             commit.commit(write.prepareCommit());
+            return hit;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
@@ -19,24 +19,40 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.CoreOptions.MergeEngine;
+import org.apache.paimon.flink.LogicalTypeConversion;
+import org.apache.paimon.flink.PredicateConverter;
+import org.apache.paimon.flink.action.Action;
+import org.apache.paimon.flink.action.DropPartitionAction;
 import org.apache.paimon.flink.log.LogStoreTableFactory;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Or;
+import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.ChangelogValueCountFileStoreTable;
 import org.apache.paimon.table.ChangelogWithKeyFileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.TableUtils;
 
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.RowLevelModificationScanContext;
+import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelUpdate;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,7 +60,11 @@ import static org.apache.paimon.CoreOptions.MERGE_ENGINE;
 
 /** Table sink to create sink. */
 public class FlinkTableSink extends FlinkTableSinkBase
-        implements SupportsRowLevelUpdate, SupportsRowLevelDelete {
+        implements SupportsRowLevelUpdate, SupportsRowLevelDelete, SupportsDeletePushDown {
+
+    @Nullable protected List<Predicate> predicates;
+
+    private static final String TABLE_PATH_KEY = "path";
 
     public FlinkTableSink(
             ObjectIdentifier tableIdentifier,
@@ -134,5 +154,145 @@ public class FlinkTableSink extends FlinkTableSinkBase
                             "%s can not support delete, because it is an unknown subclass of FileStoreTable.",
                             table.getClass().getName()));
         }
+    }
+
+    /*
+    supported filters:
+    1. where primary key = x
+    2. where primary key = x or key = y
+    3. where primary key in (x, y, z)
+    4. where partition key = x
+    */
+    @Override
+    public boolean applyDeleteFilters(List<ResolvedExpression> list) {
+        if (list.size() == 0) {
+            return false;
+        }
+
+        predicates = new ArrayList<>();
+        RowType rowType = LogicalTypeConversion.toLogicalType(table.rowType());
+        for (ResolvedExpression filter : list) {
+            Optional<Predicate> predicate = PredicateConverter.convert(rowType, filter);
+            if (predicate.isPresent() && shouldPushdownDeleteFilter(predicate.get(), list.size())) {
+                predicates.add(predicate.get());
+            } else {
+                // convert failed, leave it to flink
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public Optional<Long> executeDeletion() {
+        if (table instanceof ChangelogWithKeyFileStoreTable) {
+            Options options = Options.fromMap(table.options());
+            if (options.get(MERGE_ENGINE) == MergeEngine.DEDUPLICATE) {
+                return executeDeletionInternal();
+            }
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "merge engine '%s' can not support delete, currently only %s can support delete.",
+                            options.get(MERGE_ENGINE), MergeEngine.DEDUPLICATE));
+        } else if (table instanceof ChangelogValueCountFileStoreTable) {
+            return executeDeletionInternal();
+        } else if (table instanceof AppendOnlyFileStoreTable) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "table '%s' can not support delete, because there is no primary key.",
+                            table.getClass().getName()));
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "%s can not support delete, because it is an unknown subclass of FileStoreTable.",
+                            table.getClass().getName()));
+        }
+    }
+
+    private Optional<Long> executeDeletionInternal() {
+        // delete partition
+        if (predicates.size() == 1
+                && predicates.get(0) instanceof LeafPredicate
+                && table.partitionKeys()
+                        .contains(((LeafPredicate) predicates.get(0)).fieldName())) {
+            String tablePath = table.options().get(TABLE_PATH_KEY);
+            if (tablePath == null) {
+                throw new RuntimeException(
+                        String.format("Cannot find path from options of table %s.", table.name()));
+            }
+
+            LeafPredicate leaf = (LeafPredicate) predicates.get(0);
+            String[] args =
+                    new String[] {
+                        "--path",
+                        tablePath,
+                        "--partition",
+                        String.format("%s=%s", leaf.fieldName(), leaf.literals().get(0))
+                    };
+
+            Optional<Action> action = DropPartitionAction.create(args);
+            try {
+                action.get().run();
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        String.format("DropPartitionAction %s failed.", Arrays.toString(args)), e);
+            }
+            return Optional.empty();
+        }
+
+        // delete primary key related data
+        return Optional.of(TableUtils.deleteWhere(table, predicates));
+    }
+
+    private boolean shouldPushdownDeleteFilter(Predicate predicate, int predicateSize) {
+        if (predicate instanceof CompoundPredicate) { // where pk in ('A', 'B', 'C')
+            return shouldPushdownDeleteFilter((CompoundPredicate) predicate);
+        } else if (predicate instanceof LeafPredicate) { // where pk = 'A'
+            LeafPredicate leafPredicate = (LeafPredicate) predicate;
+
+            if (!(leafPredicate.function() instanceof Equal)) {
+                return false;
+            }
+
+            if (table.partitionKeys().contains(leafPredicate.fieldName())) {
+                return predicateSize == 1;
+            } else {
+                return table.primaryKeys().contains(leafPredicate.fieldName());
+            }
+        }
+
+        return false;
+    }
+
+    private boolean shouldPushdownDeleteFilter(CompoundPredicate predicate) {
+        if (!(predicate.function() instanceof Or)) {
+            return false;
+        }
+
+        List<Predicate> children = predicate.children();
+        if (children.size() == 2) {
+            Predicate first = children.get(0);
+            Predicate second = children.get(1);
+            if (first instanceof LeafPredicate && second instanceof LeafPredicate) {
+                return ((LeafPredicate) first).function() instanceof Equal
+                        && table.primaryKeys().contains(((LeafPredicate) first).fieldName())
+                        && ((LeafPredicate) second).function() instanceof Equal
+                        && table.primaryKeys().contains(((LeafPredicate) second).fieldName());
+            } else if (first instanceof LeafPredicate) {
+                return ((LeafPredicate) first).function() instanceof Equal
+                        && table.primaryKeys().contains(((LeafPredicate) first).fieldName())
+                        && shouldPushdownDeleteFilter((CompoundPredicate) second);
+            } else if (second instanceof LeafPredicate) {
+                return ((LeafPredicate) second).function() instanceof Equal
+                        && table.primaryKeys().contains(((LeafPredicate) second).fieldName())
+                        && shouldPushdownDeleteFilter((CompoundPredicate) children.get(0));
+            } else {
+                return shouldPushdownDeleteFilter((CompoundPredicate) first)
+                        && shouldPushdownDeleteFilter((CompoundPredicate) second);
+            }
+        }
+
+        return false;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSink.java
@@ -221,12 +221,9 @@ public class FlinkTableSink extends FlinkTableSinkBase
 
     private boolean canPushDownDeleteFilter(Predicate predicate, int predicateSize) {
         try {
-            predicate.visit(
+            return predicate.visit(
                     new DeletePushDownFunctionVisitor(
                             table.primaryKeys(), table.partitionKeys(), predicateSize));
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
         } catch (RuntimeException e) {
             return false;
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -1701,7 +1701,7 @@ public class ReadWriteTableITCase extends AbstractTestBase {
 
         // Step3: prepare delete statement 'where pk = x'
         String deleteStatement =
-                String.format("DELETE FROM %s WHERE id = 1 and dt = '2022-01-01'", table);
+                String.format("DELETE FROM %s WHERE id = 2 and dt = '2022-01-01'", table);
 
         // Step4: execute delete statement and verify result
         List<Row> expectedRecords =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -1693,21 +1693,22 @@ public class ReadWriteTableITCase extends AbstractTestBase {
                 "(1, 'US Dollar', 114, '2022-01-01')",
                 "(2, 'UNKNOWN', -1, '2022-01-01')",
                 "(3, 'Euro', 119, '2022-01-02')",
-                "(4, 'CNY', 119, '2022-01-03')",
+                "(4, 'CNY', 119, '2022-01-02')",
                 "(5, 'HKD', 119, '2022-01-03')",
                 "(6, 'CAD', 119, '2022-01-03')",
                 "(7, 'INR', 119, '2022-01-03')",
                 "(8, 'MOP', 119, '2022-01-03')");
 
         // Step3: prepare delete statement 'where pk = x'
-        String deleteStatement = String.format("DELETE FROM %s WHERE id = 2", table);
+        String deleteStatement =
+                String.format("DELETE FROM %s WHERE id = 1 and dt = '2022-01-01'", table);
 
         // Step4: execute delete statement and verify result
         List<Row> expectedRecords =
                 Arrays.asList(
                         changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
                         changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"),
-                        changelogRow("+I", 4L, "CNY", 119L, "2022-01-03"),
+                        changelogRow("+I", 4L, "CNY", 119L, "2022-01-02"),
                         changelogRow("+I", 5L, "HKD", 119L, "2022-01-03"),
                         changelogRow("+I", 6L, "CAD", 119L, "2022-01-03"),
                         changelogRow("+I", 7L, "INR", 119L, "2022-01-03"),
@@ -1722,7 +1723,8 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         }
 
         // Step5: prepare delete statement 'where pk = x or pk = y'
-        String deleteStatement1 = String.format("DELETE FROM %s WHERE id =3 or id = 4", table);
+        String deleteStatement1 =
+                String.format("DELETE FROM %s WHERE id = 3 or id = 4 and dt = '2022-01-02'", table);
         List<Row> expectedRecords1 =
                 Arrays.asList(
                         changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
@@ -1740,7 +1742,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         }
 
         // Step5: prepare delete statement 'where pk in (x, y, z)'
-        String deleteStatement2 = String.format("DELETE FROM %s WHERE id in (5, 6, 7, 8)", table);
+        String deleteStatement2 =
+                String.format(
+                        "DELETE FROM %s WHERE id in (5, 6, 7, 8) and dt = '2022-01-03'", table);
         List<Row> expectedRecords2 =
                 Arrays.asList(changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"));
         if (supportUpdateEngines.contains(mergeEngine)) {
@@ -1790,7 +1794,7 @@ public class ReadWriteTableITCase extends AbstractTestBase {
 
         // Step3: partition key not delete push down
         String deleteStatement =
-                String.format("DELETE FROM %s WHERE dt = '2022-01-03' AND id = 4", table);
+                String.format("DELETE FROM %s WHERE dt = '2022-01-03' AND currency = 'CNY'", table);
 
         // Step4: execute delete statement and verify result
         List<Row> expectedRecords =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -1770,22 +1770,23 @@ public class ReadWriteTableITCase extends AbstractTestBase {
                                 "id BIGINT NOT NULL",
                                 "currency STRING",
                                 "rate BIGINT",
-                                "dt String"),
-                        Arrays.asList("id", "dt"),
-                        Collections.singletonList("dt"),
+                                "dt String",
+                                "hh String"),
+                        Arrays.asList("id", "dt", "hh"),
+                        Arrays.asList("dt", "hh"),
                         options);
 
         // Step2: batch write some historical data
         insertInto(
                 table,
-                "(1, 'US Dollar', 114, '2022-01-01')",
-                "(2, 'UNKNOWN', -1, '2022-01-01')",
-                "(3, 'Euro', 119, '2022-01-02')",
-                "(4, 'CNY', 119, '2022-01-03')",
-                "(5, 'HKD', 119, '2022-01-03')",
-                "(6, 'CAD', 119, '2022-01-03')",
-                "(7, 'INR', 119, '2022-01-03')",
-                "(8, 'MOP', 119, '2022-01-03')");
+                "(1, 'US Dollar', 114, '2022-01-01', '11')",
+                "(2, 'UNKNOWN', -1, '2022-01-01', '12')",
+                "(3, 'Euro', 119, '2022-01-02', '13')",
+                "(4, 'CNY', 119, '2022-01-03', '14')",
+                "(5, 'HKD', 119, '2022-01-03', '15')",
+                "(6, 'CAD', 119, '2022-01-03', '16')",
+                "(7, 'INR', 119, '2022-01-03', '17')",
+                "(8, 'MOP', 119, '2022-01-03', '18')");
 
         // Step3: partition key not delete push down
         String deleteStatement =
@@ -1794,13 +1795,13 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         // Step4: execute delete statement and verify result
         List<Row> expectedRecords =
                 Arrays.asList(
-                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
-                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01"),
-                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"),
-                        changelogRow("+I", 5L, "HKD", 119L, "2022-01-03"),
-                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03"),
-                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03"),
-                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03"));
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01", "11"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01", "12"),
+                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02", "13"),
+                        changelogRow("+I", 5L, "HKD", 119L, "2022-01-03", "15"),
+                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03", "16"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03", "17"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03", "18"));
         if (supportUpdateEngines.contains(mergeEngine)) {
             bEnv.executeSql(deleteStatement).await();
             String querySql = String.format("SELECT * FROM %s", table);
@@ -1810,21 +1811,59 @@ public class ReadWriteTableITCase extends AbstractTestBase {
                     .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
         }
 
-        // Step5: partition key delete push down
-        String deleteStatement1 = String.format("DELETE FROM %s WHERE dt = '2022-01-03'", table);
-
-        // Step6: execute delete statement and verify result
+        // Step5: partition key not push down
+        String deleteStatement1 =
+                String.format("DELETE FROM %s WHERE dt = '2022-01-02' or hh = '15'", table);
         List<Row> expectedRecords1 =
                 Arrays.asList(
-                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
-                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01"),
-                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"));
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01", "11"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01", "12"),
+                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03", "16"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03", "17"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03", "18"));
         if (supportUpdateEngines.contains(mergeEngine)) {
             bEnv.executeSql(deleteStatement1).await();
             String querySql = String.format("SELECT * FROM %s", table);
             testBatchRead(querySql, expectedRecords1);
         } else {
             assertThatThrownBy(() -> bEnv.executeSql(deleteStatement1).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+
+        // Step6: partition key delete push down
+        String deleteStatement2 =
+                String.format("DELETE FROM %s WHERE dt = '2022-01-03' and hh = '16'", table);
+
+        // Step7: execute delete statement and verify result
+        List<Row> expectedRecords2 =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01", "11"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01", "12"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03", "17"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03", "18"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement2).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords2);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement2).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+
+        // Step8: partition key delete push down
+        String deleteStatement3 = String.format("DELETE FROM %s WHERE dt = '2022-01-03'", table);
+
+        // Step9: execute delete statement and verify result
+        List<Row> expectedRecords3 =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01", "11"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01", "12"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement3).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords3);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement3).await())
                     .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -1665,6 +1665,170 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(CoreOptions.MergeEngine.class)
+    public void testDeletePushDownWithPrimaryKey(CoreOptions.MergeEngine mergeEngine)
+            throws Exception {
+        Set<CoreOptions.MergeEngine> supportUpdateEngines = new HashSet<>();
+        supportUpdateEngines.add(CoreOptions.MergeEngine.DEDUPLICATE);
+
+        // Step1: define table schema
+        Map<String, String> options = new HashMap<>();
+        options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
+        options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        String table =
+                createTable(
+                        Arrays.asList(
+                                "id BIGINT NOT NULL",
+                                "currency STRING",
+                                "rate BIGINT",
+                                "dt String"),
+                        Arrays.asList("id", "dt"),
+                        Collections.singletonList("dt"),
+                        options);
+
+        // Step2: batch write some historical data
+        insertInto(
+                table,
+                "(1, 'US Dollar', 114, '2022-01-01')",
+                "(2, 'UNKNOWN', -1, '2022-01-01')",
+                "(3, 'Euro', 119, '2022-01-02')",
+                "(4, 'CNY', 119, '2022-01-03')",
+                "(5, 'HKD', 119, '2022-01-03')",
+                "(6, 'CAD', 119, '2022-01-03')",
+                "(7, 'INR', 119, '2022-01-03')",
+                "(8, 'MOP', 119, '2022-01-03')");
+
+        // Step3: prepare delete statement 'where pk = x'
+        String deleteStatement = String.format("DELETE FROM %s WHERE id = 2", table);
+
+        // Step4: execute delete statement and verify result
+        List<Row> expectedRecords =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
+                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", 4L, "CNY", 119L, "2022-01-03"),
+                        changelogRow("+I", 5L, "HKD", 119L, "2022-01-03"),
+                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+
+        // Step5: prepare delete statement 'where pk = x or pk = y'
+        String deleteStatement1 = String.format("DELETE FROM %s WHERE id =3 or id = 4", table);
+        List<Row> expectedRecords1 =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
+                        changelogRow("+I", 5L, "HKD", 119L, "2022-01-03"),
+                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement1).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords1);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement1).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+
+        // Step5: prepare delete statement 'where pk in (x, y, z)'
+        String deleteStatement2 = String.format("DELETE FROM %s WHERE id in (5, 6, 7, 8)", table);
+        List<Row> expectedRecords2 =
+                Arrays.asList(changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement2).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords2);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement2).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(CoreOptions.MergeEngine.class)
+    public void testDeletePushDownWithPartitionKey(CoreOptions.MergeEngine mergeEngine)
+            throws Exception {
+        Set<CoreOptions.MergeEngine> supportUpdateEngines = new HashSet<>();
+        supportUpdateEngines.add(CoreOptions.MergeEngine.DEDUPLICATE);
+
+        // Step1: define table schema
+        Map<String, String> options = new HashMap<>();
+        options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
+        options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        String table =
+                createTable(
+                        Arrays.asList(
+                                "id BIGINT NOT NULL",
+                                "currency STRING",
+                                "rate BIGINT",
+                                "dt String"),
+                        Arrays.asList("id", "dt"),
+                        Collections.singletonList("dt"),
+                        options);
+
+        // Step2: batch write some historical data
+        insertInto(
+                table,
+                "(1, 'US Dollar', 114, '2022-01-01')",
+                "(2, 'UNKNOWN', -1, '2022-01-01')",
+                "(3, 'Euro', 119, '2022-01-02')",
+                "(4, 'CNY', 119, '2022-01-03')",
+                "(5, 'HKD', 119, '2022-01-03')",
+                "(6, 'CAD', 119, '2022-01-03')",
+                "(7, 'INR', 119, '2022-01-03')",
+                "(8, 'MOP', 119, '2022-01-03')");
+
+        // Step3: partition key not delete push down
+        String deleteStatement =
+                String.format("DELETE FROM %s WHERE dt = '2022-01-03' AND id = 4", table);
+
+        // Step4: execute delete statement and verify result
+        List<Row> expectedRecords =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01"),
+                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", 5L, "HKD", 119L, "2022-01-03"),
+                        changelogRow("+I", 6L, "CAD", 119L, "2022-01-03"),
+                        changelogRow("+I", 7L, "INR", 119L, "2022-01-03"),
+                        changelogRow("+I", 8L, "MOP", 119L, "2022-01-03"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+
+        // Step5: partition key delete push down
+        String deleteStatement1 = String.format("DELETE FROM %s WHERE dt = '2022-01-03'", table);
+
+        // Step6: execute delete statement and verify result
+        List<Row> expectedRecords1 =
+                Arrays.asList(
+                        changelogRow("+I", 1L, "US Dollar", 114L, "2022-01-01"),
+                        changelogRow("+I", 2L, "UNKNOWN", -1L, "2022-01-01"),
+                        changelogRow("+I", 3L, "Euro", 119L, "2022-01-02"));
+        if (supportUpdateEngines.contains(mergeEngine)) {
+            bEnv.executeSql(deleteStatement1).await();
+            String querySql = String.format("SELECT * FROM %s", table);
+            testBatchRead(querySql, expectedRecords1);
+        } else {
+            assertThatThrownBy(() -> bEnv.executeSql(deleteStatement1).await())
+                    .satisfies(AssertionUtils.anyCauseMatches(UnsupportedOperationException.class));
+        }
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // Tools
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Linked issue: close https://github.com/apache/incubator-paimon/issues/989

### Brief change
Supported filters:
    1. where primary key = x
    2. where primary key = x or key = y
    3. where primary key in (x, y, z)
    4. where partition key = x

Note: primary key between filter now is not supported in Paimon, ignore it now and let's start a new ticket for it later.

### Tests
UT:
* ReadWriteTableITCase#testDeletePushDownWithPrimaryKey
* ReadWriteTableITCase#testDeletePushDownWithPartitionKey


### Documentation

<!-- Does this change introduce a new feature -->
