### PR TITLE
[cdc] Introduce RichCdcSinkBuilder API

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
@@ -58,6 +58,11 @@ public class CdcRecord implements Serializable {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(kind, fields);
+    }
+
+    @Override
     public String toString() {
         return kind.shortString() + " " + fields;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcParserFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcParserFactory.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-/** A {@link EventParser.Factory} for {@link RichCdcRecord} */
+/** A {@link EventParser.Factory} for {@link RichCdcRecord}. */
 public class RichCdcParserFactory implements EventParser.Factory<RichCdcRecord> {
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcParserFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcParserFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** A {@link EventParser.Factory} for {@link RichCdcRecord} */
+public class RichCdcParserFactory implements EventParser.Factory<RichCdcRecord> {
+
+    @Override
+    public RichEventParser create() {
+        return new RichEventParser();
+    }
+
+    private static class RichEventParser implements EventParser<RichCdcRecord> {
+
+        private RichCdcRecord record;
+
+        private final Map<String, DataType> previousDataFields = new HashMap<>();
+
+        @Override
+        public void setRawEvent(RichCdcRecord rawEvent) {
+            this.record = rawEvent;
+        }
+
+        @Override
+        public List<DataField> parseSchemaChange() {
+            List<DataField> change = new ArrayList<>();
+            record.fieldTypes()
+                    .forEach(
+                            (field, type) -> {
+                                DataType previous = previousDataFields.get(field);
+                                if (!Objects.equals(previous, type)) {
+                                    previousDataFields.put(field, type);
+                                    change.add(new DataField(0, field, type));
+                                }
+                            });
+            return change;
+        }
+
+        @Override
+        public List<CdcRecord> parseRecords() {
+            return Collections.singletonList(record.toCdcRecord());
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcRecord.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.RowKind;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** A change message contains schema and data. */
+@Experimental
+public class RichCdcRecord implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RowKind kind;
+    private final Map<String, DataType> fieldTypes;
+    private final Map<String, String> fieldValues;
+
+    public RichCdcRecord(
+            RowKind kind, Map<String, DataType> fieldTypes, Map<String, String> fieldValues) {
+        this.kind = kind;
+        this.fieldTypes = fieldTypes;
+        this.fieldValues = fieldValues;
+    }
+
+    public RowKind kind() {
+        return kind;
+    }
+
+    public Map<String, DataType> fieldTypes() {
+        return fieldTypes;
+    }
+
+    public Map<String, String> fieldValues() {
+        return fieldValues;
+    }
+
+    public CdcRecord toCdcRecord() {
+        return new CdcRecord(kind, fieldValues);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RichCdcRecord that = (RichCdcRecord) o;
+        return kind == that.kind
+                && Objects.equals(fieldTypes, that.fieldTypes)
+                && Objects.equals(fieldValues, that.fieldValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, fieldTypes, fieldValues);
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "kind="
+                + kind
+                + ", fieldTypes="
+                + fieldTypes
+                + ", fieldValues="
+                + fieldValues
+                + '}';
+    }
+
+    public static Builder builder(RowKind kind) {
+        return new Builder(kind);
+    }
+
+    /** Builder for {@link RichCdcRecord}. */
+    public static class Builder {
+
+        private final RowKind kind;
+        private final Map<String, DataType> fieldTypes = new HashMap<>();
+        private final Map<String, String> fieldValues = new HashMap<>();
+
+        public Builder(RowKind kind) {
+            this.kind = kind;
+        }
+
+        public Builder field(String name, DataType type, String value) {
+            fieldTypes.put(name, type);
+            fieldValues.put(name, value);
+            return this;
+        }
+
+        public RichCdcRecord build() {
+            return new RichCdcRecord(kind, fieldTypes, fieldValues);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcSinkBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.table.Table;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+
+import javax.annotation.Nullable;
+
+/** Builder for sink when syncing {@link RichCdcRecord} records into one Paimon table. */
+@Experimental
+public class RichCdcSinkBuilder {
+
+    private DataStream<RichCdcRecord> input = null;
+    private Table table = null;
+
+    @Nullable private Integer parallelism;
+
+    public RichCdcSinkBuilder withInput(DataStream<RichCdcRecord> input) {
+        this.input = input;
+        return this;
+    }
+
+    public RichCdcSinkBuilder withTable(Table table) {
+        this.table = table;
+        return this;
+    }
+
+    public RichCdcSinkBuilder withParallelism(@Nullable Integer parallelism) {
+        this.parallelism = parallelism;
+        return this;
+    }
+
+    public DataStreamSink<?> build() {
+        CdcSinkBuilder<RichCdcRecord> builder = new CdcSinkBuilder<>();
+        return builder.withTable(table)
+                .withInput(input)
+                .withParserFactory(new RichCdcParserFactory())
+                .withParallelism(parallelism)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The previous CDC API, which required the user to implement an EventParser.Factory, was a bit too complicated for the user.

This PR introduces a RichCdcSinkBuilder, the user only needs to provide a DataStream<RichCdcRecord>, which can extract Schema changes from the data.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
