### PR TITLE
[flink] ContinuousFileSplitEnumerator.assignSplits should be thread safe

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -138,8 +138,7 @@ public class ContinuousFileSplitEnumerator
 
     @Override
     public PendingSplitsCheckpoint snapshotState(long checkpointId) {
-        List<FileStoreSourceSplit> splits = new ArrayList<>();
-        splits.addAll(splitAssigner.remainingSplits());
+        List<FileStoreSourceSplit> splits = new ArrayList<>(splitAssigner.remainingSplits());
         final PendingSplitsCheckpoint checkpoint =
                 new PendingSplitsCheckpoint(splits, nextSnapshotId);
 
@@ -172,7 +171,11 @@ public class ContinuousFileSplitEnumerator
         assignSplits();
     }
 
-    private void assignSplits() {
+    /**
+     * Method should be synchronized because {@link #handleSplitRequest} and {@link
+     * #processDiscoveredSplits} have thread conflicts.
+     */
+    private synchronized void assignSplits() {
         Map<Integer, List<FileStoreSourceSplit>> assignment = createAssignment();
         if (finished) {
             Iterator<Integer> iterator = readersAwaitingSplit.iterator();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Method should be synchronized because {@link #handleSplitRequest} and {@link #processDiscoveredSplits} have thread conflicts.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
