### PR TITLE
 [flink] supports alignment with flink checkpoint when consuming paimon snapshots.

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -116,5 +116,11 @@ under the License.
             <td>Integer</td>
             <td>Defines a custom parallelism for the unaware-bucket table compaction job. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration.</td>
         </tr>
+        <tr>
+            <td><h5>source.checkpoint-aligned.mode</h5></td>
+            <td style="word-wrap: break-word;">unaligned</td>
+            <td>Enum</td>
+            <td>Alignment mode between flink checkpoint and snapshot of source table.<br /><br />Possible values:<ul><li>"unaligned": Flink's checkpoint and source table's snapshot are not aligned.</li><li>"strictly": Flink's checkpoint and source table's snapshot will be aligned one-to-one.</li><li>"loosely": Flink's checkpoint and source table's snapshot will be loosely aligned, which means that checkpoint will only be performed between the snapshots of the source table, but there is no guarantee that there is a one-to-one relationship between checkpoint and snapshot.</li></ul></td>
+        </tr>
     </tbody>
 </table>

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -39,8 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
-
 /** {@link StreamTableScan} implementation for streaming planning. */
 public class InnerStreamTableScanImpl extends AbstractInnerTableScan
         implements InnerStreamTableScan {
@@ -109,6 +107,8 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                     snapshotManager.snapshotExists(nextSnapshotId - 1)
                             && boundedChecker.shouldEndInput(
                                     snapshotManager.snapshot(nextSnapshotId - 1));
+        } else if (result instanceof StartingScanner.NoSnapshot) {
+            return SnapshotNotExistPlan.INSTANCE;
         }
         return DataFilePlan.fromResult(result);
     }
@@ -132,7 +132,7 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                 LOG.debug(
                         "Next snapshot id {} does not exist, wait for the snapshot generation.",
                         nextSnapshotId);
-                return new DataFilePlan(Collections.emptyList());
+                return SnapshotNotExistPlan.INSTANCE;
             }
 
             Snapshot snapshot = snapshotManager.snapshot(nextSnapshotId);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/SnapshotNotExistPlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/SnapshotNotExistPlan.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Indicates that the snapshot does not exist. */
+public class SnapshotNotExistPlan implements TableScan.Plan {
+
+    public static final SnapshotNotExistPlan INSTANCE = new SnapshotNotExistPlan();
+
+    private SnapshotNotExistPlan() {
+        // private constructor
+    }
+
+    @Override
+    public List<Split> splits() {
+        return Collections.emptyList();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -202,6 +202,13 @@ public class FlinkConnectorOptions {
                             "Weight of writer buffer in managed memory, Flink will compute the memory size "
                                     + "for writer according to the weight, the actual memory used depends on the running environment.");
 
+    public static final ConfigOption<CheckpointAlignMode> SOURCE_CHECKPOINT_ALIGNED_MODE =
+            ConfigOptions.key("source.checkpoint-aligned.mode")
+                    .enumType(CheckpointAlignMode.class)
+                    .defaultValue(CheckpointAlignMode.UNALIGNED)
+                    .withDescription(
+                            "Alignment mode between flink checkpoint and snapshot of source table.");
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);
@@ -259,6 +266,37 @@ public class FlinkConnectorOptions {
         private final String description;
 
         SplitAssignMode(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Alignment mode between flink checkpoint and snapshot of source table. */
+    public enum CheckpointAlignMode implements DescribedEnum {
+        UNALIGNED("unaligned", "Flink's checkpoint and source table's snapshot are not aligned."),
+        STRICTLY(
+                "strictly",
+                "Flink's checkpoint and source table's snapshot will be aligned one-to-one."),
+        LOOSELY(
+                "loosely",
+                "Flink's checkpoint and source table's snapshot will be loosely aligned, which means that "
+                        + "checkpoint will only be performed between the snapshots of the source table, but there is no "
+                        + "guarantee that there is a one-to-one relationship between checkpoint and snapshot.");
+
+        private final String value;
+        private final String description;
+
+        CheckpointAlignMode(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -205,6 +205,8 @@ public class FlinkSourceBuilder {
                 if (conf.get(FlinkConnectorOptions.SOURCE_CHECKPOINT_ALIGNED_MODE)
                         != CheckpointAlignMode.UNALIGNED) {
                     return buildAlignedContinuousFileSource();
+                } else if (conf.contains(CoreOptions.CONSUMER_ID)) {
+                    return buildContinuousStreamOperator();
                 } else {
                     return buildContinuousFileSource();
                 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSource.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.util.Map;
+
+/**
+ * Unbounded {@link Source} for reading records. It continuously monitors new snapshots.
+ *
+ * <p>The difference with {@link org.apache.paimon.flink.source.ContinuousFileStoreSource} is that
+ * it will coordinate flink's checkpoint and paimon snapshot.
+ */
+public class AlignedContinuousFileSource implements Source<Split, AlignedSourceSplit, Void> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final ReadBuilder readBuilder;
+
+    private final boolean emitSnapshotWatermark;
+
+    private final Map<String, String> options;
+
+    public AlignedContinuousFileSource(
+            ReadBuilder readBuilder, boolean emitSnapshotWatermark, Map<String, String> options) {
+        this.readBuilder = readBuilder;
+        this.emitSnapshotWatermark = emitSnapshotWatermark;
+        this.options = options;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        Long boundedWatermark = CoreOptions.fromMap(options).scanBoundedWatermark();
+        return boundedWatermark != null ? Boundedness.BOUNDED : Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SplitEnumerator<AlignedSourceSplit, Void> createEnumerator(
+            SplitEnumeratorContext<AlignedSourceSplit> enumContext) throws Exception {
+        return new AlignedEnumerator(enumContext);
+    }
+
+    @Override
+    public SplitEnumerator<AlignedSourceSplit, Void> restoreEnumerator(
+            SplitEnumeratorContext<AlignedSourceSplit> enumContext, Void checkpoint)
+            throws Exception {
+        return new AlignedEnumerator(enumContext);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<AlignedSourceSplit> getSplitSerializer() {
+        return new AlignedSourceSplitSerializer();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Void> getEnumeratorCheckpointSerializer() {
+        return new NoOpEnumStateSerializer();
+    }
+
+    @Override
+    public SourceReader<Split, AlignedSourceSplit> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        Options conf = Options.fromMap(options);
+        return new AlignedSourceReader(
+                readBuilder,
+                conf.get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL).toMillis(),
+                emitSnapshotWatermark,
+                conf.get(FlinkConnectorOptions.SOURCE_CHECKPOINT_ALIGNED_MODE));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedEnumerator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * It is only used to notify {@link AlignedSourceReader} of the checkpointId that is about to be
+ * triggered.
+ */
+public class AlignedEnumerator implements SplitEnumerator<AlignedSourceSplit, Void> {
+
+    private final SplitEnumeratorContext<AlignedSourceSplit> context;
+
+    public AlignedEnumerator(SplitEnumeratorContext<AlignedSourceSplit> context) {
+        this.context = context;
+    }
+
+    @Override
+    public void start() {
+        // do nothing
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        // ignore
+    }
+
+    @Override
+    public void addSplitsBack(List<AlignedSourceSplit> splits, int subtaskId) {
+        // ignore
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        // ignore
+    }
+
+    @Override
+    public Void snapshotState(long checkpointId) throws Exception {
+        Preconditions.checkArgument(
+                context.currentParallelism() == 1,
+                "The parallelism of the aligned source must be 1.");
+        context.sendEventToSourceReader(0, new CheckpointEvent(checkpointId));
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // ignore
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceReader.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.SnapshotNotExistPlan;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
+import org.apache.paimon.table.source.TableScan;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.apache.flink.runtime.io.AvailabilityProvider.AVAILABLE;
+import static org.apache.paimon.flink.FlinkConnectorOptions.CheckpointAlignMode;
+
+/**
+ * A non-parallel {@link org.apache.flink.api.connector.source.SourceReader} that uses Flip-27 to
+ * achieve the same function as {@link org.apache.paimon.flink.source.operator.MonitorFunction}.
+ *
+ * <p>Send {@link Split} to the downstream task at paimon snapshot granularity, and provide two
+ * alignment modes: {@link CheckpointAlignMode#STRICTLY} and {@link CheckpointAlignMode#LOOSELY}.
+ *
+ * <ol>
+ *   <li>STRICTLY: only one paimon snapshot is processed within a checkpoint interval.
+ *   <li>LOOSELY: several paimon snapshots are processed within a checkpoint interval.
+ * </ol>
+ */
+public class AlignedSourceReader
+        implements ExternallyInducedSourceReader<Split, AlignedSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlignedSourceReader.class);
+    private static final int MAX_PENDING_PLANS = 10;
+
+    private final ReadBuilder readBuilder;
+
+    private final BlockingDeque<AlignedSourceSplit> pendingSplits;
+
+    private final TreeSet<Long> pendingCheckpoints;
+
+    private final TreeMap<Long, Long> nextSnapshotPerCheckpoint;
+
+    private final long scanInterval;
+
+    private final boolean emitSnapshotWatermark;
+
+    private final ScheduledExecutorService executors;
+
+    private final CheckpointAlignMode alignMode;
+
+    private Long snapshotIdByNextCheckpoint;
+
+    private boolean blocking;
+
+    private boolean endOfScan;
+
+    private CompletableFuture<Void> availabilityFuture;
+
+    private Lock lock;
+
+    private transient StreamTableScan scan;
+
+    public AlignedSourceReader(
+            ReadBuilder readBuilder,
+            long scanInterval,
+            boolean emitSnapshotWatermark,
+            CheckpointAlignMode alignMode) {
+        this.readBuilder = readBuilder;
+        this.pendingSplits = new LinkedBlockingDeque<>();
+        this.pendingCheckpoints = new TreeSet<>();
+        this.availabilityFuture = (CompletableFuture<Void>) AVAILABLE;
+        this.nextSnapshotPerCheckpoint = new TreeMap<>();
+        this.scanInterval = scanInterval;
+        this.emitSnapshotWatermark = emitSnapshotWatermark;
+        this.alignMode = alignMode;
+        this.executors =
+                Executors.newScheduledThreadPool(
+                        1,
+                        r ->
+                                new Thread(
+                                        r,
+                                        "Aligned source scan for "
+                                                + Thread.currentThread().getName()));
+        this.snapshotIdByNextCheckpoint = null;
+        this.blocking = false;
+        this.endOfScan = false;
+        this.lock = new ReentrantLock();
+    }
+
+    @Override
+    public void start() {
+        this.scan = readBuilder.newStreamScan();
+        if (!pendingSplits.isEmpty()) {
+            AlignedSourceSplit split = pendingSplits.peekLast();
+            LOG.info(
+                    "Restore from the latest checkpoint with next snapshotId {}",
+                    split.getNextSnapshotId());
+            if (split.isPlaceHolder()) {
+                Preconditions.checkArgument(
+                        pendingSplits.size() == 1,
+                        "This is a bug, pendingSplits should contain only one split.");
+                snapshotIdByNextCheckpoint = split.getNextSnapshotId();
+                pendingSplits.poll();
+            }
+            scan.restore(split.getNextSnapshotId());
+        }
+        executors.scheduleWithFixedDelay(
+                this::scanNextSnapshot, 0, scanInterval, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public InputStatus pollNext(ReaderOutput<Split> readerOutput) throws Exception {
+        if (!blocking && !pendingSplits.isEmpty()) {
+            AlignedSourceSplit alignedSourceSplit = pendingSplits.poll();
+            snapshotIdByNextCheckpoint = alignedSourceSplit.getNextSnapshotId();
+            for (Split split : alignedSourceSplit.getSplits()) {
+                readerOutput.collect(split);
+            }
+
+            if (emitSnapshotWatermark) {
+                Long watermark = scan.watermark();
+                if (watermark != null) {
+                    readerOutput.emitWatermark(new Watermark(watermark));
+                }
+            }
+
+            if (alignMode == CheckpointAlignMode.STRICTLY) {
+                blocking = true;
+            }
+        } else if (availabilityFuture == AVAILABLE) {
+            switchToUnavailable();
+        }
+
+        // checkpoint might has not been triggered
+        if (!blocking && endOfScan && pendingSplits.isEmpty()) {
+            return InputStatus.END_OF_INPUT;
+        }
+
+        return InputStatus.NOTHING_AVAILABLE;
+    }
+
+    @Override
+    public List<AlignedSourceSplit> snapshotState(long checkpointId) {
+        blocking = false;
+        nextSnapshotPerCheckpoint.put(checkpointId, snapshotIdByNextCheckpoint);
+        switchToAvailable();
+        if (pendingSplits.isEmpty() && snapshotIdByNextCheckpoint != null) {
+            return Collections.singletonList(
+                    new AlignedSourceSplit(
+                            Collections.emptyList(), snapshotIdByNextCheckpoint, true));
+        } else {
+            return new ArrayList<>(pendingSplits);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> isAvailable() {
+        return availabilityFuture;
+    }
+
+    @Override
+    public void addSplits(List<AlignedSourceSplit> splits) {
+        pendingSplits.addAll(splits);
+    }
+
+    @Override
+    public void notifyNoMoreSplits() {
+        endOfScan = true;
+    }
+
+    @Override
+    public Optional<Long> shouldTriggerCheckpoint() {
+        LOG.debug(
+                "Ask if checkpoint can be triggered. blocking {}, pending checkpoints {}",
+                blocking,
+                pendingCheckpoints);
+        if (blocking || alignMode == CheckpointAlignMode.LOOSELY) {
+            Long checkpoint = pendingCheckpoints.pollFirst();
+            if (checkpoint != null) {
+                return Optional.of(checkpoint);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void handleSourceEvents(SourceEvent sourceEvent) {
+        if (sourceEvent instanceof CheckpointEvent) {
+            LOG.info("Received checkpoint event {}", sourceEvent);
+            long checkpointId = ((CheckpointEvent) sourceEvent).getCheckpointId();
+            pendingCheckpoints.add(checkpointId);
+            switchToAvailable();
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (alignMode == CheckpointAlignMode.STRICTLY) {
+            // There is no guarantee that checkpoints will be completed in order.
+            // Some checkpoints triggered later may be completed first, which will
+            // cause the previous checkpoints to be aborted.
+            Preconditions.checkArgument(
+                    nextSnapshotPerCheckpoint.firstKey() == checkpointId,
+                    "Checkpoint should be completed in order.");
+        }
+        long nextSnapshotId = nextSnapshotPerCheckpoint.get(checkpointId);
+        scan.notifyCheckpointComplete(nextSnapshotId);
+        nextSnapshotPerCheckpoint.headMap(checkpointId, true).clear();
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        if (alignMode == CheckpointAlignMode.STRICTLY
+                && !pendingCheckpoints.contains(checkpointId)) {
+            // checkpoint has been triggered from source
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "The alignment mode of strictly requires that the checkpoint %s must be successful.",
+                            checkpointId));
+        } else {
+            // checkpoint may not been triggered from source
+            pendingCheckpoints.remove(checkpointId);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (executors != null) {
+            executors.shutdownNow();
+        }
+    }
+
+    private void scanNextSnapshot() {
+        LOG.debug(
+                "SnapshotId by next checkpoint is {}, pending splits {}",
+                snapshotIdByNextCheckpoint,
+                pendingSplits);
+        if (pendingSplits.size() < MAX_PENDING_PLANS) {
+            try {
+                TableScan.Plan plan = scan.plan();
+                if (!(plan instanceof SnapshotNotExistPlan)) {
+                    pendingSplits.add(
+                            new AlignedSourceSplit(plan.splits(), scan.checkpoint(), false));
+                    switchToAvailable();
+                }
+            } catch (EndOfScanException e) {
+                LOG.info("Catching EndOfScanException, the stream is finished.");
+                endOfScan = true;
+            } catch (Throwable error) {
+                LOG.error("Failed to get plans", error);
+            }
+        }
+    }
+
+    private void switchToUnavailable() {
+        lock.lock();
+        try {
+            final CompletableFuture<Void> current = availabilityFuture;
+            if (current == AvailabilityProvider.AVAILABLE) {
+                LOG.debug("source temporarily switched to unavailable.");
+                availabilityFuture = new CompletableFuture<>();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void switchToAvailable() {
+        lock.lock();
+        try {
+            final CompletableFuture<Void> current = availabilityFuture;
+            if (current != AvailabilityProvider.AVAILABLE) {
+                LOG.debug("source switched to available.");
+                availabilityFuture = (CompletableFuture<Void>) AVAILABLE;
+                current.complete(null);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceReader.java
@@ -158,7 +158,7 @@ public class AlignedSourceReader
             }
 
             if (emitSnapshotWatermark) {
-                Long watermark = scan.watermark();
+                Long watermark = alignedSourceSplit.getWatermark();
                 if (watermark != null) {
                     readerOutput.emitWatermark(new Watermark(watermark));
                 }
@@ -187,7 +187,7 @@ public class AlignedSourceReader
         if (pendingSplits.isEmpty() && snapshotIdByNextCheckpoint != null) {
             return Collections.singletonList(
                     new AlignedSourceSplit(
-                            Collections.emptyList(), snapshotIdByNextCheckpoint, true));
+                            Collections.emptyList(), snapshotIdByNextCheckpoint, null, true));
         } else {
             return new ArrayList<>(pendingSplits);
         }
@@ -280,7 +280,8 @@ public class AlignedSourceReader
                 TableScan.Plan plan = scan.plan();
                 if (!(plan instanceof SnapshotNotExistPlan)) {
                     pendingSplits.add(
-                            new AlignedSourceSplit(plan.splits(), scan.checkpoint(), false));
+                            new AlignedSourceSplit(
+                                    plan.splits(), scan.checkpoint(), scan.watermark(), false));
                     switchToAvailable();
                 }
             } catch (EndOfScanException e) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
@@ -22,6 +22,8 @@ import org.apache.paimon.table.source.Split;
 
 import org.apache.flink.api.connector.source.SourceSplit;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -31,11 +33,17 @@ import java.util.List;
 public class AlignedSourceSplit implements SourceSplit {
     private final List<Split> splits;
     private final long nextSnapshotId;
+    private final @Nullable Long watermark;
     private final boolean placeHolder;
 
-    public AlignedSourceSplit(List<Split> splits, long nextSnapshotId, boolean placeHolder) {
+    public AlignedSourceSplit(
+            List<Split> splits,
+            long nextSnapshotId,
+            @Nullable Long watermark,
+            boolean placeHolder) {
         this.splits = splits;
         this.nextSnapshotId = nextSnapshotId;
+        this.watermark = watermark;
         this.placeHolder = placeHolder;
     }
 
@@ -50,6 +58,11 @@ public class AlignedSourceSplit implements SourceSplit {
 
     public List<Split> getSplits() {
         return splits;
+    }
+
+    @Nullable
+    public Long getWatermark() {
+        return watermark;
     }
 
     public boolean isPlaceHolder() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.util.List;
+
+/**
+ * Record the plan scanned by {@link AlignedSourceReader}, which is used to distribute splits to
+ * {@link org.apache.paimon.flink.source.operator.ReadOperator}, restore state, etc.
+ */
+public class AlignedSourceSplit implements SourceSplit {
+    private final List<Split> splits;
+    private final long nextSnapshotId;
+    private final boolean placeHolder;
+
+    public AlignedSourceSplit(List<Split> splits, long nextSnapshotId, boolean placeHolder) {
+        this.splits = splits;
+        this.nextSnapshotId = nextSnapshotId;
+        this.placeHolder = placeHolder;
+    }
+
+    @Override
+    public String splitId() {
+        return String.valueOf(nextSnapshotId);
+    }
+
+    public long getNextSnapshotId() {
+        return nextSnapshotId;
+    }
+
+    public List<Split> getSplits() {
+        return splits;
+    }
+
+    public boolean isPlaceHolder() {
+        return placeHolder;
+    }
+
+    @Override
+    public String toString() {
+        return "AlignedSourceSplit{"
+                + "splits="
+                + splits
+                + ", nextSnapshotId="
+                + nextSnapshotId
+                + ", placeHolder="
+                + placeHolder
+                + '}';
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplit.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Record the plan scanned by {@link AlignedSourceReader}, which is used to distribute splits to
@@ -67,6 +68,26 @@ public class AlignedSourceSplit implements SourceSplit {
 
     public boolean isPlaceHolder() {
         return placeHolder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlignedSourceSplit that = (AlignedSourceSplit) o;
+        return nextSnapshotId == that.nextSnapshotId
+                && placeHolder == that.placeHolder
+                && Objects.equals(splits, that.splits)
+                && Objects.equals(watermark, that.watermark);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(splits, nextSnapshotId, watermark, placeHolder);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplitSerializer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplitSerializer.java
@@ -51,6 +51,12 @@ public class AlignedSourceSplitSerializer implements SimpleVersionedSerializer<A
                 InstantiationUtil.serializeObject(view, split);
             }
             view.writeLong(alignedSourceSplit.getNextSnapshotId());
+            if (alignedSourceSplit.getWatermark() == null) {
+                view.writeBoolean(true);
+            } else {
+                view.writeBoolean(false);
+                view.writeLong(alignedSourceSplit.getWatermark());
+            }
             view.writeBoolean(alignedSourceSplit.isPlaceHolder());
             return baos.toByteArray();
         }
@@ -73,8 +79,13 @@ public class AlignedSourceSplitSerializer implements SimpleVersionedSerializer<A
                 throw new IOException(e);
             }
             long nextSnapshotId = view.readLong();
+            Long watermark = null;
+            boolean isNull = view.readBoolean();
+            if (!isNull) {
+                watermark = view.readLong();
+            }
             boolean isPlaceHolder = view.readBoolean();
-            return new AlignedSourceSplit(splits, nextSnapshotId, isPlaceHolder);
+            return new AlignedSourceSplit(splits, nextSnapshotId, watermark, isPlaceHolder);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplitSerializer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedSourceSplitSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.io.DataOutputViewStreamWrapper;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** {@link SimpleVersionedSerializer} for {@link AlignedSourceSplit}. */
+public class AlignedSourceSplitSerializer implements SimpleVersionedSerializer<AlignedSourceSplit> {
+
+    private static final int CURRENT_VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(AlignedSourceSplit alignedSourceSplit) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(baos)) {
+            List<Split> splits = alignedSourceSplit.getSplits();
+            view.writeInt(splits.size());
+            for (Split split : splits) {
+                InstantiationUtil.serializeObject(view, split);
+            }
+            view.writeLong(alignedSourceSplit.getNextSnapshotId());
+            view.writeBoolean(alignedSourceSplit.isPlaceHolder());
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public AlignedSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(serialized);
+                DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(in)) {
+            int size = view.readInt();
+            List<Split> splits = new ArrayList<>(size);
+            ClassLoader classLoader = getClass().getClassLoader();
+            Split split;
+            try {
+                for (int i = 0; i < size; i++) {
+                    split = InstantiationUtil.deserializeObject(in, classLoader);
+                    splits.add(split);
+                }
+            } catch (ClassNotFoundException e) {
+                throw new IOException(e);
+            }
+            long nextSnapshotId = view.readLong();
+            boolean isPlaceHolder = view.readBoolean();
+            return new AlignedSourceSplit(splits, nextSnapshotId, isPlaceHolder);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/CheckpointEvent.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/CheckpointEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import javax.annotation.Nonnull;
+
+import java.util.Objects;
+
+/**
+ * Event sent from {@link AlignedEnumerator} to {@link AlignedSourceReader} to notify the
+ * checkpointId that is about to be triggered.
+ */
+public class CheckpointEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    @Nonnull private final long checkpointId;
+
+    public CheckpointEvent(long checkpointId) {
+        this.checkpointId = checkpointId;
+    }
+
+    @Nonnull
+    public long getCheckpointId() {
+        return checkpointId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CheckpointEvent that = (CheckpointEvent) o;
+        return checkpointId == that.checkpointId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(checkpointId);
+    }
+
+    @Override
+    public String toString() {
+        return "CheckpointEvent{" + "checkpointId=" + checkpointId + '}';
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/FutureCompletingBlockingDeque.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/FutureCompletingBlockingDeque.java
@@ -1,4 +1,3 @@
-package org.apache.paimon.flink.source.align;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,6 +15,8 @@ package org.apache.paimon.flink.source.align;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.paimon.flink.source.align;
 
 import org.apache.flink.runtime.io.AvailabilityProvider;
 
@@ -172,6 +173,23 @@ public class FutureCompletingBlockingDeque<T> {
      */
     public CompletableFuture<Void> getAvailabilityFuture() {
         return currentFuture;
+    }
+
+    /**
+     * Makes sure the availability future is complete, if it is not complete already. All futures
+     * returned by previous calls to {@link #getAvailabilityFuture()} are guaranteed to be
+     * completed.
+     *
+     * <p>All future calls to the method will return a completed future, until the point that the
+     * availability is reset via calls to {@link #poll()} that leave the queue empty.
+     */
+    public void notifyAvailable() {
+        lock.lock();
+        try {
+            moveToAvailable();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /** Internal utility to make sure that the current future futures are complete (until reset). */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/FutureCompletingBlockingDeque.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/FutureCompletingBlockingDeque.java
@@ -1,0 +1,194 @@
+package org.apache.paimon.flink.source.align;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.runtime.io.AvailabilityProvider;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A simple implementation of <code>FutureCompletingBlockingDeque</code>, which refers to {@link
+ * org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue}.
+ */
+public class FutureCompletingBlockingDeque<T> {
+
+    public static final CompletableFuture<Void> AVAILABLE =
+            (CompletableFuture<Void>) AvailabilityProvider.AVAILABLE;
+
+    /** The element queue. */
+    @GuardedBy("lock")
+    private final Deque<T> queue;
+
+    /**
+     * The availability future. This doubles as a "non empty" condition. This value is never null.
+     */
+    private CompletableFuture<Void> currentFuture;
+
+    /** The lock for synchronization. */
+    private final Lock lock;
+
+    public FutureCompletingBlockingDeque() {
+        this.queue = new ArrayDeque<>();
+        this.lock = new ReentrantLock();
+
+        // initially the queue is empty and thus unavailable
+        this.currentFuture = new CompletableFuture<>();
+    }
+
+    /**
+     * Get the last element from the queue without removing it.
+     *
+     * @return the last element in the queue, or Null if the queue is empty.
+     */
+    public T peekLast() {
+        lock.lock();
+        try {
+            return queue.peekLast();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get and remove the first element from the queue.
+     *
+     * @return the first element from the queue, or Null if the queue is empty.
+     */
+    public T poll() {
+        lock.lock();
+        try {
+            final T element = queue.poll();
+            if (queue.size() == 0) {
+                moveToUnAvailable();
+            }
+            return element;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Put an element into the queue.
+     *
+     * @param element the element to put.
+     * @throws InterruptedException when the thread is interrupted.
+     */
+    public void put(T element) {
+        if (element == null) {
+            throw new NullPointerException();
+        }
+        lock.lock();
+        try {
+            final int sizeBefore = queue.size();
+            queue.add(element);
+            if (sizeBefore == 0) {
+                moveToAvailable();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Put all elements into the queue.
+     *
+     * @param elements the elements to put.
+     * @throws InterruptedException when the thread is interrupted.
+     */
+    public void putAll(Collection<T> elements) {
+        if (elements == null) {
+            throw new NullPointerException();
+        }
+        lock.lock();
+        try {
+            final int sizeBefore = queue.size();
+            queue.addAll(elements);
+            if (sizeBefore == 0 && elements.size() > 0) {
+                moveToAvailable();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Gets the size of the queue. */
+    public int size() {
+        lock.lock();
+        try {
+            return queue.size();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Checks whether the queue is empty. */
+    public boolean isEmpty() {
+        lock.lock();
+        try {
+            return queue.isEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Returns all the elements in this queue. */
+    public List<T> remainingElements() {
+        lock.lock();
+        try {
+            return new ArrayList<>(queue);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the availability future. If the queue is non-empty, then this future will already be
+     * complete. Otherwise the obtained future is guaranteed to get completed the next time the
+     * queue becomes non-empty.
+     */
+    public CompletableFuture<Void> getAvailabilityFuture() {
+        return currentFuture;
+    }
+
+    /** Internal utility to make sure that the current future futures are complete (until reset). */
+    @GuardedBy("lock")
+    private void moveToAvailable() {
+        final CompletableFuture<Void> current = currentFuture;
+        if (current != AVAILABLE) {
+            currentFuture = AVAILABLE;
+            current.complete(null);
+        }
+    }
+
+    /** Makes sure the availability future is incomplete, if it was complete before. */
+    @GuardedBy("lock")
+    private void moveToUnAvailable() {
+        if (currentFuture == AVAILABLE) {
+            currentFuture = new CompletableFuture<>();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/LooselyAlignedSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/LooselyAlignedSourceReader.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.table.source.ReadBuilder;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.CheckpointAlignMode;
+
+/** {@link AlignedSourceReader} for {@link CheckpointAlignMode#LOOSELY}. */
+public class LooselyAlignedSourceReader extends AlignedSourceReader {
+
+    public LooselyAlignedSourceReader(
+            ReadBuilder readBuilder, long scanInterval, boolean emitSnapshotWatermark) {
+        super(
+                readBuilder,
+                scanInterval,
+                emitSnapshotWatermark,
+                Executors.newScheduledThreadPool(
+                        1,
+                        r ->
+                                new Thread(
+                                        r,
+                                        "Loosely aligned source scan for "
+                                                + Thread.currentThread().getName())));
+    }
+
+    @VisibleForTesting
+    public LooselyAlignedSourceReader(
+            ReadBuilder readBuilder,
+            long scanInterval,
+            boolean emitSnapshotWatermark,
+            ScheduledExecutorService executors) {
+        super(readBuilder, scanInterval, emitSnapshotWatermark, executors);
+    }
+
+    @Override
+    protected boolean blockingAfterSendSnapshot(boolean hasPendingCheckpoint) {
+        return hasPendingCheckpoint;
+    }
+
+    @Override
+    protected boolean shouldTriggerCheckpoint(boolean blocking) {
+        return true;
+    }
+
+    @Override
+    protected void handleCheckpointCompletedOutOfOrder(long checkpointId) {
+        // ignore
+    }
+
+    @Override
+    protected void handleCheckpointAborted(long checkpointId) {
+        // ignore;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/NoOpEnumStateSerializer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/NoOpEnumStateSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+
+/** Mock enumerator state serializer. */
+public class NoOpEnumStateSerializer implements SimpleVersionedSerializer<Void> {
+
+    private static final int CURRENT_VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(Void obj) throws IOException {
+        return new byte[0];
+    }
+
+    @Override
+    public Void deserialize(int version, byte[] serialized) throws IOException {
+        return null;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/StrictlyAlignedSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/StrictlyAlignedSourceReader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.table.source.ReadBuilder;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.CheckpointAlignMode;
+
+/** {@link AlignedSourceReader} for {@link CheckpointAlignMode#STRICTLY}. */
+public class StrictlyAlignedSourceReader extends AlignedSourceReader {
+
+    public StrictlyAlignedSourceReader(
+            ReadBuilder readBuilder, long scanInterval, boolean emitSnapshotWatermark) {
+        super(
+                readBuilder,
+                scanInterval,
+                emitSnapshotWatermark,
+                Executors.newScheduledThreadPool(
+                        1,
+                        r ->
+                                new Thread(
+                                        r,
+                                        "Strictly aligned source scan for "
+                                                + Thread.currentThread().getName())));
+    }
+
+    @VisibleForTesting
+    public StrictlyAlignedSourceReader(
+            ReadBuilder readBuilder,
+            long scanInterval,
+            boolean emitSnapshotWatermark,
+            ScheduledExecutorService executors) {
+        super(readBuilder, scanInterval, emitSnapshotWatermark, executors);
+    }
+
+    @Override
+    protected boolean blockingAfterSendSnapshot(boolean hasPendingCheckpoint) {
+        return true;
+    }
+
+    @Override
+    protected boolean shouldTriggerCheckpoint(boolean blocking) {
+        return blocking;
+    }
+
+    @Override
+    protected void handleCheckpointCompletedOutOfOrder(long checkpointId) {
+        throw new FlinkRuntimeException(
+                String.format(
+                        "The alignment mode of strictly requires that the checkpoint %s must be completed in order.",
+                        checkpointId));
+    }
+
+    @Override
+    protected void handleCheckpointAborted(long checkpointId) {
+        throw new FlinkRuntimeException(
+                String.format(
+                        "The alignment mode of strictly requires that the checkpoint %s must be successful.",
+                        checkpointId));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedEnumeratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link AlignedEnumerator}. */
+public class AlignedEnumeratorTest {
+    @Test
+    public void testSnapshotEnumerator() throws Exception {
+        final TestingSplitEnumeratorContext<AlignedSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(1);
+        context.registerReader(0, "test-host");
+
+        SplitEnumerator<AlignedSourceSplit, Void> enumerator = new AlignedEnumerator(context);
+        enumerator.start();
+
+        enumerator.addSplitsBack(
+                Collections.singletonList(
+                        new AlignedSourceSplit(Collections.emptyList(), 2, null, false)),
+                0);
+        enumerator.handleSplitRequest(0, "test-host");
+        assertThat(context.getSplitAssignments()).isEmpty();
+
+        Void state = enumerator.snapshotState(1L);
+        assertThat(state).isNull();
+
+        Map<Integer, List<SourceEvent>> expectedEvents = new HashMap<>(1);
+        expectedEvents.put(0, Collections.singletonList(new CheckpointEvent(1L)));
+        assertThat(context.getSentEvents()).containsExactlyEntriesOf(expectedEvents);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
@@ -352,8 +352,20 @@ public class AlignedSourceReaderTest {
             CheckpointAlignMode alignMode,
             ScheduledExecutorService executors,
             List<AlignedSourceSplit> restoredSplits) {
-        AlignedSourceReader reader =
-                new AlignedSourceReader(table.newReadBuilder(), 10, true, alignMode, executors);
+        AlignedSourceReader reader;
+        switch (alignMode) {
+            case STRICTLY:
+                reader =
+                        new StrictlyAlignedSourceReader(
+                                table.newReadBuilder(), 10, true, executors);
+                break;
+            case LOOSELY:
+                reader =
+                        new LooselyAlignedSourceReader(table.newReadBuilder(), 10, true, executors);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported align mode");
+        }
         reader.addSplits(restoredSplits);
         reader.start();
         return reader;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.align;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nullable;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
+
+import static org.apache.paimon.CoreOptions.CONSUMER_ID;
+import static org.apache.paimon.flink.FlinkConnectorOptions.CheckpointAlignMode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link AlignedSourceReader}. */
+public class AlignedSourceReaderTest {
+
+    private static final Predicate<CompletableFuture<Void>> UNCOMPLETED_PREDICATE =
+            future -> !future.isDone();
+
+    @TempDir Path tempDir;
+
+    private FileStoreTable table;
+
+    @BeforeEach
+    public void before()
+            throws Catalog.TableAlreadyExistException, Catalog.DatabaseNotExistException,
+                    Catalog.TableNotExistException, Catalog.DatabaseAlreadyExistException {
+        Catalog catalog =
+                CatalogFactory.createCatalog(
+                        CatalogContext.create(new org.apache.paimon.fs.Path(tempDir.toUri())));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.INT())
+                        .column("c", DataTypes.INT())
+                        .primaryKey("a")
+                        .options(Collections.singletonMap(CONSUMER_ID.key(), "my_consumer"))
+                        .build();
+        Identifier identifier = Identifier.create("default", "t");
+        catalog.createDatabase("default", false);
+        catalog.createTable(identifier, schema, false);
+        this.table = (FileStoreTable) catalog.getTable(identifier);
+    }
+
+    @Test
+    public void testStrictlyAlignMode() throws Exception {
+        ManuallyTriggeredScheduledExecutorService executors =
+                new ManuallyTriggeredScheduledExecutorService();
+        AlignedSourceReader reader =
+                createAndStartReader(
+                        CheckpointAlignMode.STRICTLY, executors, Collections.emptyList());
+        StreamTableScan scan = table.newStreamScan();
+        TestingCollectReaderOutput<Split> output = new TestingCollectReaderOutput<>();
+
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                Collections.emptyList(),
+                null,
+                UNCOMPLETED_PREDICATE);
+
+        // assume checkpoint arrives first
+        reader.handleSourceEvents(new CheckpointEvent(1L));
+        assertThat(reader.shouldTriggerCheckpoint()).isEmpty();
+
+        // write 1 snapshot and scan the first snapshot
+        writeAndScanForReader(1L, 10L, GenericRow.of(1, 2, 3), executors);
+        List<Split> firstSplits = scan.plan().splits();
+
+        // send the first snapshot
+        CompletableFuture<Void> availableFuture = reader.isAvailable();
+        assertThat(availableFuture).isDone();
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                firstSplits,
+                new Watermark(10L),
+                UNCOMPLETED_PREDICATE);
+
+        // after send the first snapshot, we can trigger checkpoint
+        assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(1L));
+        List<AlignedSourceSplit> state = reader.snapshotState(1L);
+        assertThat(state)
+                .containsExactly(new AlignedSourceSplit(Collections.emptyList(), 2L, null, true));
+        reader.notifyCheckpointComplete(1L);
+
+        // write 2 snapshots and scan the remaining snapshot
+        writeAndScanForReader(2L, 20L, GenericRow.of(4, 5, 6), executors);
+        writeAndScanForReader(3L, 30L, GenericRow.of(7, 8, 9), executors);
+        List<Split> secondSplits = scan.plan().splits();
+        List<Split> thirdSplits = scan.plan().splits();
+
+        // assume checkpoint arrives late.
+        availableFuture = reader.isAvailable();
+        assertThat(availableFuture).isDone();
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                secondSplits,
+                new Watermark(20L),
+                UNCOMPLETED_PREDICATE);
+
+        // no checkpoint is triggered and no more snapshots are expected to be sent.
+        availableFuture = reader.isAvailable();
+        assertThat(availableFuture).isNotDone();
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                Collections.emptyList(),
+                null,
+                UNCOMPLETED_PREDICATE);
+
+        // trigger checkpoint
+        reader.handleSourceEvents(new CheckpointEvent(2L));
+        assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(2L));
+        state = reader.snapshotState(2L);
+        assertThat(state).containsExactly(new AlignedSourceSplit(thirdSplits, 4L, 30L, false));
+        reader.notifyCheckpointComplete(2L);
+
+        // after checkpoint triggered, we can poll last snapshot
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                thirdSplits,
+                new Watermark(30L),
+                UNCOMPLETED_PREDICATE);
+    }
+
+    @Test
+    public void testLooselyAlignMode() throws Exception {
+        ManuallyTriggeredScheduledExecutorService executors =
+                new ManuallyTriggeredScheduledExecutorService();
+        AlignedSourceReader reader =
+                createAndStartReader(
+                        CheckpointAlignMode.LOOSELY, executors, Collections.emptyList());
+        StreamTableScan scan = table.newStreamScan();
+        TestingCollectReaderOutput<Split> output = new TestingCollectReaderOutput<>();
+
+        // first call
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                Collections.emptyList(),
+                null,
+                UNCOMPLETED_PREDICATE);
+
+        // checkpoint arrives first
+        reader.handleSourceEvents(new CheckpointEvent(1L));
+        assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(1L));
+        List<AlignedSourceSplit> state = reader.snapshotState(1L);
+        assertThat(state).isEmpty();
+        reader.notifyCheckpointComplete(1L);
+
+        // write 1 snapshot and scan the first snapshot
+        writeAndScanForReader(1L, 10L, GenericRow.of(1, 2, 3), executors);
+        List<Split> firstSplits = scan.plan().splits();
+
+        // send the first snapshot
+        CompletableFuture<Void> availableFuture = reader.isAvailable();
+        assertThat(availableFuture).isDone();
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                firstSplits,
+                new Watermark(10L),
+                UNCOMPLETED_PREDICATE);
+
+        // write 2 snapshots and scan the remaining snapshot
+        writeAndScanForReader(2L, 20L, GenericRow.of(4, 5, 6), executors);
+        writeAndScanForReader(3L, 30L, GenericRow.of(7, 8, 9), executors);
+        List<Split> secondSplits = scan.plan().splits();
+        List<Split> thirdSplits = scan.plan().splits();
+
+        // send the second snapshot
+        availableFuture = reader.isAvailable();
+        assertThat(availableFuture).isDone();
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.MORE_AVAILABLE,
+                secondSplits,
+                new Watermark(20L),
+                CompletableFuture::isDone);
+
+        // send the third snapshot
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                thirdSplits,
+                new Watermark(30L),
+                UNCOMPLETED_PREDICATE);
+
+        // trigger checkpoint
+        reader.handleSourceEvents(new CheckpointEvent(2L));
+        assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(2L));
+        state = reader.snapshotState(2L);
+        assertThat(state)
+                .containsExactly(new AlignedSourceSplit(Collections.emptyList(), 4L, null, true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = CheckpointAlignMode.class,
+            names = {"UNALIGNED"},
+            mode = EnumSource.Mode.EXCLUDE)
+    public void testRestore(CheckpointAlignMode alignMode) throws Exception {
+        ManuallyTriggeredScheduledExecutorService executors =
+                new ManuallyTriggeredScheduledExecutorService();
+        AlignedSourceReader reader =
+                createAndStartReader(
+                        CheckpointAlignMode.STRICTLY, executors, Collections.emptyList());
+        StreamTableScan scan = table.newStreamScan();
+        TestingCollectReaderOutput<Split> output = new TestingCollectReaderOutput<>();
+
+        // write a snapshot and scan the first snapshot
+        writeAndScanForReader(1L, 10L, GenericRow.of(1, 2, 3), executors);
+        List<Split> firstSplits = scan.plan().splits();
+
+        // send the first snapshot
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                firstSplits,
+                new Watermark(10L),
+                UNCOMPLETED_PREDICATE);
+
+        // trigger first checkpoint and shutdown
+        List<AlignedSourceSplit> state =
+                triggerCheckpoint(
+                        reader,
+                        1L,
+                        Collections.singletonList(
+                                new AlignedSourceSplit(Collections.emptyList(), 2L, null, true)));
+        reader.close();
+
+        // restore from the first checkpoint which contain a placeholder state
+        executors = new ManuallyTriggeredScheduledExecutorService();
+        reader = createAndStartReader(alignMode, executors, state);
+
+        // first call with empty splits
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                Collections.emptyList(),
+                null,
+                UNCOMPLETED_PREDICATE);
+
+        // write 2 snapshots and scan the remaining snapshots
+        writeAndScanForReader(2L, 20L, GenericRow.of(4, 5, 6), executors);
+        writeAndScanForReader(3L, 30L, GenericRow.of(7, 8, 9), executors);
+        List<Split> secondSplits = scan.plan().splits();
+        List<Split> thirdSplits = scan.plan().splits();
+
+        // poll second snapshot
+        InputStatus expectedStatus =
+                alignMode == CheckpointAlignMode.STRICTLY
+                        ? InputStatus.NOTHING_AVAILABLE
+                        : InputStatus.MORE_AVAILABLE;
+        Predicate<CompletableFuture<Void>> expectedPredicate =
+                alignMode == CheckpointAlignMode.STRICTLY
+                        ? UNCOMPLETED_PREDICATE
+                        : CompletableFuture::isDone;
+        pollNextAndCheck(
+                reader,
+                output,
+                expectedStatus,
+                secondSplits,
+                new Watermark(20L),
+                expectedPredicate);
+
+        // trigger second checkpoint and shutdown
+        state =
+                triggerCheckpoint(
+                        reader,
+                        2L,
+                        Collections.singletonList(
+                                new AlignedSourceSplit(thirdSplits, 4L, 30L, false)));
+        reader.close();
+
+        // restore from second checkpoint
+        executors = new ManuallyTriggeredScheduledExecutorService();
+        reader = createAndStartReader(alignMode, executors, state);
+
+        // poll third snapshot
+        pollNextAndCheck(
+                reader,
+                output,
+                InputStatus.NOTHING_AVAILABLE,
+                thirdSplits,
+                new Watermark(30L),
+                UNCOMPLETED_PREDICATE);
+    }
+
+    private AlignedSourceReader createAndStartReader(
+            CheckpointAlignMode alignMode,
+            ScheduledExecutorService executors,
+            List<AlignedSourceSplit> restoredSplits) {
+        AlignedSourceReader reader =
+                new AlignedSourceReader(table.newReadBuilder(), 10, true, alignMode, executors);
+        reader.addSplits(restoredSplits);
+        reader.start();
+        return reader;
+    }
+
+    private void pollNextAndCheck(
+            AlignedSourceReader reader,
+            TestingCollectReaderOutput<Split> output,
+            InputStatus expectedStatus,
+            List<Split> expectedRecords,
+            @Nullable Watermark expectedWatermark,
+            Predicate<CompletableFuture<Void>> availablePredicate)
+            throws Exception {
+        output.clear();
+        InputStatus status = reader.pollNext(output);
+        assertThat(status).isEqualTo(expectedStatus);
+        assertThat(output.getEmittedRecords()).containsExactlyInAnyOrderElementsOf(expectedRecords);
+        if (expectedWatermark != null) {
+            assertThat(output.getEmittedWatermarks()).containsExactly(expectedWatermark);
+        } else {
+            assertThat(output.getEmittedWatermarks()).isEmpty();
+        }
+        assertThat(reader.isAvailable()).matches(availablePredicate);
+    }
+
+    private List<AlignedSourceSplit> triggerCheckpoint(
+            AlignedSourceReader reader, long checkpointId, List<AlignedSourceSplit> expectedState)
+            throws Exception {
+        reader.handleSourceEvents(new CheckpointEvent(checkpointId));
+        assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(checkpointId));
+        List<AlignedSourceSplit> state = reader.snapshotState(checkpointId);
+        assertThat(state).containsExactlyElementsOf(expectedState);
+        reader.notifyCheckpointComplete(checkpointId);
+        return state;
+    }
+
+    private void writeAndScanForReader(
+            long identifier,
+            long watermark,
+            InternalRow row,
+            ManuallyTriggeredScheduledExecutorService executors)
+            throws Exception {
+        writeToTable(identifier, watermark, row);
+        executors.triggerScheduledTasks();
+    }
+
+    private void writeToTable(long identifier, long watermark, InternalRow row) throws Exception {
+        TableWriteImpl<?> write = table.newWrite("commitUser");
+        TableCommitImpl commit = table.newCommit("commitUser");
+        write.write(row);
+        ManifestCommittable committable = new ManifestCommittable(identifier, watermark);
+        write.prepareCommit(true, 0).forEach(committable::addFileCommittable);
+        commit.commit(committable);
+        commit.close();
+        write.close();
+    }
+
+    /** A {@code ReaderOutput} for testing that collects the emitted records and watermarks. */
+    private static final class TestingCollectReaderOutput<E> extends TestingReaderOutput<E> {
+
+        private final ArrayList<Watermark> emittedWatermarks = new ArrayList<>();
+
+        @Override
+        public void emitWatermark(Watermark watermark) {
+            emittedWatermarks.add(watermark);
+        }
+
+        public ArrayList<Watermark> getEmittedWatermarks() {
+            return emittedWatermarks;
+        }
+
+        public void clear() {
+            super.clearEmittedRecords();
+            emittedWatermarks.clear();
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
 [flink] supports alignment with flink checkpoint when consuming paimon snapshots. closes #1486 

As a subtask of [PIP-5](https://cwiki.apache.org/confluence/x/jRE0Dw).

### Tests

- Added `AlignedEnumeratorTest` to verify that `AlignedEnumerator` will send `CheckpointEvent` during checkpoint.
- Added `AlignedSourceReaderTest` to verify that `AlignedSourceReader` can correctly send split, create checkpoint, and restore in different `CheckpointAlignMode`.

### API and Format

No.

### Documentation

https://cwiki.apache.org/confluence/x/jRE0Dw
