### PR TITLE
[bug][flink] CDC schema evolution should pass catalog information

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -182,10 +182,10 @@ public interface Catalog extends AutoCloseable {
      * @throws TableNotExistException if the table does not exist
      */
     void alterTable(Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
-            throws TableNotExistException;
+            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException;
 
     default void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
-            throws TableNotExistException {
+            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         alterTable(identifier, Collections.singletonList(change), ignoreIfNotExists);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -24,6 +24,7 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -182,6 +183,11 @@ public interface Catalog extends AutoCloseable {
      */
     void alterTable(Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
             throws TableNotExistException;
+
+    default void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
+            throws TableNotExistException {
+        alterTable(identifier, Collections.singletonList(change), ignoreIfNotExists);
+    }
 
     /** Return a boolean that indicates whether this catalog is case-sensitive. */
     default boolean caseSensitive() {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -189,15 +189,13 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void alterTable(
             Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
-            throws TableNotExistException {
+            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         checkNotSystemTable(identifier, "alterTable");
         if (!tableExists(getDataTableLocation(identifier))) {
             throw new TableNotExistException(identifier);
         }
-        uncheck(
-                () ->
-                        new SchemaManager(fileIO, getDataTableLocation(identifier))
-                                .commitChanges(changes));
+
+        new SchemaManager(fileIO, getDataTableLocation(identifier)).commitChanges(changes);
     }
 
     private static <T> T uncheck(Callable<T> callable) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -187,7 +187,9 @@ public class SchemaManager implements Serializable {
     }
 
     /** Update {@link SchemaChange}s. */
-    public TableSchema commitChanges(List<SchemaChange> changes) throws Exception {
+    public TableSchema commitChanges(List<SchemaChange> changes)
+            throws Catalog.TableNotExistException, Catalog.ColumnAlreadyExistException,
+                    Catalog.ColumnNotExistException {
         while (true) {
             TableSchema schema =
                     latest().orElseThrow(
@@ -372,9 +374,13 @@ public class SchemaManager implements Serializable {
                             newOptions,
                             schema.comment());
 
-            boolean success = commit(newSchema);
-            if (success) {
-                return newSchema;
+            try {
+                boolean success = commit(newSchema);
+                if (success) {
+                    return newSchema;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.paimon.testutils.assertj.AssertionUtils.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -468,8 +469,10 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.addColumn("col1", DataTypes.INT())),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnAlreadyExistException.class)
-                .hasRootCauseMessage("Column col1 already exists in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnAlreadyExistException.class,
+                                "Column col1 already exists in the test_db.test_table table."));
     }
 
     @Test
@@ -506,8 +509,10 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.renameColumn("col1", "new_col1")),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnAlreadyExistException.class)
-                .hasRootCauseMessage("Column col1 already exists in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnAlreadyExistException.class,
+                                "Column col1 already exists in the test_db.test_table table."));
 
         // Alter table renames a column throws ColumnNotExistException when column does not exist
         assertThatThrownBy(
@@ -518,9 +523,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.renameColumn(
                                                         "non_existing_col", "new_col2")),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
-                .hasRootCauseMessage(
-                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnNotExistException.class,
+                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
     }
 
     @Test
@@ -553,8 +559,9 @@ public abstract class CatalogTestBase {
                                         identifier,
                                         Lists.newArrayList(SchemaChange.dropColumn("col2")),
                                         false))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(" Cannot drop all fields in table");
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class, "Cannot drop all fields in table"));
 
         // Alter table drop a column throws ColumnNotExistException when column does not exist
         assertThatThrownBy(
@@ -564,9 +571,10 @@ public abstract class CatalogTestBase {
                                         Lists.newArrayList(
                                                 SchemaChange.dropColumn("non_existing_col")),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
-                .hasRootCauseMessage(
-                        "Column non_existing_col does not exist in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnNotExistException.class,
+                                "Column non_existing_col does not exist in the test_db.test_table table."));
     }
 
     @Test
@@ -605,9 +613,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnType(
                                                         "col1", DataTypes.DATE())),
                                         false))
-                .hasRootCauseInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(
-                        "Column type col1[DOUBLE] cannot be converted to DATE without loosing information.");
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalStateException.class,
+                                "Column type col1[DOUBLE] cannot be converted to DATE without loosing information."));
 
         // Alter table update a column type throws ColumnNotExistException when column does not
         // exist
@@ -619,9 +628,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnType(
                                                         "non_existing_col", DataTypes.INT())),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
-                .hasRootCauseMessage(
-                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnNotExistException.class,
+                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
         // Alter table update a column type throws Exception when column is partition columns
         assertThatThrownBy(
                         () ->
@@ -631,8 +641,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnType(
                                                         "dt", DataTypes.DATE())),
                                         false))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Cannot update partition column [dt] type in the table");
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Cannot update partition column [dt] type in the table"));
     }
 
     @Test
@@ -687,9 +699,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnComment(
                                                         new String[] {"non_existing_col"}, "")),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
-                .hasMessageContaining(
-                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnNotExistException.class,
+                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
     }
 
     @Test
@@ -742,9 +755,10 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnNullability(
                                                         new String[] {"non_existing_col"}, false)),
                                         false))
-                .hasRootCauseInstanceOf(Catalog.ColumnNotExistException.class)
-                .hasMessageContaining(
-                        "Column [non_existing_col] does not exist in the test_db.test_table table.");
+                .satisfies(
+                        anyCauseMatches(
+                                Catalog.ColumnNotExistException.class,
+                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
 
         // Alter table update a column nullability throws Exception when column is pk columns
         assertThatThrownBy(
@@ -755,7 +769,9 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.updateColumnNullability(
                                                         new String[] {"col2"}, true)),
                                         false))
-                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("Cannot change nullability of primary key");
+                .satisfies(
+                        anyCauseMatches(
+                                UnsupportedOperationException.class,
+                                "Cannot change nullability of primary key"));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
@@ -513,7 +513,7 @@ public abstract class SchemaEvolutionTableTestBase {
         }
 
         @Override
-        public TableSchema commitChanges(List<SchemaChange> changes) throws Exception {
+        public TableSchema commitChanges(List<SchemaChange> changes) {
             throw new UnsupportedOperationException();
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.testutils.assertj.AssertionUtils;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -332,11 +333,12 @@ public class SchemaEvolutionTest {
                                 schemaManager.commitChanges(
                                         Collections.singletonList(
                                                 SchemaChange.renameColumn("f0", "_VALUE_KIND"))))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(
-                        String.format(
-                                "Field name[%s] in schema cannot be exist in %s",
-                                "_VALUE_KIND", SYSTEM_FIELD_NAMES));
+                .satisfies(
+                        AssertionUtils.anyCauseMatches(
+                                RuntimeException.class,
+                                String.format(
+                                        "Field name[%s] in schema cannot be exist in %s",
+                                        "_VALUE_KIND", SYSTEM_FIELD_NAMES)));
     }
 
     private List<String> readRecords(FileStoreTable table, Predicate filter) throws IOException {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -384,7 +384,9 @@ public class FlinkCatalog extends AbstractCatalog {
 
         try {
             catalog.alterTable(toIdentifier(tablePath), changes, ignoreIfNotExists);
-        } catch (Catalog.TableNotExistException e) {
+        } catch (Catalog.TableNotExistException
+                | Catalog.ColumnAlreadyExistException
+                | Catalog.ColumnNotExistException e) {
             throw new TableNotExistException(getName(), tablePath);
         }
     }
@@ -415,7 +417,9 @@ public class FlinkCatalog extends AbstractCatalog {
 
         try {
             catalog.alterTable(toIdentifier(tablePath), changes, ignoreIfNotExists);
-        } catch (Catalog.TableNotExistException e) {
+        } catch (Catalog.TableNotExistException
+                | Catalog.ColumnAlreadyExistException
+                | Catalog.ColumnNotExistException e) {
             throw new TableNotExistException(getName(), tablePath);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
@@ -229,7 +229,9 @@ public class KafkaSyncDatabaseAction extends ActionBase {
                                 env.fromSource(
                                         source, WatermarkStrategy.noWatermarks(), "Kafka Source"))
                         .withParserFactory(parserFactory)
-                        .withTables(fileStoreTables);
+                        .withTables(fileStoreTables)
+                        .withCatalogLoader(catalogLoader())
+                        .withDatabase(database);
         String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
@@ -187,7 +187,9 @@ public class KafkaSyncTableAction extends ActionBase {
                                 env.fromSource(
                                         source, WatermarkStrategy.noWatermarks(), "Kafka Source"))
                         .withParserFactory(parserFactory)
-                        .withTable(table);
+                        .withTable(table)
+                        .withIdentifier(identifier)
+                        .withCatalogLoader(catalogLoader());
         String sinkParallelism = paimonConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -191,7 +191,9 @@ public class MySqlSyncTableAction extends ActionBase {
                                 env.fromSource(
                                         source, WatermarkStrategy.noWatermarks(), "MySQL Source"))
                         .withParserFactory(parserFactory)
-                        .withTable(table);
+                        .withTable(table)
+                        .withIdentifier(identifier)
+                        .withCatalogLoader(catalogLoader());
         String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -111,7 +111,6 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
         Preconditions.checkNotNull(parserFactory);
         Preconditions.checkNotNull(database);
         Preconditions.checkNotNull(catalogLoader);
-        Preconditions.checkNotNull(mode);
 
         if (mode == UNIFIED) {
             buildUnifiedCdcSink();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.cdc.mysql.MySqlDatabaseSyncMode;
 import org.apache.paimon.flink.sink.FlinkStreamPartitioner;
 import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
@@ -90,9 +91,27 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
         return this;
     }
 
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withDatabase(String database) {
+        this.database = database;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withCatalogLoader(Catalog.Loader catalogLoader) {
+        this.catalogLoader = catalogLoader;
+        return this;
+    }
+
+    public FlinkCdcSyncDatabaseSinkBuilder<T> withMode(MySqlDatabaseSyncMode mode) {
+        this.mode = mode;
+        return this;
+    }
+
     public void build() {
         Preconditions.checkNotNull(input);
         Preconditions.checkNotNull(parserFactory);
+        Preconditions.checkNotNull(database);
+        Preconditions.checkNotNull(catalogLoader);
+        Preconditions.checkNotNull(mode);
 
         if (mode == UNIFIED) {
             buildUnifiedCdcSink();
@@ -145,6 +164,8 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     }
 
     private void buildStaticCdcSink() {
+        Preconditions.checkNotNull(tables);
+
         SingleOutputStreamOperator<Void> parsed =
                 input.forward()
                         .process(new CdcMultiTableParsingProcessFunction<>(parserFactory))
@@ -158,7 +179,9 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
                                             .createUpdatedDataFieldsOutputTag(table.name()))
                             .process(
                                     new UpdatedDataFieldsProcessFunction(
-                                            new SchemaManager(table.fileIO(), table.location())));
+                                            new SchemaManager(table.fileIO(), table.location()),
+                                            Identifier.create(database, table.name()),
+                                            catalogLoader));
             schemaChangeProcessFunction.getTransformation().setParallelism(1);
             schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
@@ -182,20 +205,5 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
                             "Unsupported bucket mode: " + bucketMode);
             }
         }
-    }
-
-    public FlinkCdcSyncDatabaseSinkBuilder<T> withDatabase(String database) {
-        this.database = database;
-        return this;
-    }
-
-    public FlinkCdcSyncDatabaseSinkBuilder<T> withCatalogLoader(Catalog.Loader catalogLoader) {
-        this.catalogLoader = catalogLoader;
-        return this;
-    }
-
-    public FlinkCdcSyncDatabaseSinkBuilder<T> withMode(MySqlDatabaseSyncMode mode) {
-        this.mode = mode;
-        return this;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
@@ -145,21 +145,16 @@ public class MultiTableUpdatedDataFieldsProcessFunction
         if (schemaChange instanceof SchemaChange.AddColumn) {
             try {
                 catalog.alterTable(identifier, schemaChange, false);
-            } catch (Exception e) {
-                if (e.getCause() instanceof Catalog.ColumnAlreadyExistException) {
-                    // This is normal. For example when a table is split into multiple database
-                    // tables,
-                    // all these tables will be added the same column. However schemaManager can't
-                    // handle duplicated column adds, so we just catch the exception and log it.
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Failed to perform SchemaChange.AddColumn {}, "
-                                        + "possibly due to duplicated column name",
-                                schemaChange,
-                                e);
-                    }
-                } else {
-                    throw e;
+            } catch (Catalog.ColumnAlreadyExistException e) {
+                // This is normal. For example when a table is split into multiple database tables,
+                // all these tables will be added the same column. However, schemaManager can't
+                // handle duplicated column adds, so we just catch the exception and log it.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Failed to perform SchemaChange.AddColumn {}, "
+                                    + "possibly due to duplicated column name",
+                            schemaChange,
+                            e);
                 }
             }
         } else if (schemaChange instanceof SchemaChange.UpdateColumnType) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcSinkBuilder.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.Table;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -32,6 +34,8 @@ public class RichCdcSinkBuilder {
 
     private DataStream<RichCdcRecord> input = null;
     private Table table = null;
+    private Identifier identifier = null;
+    private Catalog.Loader catalogLoader = null;
 
     @Nullable private Integer parallelism;
 
@@ -50,12 +54,24 @@ public class RichCdcSinkBuilder {
         return this;
     }
 
+    public RichCdcSinkBuilder withIdentifier(Identifier identifier) {
+        this.identifier = identifier;
+        return this;
+    }
+
+    public RichCdcSinkBuilder withCatalogLoader(Catalog.Loader catalogLoader) {
+        this.catalogLoader = catalogLoader;
+        return this;
+    }
+
     public DataStreamSink<?> build() {
         CdcSinkBuilder<RichCdcRecord> builder = new CdcSinkBuilder<>();
         return builder.withTable(table)
                 .withInput(input)
                 .withParserFactory(new RichCdcParserFactory())
                 .withParallelism(parallelism)
+                .withIdentifier(identifier)
+                .withCatalogLoader(catalogLoader)
                 .build();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
@@ -123,21 +123,16 @@ public class UpdatedDataFieldsProcessFunction extends ProcessFunction<List<DataF
         if (schemaChange instanceof SchemaChange.AddColumn) {
             try {
                 catalog.alterTable(identifier, schemaChange, false);
-            } catch (Exception e) {
-                if (e.getCause() instanceof Catalog.ColumnAlreadyExistException) {
-                    // This is normal. For example when a table is split into multiple database
-                    // tables,
-                    // all these tables will be added the same column. However schemaManager can't
-                    // handle duplicated column adds, so we just catch the exception and log it.
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Failed to perform SchemaChange.AddColumn {}, "
-                                        + "possibly due to duplicated column name",
-                                schemaChange,
-                                e);
-                    }
-                } else {
-                    throw e;
+            } catch (Catalog.ColumnAlreadyExistException e) {
+                // This is normal. For example when a table is split into multiple database tables,
+                // all these tables will be added the same column. However, schemaManager can't
+                // handle duplicated column adds, so we just catch the exception and log it.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Failed to perform SchemaChange.AddColumn {}, "
+                                    + "possibly due to duplicated column name",
+                            schemaChange,
+                            e);
                 }
             }
         } else if (schemaChange instanceof SchemaChange.UpdateColumnType) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -79,7 +80,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.emptyMap(),
+                        Collections.singletonMap(
+                                CatalogOptions.METASTORE.key(), "test-alter-table"),
                         tableConfig);
         action.build(env);
         JobClient client = env.executeAsync();
@@ -245,6 +247,9 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         "+I[2, 8, very long string, 80000000000, NULL, NULL, NULL]",
                         "+I[1, 9, nine, 90000000000, 99999.999, [110, 105, 110, 101, 46, 98, 105, 110, 46, 108, 111, 110, 103], 9.00000000009]");
         waitForResult(expected, table, rowType, primaryKeys);
+
+        // test that catalog loader works
+        assertThat(getFileStoreTable().options()).containsEntry("alter-table-test", "true");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.mysql;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.SchemaChange;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Factory to create a mock case-insensitive catalog for test. */
+public class TestAlterTableCatalogFactory implements CatalogFactory {
+
+    @Override
+    public String identifier() {
+        return "test-alter-table";
+    }
+
+    @Override
+    public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
+        return new FileSystemCatalog(fileIO, warehouse, context.options().toMap()) {
+
+            @Override
+            public void alterTable(
+                    Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
+                    throws TableNotExistException {
+                List<SchemaChange> newChanges = new ArrayList<>(changes);
+                newChanges.add(SchemaChange.setOption("alter-table-test", "true"));
+                super.alterTable(identifier, newChanges, ignoreIfNotExists);
+            }
+        };
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
@@ -30,7 +30,10 @@ import org.apache.paimon.schema.SchemaChange;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Factory to create a mock case-insensitive catalog for test. */
+/**
+ * Factory to create a mock catalog for catalog loader test. If catalog loader works, the
+ * 'alterTable' method will leave a special option.
+ */
 public class TestAlterTableCatalogFactory implements CatalogFactory {
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
@@ -45,7 +45,8 @@ public class TestAlterTableCatalogFactory implements CatalogFactory {
             @Override
             public void alterTable(
                     Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
-                    throws TableNotExistException {
+                    throws TableNotExistException, ColumnAlreadyExistException,
+                            ColumnNotExistException {
                 List<SchemaChange> newChanges = new ArrayList<>(changes);
                 newChanges.add(SchemaChange.setOption("alter-table-test", "true"));
                 super.alterTable(identifier, newChanges, ignoreIfNotExists);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestCaseInsensitiveCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestCaseInsensitiveCatalogFactory.java
@@ -71,7 +71,8 @@ public class TestCaseInsensitiveCatalogFactory implements CatalogFactory {
             @Override
             public void alterTable(
                     Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
-                    throws TableNotExistException {
+                    throws TableNotExistException, ColumnAlreadyExistException,
+                            ColumnNotExistException {
                 for (SchemaChange change : changes) {
                     if (change instanceof SchemaChange.AddColumn) {
                         checkCaseInsensitive(((SchemaChange.AddColumn) change).fieldName());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -19,7 +19,11 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogUtils;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.FlinkCatalogFactory;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -55,6 +59,9 @@ import java.util.concurrent.ThreadLocalRandom;
 /** IT cases for {@link CdcSinkBuilder}. */
 public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
 
+    private static final String DATABASE_NAME = "test";
+    private static final String TABLE_NAME = "test_tbl";
+
     @TempDir java.nio.file.Path tempDir;
 
     @Test
@@ -79,16 +86,26 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         boolean enableFailure = random.nextBoolean();
 
         TestTable testTable =
-                new TestTable("test_tbl", numEvents, numSchemaChanges, numPartitions, numKeys);
+                new TestTable(TABLE_NAME, numEvents, numSchemaChanges, numPartitions, numKeys);
 
         Path tablePath;
         FileIO fileIO;
         String failingName = UUID.randomUUID().toString();
         if (enableFailure) {
-            tablePath = new Path(FailingFileIO.getFailingPath(failingName, tempDir.toString()));
+            tablePath =
+                    new Path(
+                            FailingFileIO.getFailingPath(
+                                    failingName,
+                                    CatalogUtils.stringifyPath(
+                                            tempDir.toString(), DATABASE_NAME, TABLE_NAME)));
             fileIO = new FailingFileIO();
         } else {
-            tablePath = new Path(TraceableFileIO.SCHEME + "://" + tempDir.toString());
+            tablePath =
+                    new Path(
+                            TraceableFileIO.SCHEME
+                                    + "://"
+                                    + CatalogUtils.stringifyPath(
+                                            tempDir.toString(), DATABASE_NAME, TABLE_NAME));
             fileIO = LocalFileIO.create();
         }
 
@@ -113,11 +130,19 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         TestCdcSourceFunction sourceFunction = new TestCdcSourceFunction(testTable.events());
         DataStreamSource<TestCdcEvent> source = env.addSource(sourceFunction);
         source.setParallelism(2);
+
+        Options catalogOptions = new Options();
+        catalogOptions.set("warehouse", tempDir.toString());
+        Catalog.Loader catalogLoader =
+                () -> FlinkCatalogFactory.createPaimonCatalog(catalogOptions);
+
         new CdcSinkBuilder<TestCdcEvent>()
                 .withInput(source)
                 .withParserFactory(TestCdcEventParser::new)
                 .withTable(table)
                 .withParallelism(3)
+                .withIdentifier(Identifier.create(DATABASE_NAME, TABLE_NAME))
+                .withCatalogLoader(catalogLoader)
                 .build();
 
         // enable failure when running jobs if needed

--- a/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.paimon.catalog.CatalogFactory
+++ b/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.paimon.catalog.CatalogFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.paimon.flink.action.cdc.mysql.TestCaseInsensitiveCatalogFactory
+org.apache.paimon.flink.action.cdc.mysql.TestAlterTableCatalogFactory

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -278,7 +278,9 @@ public class SparkCatalog implements TableCatalog, SupportsNamespaces {
         try {
             catalog.alterTable(toIdentifier(ident), schemaChanges, false);
             return loadTable(ident);
-        } catch (Catalog.TableNotExistException e) {
+        } catch (Catalog.TableNotExistException
+                | Catalog.ColumnAlreadyExistException
+                | Catalog.ColumnNotExistException e) {
             throw new NoSuchTableException(ident);
         }
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.spark;
 
-import org.apache.paimon.testutils.assertj.AssertionUtils;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
@@ -31,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.testutils.assertj.AssertionUtils.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -97,9 +96,10 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                         () ->
                                 spark.sql(
                                         "ALTER TABLE testAddNotNullColumn ADD COLUMNS (d INT NOT NULL)"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(
-                        "java.lang.IllegalArgumentException: ADD COLUMN cannot specify NOT NULL.");
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "ADD COLUMN cannot specify NOT NULL."));
     }
 
     @Test
@@ -193,9 +193,10 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
 
         assertThatThrownBy(
                         () -> spark.sql("ALTER TABLE testRenamePartitionKey RENAME COLUMN a to aa"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(
-                        "java.lang.UnsupportedOperationException: Cannot drop/rename partition key[a]");
+                .satisfies(
+                        anyCauseMatches(
+                                UnsupportedOperationException.class,
+                                "Cannot drop/rename partition key[a]"));
     }
 
     @Test
@@ -242,9 +243,10 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                 .contains(showCreateString("testDropPartitionKey", "a BIGINT", "b STRING"));
 
         assertThatThrownBy(() -> spark.sql("ALTER TABLE testDropPartitionKey DROP COLUMN a"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(
-                        "java.lang.UnsupportedOperationException: Cannot drop/rename partition key[a]");
+                .satisfies(
+                        anyCauseMatches(
+                                UnsupportedOperationException.class,
+                                "Cannot drop/rename partition key[a]"));
     }
 
     @Test
@@ -261,9 +263,10 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                 .contains(showCreateString("testDropPrimaryKey", "a BIGINT", "b STRING"));
 
         assertThatThrownBy(() -> spark.sql("ALTER TABLE testDropPrimaryKey DROP COLUMN b"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(
-                        "java.lang.UnsupportedOperationException: Cannot drop/rename primary key[b]");
+                .satisfies(
+                        anyCauseMatches(
+                                UnsupportedOperationException.class,
+                                "Cannot drop/rename primary key[b]"));
     }
 
     @Test
@@ -294,7 +297,7 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
         createTable("tableFirstSelf");
         assertThatThrownBy(() -> spark.sql("ALTER TABLE tableFirstSelf ALTER COLUMN a FIRST"))
                 .satisfies(
-                        AssertionUtils.anyCauseMatches(
+                        anyCauseMatches(
                                 UnsupportedOperationException.class,
                                 "Cannot move itself for column a"));
 
@@ -302,7 +305,7 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
         createTable("tableAfterSelf");
         assertThatThrownBy(() -> spark.sql("ALTER TABLE tableAfterSelf ALTER COLUMN b AFTER b"))
                 .satisfies(
-                        AssertionUtils.anyCauseMatches(
+                        anyCauseMatches(
                                 UnsupportedOperationException.class,
                                 "Cannot move itself for column b"));
 
@@ -375,7 +378,7 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                                 spark.sql(
                                         "ALTER TABLE testAlterPkNullability ALTER COLUMN a DROP NOT NULL"))
                 .satisfies(
-                        AssertionUtils.anyCauseMatches(
+                        anyCauseMatches(
                                 UnsupportedOperationException.class,
                                 "Cannot change nullability of primary key"));
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
For example, if user use Hive catalog in CDC, currently the schema change information is only recorded into file system, but 
cannot be seen in Hive meta store. This PR fix it.
 

### Tests

<!-- List UT and IT cases to verify this change -->
`TestAlterTableCatalogFactory`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
