### PR TITLE
[core] Query audit_log with incremental between should see DELETE rec…

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -106,6 +106,17 @@ spark.read()
 
 {{< /tabs >}}
 
+In Batch SQL, the `DELETE` records are not allowed to be returned, so records of `-D` will be dropped.
+If you want see `DELETE` records, you can use audit_log table:
+
+{{< tabs "incremental-audit_log" >}}
+{{< tab "Flink" >}}
+```sql
+SELECT * FROM t$audit_log /*+ OPTIONS('incremental-between' = '12,20') */;
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 ## Streaming Query
 
 By default, Streaming read produces the latest snapshot on the table upon first startup,

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
@@ -141,6 +141,12 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
                     RecordReader.RecordIterator<KeyValue> kvRecordIterator) {
                 return new ValueCountRowDataRecordIterator(kvRecordIterator);
             }
+
+            @Override
+            public InnerTableRead forceKeepDelete() {
+                read.forceKeepDelete();
+                return this;
+            }
         };
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -212,6 +212,12 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                     RecordReader.RecordIterator<KeyValue> kvRecordIterator) {
                 return new ValueContentRowDataRecordIterator(kvRecordIterator);
             }
+
+            @Override
+            public InnerTableRead forceKeepDelete() {
+                read.forceKeepDelete();
+                return this;
+            }
         };
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -46,4 +46,8 @@ public interface InnerTableRead extends TableRead {
     }
 
     InnerTableRead withProjection(int[][] projection);
+
+    default InnerTableRead forceKeepDelete() {
+        return this;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -327,7 +327,7 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         private int[] readProjection;
 
         private AuditLogRead(InnerTableRead dataRead) {
-            this.dataRead = dataRead;
+            this.dataRead = dataRead.forceKeepDelete();
             this.readProjection = defaultProjection();
         }
 


### PR DESCRIPTION
…ords

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For increment-between:
In Batch SQL, the `DELETE` records are not allowed to be returned, so records of `-D` will be dropped.
If you want see `DELETE` records, you can use audit_log table:

```sql
SELECT * FROM t$audit_log /*+ OPTIONS('incremental-between' = '12,20') */;
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
