### PR TITLE
[hive] Support syncing partition into Hive metastore when using Hive catalog

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,6 +30,8 @@ import static java.util.Arrays.asList;
 
 /** An utility class for I/O related functionality. */
 public final class IOUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IOUtils.class);
 
     /** The block size for byte operations in byte. */
     private static final int BLOCKSIZE = 4096;
@@ -186,7 +191,8 @@ public final class IOUtils {
             if (closeable != null) {
                 closeable.close();
             }
-        } catch (Throwable ignored) {
+        } catch (Throwable e) {
+            LOG.debug("Exception occurs when closing " + closeable, e);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -85,7 +85,8 @@ public abstract class AbstractCatalog implements Catalog {
                 fileIO,
                 getDataTableLocation(identifier),
                 tableSchema,
-                Lock.factory(lockFactory().orElse(null), identifier));
+                Lock.factory(lockFactory().orElse(null), identifier),
+                commitCallbackFactories(identifier));
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -22,8 +22,10 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.CommitCallback;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,6 +48,16 @@ public interface Catalog extends AutoCloseable {
      * object store.
      */
     Optional<CatalogLock.Factory> lockFactory();
+
+    /**
+     * Get a list of {@link CommitCallback.Factory} related to {@code identifier} from catalog.
+     * {@link CommitCallback} is called after a series of changes to the table is successfully
+     * committed. For example, {@link CommitCallback} can be used to register newly created
+     * partitions into Hive metastore. See {@link CommitCallback} for more details.
+     */
+    default List<CommitCallback.Factory> commitCallbackFactories(Identifier identifier) {
+        return Collections.emptyList();
+    }
 
     /**
      * Get the names of all databases in this catalog.

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -34,6 +34,7 @@ import org.apache.paimon.operation.ReverseReader;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.AppendOnlySplitGenerator;
 import org.apache.paimon.table.source.DataSplit;
@@ -44,6 +45,8 @@ import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 
 /** {@link FileStoreTable} for {@link WriteMode#APPEND_ONLY} write mode. */
@@ -54,17 +57,22 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     private transient AppendOnlyFileStore lazyStore;
 
     AppendOnlyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), Collections.emptyList());
     }
 
     AppendOnlyFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            List<CommitCallback.Factory> commitCallbackFactories) {
+        super(fileIO, path, tableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new AppendOnlyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new AppendOnlyFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
@@ -38,6 +38,7 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.BinaryTableStats;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.KeyValueTableRead;
@@ -62,17 +63,22 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     private transient KeyValueFileStore lazyStore;
 
     ChangelogValueCountFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), Collections.emptyList());
     }
 
     ChangelogValueCountFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            List<CommitCallback.Factory> commitCallbackFactories) {
+        super(fileIO, path, tableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogValueCountFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new ChangelogValueCountFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -40,6 +40,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.SequenceGenerator;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableRead;
@@ -50,6 +51,7 @@ import org.apache.paimon.table.source.ValueContentRowDataRecordIterator;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -67,17 +69,22 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private transient KeyValueFileStore lazyStore;
 
     ChangelogWithKeyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), Collections.emptyList());
     }
 
     ChangelogWithKeyFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            List<CommitCallback.Factory> commitCallbackFactories) {
+        super(fileIO, path, tableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogWithKeyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new ChangelogWithKeyFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, commitCallbackFactories);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.table.FileStoreTable;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * This callback will be called after a list of {@link ManifestCommittable}s is committed.
+ *
+ * <p>As an usage example, we can extract what partitions are created from the {@link
+ * ManifestCommittable}s and add these partitions into Hive metastore.
+ *
+ * <p>NOTE: To guarantee that this callback is called, if a failure occurs right after the commit,
+ * this callback might be called multiple times. Please make sure that your implementation is
+ * idempotent. That is, your callback can be called multiple times and still have the desired
+ * effect.
+ */
+public interface CommitCallback extends AutoCloseable {
+
+    void call(List<ManifestCommittable> committables);
+
+    /** Factory to create {@link CommitCallback}. */
+    interface Factory extends Serializable {
+
+        CommitCallback create(FileStoreTable table);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.WriteMode;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FailingFileIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableCommit}. */
+public class TableCommitTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testCommitCallbackWithFailure() throws Exception {
+        int numIdentifiers = 30;
+
+        String failingName = UUID.randomUUID().toString();
+        // no failure when creating table and writing data
+        FailingFileIO.reset(failingName, 0, 1);
+
+        String path = FailingFileIO.getFailingPath(failingName, tempDir.toString());
+
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.BIGINT()},
+                        new String[] {"k", "v"});
+
+        Options conf = new Options();
+        conf.set(CoreOptions.PATH, path);
+        conf.set(CoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), new Path(path)),
+                        new Schema(
+                                rowType.getFields(),
+                                Collections.emptyList(),
+                                Collections.singletonList("k"),
+                                conf.toMap(),
+                                ""));
+
+        Set<Long> identifiers = new HashSet<>();
+        FileStoreTable table =
+                FileStoreTableFactory.create(
+                        new FailingFileIO(),
+                        new Path(path),
+                        tableSchema,
+                        Lock.emptyFactory(),
+                        Collections.singletonList(t -> new TestCommitCallback(identifiers)));
+
+        String commitUser = UUID.randomUUID().toString();
+        StreamTableWrite write = table.newWrite(commitUser);
+        Map<Long, List<CommitMessage>> commitMessages = new HashMap<>();
+        for (int i = 0; i < numIdentifiers; i++) {
+            write.write(GenericRow.of(i, i * 1000L));
+            commitMessages.put((long) i, write.prepareCommit(true, i));
+        }
+
+        StreamTableCommit commit = table.newCommit(commitUser);
+        // enable failure when committing
+        FailingFileIO.reset(failingName, 3, 1000);
+        FailingFileIO.retryArtificialException(() -> commit.filterAndCommit(commitMessages));
+
+        assertThat(identifiers)
+                .isEqualTo(LongStream.range(0, numIdentifiers).boxed().collect(Collectors.toSet()));
+    }
+
+    private static class TestCommitCallback implements CommitCallback {
+
+        private final Set<Long> identifiers;
+
+        private TestCommitCallback(Set<Long> identifiers) {
+            this.identifiers = identifiers;
+        }
+
+        @Override
+        public void call(List<ManifestCommittable> committables) {
+            committables.forEach(c -> identifiers.add(c.identifier()));
+        }
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -144,6 +144,6 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory(), Collections.emptyList());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -138,7 +138,7 @@ public abstract class ScannerTestBase {
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory(), Collections.emptyList());
     }
 
     protected List<Split> toSplits(List<DataSplit> dataSplits) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 
 /** Test class for {@link FlinkSink}. */
@@ -123,10 +122,15 @@ public class FlinkSinkTest {
                         new Schema(
                                 ROW_TYPE.getFields(),
                                 Collections.emptyList(),
-                                Arrays.asList("pk"),
+                                Collections.singletonList("pk"),
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                FileIOFinder.find(tablePath), tablePath, tableSchema, conf, Lock.emptyFactory());
+                FileIOFinder.find(tablePath),
+                tablePath,
+                tableSchema,
+                conf,
+                Lock.emptyFactory(),
+                Collections.emptyList());
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/AddPartitionCommitCallback.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/AddPartitionCommitCallback.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.utils.PartitionPathUtils;
+import org.apache.paimon.utils.RowDataPartitionComputer;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Add all partitions extracted from the list of {@link ManifestCommittable} to Hive metastore and
+ * ignore existing partitions.
+ */
+public class AddPartitionCommitCallback implements CommitCallback {
+
+    private final Identifier identifier;
+    private final String tablePath;
+    private final RowDataPartitionComputer partitionComputer;
+
+    private final IMetaStoreClient client;
+    private final StorageDescriptor sd;
+
+    public AddPartitionCommitCallback(
+            Identifier identifier, FileStoreTable table, IMetaStoreClient client) {
+        this.identifier = identifier;
+        this.tablePath = table.location().toString();
+        this.partitionComputer =
+                new RowDataPartitionComputer(
+                        table.coreOptions().partitionDefaultName(),
+                        table.schema().logicalPartitionType(),
+                        table.schema().partitionKeys().toArray(new String[0]));
+
+        this.client = client;
+        try {
+            this.sd =
+                    client.getTable(identifier.getDatabaseName(), identifier.getObjectName())
+                            .getSd();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void call(List<ManifestCommittable> committables) {
+        committables.stream()
+                .flatMap(c -> c.fileCommittables().stream())
+                .map(CommitMessage::partition)
+                .distinct()
+                .forEach(this::createPartitionIfNeeded);
+    }
+
+    private void createPartitionIfNeeded(BinaryRow partition) {
+        LinkedHashMap<String, String> partitionMap =
+                partitionComputer.generatePartValues(partition);
+        List<String> partitionValues = new ArrayList<>(partitionMap.values());
+
+        try {
+            try {
+                client.getPartition(
+                        identifier.getDatabaseName(), identifier.getObjectName(), partitionValues);
+                // do nothing if the partition already exists
+            } catch (NoSuchObjectException e) {
+                // partition not found, create new partition
+                StorageDescriptor newSd = new StorageDescriptor(sd);
+                newSd.setLocation(
+                        tablePath + "/" + PartitionPathUtils.generatePartitionPath(partitionMap));
+
+                Partition hivePartition = new Partition();
+                hivePartition.setDbName(identifier.getDatabaseName());
+                hivePartition.setTableName(identifier.getObjectName());
+                hivePartition.setValues(partitionValues);
+                hivePartition.setSd(newSd);
+                int currentTime = (int) (System.currentTimeMillis() / 1000);
+                hivePartition.setCreateTime(currentTime);
+                hivePartition.setLastAccessTime(currentTime);
+
+                client.add_partition(hivePartition);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+    }
+
+    /** Factory to create {@link AddPartitionCommitCallback}. */
+    public static class Factory implements CommitCallback.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Identifier identifier;
+        private final SerializableHiveConf hiveConf;
+        private final String clientClassName;
+
+        public Factory(Identifier identifier, HiveConf hiveConf, String clientClassName) {
+            this.identifier = identifier;
+            this.hiveConf = new SerializableHiveConf(hiveConf);
+            this.clientClassName = clientClassName;
+        }
+
+        @Override
+        public CommitCallback create(FileStoreTable table) {
+            HiveConf conf = hiveConf.conf();
+            return new AddPartitionCommitCallback(
+                    identifier, table, HiveCatalog.createClient(conf, clientClassName));
+        }
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/AddPartitionCommitCallback.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/AddPartitionCommitCallback.java
@@ -44,7 +44,6 @@ import java.util.List;
 public class AddPartitionCommitCallback implements CommitCallback {
 
     private final Identifier identifier;
-    private final String tablePath;
     private final RowDataPartitionComputer partitionComputer;
 
     private final IMetaStoreClient client;
@@ -53,7 +52,6 @@ public class AddPartitionCommitCallback implements CommitCallback {
     public AddPartitionCommitCallback(
             Identifier identifier, FileStoreTable table, IMetaStoreClient client) {
         this.identifier = identifier;
-        this.tablePath = table.location().toString();
         this.partitionComputer =
                 new RowDataPartitionComputer(
                         table.coreOptions().partitionDefaultName(),
@@ -93,7 +91,9 @@ public class AddPartitionCommitCallback implements CommitCallback {
                 // partition not found, create new partition
                 StorageDescriptor newSd = new StorageDescriptor(sd);
                 newSd.setLocation(
-                        tablePath + "/" + PartitionPathUtils.generatePartitionPath(partitionMap));
+                        sd.getLocation()
+                                + "/"
+                                + PartitionPathUtils.generatePartitionPath(partitionMap));
 
                 Partition hivePartition = new Partition();
                 hivePartition.setDbName(identifier.getDatabaseName());

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -25,12 +25,16 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.Lock;
+import org.apache.paimon.options.ConfigOption;
+import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.options.OptionsUtils;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.TableType;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.types.DataField;
 
 import org.apache.flink.table.hive.LegacyHiveClasses;
@@ -64,11 +68,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.hive.HiveCatalogLock.acquireTimeout;
@@ -81,7 +88,11 @@ import static org.apache.paimon.utils.StringUtils.isNullOrWhitespaceOnly;
 
 /** A catalog implementation for Hive. */
 public class HiveCatalog extends AbstractCatalog {
+
     private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
+
+    private static final ConfigOption<Boolean> ADD_PARTITION_TO_METASTORE =
+            ConfigOptions.key("add-partition-to-metastore").booleanType().defaultValue(false);
 
     // we don't include paimon-hive-connector as dependencies because it depends on
     // hive-exec
@@ -141,6 +152,28 @@ public class HiveCatalog extends AbstractCatalog {
     private boolean lockEnabled() {
         return Boolean.parseBoolean(
                 hiveConf.get(LOCK_ENABLED.key(), LOCK_ENABLED.defaultValue().toString()));
+    }
+
+    @Override
+    public List<CommitCallback.Factory> commitCallbackFactories(Identifier identifier) {
+        return addPartitionToMetastore(identifier)
+                ? Collections.singletonList(
+                        new AddPartitionCommitCallback.Factory(
+                                identifier, hiveConf, clientClassName))
+                : Collections.emptyList();
+    }
+
+    private boolean addPartitionToMetastore(Identifier identifier) {
+        try {
+            return addPartitionToMetastore(getDataTableSchema(identifier).options());
+        } catch (TableNotExistException e) {
+            throw new RuntimeException(
+                    "Table " + identifier + " not found. This is unexpected.", e);
+        }
+    }
+
+    private boolean addPartitionToMetastore(Map<String, String> options) {
+        return new Options(options).get(ADD_PARTITION_TO_METASTORE);
     }
 
     @Override
@@ -467,20 +500,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private void updateHmsTable(Table table, Identifier identifier, TableSchema schema) {
-        StorageDescriptor sd = convertToStorageDescriptor(schema);
-        table.setSd(sd);
-
-        // update location
-        locationHelper.specifyTableLocation(table, getDataTableLocation(identifier).toString());
-    }
-
-    private StorageDescriptor convertToStorageDescriptor(TableSchema schema) {
         StorageDescriptor sd = new StorageDescriptor();
-
-        sd.setCols(
-                schema.fields().stream()
-                        .map(this::convertToFieldSchema)
-                        .collect(Collectors.toList()));
 
         sd.setInputFormat(INPUT_FORMAT_CLASS_NAME);
         sd.setOutputFormat(OUTPUT_FORMAT_CLASS_NAME);
@@ -490,7 +510,34 @@ public class HiveCatalog extends AbstractCatalog {
         serDeInfo.setSerializationLib(SERDE_CLASS_NAME);
         sd.setSerdeInfo(serDeInfo);
 
-        return sd;
+        if (addPartitionToMetastore(schema.options())) {
+            Map<String, DataField> fieldMap =
+                    schema.fields().stream()
+                            .collect(Collectors.toMap(DataField::name, Function.identity()));
+            List<FieldSchema> partitionFields = new ArrayList<>();
+            for (String partitionKey : schema.partitionKeys()) {
+                partitionFields.add(convertToFieldSchema(fieldMap.get(partitionKey)));
+            }
+            table.setPartitionKeys(partitionFields);
+
+            Set<String> partitionKeys = new HashSet<>(schema.partitionKeys());
+            List<FieldSchema> normalFields = new ArrayList<>();
+            for (DataField field : schema.fields()) {
+                if (!partitionKeys.contains(field.name())) {
+                    normalFields.add(convertToFieldSchema(field));
+                }
+            }
+            sd.setCols(normalFields);
+        } else {
+            sd.setCols(
+                    schema.fields().stream()
+                            .map(this::convertToFieldSchema)
+                            .collect(Collectors.toList()));
+        }
+        table.setSd(sd);
+
+        // update location
+        locationHelper.specifyTableLocation(table, getDataTableLocation(identifier).toString());
     }
 
     @VisibleForTesting

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -56,6 +56,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** Column names, types and comments of a Hive table. */
 public class HiveSchema {
@@ -134,11 +135,17 @@ public class HiveSchema {
         String partitionTypes =
                 properties.getProperty(hive_metastoreConstants.META_TABLE_PARTITION_COLUMN_TYPES);
         List<TypeInfo> partitionTypeInfos =
-                TypeInfoUtils.getTypeInfosFromTypeString(partitionTypes);
+                StringUtils.isEmpty(partitionTypes)
+                        ? Collections.emptyList()
+                        : TypeInfoUtils.getTypeInfosFromTypeString(partitionTypes);
 
+        String commentProperty = properties.getProperty("columns.comments");
         List<String> comments =
-                Lists.newArrayList(
-                        Splitter.on('\0').split(properties.getProperty("columns.comments")));
+                StringUtils.isEmpty(commentProperty)
+                        ? IntStream.range(0, columnNames.size())
+                                .mapToObj(i -> "")
+                                .collect(Collectors.toList())
+                        : Lists.newArrayList(Splitter.on('\0').split(commentProperty));
 
         if (tableSchema.isPresent() && columnNames.size() > 0 && typeInfos.size() > 0) {
             // Both Paimon table schema and Hive table schema exist

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -240,7 +240,7 @@ public class HiveSchema {
                 mismatched.add(
                         String.format(
                                 "Field #%d\n" + "Hive DDL          : %s\n" + "Paimon Schema: %s\n",
-                                i, ddlField, schemaField));
+                                i + 1, ddlField, schemaField));
             }
         }
         if (mismatched.size() > 0) {
@@ -300,7 +300,7 @@ public class HiveSchema {
                                 "Partition Key #%d\n"
                                         + "Hive DDL          : %s\n"
                                         + "Paimon Schema: %s\n",
-                                i, ddlField, schemaField));
+                                i + 1, ddlField, schemaField));
             }
         }
         if (mismatched.size() > 0) {

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
@@ -19,21 +19,31 @@
 package org.apache.paimon.hive.mapred;
 
 import org.apache.paimon.hive.RowDataContainer;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.RowType;
 
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.hive.utils.HiveUtils.createFileStoreTable;
 import static org.apache.paimon.hive.utils.HiveUtils.createPredicate;
@@ -46,18 +56,52 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
 
     @Override
     public InputSplit[] getSplits(JobConf jobConf, int numSplits) {
+        // If the path of the Paimon table is moved from the location of the Hive table to
+        // properties, Hive will add a location for this table based on the warehouse,
+        // database, and table automatically.When querying by Hive, an exception may occur
+        // because the specified path for split for Paimon may not match the location of Hive.
+        // To work around this problem, we specify the path for split as the location of Hive.
+        String location = jobConf.get(hive_metastoreConstants.META_TABLE_LOCATION);
+
         FileStoreTable table = createFileStoreTable(jobConf);
         InnerTableScan scan = table.newScan();
-        createPredicate(table.schema(), jobConf).ifPresent(scan::withFilter);
-        // If the path of the Paimon table is moved from the location of the Hive table to
-        // properties,Hive will add a location for this table based on the warehouse ,
-        // database,and table automatically.When querying by Hive, an exception may occur
-        // because the specified path for split for Paimon may not match the location of Hive.
-        // To work around this problem,we specify the path for split as the location of Hive.
-        String location = jobConf.get(hive_metastoreConstants.META_TABLE_LOCATION);
+
+        List<Predicate> predicates = new ArrayList<>();
+        String inputDir = jobConf.get(FileInputFormat.INPUT_DIR);
+        createPartitionPredicate(table.schema().logicalRowType(), location, inputDir)
+                .ifPresent(predicates::add);
+        createPredicate(table.schema(), jobConf, false).ifPresent(predicates::add);
+        if (predicates.size() > 0) {
+            scan.withFilter(PredicateBuilder.and(predicates));
+        }
+
         return scan.plan().splits().stream()
                 .map(split -> new PaimonInputSplit(location, (DataSplit) split))
                 .toArray(PaimonInputSplit[]::new);
+    }
+
+    private Optional<Predicate> createPartitionPredicate(
+            RowType rowType, String tablePath, String inputDir) {
+        while (tablePath.length() > 0 && tablePath.endsWith("/")) {
+            tablePath = tablePath.substring(0, tablePath.length() - 1);
+        }
+        if (inputDir.length() < tablePath.length()) {
+            return Optional.empty();
+        }
+
+        LinkedHashMap<String, String> partition = new LinkedHashMap<>();
+        for (String s : inputDir.substring(tablePath.length()).split("/")) {
+            s = s.trim();
+            if (s.isEmpty()) {
+                continue;
+            }
+            String[] kv = s.split("=");
+            if (kv.length != 2) {
+                continue;
+            }
+            partition.put(kv[0].trim(), kv[1].trim());
+        }
+        return Optional.ofNullable(PredicateBuilder.partition(partition, rowType));
     }
 
     @Override
@@ -66,12 +110,28 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
         FileStoreTable table = createFileStoreTable(jobConf);
         PaimonInputSplit split = (PaimonInputSplit) inputSplit;
         ReadBuilder readBuilder = table.newReadBuilder();
-        createPredicate(table.schema(), jobConf).ifPresent(readBuilder::withFilter);
+        createPredicate(table.schema(), jobConf, true).ifPresent(readBuilder::withFilter);
+        List<String> paimonColumns = table.schema().fieldNames();
         return new PaimonRecordReader(
                 readBuilder,
                 split,
-                table.schema().fieldNames(),
+                paimonColumns,
+                getSchemaEvolutionColumns(jobConf).orElse(paimonColumns),
                 Arrays.asList(getSelectedColumns(jobConf)));
+    }
+
+    private Optional<List<String>> getSchemaEvolutionColumns(JobConf jobConf) {
+        String columns = jobConf.get(IOConstants.SCHEMA_EVOLUTION_COLUMNS);
+        String delimiter =
+                jobConf.get(
+                        // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
+                        // versions, so we use a constant string instead
+                        "column.name.delimite", String.valueOf(SerDeUtils.COMMA));
+        if (columns == null || delimiter == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(Arrays.asList(columns.split(delimiter)));
+        }
     }
 
     private String[] getSelectedColumns(JobConf jobConf) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -24,7 +24,9 @@ import org.apache.paimon.catalog.CatalogLock;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkCatalog;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.hive.annotation.Minio;
 import org.apache.paimon.hive.runner.PaimonEmbeddedHiveRunner;
+import org.apache.paimon.s3.MinioTestContainer;
 
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.annotations.HiveSQL;
@@ -36,21 +38,27 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
 
 import java.io.File;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -71,37 +79,73 @@ public abstract class HiveCatalogITCaseBase {
     @HiveSQL(files = {})
     protected static HiveShell hiveShell;
 
-    @Before
-    public void before() throws Exception {
+    @Minio private static MinioTestContainer minioTestContainer;
+
+    private void before(boolean locationInProperties) throws Exception {
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
         hiveShell.execute("CREATE TABLE hive_table ( a INT, b STRING )");
         hiveShell.execute("INSERT INTO hive_table VALUES (100, 'Hive'), (200, 'Table')");
         hiveShell.executeQuery("SHOW TABLES");
 
-        path = folder.newFolder().toURI().toString();
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("type", "paimon");
+        catalogProperties.put("metastore", "hive");
+        catalogProperties.put("uri", "");
+        catalogProperties.put("lock.enabled", "true");
+        catalogProperties.put("location-in-properties", String.valueOf(locationInProperties));
+        if (locationInProperties) {
+            path = minioTestContainer.getS3UriForDefaultBucket() + "/" + UUID.randomUUID();
+            catalogProperties.putAll(minioTestContainer.getS3ConfigOptions());
+        } else {
+            path = folder.newFolder().toURI().toString();
+        }
+        catalogProperties.put("warehouse", path);
+
         EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
         tEnv = TableEnvironmentImpl.create(settings);
         tEnv.executeSql(
                         String.join(
                                 "\n",
                                 "CREATE CATALOG my_hive WITH (",
-                                "  'type' = 'paimon',",
-                                "  'metastore' = 'hive',",
-                                "  'uri' = '',",
-                                "  'warehouse' = '" + path + "',",
-                                "  'lock.enabled' = 'true'",
+                                catalogProperties.entrySet().stream()
+                                        .map(
+                                                e ->
+                                                        String.format(
+                                                                "'%s' = '%s'",
+                                                                e.getKey(), e.getValue()))
+                                        .collect(Collectors.joining(",\n")),
                                 ")"))
                 .await();
         tEnv.executeSql("USE CATALOG my_hive").await();
         tEnv.executeSql("USE test_db").await();
     }
 
-    @After
-    public void after() {
+    private void after() {
         hiveShell.execute("DROP DATABASE IF EXISTS test_db CASCADE");
         hiveShell.execute("DROP DATABASE IF EXISTS test_db2 CASCADE");
     }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface LocationInProperties {}
+
+    @Rule
+    public TestRule environmentRule =
+            (base, description) ->
+                    new Statement() {
+                        @Override
+                        public void evaluate() throws Throwable {
+                            try {
+                                before(
+                                        description.getAnnotation(LocationInProperties.class)
+                                                != null);
+                                base.evaluate();
+                            } finally {
+                                after();
+                            }
+                        }
+                    };
 
     @Test
     public void testDatabaseOperations() throws Exception {
@@ -680,6 +724,50 @@ public abstract class HiveCatalogITCaseBase {
 
     @Test
     public void testAddPartitionsToMetastore() throws Exception {
+        prepareTestAddPartitionsToMetastore();
+
+        String sql1 =
+                "select v, ptb, k from t where "
+                        + "pta >= 2 and ptb <= '3a' and (k % 10) >= 1 and (k % 10) <= 2";
+        assertThat(hiveShell.executeQuery(sql1))
+                .containsExactlyInAnyOrder(
+                        "2001\t2a\t21", "2002\t2a\t22", "3001\t3a\t31", "3002\t3a\t32");
+
+        String sql2 =
+                "select v, ptb, k from t where "
+                        + "pta >= 2 and ptb <= '3a' and (v % 10) >= 3 and (v % 10) <= 4";
+        assertThat(hiveShell.executeQuery(sql2))
+                .containsExactlyInAnyOrder(
+                        "2003\t2a\t23", "2004\t2a\t24", "3003\t3a\t33", "3004\t3a\t34");
+    }
+
+    @Test
+    @LocationInProperties
+    public void testAddPartitionsToMetastoreLocationInProperties() throws Exception {
+        prepareTestAddPartitionsToMetastore();
+
+        String sql1 =
+                "select v, ptb, k from t where "
+                        + "pta >= 2 and ptb <= '3a' and (k % 10) >= 1 and (k % 10) <= 2";
+        assertThat(collect(sql1).stream().map(Objects::toString).collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(
+                        "+I[2001, 2a, 21]",
+                        "+I[2002, 2a, 22]",
+                        "+I[3001, 3a, 31]",
+                        "+I[3002, 3a, 32]");
+
+        String sql2 =
+                "select v, ptb, k from t where "
+                        + "pta >= 2 and ptb <= '3a' and (v % 10) >= 3 and (v % 10) <= 4";
+        assertThat(collect(sql2).stream().map(Objects::toString).collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(
+                        "+I[2003, 2a, 23]",
+                        "+I[2004, 2a, 24]",
+                        "+I[3003, 3a, 33]",
+                        "+I[3004, 3a, 34]");
+    }
+
+    private void prepareTestAddPartitionsToMetastore() throws Exception {
         tEnv.executeSql(
                 String.join(
                         "\n",
@@ -715,32 +803,6 @@ public abstract class HiveCatalogITCaseBase {
                         "ptb=2b/pta=2",
                         "ptb=3a/pta=3",
                         "ptb=3b/pta=3");
-
-        String sql1 =
-                "select v, ptb, k from t where "
-                        + "pta >= 2 and ptb <= '3a' and (k % 10) >= 1 and (k % 10) <= 2";
-        assertThat(hiveShell.executeQuery(sql1))
-                .containsExactlyInAnyOrder(
-                        "2001\t2a\t21", "2002\t2a\t22", "3001\t3a\t31", "3002\t3a\t32");
-        assertThat(collect(sql1).stream().map(Objects::toString).collect(Collectors.toList()))
-                .containsExactlyInAnyOrder(
-                        "+I[2001, 2a, 21]",
-                        "+I[2002, 2a, 22]",
-                        "+I[3001, 3a, 31]",
-                        "+I[3002, 3a, 32]");
-
-        String sql2 =
-                "select v, ptb, k from t where "
-                        + "pta >= 2 and ptb <= '3a' and (v % 10) >= 3 and (v % 10) <= 4";
-        assertThat(hiveShell.executeQuery(sql2))
-                .containsExactlyInAnyOrder(
-                        "2003\t2a\t23", "2004\t2a\t24", "3003\t3a\t33", "3004\t3a\t34");
-        assertThat(collect(sql2).stream().map(Objects::toString).collect(Collectors.toList()))
-                .containsExactlyInAnyOrder(
-                        "+I[2003, 2a, 23]",
-                        "+I[2004, 2a, 24]",
-                        "+I[3003, 3a, 33]",
-                        "+I[3004, 3a, 34]");
     }
 
     protected List<Row> collect(String sql) throws Exception {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -131,19 +131,17 @@ public class HiveTableSchemaTest {
         properties.setProperty("location", tempDir.toString());
 
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #1",
-                        "Hive DDL          : mismatched string",
-                        "Paimon Schema: b string",
-                        "--------------------",
-                        "Field #2",
-                        "Hive DDL          : c decimal(6,3)",
-                        "Paimon Schema: c decimal(5,3)");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "Mismatched fields are:\n"
+                        + "Field #2\n"
+                        + "Hive DDL          : mismatched string\n"
+                        + "Paimon Schema: b string\n"
+                        + "--------------------\n"
+                        + "Field #3\n"
+                        + "Hive DDL          : c decimal(6,3)\n"
+                        + "Paimon Schema: c decimal(5,3)";
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class, () -> HiveSchema.extract(null, properties));
@@ -159,20 +157,13 @@ public class HiveTableSchemaTest {
         properties.setProperty("columns.types", TypeInfoFactory.intTypeInfo.getTypeName());
         properties.setProperty("location", tempDir.toString());
         properties.setProperty("columns.comments", "");
+
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #1",
-                        "Hive DDL          : null",
-                        "Paimon Schema: b string",
-                        "--------------------",
-                        "Field #2",
-                        "Hive DDL          : null",
-                        "Paimon Schema: c decimal(5,3)");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 1 fields in Hive DDL: a\n"
+                        + "There are 3 fields in Paimon schema: a, b, c";
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> HiveSchema.extract(null, properties))
                 .withMessageContaining(expected);
@@ -198,19 +189,11 @@ public class HiveTableSchemaTest {
         properties.setProperty("location", tempDir.toString());
 
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #3",
-                        "Hive DDL          : d int",
-                        "Paimon Schema: null",
-                        "--------------------",
-                        "Field #4",
-                        "Hive DDL          : e string",
-                        "Paimon Schema: null");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 5 fields in Hive DDL: a, b, c, d, e\n"
+                        + "There are 3 fields in Paimon schema: a, b, c";
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> HiveSchema.extract(null, properties))
                 .withMessageContaining(expected);
@@ -223,6 +206,112 @@ public class HiveTableSchemaTest {
                                 ROW_TYPE.getFields(),
                                 Collections.emptyList(),
                                 Collections.emptyList(),
+                                new HashMap<>(),
+                                ""));
+    }
+
+    @Test
+    public void testMismatchedPartitionKeyAndType() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a/mismatched");
+        properties.setProperty(
+                "partition_columns.types",
+                String.join(
+                        ":",
+                        Arrays.asList(
+                                TypeInfoFactory.longTypeInfo.getTypeName(),
+                                TypeInfoFactory.stringTypeInfo.getTypeName())));
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                String.join(
+                        "\n",
+                        "Hive DDL and paimon schema mismatched! "
+                                + "It is recommended not to write any column definition "
+                                + "as Paimon external table can read schema from the specified location.\n"
+                                + "Mismatched partition keys are:\n"
+                                + "Partition Key #1\n"
+                                + "Hive DDL          : a bigint\n"
+                                + "Paimon Schema: a int\n"
+                                + "--------------------\n"
+                                + "Partition Key #2\n"
+                                + "Hive DDL          : mismatched string\n"
+                                + "Paimon Schema: b string");
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class, () -> HiveSchema.extract(null, properties));
+        assertThat(exception).hasMessageContaining(expected);
+    }
+
+    @Test
+    public void testTooFewPartitionKeys() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a");
+        properties.setProperty(
+                "partition_columns.types", TypeInfoFactory.intTypeInfo.getTypeName());
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 1 partition keys in Hive DDL: a\n"
+                        + "There are 2 partition keys in Paimon schema: a, b";
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> HiveSchema.extract(null, properties))
+                .withMessageContaining(expected);
+    }
+
+    @Test
+    public void testTooManyPartitionKeys() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a/b/d");
+        properties.setProperty(
+                "partition_columns.types",
+                String.join(
+                        ":",
+                        Arrays.asList(
+                                TypeInfoFactory.intTypeInfo.getTypeName(),
+                                TypeInfoFactory.stringTypeInfo.getTypeName(),
+                                TypeInfoFactory.intTypeInfo.getTypeName())));
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 3 partition keys in Hive DDL: a, b, d\n"
+                        + "There are 2 partition keys in Paimon schema: a, b";
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> HiveSchema.extract(null, properties))
+                .withMessageContaining(expected);
+    }
+
+    private void createSchemaWithPartition() throws Exception {
+        new SchemaManager(LocalFileIO.create(), new Path(tempDir.toString()))
+                .createTable(
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Arrays.asList("a", "b"),
+                                Arrays.asList("a", "b", "c"),
                                 new HashMap<>(),
                                 ""));
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -80,7 +80,6 @@ public class PaimonStorageHandlerITCase {
 
     private static String engine;
 
-    private String commitUser;
     private long commitIdentifier;
 
     @BeforeClass
@@ -111,7 +110,6 @@ public class PaimonStorageHandlerITCase {
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
 
-        commitUser = UUID.randomUUID().toString();
         commitIdentifier = 0;
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
@@ -86,7 +86,10 @@ public class SearchArgumentToPredicateConverterTest {
         SearchArgument sarg = builder.equals("a", hiveType, hiveLiteral).build();
         SearchArgumentToPredicateConverter converter =
                 new SearchArgumentToPredicateConverter(
-                        sarg, Collections.singletonList("a"), Collections.singletonList(flinkType));
+                        sarg,
+                        Collections.singletonList("a"),
+                        Collections.singletonList(flinkType),
+                        null);
 
         Predicate expected =
                 new PredicateBuilder(RowType.of(new DataType[] {flinkType}, new String[] {"a"}))
@@ -393,7 +396,7 @@ public class SearchArgumentToPredicateConverterTest {
 
     private void assertExpected(SearchArgument sarg, Predicate expected) {
         SearchArgumentToPredicateConverter converter =
-                new SearchArgumentToPredicateConverter(sarg, COLUMN_NAMES, COLUMN_TYPES);
+                new SearchArgumentToPredicateConverter(sarg, COLUMN_NAMES, COLUMN_TYPES, null);
         Predicate actual = converter.convert().orElse(null);
         assertThat(actual).isEqualTo(expected);
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -187,10 +187,12 @@ public class PaimonRecordReaderTest {
         for (Split split : table.newReadBuilder().newScan().plan().splits()) {
             DataSplit dataSplit = (DataSplit) split;
             if (dataSplit.partition().equals(partition) && dataSplit.bucket() == bucket) {
+                List<String> originalColumns = ((FileStoreTable) table).schema().fieldNames();
                 return new PaimonRecordReader(
                         table.newReadBuilder(),
                         new PaimonInputSplit(tempDir.toString(), dataSplit),
-                        ((FileStoreTable) table).schema().fieldNames(),
+                        originalColumns,
+                        originalColumns,
                         selectedColumns);
             }
         }


### PR DESCRIPTION
### Purpose

Currently we cannot create partitioned Paimon table in Hive catalog. In Hive, all fields are considered as normal fields and there is no partition key. It brings us at least two downsides:

1. Users cannot list all partitions through the `SHOW PARTITIONS` command.
2. Hive's native partition pushdown cannot be performed. Although currently we approach partition pushdown through Hive's filter pushdown, some Hive compatible system may only support partition pushdown and not filter pushdown, making Paimon nearly unusable in those systems.

This PR introduces a feature to synchronize partitions into Hive metastore when using Hive catalog. In this PR, users can create partitioned Hive table through Flink and Spark using Hive catalog. Creating partitioned table directly in Hive is currently not supported and will be introduced in the next PR.

### Tests

* `TableCommitTest`
* `HiveCatalogITCaseBase#testAddPartitionsToMetastore`

### API and Format

No.

### Documentation

Yes. Document will also be introduced in the next PR.
