### PR TITLE
[core][hive] Support syncing partition into Hive metastore when using Hive catalog

### DIFF
--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -135,14 +135,23 @@ USE paimon.default;
 
 > When using hive catalog to change incompatible column types through alter table, you need to configure `hive.metastore.disallow.incompatible.col.type.changes=false`. see [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832).
 
+> If you are using Hive3, please disable Hive ACID:
+>
+> ```shell
+> hive.strict.managed.tables=false
+> hive.create.as.insert.only=false
+> metastore.create.as.acid=false
+> ```
+
+### Setting Location in Properties
+
 If you are using an object storage , and you don't want that the location of paimon table/database is accessed by the filesystem of hive,
 which may lead to the error such as "No FileSystem for scheme: s3a".
 You can set location in the properties of table/database by the config of `location-in-properties`. See
 [setting the location of table/database in properties ]({{< ref "maintenance/configurations#HiveCatalogOptions" >}})
 
-If you are using Hive3, please disable Hive ACID:
-```shell
-hive.strict.managed.tables=false
-hive.create.as.insert.only=false
-metastore.create.as.acid=false
-```
+### Synchronizing Partitions into Hive Metastore
+
+By default, Paimon does not synchronize newly created partitions into Hive metastore. Users will see an unpartitioned table in Hive. Partition push-down will be carried out by filter push-down instead.
+
+If you want to see a partitioned table in Hive and also synchronize newly created partitions into Hive metastore, please set the table property `partition.add-to-metastore` to true. Also see [CoreOptions]({{< ref "maintenance/configurations#CoreOptions" >}}).

--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -154,4 +154,4 @@ You can set location in the properties of table/database by the config of `locat
 
 By default, Paimon does not synchronize newly created partitions into Hive metastore. Users will see an unpartitioned table in Hive. Partition push-down will be carried out by filter push-down instead.
 
-If you want to see a partitioned table in Hive and also synchronize newly created partitions into Hive metastore, please set the table property `partition.add-to-metastore` to true. Also see [CoreOptions]({{< ref "maintenance/configurations#CoreOptions" >}}).
+If you want to see a partitioned table in Hive and also synchronize newly created partitions into Hive metastore, please set the table property `metastore.partitioned-table` to true. Also see [CoreOptions]({{< ref "maintenance/configurations#CoreOptions" >}}).

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -315,6 +315,12 @@ under the License.
             <td>Define partition by table options, cannot define partition on DDL and table options at the same time.</td>
         </tr>
         <tr>
+            <td><h5>partition.add-to-metastore</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to add newly created partition into metastore. For example, if you want to list all partitions with Hive, you need to add all partitions into Hive metastore.</td>
+        </tr>
+        <tr>
             <td><h5>partition.default-name</h5></td>
             <td style="word-wrap: break-word;">"__DEFAULT_PARTITION__"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -267,6 +267,14 @@ under the License.
             <td>The mode of metadata stats collection. none, counts, truncate(16), full is available.<br /><ul><li>"none": means disable the metadata stats collection.</li></ul><ul><li>"counts" means only collect the null count.</li></ul><ul><li>"full": means collect the null count, min/max value.</li></ul><ul><li>"truncate(16)": means collect the null count, min/max value with truncated length of 16.</li></ul><ul><li>Field level stats mode can be specified by fields.{field_name}.stats-mode</li></ul></td>
         </tr>
         <tr>
+            <td><h5>metastore.partitioned-table</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to create this table as a partitioned table in metastore.
+For example, if you want to list all partitions of a Paimon table in Hive, you need to create this table as a partitioned table in Hive metastore.
+This config option does not affect the default filesystem metastore.</td>
+        </tr>
+        <tr>
             <td><h5>num-levels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -313,12 +321,6 @@ under the License.
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Define partition by table options, cannot define partition on DDL and table options at the same time.</td>
-        </tr>
-        <tr>
-            <td><h5>partition.add-to-metastore</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to add newly created partition into metastore. For example, if you want to list all partitions with Hive, you need to add all partitions into Hive metastore.</td>
         </tr>
         <tr>
             <td><h5>partition.default-name</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,6 +30,8 @@ import static java.util.Arrays.asList;
 
 /** An utility class for I/O related functionality. */
 public final class IOUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IOUtils.class);
 
     /** The block size for byte operations in byte. */
     private static final int BLOCKSIZE = 4096;
@@ -186,7 +191,8 @@ public final class IOUtils {
             if (closeable != null) {
                 closeable.close();
             }
-        } catch (Throwable ignored) {
+        } catch (Throwable e) {
+            LOG.debug("Exception occurs when closing " + closeable, e);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -755,14 +755,15 @@ public class CoreOptions implements Serializable {
                             "Parameter string for the constructor of class #. "
                                     + "Callback class should parse the parameter by itself.");
 
-    public static final ConfigOption<Boolean> PARTITION_ADD_TO_METASTORE =
-            key("partition.add-to-metastore")
+    public static final ConfigOption<Boolean> METASTORE_PARTITIONED_TABLE =
+            key("metastore.partitioned-table")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to add newly created partition into metastore. "
-                                    + "For example, if you want to list all partitions with Hive, "
-                                    + "you need to add all partitions into Hive metastore.");
+                            "Whether to create this table as a partitioned table in metastore.\n"
+                                    + "For example, if you want to list all partitions of a Paimon table in Hive, "
+                                    + "you need to create this table as a partitioned table in Hive metastore.\n"
+                                    + "This config option does not affect the default filesystem metastore.");
 
     private final Options options;
 
@@ -1096,8 +1097,8 @@ public class CoreOptions implements Serializable {
         return options.get(CONSUMER_EXPIRATION_TIME);
     }
 
-    public boolean addPartitionToMetastore() {
-        return options.get(PARTITION_ADD_TO_METASTORE);
+    public boolean partitionedTableInMetastore() {
+        return options.get(METASTORE_PARTITIONED_TABLE);
     }
 
     public Options getFieldDefaultValues() {

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -755,6 +755,15 @@ public class CoreOptions implements Serializable {
                             "Parameter string for the constructor of class #. "
                                     + "Callback class should parse the parameter by itself.");
 
+    public static final ConfigOption<Boolean> PARTITION_ADD_TO_METASTORE =
+            key("partition.add-to-metastore")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to add newly created partition into metastore. "
+                                    + "For example, if you want to list all partitions with Hive, "
+                                    + "you need to add all partitions into Hive metastore.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1085,6 +1094,10 @@ public class CoreOptions implements Serializable {
 
     public Duration consumerExpireTime() {
         return options.get(CONSUMER_EXPIRATION_TIME);
+    }
+
+    public boolean addPartitionToMetastore() {
+        return options.get(PARTITION_ADD_TO_METASTORE);
     }
 
     public Options getFieldDefaultValues() {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -85,7 +85,8 @@ public abstract class AbstractCatalog implements Catalog {
                 fileIO,
                 getDataTableLocation(identifier),
                 tableSchema,
-                Lock.factory(lockFactory().orElse(null), identifier));
+                Lock.factory(lockFactory().orElse(null), identifier),
+                metastoreClientFactory(identifier).orElse(null));
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
@@ -47,6 +48,11 @@ public interface Catalog extends AutoCloseable {
      * object store.
      */
     Optional<CatalogLock.Factory> lockFactory();
+
+    /** Get metastore client factory for the table specified by {@code identifier}. */
+    default Optional<MetastoreClient.Factory> metastoreClientFactory(Identifier identifier) {
+        return Optional.empty();
+    }
 
     /**
      * Get the names of all databases in this catalog.

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.table.sink.CommitMessage;
+
+import java.util.List;
+
+/** A {@link CommitCallback} to add newly created partitions to metastore. */
+public class AddPartitionCommitCallback implements CommitCallback {
+
+    private final MetastoreClient client;
+
+    public AddPartitionCommitCallback(MetastoreClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void call(List<ManifestCommittable> committables) {
+        committables.stream()
+                .flatMap(c -> c.fileCommittables().stream())
+                .map(CommitMessage::partition)
+                .distinct()
+                .forEach(
+                        p -> {
+                            try {
+                                client.addPartition(p);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+import org.apache.paimon.data.BinaryRow;
+
+import java.io.Serializable;
+
+/**
+ * A metastore client related to a table. All methods of this interface operate on the same specific
+ * table.
+ */
+public interface MetastoreClient extends AutoCloseable {
+
+    void addPartition(BinaryRow partition) throws Exception;
+
+    /** Factory to create {@link MetastoreClient}. */
+    interface Factory extends Serializable {
+
+        MetastoreClient create();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -24,6 +24,8 @@ import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.metastore.AddPartitionCommitCallback;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.DefaultValueAssiger;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.Lock;
@@ -33,6 +35,7 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.SchemaValidation;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.DynamicBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.FixedBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.RowKeyExtractor;
@@ -51,9 +54,13 @@ import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanne
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,9 +78,14 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     protected final Path path;
     protected final TableSchema tableSchema;
     protected final Lock.Factory lockFactory;
+    @Nullable protected final MetastoreClient.Factory metastoreClientFactory;
 
     public AbstractFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            @Nullable MetastoreClient.Factory metastoreClientFactory) {
         this.fileIO = fileIO;
         this.path = path;
         if (!tableSchema.options().containsKey(PATH.key())) {
@@ -84,6 +96,7 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
         }
         this.tableSchema = tableSchema;
         this.lockFactory = lockFactory;
+        this.metastoreClientFactory = metastoreClientFactory;
     }
 
     @Override
@@ -239,12 +252,20 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     public TableCommitImpl newCommit(String commitUser) {
         return new TableCommitImpl(
                 store().newCommit(commitUser),
-                coreOptions().commitCallbacks(),
+                createCommitCallbacks(),
                 coreOptions().writeOnly() ? null : store().newExpire(),
                 coreOptions().writeOnly() ? null : store().newPartitionExpire(commitUser),
                 lockFactory.create(),
                 CoreOptions.fromMap(options()).consumerExpireTime(),
                 new ConsumerManager(fileIO, path));
+    }
+
+    private List<CommitCallback> createCommitCallbacks() {
+        List<CommitCallback> callbacks = new ArrayList<>(coreOptions().commitCallbacks());
+        if (coreOptions().addPartitionToMetastore() && metastoreClientFactory != null) {
+            callbacks.add(new AddPartitionCommitCallback(metastoreClientFactory.create()));
+        }
+        return callbacks;
     }
 
     private Optional<TableSchema> tryTimeTravel(Options options) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -262,7 +262,7 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private List<CommitCallback> createCommitCallbacks() {
         List<CommitCallback> callbacks = new ArrayList<>(coreOptions().commitCallbacks());
-        if (coreOptions().addPartitionToMetastore() && metastoreClientFactory != null) {
+        if (coreOptions().partitionedTableInMetastore() && metastoreClientFactory != null) {
             callbacks.add(new AddPartitionCommitCallback(metastoreClientFactory.create()));
         }
         return callbacks;

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ManifestCacheFilter;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.AppendOnlyFileStoreRead;
 import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
@@ -42,6 +43,8 @@ import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
@@ -53,17 +56,22 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     private transient AppendOnlyFileStore lazyStore;
 
     AppendOnlyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), null);
     }
 
     AppendOnlyFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            @Nullable MetastoreClient.Factory metastoreClientFactory) {
+        super(fileIO, path, tableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new AppendOnlyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new AppendOnlyFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogValueCountFileStoreTable.java
@@ -29,6 +29,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.ValueCountMergeFunction;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.Lock;
@@ -48,6 +49,8 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -61,17 +64,22 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     private transient KeyValueFileStore lazyStore;
 
     ChangelogValueCountFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), null);
     }
 
     ChangelogValueCountFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            @Nullable MetastoreClient.Factory metastoreClientFactory) {
+        super(fileIO, path, tableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogValueCountFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new ChangelogValueCountFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -32,6 +32,7 @@ import org.apache.paimon.mergetree.compact.LookupMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.Lock;
@@ -50,6 +51,8 @@ import org.apache.paimon.table.source.ValueContentRowDataRecordIterator;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -67,17 +70,22 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private transient KeyValueFileStore lazyStore;
 
     ChangelogWithKeyFileStoreTable(FileIO fileIO, Path path, TableSchema tableSchema) {
-        this(fileIO, path, tableSchema, Lock.emptyFactory());
+        this(fileIO, path, tableSchema, Lock.emptyFactory(), null);
     }
 
     ChangelogWithKeyFileStoreTable(
-            FileIO fileIO, Path path, TableSchema tableSchema, Lock.Factory lockFactory) {
-        super(fileIO, path, tableSchema, lockFactory);
+            FileIO fileIO,
+            Path path,
+            TableSchema tableSchema,
+            Lock.Factory lockFactory,
+            @Nullable MetastoreClient.Factory metastoreClientFactory) {
+        super(fileIO, path, tableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override
     protected FileStoreTable copy(TableSchema newTableSchema) {
-        return new ChangelogWithKeyFileStoreTable(fileIO, path, newTableSchema, lockFactory);
+        return new ChangelogWithKeyFileStoreTable(
+                fileIO, path, newTableSchema, lockFactory, metastoreClientFactory);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
@@ -109,7 +109,11 @@ public class TableCommitTest {
 
         FileStoreTable table =
                 FileStoreTableFactory.create(
-                        new FailingFileIO(), new Path(path), tableSchema, Lock.emptyFactory());
+                        new FailingFileIO(),
+                        new Path(path),
+                        tableSchema,
+                        Lock.emptyFactory(),
+                        null);
 
         String commitUser = UUID.randomUUID().toString();
         StreamTableWrite write = table.newWrite(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -144,6 +144,6 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory(), null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -138,7 +138,7 @@ public abstract class ScannerTestBase {
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory());
+                fileIO, tablePath, tableSchema, conf, Lock.emptyFactory(), null);
     }
 
     protected List<Split> toSplits(List<DataSplit> dataSplits) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -127,6 +127,11 @@ public class FlinkSinkTest {
                                 conf.toMap(),
                                 ""));
         return FileStoreTableFactory.create(
-                FileIOFinder.find(tablePath), tablePath, tableSchema, conf, Lock.emptyFactory());
+                FileIOFinder.find(tablePath),
+                tablePath,
+                tableSchema,
+                conf,
+                Lock.emptyFactory(),
+                null);
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -490,7 +490,7 @@ public class HiveCatalog extends AbstractCatalog {
         serDeInfo.setSerializationLib(SERDE_CLASS_NAME);
         sd.setSerdeInfo(serDeInfo);
 
-        if (new CoreOptions(schema.options()).addPartitionToMetastore()) {
+        if (new CoreOptions(schema.options()).partitionedTableInMetastore()) {
             Map<String, DataField> fieldMap =
                     schema.fields().stream()
                             .collect(Collectors.toMap(DataField::name, Function.identity()));

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.utils.PartitionPathUtils;
+import org.apache.paimon.utils.RowDataPartitionComputer;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/** {@link MetastoreClient} for Hive tables. */
+public class HiveMetastoreClient implements MetastoreClient {
+
+    private final Identifier identifier;
+    private final RowDataPartitionComputer partitionComputer;
+
+    private final IMetaStoreClient client;
+    private final StorageDescriptor sd;
+
+    private HiveMetastoreClient(Identifier identifier, TableSchema schema, IMetaStoreClient client)
+            throws Exception {
+        this.identifier = identifier;
+        this.partitionComputer =
+                new RowDataPartitionComputer(
+                        new CoreOptions(schema.options()).partitionDefaultName(),
+                        schema.logicalPartitionType(),
+                        schema.partitionKeys().toArray(new String[0]));
+
+        this.client = client;
+        this.sd = client.getTable(identifier.getDatabaseName(), identifier.getObjectName()).getSd();
+    }
+
+    @Override
+    public void addPartition(BinaryRow partition) throws Exception {
+        LinkedHashMap<String, String> partitionMap =
+                partitionComputer.generatePartValues(partition);
+        List<String> partitionValues = new ArrayList<>(partitionMap.values());
+
+        try {
+            client.getPartition(
+                    identifier.getDatabaseName(), identifier.getObjectName(), partitionValues);
+            // do nothing if the partition already exists
+        } catch (NoSuchObjectException e) {
+            // partition not found, create new partition
+            StorageDescriptor newSd = new StorageDescriptor(sd);
+            newSd.setLocation(
+                    sd.getLocation()
+                            + "/"
+                            + PartitionPathUtils.generatePartitionPath(partitionMap));
+
+            Partition hivePartition = new Partition();
+            hivePartition.setDbName(identifier.getDatabaseName());
+            hivePartition.setTableName(identifier.getObjectName());
+            hivePartition.setValues(partitionValues);
+            hivePartition.setSd(newSd);
+            int currentTime = (int) (System.currentTimeMillis() / 1000);
+            hivePartition.setCreateTime(currentTime);
+            hivePartition.setLastAccessTime(currentTime);
+
+            client.add_partition(hivePartition);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+    }
+
+    /** Factory to create {@link HiveMetastoreClient}. */
+    public static class Factory implements MetastoreClient.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Identifier identifier;
+        private final TableSchema schema;
+        private final SerializableHiveConf hiveConf;
+        private final String clientClassName;
+
+        public Factory(
+                Identifier identifier,
+                TableSchema schema,
+                HiveConf hiveConf,
+                String clientClassName) {
+            this.identifier = identifier;
+            this.schema = schema;
+            this.hiveConf = new SerializableHiveConf(hiveConf);
+            this.clientClassName = clientClassName;
+        }
+
+        @Override
+        public MetastoreClient create() {
+            HiveConf conf = hiveConf.conf();
+            try {
+                return new HiveMetastoreClient(
+                        identifier, schema, HiveCatalog.createClient(conf, clientClassName));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -34,7 +34,7 @@ import org.apache.paimon.shade.guava30.com.google.common.base.Splitter;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
@@ -46,13 +46,17 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** Column names, types and comments of a Hive table. */
 public class HiveSchema {
@@ -89,8 +93,9 @@ public class HiveSchema {
     /** Extract {@link HiveSchema} from Hive serde properties. */
     public static HiveSchema extract(@Nullable Configuration configuration, Properties properties) {
         String location = LocationKeyExtractor.getLocation(properties);
-        Optional<TableSchema> tableSchema = getExistsSchema(configuration, location);
-        String columnProperty = properties.getProperty(serdeConstants.LIST_COLUMNS);
+        Optional<TableSchema> tableSchema = getExistingSchema(configuration, location);
+        String columnProperty = properties.getProperty(hive_metastoreConstants.META_TABLE_COLUMNS);
+
         // Create hive external table with empty ddl
         if (StringUtils.isEmpty(columnProperty)) {
             if (!tableSchema.isPresent()) {
@@ -109,35 +114,60 @@ public class HiveSchema {
                         // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
                         // versions, so we use a constant string instead
                         "column.name.delimite", String.valueOf(SerDeUtils.COMMA));
+
         List<String> columnNames = Arrays.asList(columnProperty.split(columnNameDelimiter));
-        String columnTypes = properties.getProperty(serdeConstants.LIST_COLUMN_TYPES);
+        String columnTypes =
+                properties.getProperty(hive_metastoreConstants.META_TABLE_COLUMN_TYPES);
         List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(columnTypes);
         List<DataType> dataTypes =
                 typeInfos.stream()
                         .map(HiveTypeUtils::typeInfoToLogicalType)
                         .collect(Collectors.toList());
+
+        // Partitions are only used for checking. They are not contained in the fields of a Hive
+        // table.
+        String partitionProperty =
+                properties.getProperty(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS);
+        List<String> partitionKeys =
+                StringUtils.isEmpty(partitionProperty)
+                        ? Collections.emptyList()
+                        : Arrays.asList(partitionProperty.split("/"));
+        String partitionTypes =
+                properties.getProperty(hive_metastoreConstants.META_TABLE_PARTITION_COLUMN_TYPES);
+        List<TypeInfo> partitionTypeInfos =
+                StringUtils.isEmpty(partitionTypes)
+                        ? Collections.emptyList()
+                        : TypeInfoUtils.getTypeInfosFromTypeString(partitionTypes);
+
+        String commentProperty = properties.getProperty("columns.comments");
         List<String> comments =
-                Lists.newArrayList(
-                        Splitter.on('\0').split(properties.getProperty("columns.comments")));
-        // Both Paimon table schema and Hive table schema exist
+                StringUtils.isEmpty(commentProperty)
+                        ? IntStream.range(0, columnNames.size())
+                                .mapToObj(i -> "")
+                                .collect(Collectors.toList())
+                        : Lists.newArrayList(Splitter.on('\0').split(commentProperty));
+
         if (tableSchema.isPresent() && columnNames.size() > 0 && typeInfos.size() > 0) {
+            // Both Paimon table schema and Hive table schema exist
             LOG.debug(
                     "Extract schema with exists DDL and exists paimon table, table location:[{}].",
                     location);
-            checkSchemaMatched(columnNames, typeInfos, tableSchema.get());
+            checkSchemaMatched(
+                    columnNames, typeInfos, partitionKeys, partitionTypeInfos, tableSchema.get());
+
             // Use paimon table data types and column comments when the paimon table exists.
             // Using paimon data types first because hive's TypeInfoFactory.timestampTypeInfo
             // doesn't contain precision and thus may cause casting problems
             Map<String, DataField> paimonFields =
                     tableSchema.get().fields().stream()
                             .collect(Collectors.toMap(DataField::name, Function.identity()));
-
             for (int i = 0; i < columnNames.size(); i++) {
                 String columnName = columnNames.get(i);
                 dataTypes.set(i, paimonFields.get(columnName).type());
                 comments.set(i, paimonFields.get(columnName).description());
             }
         }
+
         RowType.Builder builder = RowType.builder();
         for (int i = 0; i < columnNames.size(); i++) {
             builder.field(columnNames.get(i), dataTypes.get(i), comments.get(i));
@@ -145,7 +175,7 @@ public class HiveSchema {
         return new HiveSchema(builder.build());
     }
 
-    private static Optional<TableSchema> getExistsSchema(
+    private static Optional<TableSchema> getExistingSchema(
             @Nullable Configuration configuration, @Nullable String location) {
         if (location == null) {
             return Optional.empty();
@@ -162,55 +192,123 @@ public class HiveSchema {
     }
 
     private static void checkSchemaMatched(
-            List<String> names, List<TypeInfo> typeInfos, TableSchema tableSchema) {
-        List<String> ddlNames = new ArrayList<>(names);
-        List<TypeInfo> ddlTypeInfos = new ArrayList<>(typeInfos);
-        List<String> schemaNames = tableSchema.fieldNames();
-        List<TypeInfo> schemaTypeInfos =
-                tableSchema.logicalRowType().getFieldTypes().stream()
-                        .map(HiveTypeUtils::logicalTypeToTypeInfo)
-                        .collect(Collectors.toList());
+            List<String> hiveFieldNames,
+            List<TypeInfo> hiveFieldTypeInfos,
+            List<String> hivePartitionKeys,
+            List<TypeInfo> hivePartitionTypeInfos,
+            TableSchema tableSchema) {
+        // compare field names and type infos
 
-        // make the lengths of lists equal
-        while (ddlNames.size() < schemaNames.size()) {
-            ddlNames.add(null);
-        }
-        while (schemaNames.size() < ddlNames.size()) {
-            schemaNames.add(null);
-        }
-        while (ddlTypeInfos.size() < schemaTypeInfos.size()) {
-            ddlTypeInfos.add(null);
-        }
-        while (schemaTypeInfos.size() < ddlTypeInfos.size()) {
-            schemaTypeInfos.add(null);
-        }
-
-        // compare names and type infos
-        List<String> mismatched = new ArrayList<>();
-        for (int i = 0; i < ddlNames.size(); i++) {
-            if (!Objects.equals(ddlNames.get(i), schemaNames.get(i))
-                    || !Objects.equals(ddlTypeInfos.get(i), schemaTypeInfos.get(i))) {
-                String ddlField =
-                        ddlNames.get(i) == null
-                                ? "null"
-                                : ddlNames.get(i) + " " + ddlTypeInfos.get(i).getTypeName();
-                String schemaField =
-                        schemaNames.get(i) == null
-                                ? "null"
-                                : schemaNames.get(i) + " " + schemaTypeInfos.get(i).getTypeName();
-                mismatched.add(
-                        String.format(
-                                "Field #%d\n" + "Hive DDL          : %s\n" + "Paimon Schema: %s\n",
-                                i, ddlField, schemaField));
+        Set<String> schemaPartitionKeySet = new HashSet<>(tableSchema.partitionKeys());
+        List<String> schemaFieldNames = new ArrayList<>();
+        List<TypeInfo> schemaFieldTypeInfos = new ArrayList<>();
+        for (DataField field : tableSchema.fields()) {
+            // case #1: if the Hive table is not a partitioned table, pick all fields
+            // case #2: if the Hive table is a partitioned table, we only pick fields which are not
+            //          part of partition keys
+            if (hivePartitionKeys.isEmpty() || !schemaPartitionKeySet.contains(field.name())) {
+                schemaFieldNames.add(field.name());
+                schemaFieldTypeInfos.add(HiveTypeUtils.logicalTypeToTypeInfo(field.type()));
             }
         }
 
+        if (schemaFieldNames.size() != hiveFieldNames.size()) {
+            throw new IllegalArgumentException(
+                    "Hive DDL and paimon schema mismatched! "
+                            + "It is recommended not to write any column definition "
+                            + "as Paimon external table can read schema from the specified location.\n"
+                            + "There are "
+                            + hiveFieldNames.size()
+                            + " fields in Hive DDL: "
+                            + String.join(", ", hiveFieldNames)
+                            + "\n"
+                            + "There are "
+                            + schemaFieldNames.size()
+                            + " fields in Paimon schema: "
+                            + String.join(", ", schemaFieldNames)
+                            + "\n");
+        }
+
+        List<String> mismatched = new ArrayList<>();
+        for (int i = 0; i < hiveFieldNames.size(); i++) {
+            if (!Objects.equals(hiveFieldNames.get(i), schemaFieldNames.get(i))
+                    || !Objects.equals(hiveFieldTypeInfos.get(i), schemaFieldTypeInfos.get(i))) {
+                String ddlField =
+                        hiveFieldNames.get(i) + " " + hiveFieldTypeInfos.get(i).getTypeName();
+                String schemaField =
+                        schemaFieldNames.get(i) + " " + schemaFieldTypeInfos.get(i).getTypeName();
+                mismatched.add(
+                        String.format(
+                                "Field #%d\n" + "Hive DDL          : %s\n" + "Paimon Schema: %s\n",
+                                i + 1, ddlField, schemaField));
+            }
+        }
         if (mismatched.size() > 0) {
             throw new IllegalArgumentException(
                     "Hive DDL and paimon schema mismatched! "
                             + "It is recommended not to write any column definition "
                             + "as Paimon external table can read schema from the specified location.\n"
                             + "Mismatched fields are:\n"
+                            + String.join("--------------------\n", mismatched));
+        }
+
+        // compare partition keys and type infos
+
+        if (hivePartitionKeys.isEmpty()) {
+            // only partitioned Hive table needs to consider this part
+            return;
+        }
+
+        List<String> schemaPartitionKeys = tableSchema.partitionKeys();
+        List<TypeInfo> schemaPartitionTypeInfos =
+                tableSchema.logicalPartitionType().getFields().stream()
+                        .map(f -> HiveTypeUtils.logicalTypeToTypeInfo(f.type()))
+                        .collect(Collectors.toList());
+
+        if (schemaPartitionKeys.size() != hivePartitionKeys.size()) {
+            throw new IllegalArgumentException(
+                    "Hive DDL and paimon schema mismatched! "
+                            + "It is recommended not to write any column definition "
+                            + "as Paimon external table can read schema from the specified location.\n"
+                            + "There are "
+                            + hivePartitionKeys.size()
+                            + " partition keys in Hive DDL: "
+                            + String.join(", ", hivePartitionKeys)
+                            + "\n"
+                            + "There are "
+                            + schemaPartitionKeys.size()
+                            + " partition keys in Paimon schema: "
+                            + String.join(", ", schemaPartitionKeys)
+                            + "\n");
+        }
+
+        mismatched = new ArrayList<>();
+        for (int i = 0; i < hivePartitionKeys.size(); i++) {
+            if (!Objects.equals(hivePartitionKeys.get(i), schemaPartitionKeys.get(i))
+                    || !Objects.equals(
+                            hivePartitionTypeInfos.get(i), schemaPartitionTypeInfos.get(i))) {
+                String ddlField =
+                        hivePartitionKeys.get(i)
+                                + " "
+                                + hivePartitionTypeInfos.get(i).getTypeName();
+                String schemaField =
+                        schemaPartitionKeys.get(i)
+                                + " "
+                                + schemaPartitionTypeInfos.get(i).getTypeName();
+                mismatched.add(
+                        String.format(
+                                "Partition Key #%d\n"
+                                        + "Hive DDL          : %s\n"
+                                        + "Paimon Schema: %s\n",
+                                i + 1, ddlField, schemaField));
+            }
+        }
+        if (mismatched.size() > 0) {
+            throw new IllegalArgumentException(
+                    "Hive DDL and paimon schema mismatched! "
+                            + "It is recommended not to write any column definition "
+                            + "as Paimon external table can read schema from the specified location.\n"
+                            + "Mismatched partition keys are:\n"
                             + String.join("--------------------\n", mismatched));
         }
     }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
@@ -19,21 +19,31 @@
 package org.apache.paimon.hive.mapred;
 
 import org.apache.paimon.hive.RowDataContainer;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.RowType;
 
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.hive.utils.HiveUtils.createFileStoreTable;
 import static org.apache.paimon.hive.utils.HiveUtils.createPredicate;
@@ -46,18 +56,52 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
 
     @Override
     public InputSplit[] getSplits(JobConf jobConf, int numSplits) {
+        // If the path of the Paimon table is moved from the location of the Hive table to
+        // properties, Hive will add a location for this table based on the warehouse,
+        // database, and table automatically.When querying by Hive, an exception may occur
+        // because the specified path for split for Paimon may not match the location of Hive.
+        // To work around this problem, we specify the path for split as the location of Hive.
+        String location = jobConf.get(hive_metastoreConstants.META_TABLE_LOCATION);
+
         FileStoreTable table = createFileStoreTable(jobConf);
         InnerTableScan scan = table.newScan();
-        createPredicate(table.schema(), jobConf).ifPresent(scan::withFilter);
-        // If the path of the Paimon table is moved from the location of the Hive table to
-        // properties,Hive will add a location for this table based on the warehouse ,
-        // database,and table automatically.When querying by Hive, an exception may occur
-        // because the specified path for split for Paimon may not match the location of Hive.
-        // To work around this problem,we specify the path for split as the location of Hive.
-        String location = jobConf.get(hive_metastoreConstants.META_TABLE_LOCATION);
+
+        List<Predicate> predicates = new ArrayList<>();
+        String inputDir = jobConf.get(FileInputFormat.INPUT_DIR);
+        createPartitionPredicate(table.schema().logicalRowType(), location, inputDir)
+                .ifPresent(predicates::add);
+        createPredicate(table.schema(), jobConf, false).ifPresent(predicates::add);
+        if (predicates.size() > 0) {
+            scan.withFilter(PredicateBuilder.and(predicates));
+        }
+
         return scan.plan().splits().stream()
                 .map(split -> new PaimonInputSplit(location, (DataSplit) split))
                 .toArray(PaimonInputSplit[]::new);
+    }
+
+    private Optional<Predicate> createPartitionPredicate(
+            RowType rowType, String tablePath, String inputDir) {
+        while (tablePath.length() > 0 && tablePath.endsWith("/")) {
+            tablePath = tablePath.substring(0, tablePath.length() - 1);
+        }
+        if (inputDir.length() < tablePath.length()) {
+            return Optional.empty();
+        }
+
+        LinkedHashMap<String, String> partition = new LinkedHashMap<>();
+        for (String s : inputDir.substring(tablePath.length()).split("/")) {
+            s = s.trim();
+            if (s.isEmpty()) {
+                continue;
+            }
+            String[] kv = s.split("=");
+            if (kv.length != 2) {
+                continue;
+            }
+            partition.put(kv[0].trim(), kv[1].trim());
+        }
+        return Optional.ofNullable(PredicateBuilder.partition(partition, rowType));
     }
 
     @Override
@@ -66,12 +110,28 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
         FileStoreTable table = createFileStoreTable(jobConf);
         PaimonInputSplit split = (PaimonInputSplit) inputSplit;
         ReadBuilder readBuilder = table.newReadBuilder();
-        createPredicate(table.schema(), jobConf).ifPresent(readBuilder::withFilter);
+        createPredicate(table.schema(), jobConf, true).ifPresent(readBuilder::withFilter);
+        List<String> paimonColumns = table.schema().fieldNames();
         return new PaimonRecordReader(
                 readBuilder,
                 split,
-                table.schema().fieldNames(),
+                paimonColumns,
+                getSchemaEvolutionColumns(jobConf).orElse(paimonColumns),
                 Arrays.asList(getSelectedColumns(jobConf)));
+    }
+
+    private Optional<List<String>> getSchemaEvolutionColumns(JobConf jobConf) {
+        String columns = jobConf.get(IOConstants.SCHEMA_EVOLUTION_COLUMNS);
+        String delimiter =
+                jobConf.get(
+                        // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
+                        // versions, so we use a constant string instead
+                        "column.name.delimite", String.valueOf(SerDeUtils.COMMA));
+        if (columns == null || delimiter == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(Arrays.asList(columns.split(delimiter)));
+        }
     }
 
     private String[] getSelectedColumns(JobConf jobConf) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -779,7 +779,7 @@ public abstract class HiveCatalogITCaseBase {
                         "    PRIMARY KEY (k, pta, ptb) NOT ENFORCED",
                         ") PARTITIONED BY (ptb, pta) WITH (",
                         "    'bucket' = '2',",
-                        "    'partition.add-to-metastore' = 'true'",
+                        "    'metastore.partitioned-table' = 'true'",
                         ")"));
         List<String> values = new ArrayList<>();
         for (int pta = 1; pta <= 3; pta++) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -131,19 +131,17 @@ public class HiveTableSchemaTest {
         properties.setProperty("location", tempDir.toString());
 
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #1",
-                        "Hive DDL          : mismatched string",
-                        "Paimon Schema: b string",
-                        "--------------------",
-                        "Field #2",
-                        "Hive DDL          : c decimal(6,3)",
-                        "Paimon Schema: c decimal(5,3)");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "Mismatched fields are:\n"
+                        + "Field #2\n"
+                        + "Hive DDL          : mismatched string\n"
+                        + "Paimon Schema: b string\n"
+                        + "--------------------\n"
+                        + "Field #3\n"
+                        + "Hive DDL          : c decimal(6,3)\n"
+                        + "Paimon Schema: c decimal(5,3)";
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class, () -> HiveSchema.extract(null, properties));
@@ -159,20 +157,13 @@ public class HiveTableSchemaTest {
         properties.setProperty("columns.types", TypeInfoFactory.intTypeInfo.getTypeName());
         properties.setProperty("location", tempDir.toString());
         properties.setProperty("columns.comments", "");
+
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #1",
-                        "Hive DDL          : null",
-                        "Paimon Schema: b string",
-                        "--------------------",
-                        "Field #2",
-                        "Hive DDL          : null",
-                        "Paimon Schema: c decimal(5,3)");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 1 fields in Hive DDL: a\n"
+                        + "There are 3 fields in Paimon schema: a, b, c";
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> HiveSchema.extract(null, properties))
                 .withMessageContaining(expected);
@@ -198,19 +189,11 @@ public class HiveTableSchemaTest {
         properties.setProperty("location", tempDir.toString());
 
         String expected =
-                String.join(
-                        "\n",
-                        "Hive DDL and paimon schema mismatched! "
-                                + "It is recommended not to write any column definition "
-                                + "as Paimon external table can read schema from the specified location.",
-                        "Mismatched fields are:",
-                        "Field #3",
-                        "Hive DDL          : d int",
-                        "Paimon Schema: null",
-                        "--------------------",
-                        "Field #4",
-                        "Hive DDL          : e string",
-                        "Paimon Schema: null");
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 5 fields in Hive DDL: a, b, c, d, e\n"
+                        + "There are 3 fields in Paimon schema: a, b, c";
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> HiveSchema.extract(null, properties))
                 .withMessageContaining(expected);
@@ -223,6 +206,112 @@ public class HiveTableSchemaTest {
                                 ROW_TYPE.getFields(),
                                 Collections.emptyList(),
                                 Collections.emptyList(),
+                                new HashMap<>(),
+                                ""));
+    }
+
+    @Test
+    public void testMismatchedPartitionKeyAndType() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a/mismatched");
+        properties.setProperty(
+                "partition_columns.types",
+                String.join(
+                        ":",
+                        Arrays.asList(
+                                TypeInfoFactory.longTypeInfo.getTypeName(),
+                                TypeInfoFactory.stringTypeInfo.getTypeName())));
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                String.join(
+                        "\n",
+                        "Hive DDL and paimon schema mismatched! "
+                                + "It is recommended not to write any column definition "
+                                + "as Paimon external table can read schema from the specified location.\n"
+                                + "Mismatched partition keys are:\n"
+                                + "Partition Key #1\n"
+                                + "Hive DDL          : a bigint\n"
+                                + "Paimon Schema: a int\n"
+                                + "--------------------\n"
+                                + "Partition Key #2\n"
+                                + "Hive DDL          : mismatched string\n"
+                                + "Paimon Schema: b string");
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class, () -> HiveSchema.extract(null, properties));
+        assertThat(exception).hasMessageContaining(expected);
+    }
+
+    @Test
+    public void testTooFewPartitionKeys() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a");
+        properties.setProperty(
+                "partition_columns.types", TypeInfoFactory.intTypeInfo.getTypeName());
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 1 partition keys in Hive DDL: a\n"
+                        + "There are 2 partition keys in Paimon schema: a, b";
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> HiveSchema.extract(null, properties))
+                .withMessageContaining(expected);
+    }
+
+    @Test
+    public void testTooManyPartitionKeys() throws Exception {
+        createSchemaWithPartition();
+
+        Properties properties = new Properties();
+        properties.setProperty("partition_columns", "a/b/d");
+        properties.setProperty(
+                "partition_columns.types",
+                String.join(
+                        ":",
+                        Arrays.asList(
+                                TypeInfoFactory.intTypeInfo.getTypeName(),
+                                TypeInfoFactory.stringTypeInfo.getTypeName(),
+                                TypeInfoFactory.intTypeInfo.getTypeName())));
+        properties.setProperty("columns", "c");
+        properties.setProperty(
+                "columns.types", TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName());
+        properties.setProperty("columns.comments", "");
+        properties.setProperty("location", tempDir.toString());
+
+        String expected =
+                "Hive DDL and paimon schema mismatched! "
+                        + "It is recommended not to write any column definition "
+                        + "as Paimon external table can read schema from the specified location.\n"
+                        + "There are 3 partition keys in Hive DDL: a, b, d\n"
+                        + "There are 2 partition keys in Paimon schema: a, b";
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> HiveSchema.extract(null, properties))
+                .withMessageContaining(expected);
+    }
+
+    private void createSchemaWithPartition() throws Exception {
+        new SchemaManager(LocalFileIO.create(), new Path(tempDir.toString()))
+                .createTable(
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Arrays.asList("a", "b"),
+                                Arrays.asList("a", "b", "c"),
                                 new HashMap<>(),
                                 ""));
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -80,7 +80,6 @@ public class PaimonStorageHandlerITCase {
 
     private static String engine;
 
-    private String commitUser;
     private long commitIdentifier;
 
     @BeforeClass
@@ -111,7 +110,6 @@ public class PaimonStorageHandlerITCase {
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
 
-        commitUser = UUID.randomUUID().toString();
         commitIdentifier = 0;
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
@@ -86,7 +86,10 @@ public class SearchArgumentToPredicateConverterTest {
         SearchArgument sarg = builder.equals("a", hiveType, hiveLiteral).build();
         SearchArgumentToPredicateConverter converter =
                 new SearchArgumentToPredicateConverter(
-                        sarg, Collections.singletonList("a"), Collections.singletonList(flinkType));
+                        sarg,
+                        Collections.singletonList("a"),
+                        Collections.singletonList(flinkType),
+                        null);
 
         Predicate expected =
                 new PredicateBuilder(RowType.of(new DataType[] {flinkType}, new String[] {"a"}))
@@ -393,7 +396,7 @@ public class SearchArgumentToPredicateConverterTest {
 
     private void assertExpected(SearchArgument sarg, Predicate expected) {
         SearchArgumentToPredicateConverter converter =
-                new SearchArgumentToPredicateConverter(sarg, COLUMN_NAMES, COLUMN_TYPES);
+                new SearchArgumentToPredicateConverter(sarg, COLUMN_NAMES, COLUMN_TYPES, null);
         Predicate actual = converter.convert().orElse(null);
         assertThat(actual).isEqualTo(expected);
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -187,10 +187,12 @@ public class PaimonRecordReaderTest {
         for (Split split : table.newReadBuilder().newScan().plan().splits()) {
             DataSplit dataSplit = (DataSplit) split;
             if (dataSplit.partition().equals(partition) && dataSplit.bucket() == bucket) {
+                List<String> originalColumns = ((FileStoreTable) table).schema().fieldNames();
                 return new PaimonRecordReader(
                         table.newReadBuilder(),
                         new PaimonInputSplit(tempDir.toString(), dataSplit),
-                        ((FileStoreTable) table).schema().fieldNames(),
+                        originalColumns,
+                        originalColumns,
                         selectedColumns);
             }
         }


### PR DESCRIPTION
### Purpose

Currently we cannot create partitioned Paimon table in Hive catalog. In Hive, all fields are considered as normal fields and there is no partition key. It brings us at least two downsides:

1. Users cannot list all partitions through the SHOW PARTITIONS command.
2. Hive's native partition pushdown cannot be performed. Although currently we approach partition pushdown through Hive's filter pushdown, some Hive compatible system may only support partition pushdown and not filter pushdown, making Paimon nearly unusable in those systems.

This PR introduces a feature to synchronize partitions into Hive metastore when using Hive catalog. In this PR, users can create partitioned Hive table through Flink and Spark using Hive catalog. Creating partitioned table directly in Hive is currently not supported and will be introduced in the next PR.

### Tests

* `HiveCatalogITCaseBase#testAddPartitionsToMetastore`

### API and Format

No.

### Documentation

Yes.
