### PR TITLE
[spark] Supports paimon_incremental_query Table Valued Function

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -138,7 +138,7 @@ To enable this needs these configs below:
 
 ```text
 --conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog
---conf spark.sql.extensions=org.apache.paimon.spark.PaimonSparkSessionExtensions
+--conf spark.sql.extensions=org.apache.paimon.spark.PaimonSparkSessionExtension
 ```
 
 you can use `paimon_incremental_query` in query to extract the incremental data:

--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -129,7 +129,20 @@ SELECT * FROM t /*+ OPTIONS('incremental-between' = '12,20') */;
 ```
 {{< /tab >}}
 
-{{< tab "Spark" >}}
+{{< tab "Spark3" >}}
+
+Requires Spark 3.2+.
+
+you can use `paimon_incremental_query` in query to extract the incremental data:
+
+```sql
+-- read the incremental data between snapshot id 12 and snapshot id 20.
+SELECT * FROM paimon_incremental_query('tableName', 12, 20);
+```
+
+{{< /tab >}}
+
+{{< tab "Spark-DF" >}}
 
 ```java
 spark.read()

--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -133,6 +133,14 @@ SELECT * FROM t /*+ OPTIONS('incremental-between' = '12,20') */;
 
 Requires Spark 3.2+.
 
+Paimon supports that use Spark SQL to do the incremental query that implemented by Spark Table Valued Function.
+To enable this needs these configs below:
+
+```text
+--conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog
+--conf spark.sql.extensions=org.apache.paimon.spark.PaimonSparkSessionExtensions
+```
+
 you can use `paimon_incremental_query` in query to extract the incremental data:
 
 ```sql

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTable.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTable.java
@@ -62,8 +62,8 @@ public class SparkTable
 
     @Override
     public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
-        // options is already merged into table
-        return new SparkScanBuilder(table);
+        Table newTable = table.copy(options.asCaseSensitiveMap());
+        return new SparkScanBuilder(newTable);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonAnalysis.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+
+    case func: PaimonTableValueFunction if func.args.forall(_.resolved) =>
+      PaimonTableValuedFunctions.resolvePaimonTableValuedFunction(session, func)
+
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSparkSessionExtension.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSparkSessionExtension.scala
@@ -19,7 +19,7 @@ package org.apache.paimon.spark
 
 import org.apache.spark.sql.SparkSessionExtensions
 
-class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+class PaimonSparkSessionExtension extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSparkSessionExtensions.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark
+
+import org.apache.spark.sql.SparkSessionExtensions
+
+class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+
+    extensions.injectResolutionRule(sparkSession => new PaimonAnalysis(sparkSession))
+
+    PaimonTableValuedFunctions.supportedFnNames.foreach {
+      fnName =>
+        extensions.injectTableFunction(
+          PaimonTableValuedFunctions.getTableValueFunctionInjection(fnName))
+    }
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonTableValuedFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonTableValuedFunctions.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.spark.catalog.Catalogs
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase
+import org.apache.spark.sql.catalyst.analysis.TableFunctionRegistry.TableFunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExpressionInfo}
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.collection.JavaConverters._
+
+object PaimonTableValuedFunctions {
+
+  val INCREMENTAL_QUERY = "paimon_incremental_query"
+
+  val supportedFnNames: Seq[String] = Seq(INCREMENTAL_QUERY)
+
+  type TableFunctionDescription = (FunctionIdentifier, ExpressionInfo, TableFunctionBuilder)
+
+  def getTableValueFunctionInjection(fnName: String): TableFunctionDescription = {
+    val (info, builder) = fnName match {
+      case INCREMENTAL_QUERY =>
+        FunctionRegistryBase.build[IncrementalQuery](fnName, since = None)
+      case _ =>
+        throw new Exception(s"Function $fnName isn't a supported table valued function.")
+    }
+    val ident = FunctionIdentifier(fnName)
+    (ident, info, builder)
+  }
+
+  def resolvePaimonTableValuedFunction(
+      spark: SparkSession,
+      tvf: PaimonTableValueFunction): LogicalPlan = {
+    val args = tvf.expressions
+
+    val sessionState = spark.sessionState
+    val catalogManager = sessionState.catalogManager
+
+    val sparkCatalog = new SparkCatalog()
+    val currentCatalog = catalogManager.currentCatalog.name()
+    sparkCatalog.initialize(
+      currentCatalog,
+      Catalogs.catalogOptions(currentCatalog, spark.sessionState.conf))
+
+    val tableId = sessionState.sqlParser.parseTableIdentifier(args.head.eval().toString)
+    val namespace = tableId.database.map(Array(_)).getOrElse(catalogManager.currentNamespace)
+    val ident = Identifier.of(namespace, tableId.table)
+    val sparkTable = sparkCatalog.loadTable(ident)
+    val options = tvf.parseArgs(args.tail)
+    DataSourceV2Relation.create(
+      sparkTable,
+      Some(sparkCatalog),
+      Some(ident),
+      new CaseInsensitiveStringMap(options.asJava))
+  }
+}
+
+/**
+ * Represents an unresolved Paimon Table Valued Function
+ *
+ * @param fnName
+ *   can be one of [[PaimonTableValuedFunctions.supportedFnNames]].
+ */
+abstract class PaimonTableValueFunction(val fnName: String) extends LeafNode {
+
+  override def output: Seq[Attribute] = Nil
+
+  override lazy val resolved = false
+
+  val args: Seq[Expression]
+
+  def parseArgs(args: Seq[Expression]): Map[String, String]
+
+}
+
+/** Plan for the "paimon_incremental_query" function */
+case class IncrementalQuery(override val args: Seq[Expression])
+  extends PaimonTableValueFunction(PaimonTableValuedFunctions.INCREMENTAL_QUERY) {
+
+  override def parseArgs(args: Seq[Expression]): Map[String, String] = {
+    assert(
+      args.size >= 1 && args.size <= 2,
+      "paimon_incremental_query needs two parameters: startSnapshotId, and endSnapshotId.")
+
+    val start = args.head.eval().toString
+    val end = args.last.eval().toString
+    Map(CoreOptions.INCREMENTAL_BETWEEN.key -> s"$start,$end")
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/Catalogs.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/Catalogs.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.catalog
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+import java.util.regex.Pattern
+
+object Catalogs {
+
+  /**
+   * Copy from [[org.apache.spark.sql.connector.catalog.Catalogs]].
+   *
+   * Extracts a named catalog's configuration from a SQLConf.
+   *
+   * @param name
+   *   a catalog name
+   * @param conf
+   *   a SQLConf
+   * @return
+   *   a case insensitive string map of options starting with spark.sql.catalog.(name).
+   */
+  def catalogOptions(name: String, conf: SQLConf): CaseInsensitiveStringMap = {
+    val prefix = Pattern.compile("^spark\\.sql\\.catalog\\." + name + "\\.(.+)")
+    val options = new util.HashMap[String, String]
+    conf.getAllConfs.foreach {
+      case (key, value) =>
+        val matcher = prefix.matcher(key)
+        if (matcher.matches && matcher.groupCount > 0) options.put(matcher.group(1), value)
+    }
+    new CaseInsensitiveStringMap(options)
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonSparkTestBase.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.paimon.spark.sql
 
-import org.apache.paimon.spark.{PaimonSparkSessionExtensions, SparkCatalog, SparkGenericCatalog}
+import org.apache.paimon.spark.{PaimonSparkSessionExtension, SparkCatalog, SparkGenericCatalog}
 
 import org.apache.spark.paimon.Utils
 import org.apache.spark.sql.QueryTest
@@ -37,7 +37,7 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession {
     super.sparkConf
       .set("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
       .set("spark.sql.catalog.paimon.warehouse", tempDBDir.getCanonicalPath)
-      .set("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
+      .set("spark.sql.extensions", classOf[PaimonSparkSessionExtension].getName)
   }
 
   override protected def beforeAll(): Unit = {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -18,7 +18,7 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.WriteMode.{APPEND_ONLY, CHANGE_LOG}
-import org.apache.paimon.spark.PaimonSparkSessionExtensions
+import org.apache.paimon.spark.PaimonSparkSessionExtension
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row}
@@ -28,7 +28,7 @@ class TableValuedFunctionsTest extends PaimonSparkTestBase {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.sql.catalog.spark_catalog", "org.apache.paimon.spark.SparkGenericCatalog")
-      .set("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
+      .set("spark.sql.extensions", classOf[PaimonSparkSessionExtension].getName)
   }
 
   // 3: fixed bucket, -1: dynamic bucket

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.WriteMode.{APPEND_ONLY, CHANGE_LOG}
+import org.apache.paimon.spark.PaimonSparkSessionExtensions
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+
+class TableValuedFunctionsTest extends PaimonSparkTestBase {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.sql.catalog.spark_catalog", "org.apache.paimon.spark.SparkGenericCatalog")
+      .set("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
+  }
+
+  // 3: fixed bucket, -1: dynamic bucket
+  private val bucketModes = Seq(3, -1)
+
+  Seq(APPEND_ONLY, CHANGE_LOG).foreach {
+    writeMode =>
+      bucketModes.foreach {
+        bucket =>
+          test(s"incremental query: write-mode: $writeMode, bucket: $bucket") {
+            val primaryKeysProp = if (writeMode == CHANGE_LOG) {
+              "'primary-key'='a,b',"
+            } else {
+              ""
+            }
+            spark.sql(
+              s"""
+                 |CREATE TABLE T (a INT, b INT, c STRING)
+                 |USING paimon
+                 |TBLPROPERTIES ($primaryKeysProp 'write-mode'='${writeMode.toString}', 'bucket'='$bucket')
+                 |PARTITIONED BY (a)
+                 |""".stripMargin)
+
+            spark.sql("INSERT INTO T values (1, 1, '1'), (2, 2, '2')")
+            spark.sql("INSERT INTO T VALUES (1, 3, '3'), (2, 4, '4')")
+            spark.sql("INSERT INTO T VALUES (1, 5, '5'), (1, 7, '7')")
+
+            checkAnswer(
+              incrementalDF("T", 0, 1).orderBy("a", "b"),
+              Row(1, 1, "1") :: Row(2, 2, "2") :: Nil)
+            checkAnswer(
+              spark.sql("SELECT * FROM paimon_incremental_query('T', '0', '1') ORDER BY a, b"),
+              Row(1, 1, "1") :: Row(2, 2, "2") :: Nil)
+
+            checkAnswer(
+              incrementalDF("T", 1, 2).orderBy("a", "b"),
+              Row(1, 3, "3") :: Row(2, 4, "4") :: Nil)
+            checkAnswer(
+              spark.sql("SELECT * FROM paimon_incremental_query('T', '1', '2') ORDER BY a, b"),
+              Row(1, 3, "3") :: Row(2, 4, "4") :: Nil)
+
+            checkAnswer(
+              incrementalDF("T", 2, 3).orderBy("a", "b"),
+              Row(1, 5, "5") :: Row(1, 7, "7") :: Nil)
+            checkAnswer(
+              spark.sql("SELECT * FROM paimon_incremental_query('T', '2', '3') ORDER BY a, b"),
+              Row(1, 5, "5") :: Row(1, 7, "7") :: Nil)
+
+            checkAnswer(
+              incrementalDF("T", 1, 3).orderBy("a", "b"),
+              Row(1, 3, "3") :: Row(1, 5, "5") :: Row(1, 7, "7") :: Row(2, 4, "4") :: Nil
+            )
+            checkAnswer(
+              spark.sql("SELECT * FROM paimon_incremental_query('T', '1', '3') ORDER BY a, b"),
+              Row(1, 3, "3") :: Row(1, 5, "5") :: Row(1, 7, "7") :: Row(2, 4, "4") :: Nil)
+          }
+      }
+  }
+
+  private def incrementalDF(tableIdent: String, start: Int, end: Int): DataFrame = {
+    spark.read
+      .format("paimon")
+      .option("incremental-between", s"$start,$end")
+      .table(tableIdent)
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

- Builds Paimon SparkSession Extensions Arch;
- Supports paimon_incremental_query TVF to query the incr data between the two versions provided.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
