### PR TITLE
paimon-cdc upgrade

### DIFF
--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
     <properties>
         <flink.version>1.17.1</flink.version>
-        <flink.cdc.version>2.3.0</flink.cdc.version>
+        <flink.cdc.version>2.4.0</flink.cdc.version>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
         <geometry.version>2.2.0</geometry.version>
         <druid.version>1.2.15</druid.version>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/JdbcConstant.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/JdbcConstant.java
@@ -1,9 +1,0 @@
-package org.apache.paimon.flink.action.cdc.mysql;
-
-/**
- * @author jiangchao @Description:
- * @date 2023/7/4 17:09
- */
-public class JdbcConstant {
-    public static final String PROPERTIES_PREFIX = "jdbc.properties.";
-}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/JdbcConstant.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/JdbcConstant.java
@@ -1,0 +1,9 @@
+package org.apache.paimon.flink.action.cdc.mysql;
+
+/**
+ * @author jiangchao @Description:
+ * @date 2023/7/4 17:09
+ */
+public class JdbcConstant {
+    public static final String PROPERTIES_PREFIX = "jdbc.properties.";
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -58,6 +58,9 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 class MySqlActionUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlActionUtils.class);
+
+    public static final String JDBC_PROPERTIES_PREFIX = "jdbc.properties.";
+
     public static final ConfigOption<Boolean> SCAN_NEWLY_ADDED_TABLE_ENABLED =
             ConfigOptions.key("scan.newly-added-table.enabled")
                     .booleanType()
@@ -199,7 +202,8 @@ class MySqlActionUtils {
         mySqlConfig
                 .getOptional(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE)
                 .ifPresent(sourceBuilder::splitSize);
-        //Whether to close idle readers at the end of the snapshot phase. The flink version is required to be greater than or equal to 1.14
+        // Whether to close idle readers at the end of the snapshot phase. The flink version is
+        // required to be greater than or equal to 1.14
         // when 'execution.checkpointing.checkpoints-after-tasks-finish.enabled' is set to true.
         mySqlConfig
                 .getOptional(MySqlSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED)
@@ -254,8 +258,8 @@ class MySqlActionUtils {
         for (Map.Entry<String, String> entry : mySqlConfig.toMap().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            if (key.startsWith(JdbcConstant.PROPERTIES_PREFIX)) {
-                jdbcProperties.put(key.substring(JdbcConstant.PROPERTIES_PREFIX.length()), value);
+            if (key.startsWith(JDBC_PROPERTIES_PREFIX)) {
+                jdbcProperties.put(key.substring(JDBC_PROPERTIES_PREFIX.length()), value);
             } else if (key.startsWith(DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX)) {
                 debeziumProperties.put(
                         key.substring(DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX.length()), value);


### PR DESCRIPTION
1、Removed the JdbcUrlUtils class.
2、Added a configuration parameter 'scan.incremental.close-idle-reader.enabled' for MySQL CDC.
3、 upgrade flink-cdc to 2.4

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
