### PR TITLE
[fix] fix bug: raised ConcurrentModificationException while readers removed in SplitEnumeratorContext

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -190,19 +190,18 @@ public class ContinuousFileSplitEnumerator
 
     private Map<Integer, List<FileStoreSourceSplit>> createAssignment() {
         Map<Integer, List<FileStoreSourceSplit>> assignment = new HashMap<>();
-        readersAwaitingSplit.forEach(
-                task -> {
-                    // if the reader that requested another split has failed in the meantime, remove
-                    // it from the list of waiting readers
-                    if (!context.registeredReaders().containsKey(task)) {
-                        readersAwaitingSplit.remove(task);
-                        return;
-                    }
-                    List<FileStoreSourceSplit> splits = splitAssigner.getNext(task, null);
-                    if (splits.size() > 0) {
-                        assignment.put(task, splits);
-                    }
-                });
+        Iterator<Integer> readersAwait = readersAwaitingSplit.iterator();
+        while (readersAwait.hasNext()) {
+            Integer task = readersAwait.next();
+            if (!context.registeredReaders().containsKey(task)) {
+                readersAwait.remove();
+                continue;
+            }
+            List<FileStoreSourceSplit> splits = splitAssigner.getNext(task, null);
+            if (splits.size() > 0) {
+                assignment.put(task, splits);
+            }
+        }
         return assignment;
     }
 


### PR DESCRIPTION
Raised ConcurrentModificationException in SplitEnumeratorContext if registered reader has been removed.