### PR TITLE
[core] Change default sort engine back to min heap

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -406,7 +406,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>
-            <td style="word-wrap: break-word;">loser-tree</td>
+            <td style="word-wrap: break-word;">min-heap</td>
             <td><p>Enum</p></td>
             <td>Specify the sort engine for table with primary key.<br /><br />Possible values:<ul><li>"min-heap": Use min-heap for multiway sorting.</li><li>"loser-tree": Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.</li></ul></td>
         </tr>

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -197,7 +197,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<SortEngine> SORT_ENGINE =
             key("sort-engine")
                     .enumType(SortEngine.class)
-                    .defaultValue(SortEngine.LOSER_TREE)
+                    .defaultValue(SortEngine.MIN_HEAP)
                     .withDescription("Specify the sort engine for table with primary key.");
 
     public static final ConfigOption<Integer> SORT_SPILL_THRESHOLD =


### PR DESCRIPTION
### Purpose

We've heard from some users that they experience some issues when using loser tree as the sort engine. This PR changes the default sort engine back to `min-heap`, which is more stable.

### Tests

N/A

### API and Format

No.

### Documentation

Document for `sort-engine` option is also changed.
