### PR TITLE
[core] compacted_full should never return null

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -53,6 +54,6 @@ public class CompactedStartingScanner implements StartingScanner {
 
     @Nullable
     protected Long pick(SnapshotManager snapshotManager) {
-        return snapshotManager.latestCompactedSnapshotId();
+        return snapshotManager.pickOrLatest(s -> s.commitKind() == Snapshot.CommitKind.COMPACT);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullCompactedStartingScanner.java
@@ -40,7 +40,7 @@ public class FullCompactedStartingScanner extends CompactedStartingScanner {
     @Override
     @Nullable
     protected Long pick(SnapshotManager snapshotManager) {
-        return snapshotManager.pickFromLatest(this::picked);
+        return snapshotManager.pickOrLatest(this::picked);
     }
 
     private boolean picked(Snapshot snapshot) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.utils;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.Snapshot.CommitKind;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 
@@ -113,11 +112,7 @@ public class SnapshotManager implements Serializable {
         }
     }
 
-    public @Nullable Long latestCompactedSnapshotId() {
-        return pickFromLatest(s -> s.commitKind() == CommitKind.COMPACT);
-    }
-
-    public @Nullable Long pickFromLatest(Predicate<Snapshot> predicate) {
+    public @Nullable Long pickOrLatest(Predicate<Snapshot> predicate) {
         Long latestId = latestSnapshotId();
         Long earliestId = earliestSnapshotId();
         if (latestId == null || earliestId == null) {
@@ -133,7 +128,7 @@ public class SnapshotManager implements Serializable {
             }
         }
 
-        return null;
+        return latestId;
     }
 
     /**

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -889,6 +889,14 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(1, 10, 100L));
         commit.commit(0, write.prepareCommit(true, 0));
 
+        ReadBuilder readBuilder = table.newReadBuilder();
+        assertThat(
+                        getResult(
+                                readBuilder.newRead(),
+                                readBuilder.newScan().plan().splits(),
+                                BATCH_ROW_TO_STRING))
+                .containsExactly("1|10|100|binary|varbinary|mapKey:mapVal|multiset");
+
         write.write(rowData(1, 10, 200L));
         commit.commit(1, write.prepareCommit(true, 1));
 
@@ -901,7 +909,6 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.close();
 
-        ReadBuilder readBuilder = table.newReadBuilder();
         assertThat(
                         getResult(
                                 readBuilder.newRead(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Scan mode should just try its best to find a snapshot, and if it cannot be found, it should return the closest snapshot

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
