### PR TITLE
[core] Support incremental read on tags

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -117,7 +117,9 @@ SELECT * FROM t;
 
 Read incremental changes between start snapshot (exclusive) and end snapshot.
 
-For example, '5,10' means changes between snapshot 5 and snapshot 10.
+For example:
+- '5,10' means changes between snapshot 5 and snapshot 10.
+- 'TAG1,TAG3' means changes between TAG1 and TAG3.
 
 {{< tabs "incremental-example" >}}
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
@@ -39,6 +39,9 @@ import org.apache.paimon.utils.BulkFormatMapping;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Projection;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -52,10 +55,11 @@ import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
 /** {@link FileStoreRead} for {@link AppendOnlyFileStore}. */
 public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(AppendOnlyFileStoreRead.class);
+
     private final FileIO fileIO;
     private final SchemaManager schemaManager;
     private final long schemaId;
-    private final RowType rowType;
     private final FileFormatDiscover formatDiscover;
     private final FileStorePathFactory pathFactory;
     private final Map<FormatKey, BulkFormatMapping> bulkFormatMappings;
@@ -74,7 +78,6 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.schemaId = schemaId;
-        this.rowType = rowType;
         this.formatDiscover = formatDiscover;
         this.pathFactory = pathFactory;
         this.bulkFormatMappings = new HashMap<>();
@@ -99,9 +102,7 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
                 pathFactory.createDataFilePathFactory(split.partition(), split.bucket());
         List<ConcatRecordReader.ReaderSupplier<InternalRow>> suppliers = new ArrayList<>();
         if (split.beforeFiles().size() > 0) {
-            throw new UnsupportedOperationException(
-                    "Append only not support before files now, "
-                            + "please create an issue to describe your requirements.");
+            LOG.info("Ignore split before files: " + split.beforeFiles());
         }
         for (DataFileMeta file : split.dataFiles()) {
             String formatIdentifier = DataFilePathFactory.formatIdentifier(file.fileName());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
@@ -98,6 +98,11 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
         DataFilePathFactory dataFilePathFactory =
                 pathFactory.createDataFilePathFactory(split.partition(), split.bucket());
         List<ConcatRecordReader.ReaderSupplier<InternalRow>> suppliers = new ArrayList<>();
+        if (split.beforeFiles().size() > 0) {
+            throw new UnsupportedOperationException(
+                    "Append only not support before files now, "
+                            + "please create an issue to describe your requirements.");
+        }
         for (DataFileMeta file : split.dataFiles()) {
             String formatIdentifier = DataFilePathFactory.formatIdentifier(file.fileName());
             BulkFormatMapping bulkFormatMapping =

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.mergetree.MergeSorter;
+import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/** A {@link RecordReader} util to read diff between before reader and after reader. */
+public class DiffReader {
+
+    private static final int BEFORE_LEVEL = Integer.MIN_VALUE;
+    private static final int AFTER_LEVEL = Integer.MAX_VALUE;
+
+    public static RecordReader<KeyValue> readDiff(
+            RecordReader<KeyValue> beforeReader,
+            RecordReader<KeyValue> afterReader,
+            Comparator<InternalRow> keyComparator,
+            MergeSorter sorter,
+            boolean keepDelete)
+            throws IOException {
+        return sorter.mergeSort(
+                Arrays.asList(
+                        () -> wrapLevelToReader(beforeReader, BEFORE_LEVEL),
+                        () -> wrapLevelToReader(afterReader, AFTER_LEVEL)),
+                keyComparator,
+                new DiffMerger(keepDelete));
+    }
+
+    private static RecordReader<KeyValue> wrapLevelToReader(
+            RecordReader<KeyValue> reader, int level) {
+        return new RecordReader<KeyValue>() {
+            @Nullable
+            @Override
+            public RecordIterator<KeyValue> readBatch() throws IOException {
+                RecordIterator<KeyValue> batch = reader.readBatch();
+                if (batch == null) {
+                    return null;
+                }
+
+                return new RecordIterator<KeyValue>() {
+                    @Nullable
+                    @Override
+                    public KeyValue next() throws IOException {
+                        KeyValue kv = batch.next();
+                        if (kv != null) {
+                            kv.setLevel(level);
+                        }
+                        return kv;
+                    }
+
+                    @Override
+                    public void releaseBatch() {
+                        batch.releaseBatch();
+                    }
+                };
+            }
+
+            @Override
+            public void close() throws IOException {
+                reader.close();
+            }
+        };
+    }
+
+    private static class DiffMerger implements MergeFunctionWrapper<KeyValue> {
+
+        private final boolean keepDelete;
+
+        private final List<KeyValue> kvs = new ArrayList<>();
+
+        public DiffMerger(boolean keepDelete) {
+            this.keepDelete = keepDelete;
+        }
+
+        @Override
+        public void reset() {
+            this.kvs.clear();
+        }
+
+        @Override
+        public void add(KeyValue kv) {
+            this.kvs.add(kv);
+        }
+
+        @Nullable
+        @Override
+        public KeyValue getResult() {
+            if (kvs.size() == 1) {
+                KeyValue kv = kvs.get(0);
+                if (kv.level() == BEFORE_LEVEL) {
+                    if (keepDelete) {
+                        return kv.replaceValueKind(RowKind.DELETE);
+                    }
+                } else {
+                    return kv;
+                }
+            } else if (kvs.size() == 2) {
+                KeyValue latest = kvs.get(1);
+                if (latest.level() == AFTER_LEVEL) {
+                    return latest;
+                }
+            } else {
+                throw new IllegalArgumentException("Illegal kv number: " + kvs.size());
+            }
+
+            return null;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.source.snapshot.ContinuousLatestStartingScanner;
 import org.apache.paimon.table.source.snapshot.FullCompactedStartingScanner;
 import org.apache.paimon.table.source.snapshot.FullStartingScanner;
 import org.apache.paimon.table.source.snapshot.IncrementalStartingScanner;
+import org.apache.paimon.table.source.snapshot.IncrementalTagStartingScanner;
 import org.apache.paimon.table.source.snapshot.IncrementalTimeStampStartingScanner;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.StartingScanner;
@@ -137,9 +138,14 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                 checkArgument(!isStreaming, "Cannot read incremental in streaming mode.");
                 Pair<String, String> incrementalBetween = options.incrementalBetween();
                 if (options.toMap().get(CoreOptions.INCREMENTAL_BETWEEN.key()) != null) {
-                    return new IncrementalStartingScanner(
-                            Long.parseLong(incrementalBetween.getLeft()),
-                            Long.parseLong(incrementalBetween.getRight()));
+                    try {
+                        return new IncrementalStartingScanner(
+                                Long.parseLong(incrementalBetween.getLeft()),
+                                Long.parseLong(incrementalBetween.getRight()));
+                    } catch (NumberFormatException e) {
+                        return new IncrementalTagStartingScanner(
+                                incrementalBetween.getLeft(), incrementalBetween.getRight());
+                    }
                 } else {
                     return new IncrementalTimeStampStartingScanner(
                             Long.parseLong(incrementalBetween.getLeft()),

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTagStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTagStartingScanner.java
@@ -38,6 +38,14 @@ public class IncrementalTagStartingScanner implements StartingScanner {
         TagManager tagManager = new TagManager(manager.fileIO(), manager.tablePath());
         Snapshot tag1 = tagManager.taggedSnapshot(start);
         Snapshot tag2 = tagManager.taggedSnapshot(end);
+
+        if (tag2.id() <= tag1.id()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Tag end %s with snapshot id %s should be larger than tag start %s with snapshot id %s",
+                            end, tag2.id(), start, tag1.id()));
+        }
+
         return StartingScanner.fromPlan(reader.withSnapshot(tag2).readIncrementalDiff(tag1));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTagStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTagStartingScanner.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source.snapshot;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+/** {@link StartingScanner} for incremental changes by tag. */
+public class IncrementalTagStartingScanner implements StartingScanner {
+
+    private final String start;
+    private final String end;
+
+    public IncrementalTagStartingScanner(String start, String end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public Result scan(SnapshotManager manager, SnapshotReader reader) {
+        TagManager tagManager = new TagManager(manager.fileIO(), manager.tablePath());
+        Snapshot tag1 = tagManager.taggedSnapshot(start);
+        Snapshot tag2 = tagManager.taggedSnapshot(end);
+        return StartingScanner.fromPlan(reader.withSnapshot(tag2).readIncrementalDiff(tag1));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -61,6 +61,8 @@ public interface SnapshotReader {
     /** Get splits plan from an overwritten snapshot. */
     Plan readOverwrittenChanges();
 
+    Plan readIncrementalDiff(Snapshot before);
+
     /** Get partitions from a snapshot. */
     List<BinaryRow> partitions();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -243,6 +243,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public Plan readIncrementalDiff(Snapshot before) {
+            return snapshotReader.readIncrementalDiff(before);
+        }
+
+        @Override
         public List<BinaryRow> partitions() {
             return snapshotReader.partitions();
         }

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
@@ -35,6 +35,7 @@ import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN;
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link CoreOptions#INCREMENTAL_BETWEEN}. */
 public class IncrementalTableTest extends TableTestBase {
@@ -261,6 +262,10 @@ public class IncrementalTableTest extends TableTestBase {
                         GenericRow.of(fromString("-D"), 1, 1, 1),
                         GenericRow.of(fromString("+I"), 1, 2, 2),
                         GenericRow.of(fromString("+I"), 1, 4, 1));
+
+        assertThatThrownBy(() -> read(table, Pair.of(INCREMENTAL_BETWEEN, "TAG2,TAG1")))
+                .hasMessageContaining(
+                        "Tag end TAG1 with snapshot id 1 should be larger than tag start TAG2 with snapshot id 2");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
@@ -35,7 +35,6 @@ import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN;
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link CoreOptions#INCREMENTAL_BETWEEN}. */
 public class IncrementalTableTest extends TableTestBase {
@@ -283,7 +282,7 @@ public class IncrementalTableTest extends TableTestBase {
         table.createTag("TAG1", 1);
         table.createTag("TAG2", 2);
 
-        assertThatThrownBy(() -> read(table, Pair.of(INCREMENTAL_BETWEEN, "TAG1,TAG2")))
-                .hasMessageContaining("Append only not support before files now");
+        assertThat(read(table, Pair.of(INCREMENTAL_BETWEEN, "TAG1,TAG2")))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 1, 2));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

Process:
- First get the differences in the files and delete the same files directly
- Then compare the before and after files to get the incremental data.

Table types:
- Primary Key table: Compare diff with two tags, perfect.
- Append table: Ignore before files, this may cause some more data to be read due to compaction

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
