### PR TITLE
[flink][kafka-cdc] Kafka cdc should dynamically create table

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -289,8 +289,6 @@ To use this feature through `flink run`, run the following shell command.
     kafka-sync-database
     --warehouse <warehouse-path> \
     --database <database-name> \
-    [--schema-init-max-read <int>] \
-    [--ignore-incompatible <true/false>] \
     [--table-prefix <paimon-table-prefix>] \
     [--table-suffix <paimon-table-suffix>] \
     [--including-tables <table-name|name-regular-expr>] \
@@ -304,8 +302,9 @@ To use this feature through `flink run`, run the following shell command.
 
 Only tables with primary keys will be synchronized.
 
-For each Kafka topic's table to be synchronized, if the corresponding Paimon table does not exist, this action will automatically create the table.
-Its schema will be derived from all specified Kafka topic's tables,it gets the earliest non-DDL data parsing schema from topic. If the Paimon table already exists, its schema will be compared against the schema of all specified Kafka topic's tables.
+For each Kafka topic's table to be synchronized, if the corresponding Paimon table does not exist, this action will automatically 
+create the table, and its schema will be derived from all specified Kafka topic's tables. If the Paimon table already exists 
+and its schema is different from that parsed from Kafka record, this action will try to preform schema evolution.
 
 Example
 
@@ -317,7 +316,6 @@ Synchronization from one Kafka topic to Paimon database.
     kafka-sync-database \
     --warehouse hdfs:///path/to/warehouse \
     --database test_db \
-    --schema-init-max-read 500 \
     --kafka-conf properties.bootstrap.servers=127.0.0.1:9020 \
     --kafka-conf topic=order \
     --kafka-conf properties.group.id=123456 \

--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -113,6 +113,7 @@ To use this feature through `flink run`, run the following shell command.
     [--table-suffix <paimon-table-suffix>] \
     [--including-tables <mysql-table-name|name-regular-expr>] \
     [--excluding-tables <mysql-table-name|name-regular-expr>] \
+    [--mode <sync-mode>] \
     [--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
     [--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]
@@ -302,9 +303,10 @@ To use this feature through `flink run`, run the following shell command.
 
 Only tables with primary keys will be synchronized.
 
-For each Kafka topic's table to be synchronized, if the corresponding Paimon table does not exist, this action will automatically 
-create the table, and its schema will be derived from all specified Kafka topic's tables. If the Paimon table already exists 
-and its schema is different from that parsed from Kafka record, this action will try to preform schema evolution.
+This action will build a single combined sink for all tables. For each Kafka topic's table to be synchronized, if the 
+corresponding Paimon table does not exist, this action will automatically create the table, and its schema will be derived 
+from all specified Kafka topic's tables. If the Paimon table already exists and its schema is different from that parsed 
+from Kafka record, this action will try to preform schema evolution.
 
 Example
 

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -54,6 +54,10 @@ under the License.
         <td>It is used to specify which source tables are not to be synchronized. The usage is same as "--including-tables". "--excluding-tables" has higher priority than "--including-tables" if you specified both.</td>
     </tr>
     <tr>
+        <td><h5>--mode</h5></td>
+        <td>It is used to specify synchronization mode.<br />Possible values:<ul><li>"divided" (the default mode if you haven't specified one): start a sink for each table, the synchronization of the new table requires restarting the job.</li><li>"combined": start a single combined sink for all tables, the new table will be automatically synchronized.</li></ul></td>
+    </tr>
+    <tr>
         <td><h5>--mysql-conf</h5></td>
         <td>The configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options">document</a> for a complete list of configurations.</td>
     </tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/DatabaseSyncMode.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/DatabaseSyncMode.java
@@ -16,19 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.mysql;
+package org.apache.paimon.flink.action.cdc;
 
 import java.io.Serializable;
 
 /**
  * There are two modes for database sync.
  *
- * <p>1) SEPARATE mode, start a sink for each table, the synchronization of the new table requires
+ * <p>1) DIVIDED mode, start a sink for each table, the synchronization of the new table requires
  * restarting the job.
  *
- * <p>2) UNIFIED mode, start a unified sink, the new table will be automatically synchronized.
+ * <p>2) COMBINED mode, start a single combined sink for all tables, the new table will be
+ * automatically synchronized.
  */
-public enum MySqlDatabaseSyncMode implements Serializable {
-    SEPARATE,
-    UNIFIED
+public enum DatabaseSyncMode implements Serializable {
+    DIVIDED,
+    COMBINED
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
@@ -18,21 +18,17 @@
 
 package org.apache.paimon.flink.action.cdc.kafka;
 
-import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionBase;
 import org.apache.paimon.flink.action.cdc.TableNameConverter;
 import org.apache.paimon.flink.action.cdc.kafka.canal.CanalRecordParser;
+import org.apache.paimon.flink.action.cdc.mysql.MySqlDatabaseSyncMode;
 import org.apache.paimon.flink.sink.cdc.EventParser;
 import org.apache.paimon.flink.sink.cdc.FlinkCdcSyncDatabaseSinkBuilder;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecordEventParser;
-import org.apache.paimon.schema.Schema;
-import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecordSchemaBuilder;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.Configuration;
@@ -40,19 +36,11 @@ import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions;
 import org.apache.flink.util.CollectionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -63,10 +51,10 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  * href="https://nightlies.apache.org/flink/flink-docs-release-1.16/zh/docs/connectors/table/kafka/">document
  * of flink-connectors</a> for detailed keys and values.
  *
- * <p>For each topic's table to be synchronized, if the corresponding Paimon table does not exist,
- * this action will automatically create the table. Its schema will be derived from all specified
- * tables. If the Paimon table already exists, its schema will be compared against the schema of all
- * specified tables.
+ * <p>For each Kafka topic's table to be synchronized, if the corresponding Paimon table does not
+ * exist, this action will automatically create the table, and its schema will be derived from all
+ * specified Kafka topic's tables. If the Paimon table already exists and its schema is different
+ * from that parsed from Kafka record, this action will try to preform schema evolution.
  *
  * <p>This action supports a limited number of schema changes. Currently, the framework can not drop
  * columns, so the behaviors of `DROP` will be ignored, `RENAME` will add a new column. Currently
@@ -88,18 +76,13 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  *       are supported.
  * </ul>
  *
- * <p>This action creates a Paimon table sink for each Paimon table to be written, so this action is
- * not very efficient in resource saving. We may optimize this action by merging all sinks into one
- * instance in the future.
+ * <p>To automatically synchronize new table, This action creates a single sink for all Paimon
+ * tables to be written. See {@link MySqlDatabaseSyncMode#UNIFIED}.
  */
 public class KafkaSyncDatabaseAction extends ActionBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaSyncDatabaseAction.class);
-
     private final Configuration kafkaConfig;
     private final String database;
-    private final int schemaInitMaxRead;
-    private final boolean ignoreIncompatible;
     private final String tablePrefix;
     private final String tableSuffix;
     @Nullable private final Pattern includingPattern;
@@ -110,29 +93,15 @@ public class KafkaSyncDatabaseAction extends ActionBase {
             Map<String, String> kafkaConfig,
             String warehouse,
             String database,
-            boolean ignoreIncompatible,
             Map<String, String> catalogConfig,
             Map<String, String> tableConfig) {
-        this(
-                kafkaConfig,
-                warehouse,
-                database,
-                0,
-                ignoreIncompatible,
-                null,
-                null,
-                null,
-                null,
-                catalogConfig,
-                tableConfig);
+        this(kafkaConfig, warehouse, database, null, null, null, null, catalogConfig, tableConfig);
     }
 
     KafkaSyncDatabaseAction(
             Map<String, String> kafkaConfig,
             String warehouse,
             String database,
-            int schemaInitMaxRead,
-            boolean ignoreIncompatible,
             @Nullable String tablePrefix,
             @Nullable String tableSuffix,
             @Nullable String includingTables,
@@ -142,8 +111,6 @@ public class KafkaSyncDatabaseAction extends ActionBase {
         super(warehouse, catalogConfig);
         this.kafkaConfig = Configuration.fromMap(kafkaConfig);
         this.database = database;
-        this.schemaInitMaxRead = schemaInitMaxRead;
-        this.ignoreIncompatible = ignoreIncompatible;
         this.tablePrefix = tablePrefix == null ? "" : tablePrefix;
         this.tableSuffix = tableSuffix == null ? "" : tableSuffix;
         this.includingPattern = includingTables == null ? null : Pattern.compile(includingTables);
@@ -165,59 +132,23 @@ public class KafkaSyncDatabaseAction extends ActionBase {
             validateCaseInsensitive();
         }
 
-        Map<String, List<KafkaSchema>> kafkaCanalSchemaMap = getKafkaCanalSchemaMap();
-
         catalog.createDatabase(database, true);
         TableNameConverter tableNameConverter =
                 new TableNameConverter(caseSensitive, tablePrefix, tableSuffix);
 
-        List<FileStoreTable> fileStoreTables = new ArrayList<>();
-        List<String> monitoredTopics = new ArrayList<>();
-        for (Map.Entry<String, List<KafkaSchema>> kafkaCanalSchemaEntry :
-                kafkaCanalSchemaMap.entrySet()) {
-            List<KafkaSchema> kafkaSchemaList = kafkaCanalSchemaEntry.getValue();
-            String topic = kafkaCanalSchemaEntry.getKey();
-            for (KafkaSchema kafkaSchema : kafkaSchemaList) {
-                String paimonTableName = tableNameConverter.convert(kafkaSchema.tableName());
-                Identifier identifier = new Identifier(database, paimonTableName);
-                FileStoreTable table;
-                Schema fromCanal =
-                        KafkaActionUtils.buildPaimonSchema(
-                                kafkaSchema,
-                                Collections.emptyList(),
-                                Collections.emptyList(),
-                                Collections.emptyList(),
-                                tableConfig,
-                                caseSensitive);
-                try {
-                    table = (FileStoreTable) catalog.getTable(identifier);
-                    Supplier<String> errMsg =
-                            incompatibleMessage(table.schema(), kafkaSchema, identifier);
-                    if (shouldMonitorTable(table.schema(), fromCanal, errMsg)) {
-                        monitoredTopics.add(topic);
-                        fileStoreTables.add(table);
-                    }
-                } catch (Catalog.TableNotExistException e) {
-                    catalog.createTable(identifier, fromCanal, false);
-                    table = (FileStoreTable) catalog.getTable(identifier);
-                    monitoredTopics.add(topic);
-                    fileStoreTables.add(table);
-                }
-            }
-        }
-        monitoredTopics = monitoredTopics.stream().distinct().collect(Collectors.toList());
-        Preconditions.checkState(
-                !fileStoreTables.isEmpty(),
-                "No tables to be synchronized. Possible cause is the schemas of all tables in specified "
-                        + "Kafka topic's table are not compatible with those of existed Paimon tables. Please check the log.");
-
-        kafkaConfig.set(KafkaConnectorOptions.TOPIC, monitoredTopics);
         KafkaSource<String> source = KafkaActionUtils.buildKafkaSource(kafkaConfig);
 
         EventParser.Factory<RichCdcMultiplexRecord> parserFactory;
         String format = kafkaConfig.get(KafkaConnectorOptions.VALUE_FORMAT);
         if ("canal-json".equals(format)) {
-            parserFactory = RichCdcMultiplexRecordEventParser::new;
+            RichCdcMultiplexRecordSchemaBuilder schemaBuilder =
+                    new RichCdcMultiplexRecordSchemaBuilder(tableConfig);
+            Pattern includingPattern = this.includingPattern;
+            Pattern excludingPattern = this.excludingPattern;
+            parserFactory =
+                    () ->
+                            new RichCdcMultiplexRecordEventParser(
+                                    schemaBuilder, includingPattern, excludingPattern);
         } else {
             throw new UnsupportedOperationException("This format: " + format + " is not support.");
         }
@@ -233,9 +164,9 @@ public class KafkaSyncDatabaseAction extends ActionBase {
                                                 new CanalRecordParser(
                                                         caseSensitive, tableNameConverter)))
                         .withParserFactory(parserFactory)
-                        .withTables(fileStoreTables)
                         .withCatalogLoader(catalogLoader())
-                        .withDatabase(database);
+                        .withDatabase(database)
+                        .withMode(MySqlDatabaseSyncMode.UNIFIED);
         String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));
@@ -259,78 +190,6 @@ public class KafkaSyncDatabaseAction extends ActionBase {
                 String.format(
                         "Table suffix [%s] cannot contain upper case in case-insensitive catalog.",
                         tableSuffix));
-    }
-
-    private Map<String, List<KafkaSchema>> getKafkaCanalSchemaMap() throws Exception {
-        Map<String, List<KafkaSchema>> kafkaCanalSchemaMap = new HashMap<>();
-        List<String> topicList = kafkaConfig.get(KafkaConnectorOptions.TOPIC);
-        if (topicList.size() > 1) {
-            topicList.forEach(
-                    topic -> {
-                        try {
-                            KafkaSchema kafkaSchema =
-                                    KafkaSchema.getKafkaSchema(kafkaConfig, topic);
-                            if (shouldMonitorTable(kafkaSchema.tableName())) {
-                                kafkaCanalSchemaMap.put(
-                                        topic, Collections.singletonList(kafkaSchema));
-                            }
-
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
-        } else {
-            List<KafkaSchema> kafkaSchemaList =
-                    KafkaSchema.getListKafkaSchema(
-                            kafkaConfig, topicList.get(0), schemaInitMaxRead);
-            kafkaSchemaList =
-                    kafkaSchemaList.stream()
-                            .filter(kafkaSchema -> shouldMonitorTable(kafkaSchema.tableName()))
-                            .collect(Collectors.toList());
-            kafkaCanalSchemaMap.put(topicList.get(0), kafkaSchemaList);
-        }
-
-        return kafkaCanalSchemaMap;
-    }
-
-    private boolean shouldMonitorTable(String mySqlTableName) {
-        boolean shouldMonitor = true;
-        if (includingPattern != null) {
-            shouldMonitor = includingPattern.matcher(mySqlTableName).matches();
-        }
-        if (excludingPattern != null) {
-            shouldMonitor = shouldMonitor && !excludingPattern.matcher(mySqlTableName).matches();
-        }
-        LOG.debug("Source table {} is monitored? {}", mySqlTableName, shouldMonitor);
-        return shouldMonitor;
-    }
-
-    private boolean shouldMonitorTable(
-            TableSchema tableSchema, Schema schema, Supplier<String> errMsg) {
-        if (KafkaActionUtils.schemaCompatible(tableSchema, schema)) {
-            return true;
-        } else if (ignoreIncompatible) {
-            LOG.warn(errMsg.get() + "This table will be ignored.");
-            return false;
-        } else {
-            throw new IllegalArgumentException(
-                    errMsg.get()
-                            + "If you want to ignore the incompatible tables, please specify --ignore-incompatible to true.");
-        }
-    }
-
-    private Supplier<String> incompatibleMessage(
-            TableSchema paimonSchema, KafkaSchema kafkaSchema, Identifier identifier) {
-        return () ->
-                String.format(
-                        "Incompatible schema found.\n"
-                                + "Paimon table is: %s, fields are: %s.\n"
-                                + "Kafka's table is: %s.%s, fields are: %s.\n",
-                        identifier.getFullName(),
-                        paimonSchema.fields(),
-                        kafkaSchema.databaseName(),
-                        kafkaSchema.tableName(),
-                        kafkaSchema.fields());
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
@@ -21,9 +21,9 @@ package org.apache.paimon.flink.action.cdc.kafka;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionBase;
+import org.apache.paimon.flink.action.cdc.DatabaseSyncMode;
 import org.apache.paimon.flink.action.cdc.TableNameConverter;
 import org.apache.paimon.flink.action.cdc.kafka.canal.CanalRecordParser;
-import org.apache.paimon.flink.action.cdc.mysql.MySqlDatabaseSyncMode;
 import org.apache.paimon.flink.sink.cdc.EventParser;
 import org.apache.paimon.flink.sink.cdc.FlinkCdcSyncDatabaseSinkBuilder;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -77,7 +77,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  * </ul>
  *
  * <p>To automatically synchronize new table, This action creates a single sink for all Paimon
- * tables to be written. See {@link MySqlDatabaseSyncMode#UNIFIED}.
+ * tables to be written. See {@link DatabaseSyncMode#COMBINED}.
  */
 public class KafkaSyncDatabaseAction extends ActionBase {
 
@@ -166,7 +166,7 @@ public class KafkaSyncDatabaseAction extends ActionBase {
                         .withParserFactory(parserFactory)
                         .withCatalogLoader(catalogLoader())
                         .withDatabase(database)
-                        .withMode(MySqlDatabaseSyncMode.UNIFIED);
+                        .withMode(DatabaseSyncMode.COMBINED);
         String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseActionFactory.java
@@ -42,14 +42,8 @@ public class KafkaSyncDatabaseActionFactory implements ActionFactory {
         checkRequiredArgument(params, "database");
         checkRequiredArgument(params, "kafka-conf");
 
-        int schemaInitMaxRead = 1000;
-        if (params.has("schema-init-max-read")) {
-            schemaInitMaxRead = Integer.parseInt(params.get("schema-init-max-read"));
-        }
-
         String warehouse = params.get("warehouse");
         String database = params.get("database");
-        boolean ignoreIncompatible = Boolean.parseBoolean(params.get("ignore-incompatible"));
         String tablePrefix = params.get("table-prefix");
         String tableSuffix = params.get("table-suffix");
         String includingTables = params.get("including-tables");
@@ -63,8 +57,6 @@ public class KafkaSyncDatabaseActionFactory implements ActionFactory {
                         kafkaConfigOption,
                         warehouse,
                         database,
-                        schemaInitMaxRead,
-                        ignoreIncompatible,
                         tablePrefix,
                         tableSuffix,
                         includingTables,
@@ -85,8 +77,6 @@ public class KafkaSyncDatabaseActionFactory implements ActionFactory {
         System.out.println("Syntax:");
         System.out.println(
                 "  kafka-sync-database --warehouse <warehouse-path> --database <database-name> "
-                        + "[--schema-init-max-read <schema-init-max-read>] "
-                        + "[--ignore-incompatible <true/false>] "
                         + "[--table-prefix <paimon-table-prefix>] "
                         + "[--table-suffix <paimon-table-suffix>] "
                         + "[--including-tables <table-name|name-regular-expr>] "
@@ -94,16 +84,6 @@ public class KafkaSyncDatabaseActionFactory implements ActionFactory {
                         + "[--kafka-conf <kafka-source-conf> [--kafka-conf <kafka-source-conf> ...]] "
                         + "[--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] "
                         + "[--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]");
-        System.out.println();
-
-        System.out.println(
-                "--schema-init-max-read is default 1000, if your tables are all from a topic, you can set this parameter to initialize the number of tables to be synchronized.");
-        System.out.println();
-
-        System.out.println(
-                "--ignore-incompatible is default false, in this case, if Topic's table name exists in Paimon "
-                        + "and their schema is incompatible, an exception will be thrown. "
-                        + "You can specify it to true explicitly to ignore the incompatible tables and exception.");
         System.out.println();
 
         System.out.println(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
@@ -156,15 +156,7 @@ public class KafkaSyncTableAction extends ActionBase {
             table = (FileStoreTable) catalog.getTable(identifier);
             KafkaActionUtils.assertSchemaCompatible(table.schema(), fromCanal);
         } catch (Catalog.TableNotExistException e) {
-            Schema schema =
-                    KafkaActionUtils.buildPaimonSchema(
-                            kafkaSchema,
-                            partitionKeys,
-                            primaryKeys,
-                            computedColumns,
-                            paimonConfig,
-                            caseSensitive);
-            catalog.createTable(identifier, schema, false);
+            catalog.createTable(identifier, fromCanal, false);
             table = (FileStoreTable) catalog.getTable(identifier);
         }
         String format = kafkaConfig.get(KafkaConnectorOptions.VALUE_FORMAT);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -39,18 +39,6 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeRefe
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.alibaba.druid.sql.SQLUtils;
-import com.alibaba.druid.sql.ast.SQLDataType;
-import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.SQLName;
-import com.alibaba.druid.sql.ast.SQLStatement;
-import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
-import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
-import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
-import com.alibaba.druid.sql.ast.statement.SQLTableElement;
-import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
-import com.alibaba.druid.util.JdbcConstants;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +52,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,29 +68,45 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     private final boolean caseSensitive;
     private final TableNameConverter tableNameConverter;
     private final List<ComputedColumn> computedColumns;
+    private final MySqlTableSchemaBuilder schemaBuilder;
 
     private JsonNode root;
     private JsonNode payload;
 
     public MySqlDebeziumJsonEventParser(
             ZoneId serverTimeZone, boolean caseSensitive, List<ComputedColumn> computedColumns) {
-        this(serverTimeZone, caseSensitive, computedColumns, new TableNameConverter(caseSensitive));
+        this(
+                serverTimeZone,
+                caseSensitive,
+                computedColumns,
+                new TableNameConverter(caseSensitive),
+                MySqlTableSchemaBuilder.dummyBuilder());
     }
 
     public MySqlDebeziumJsonEventParser(
-            ZoneId serverTimeZone, boolean caseSensitive, TableNameConverter tableNameConverter) {
-        this(serverTimeZone, caseSensitive, Collections.emptyList(), tableNameConverter);
+            ZoneId serverTimeZone,
+            boolean caseSensitive,
+            TableNameConverter tableNameConverter,
+            MySqlTableSchemaBuilder schemaBuilder) {
+        this(
+                serverTimeZone,
+                caseSensitive,
+                Collections.emptyList(),
+                tableNameConverter,
+                schemaBuilder);
     }
 
     public MySqlDebeziumJsonEventParser(
             ZoneId serverTimeZone,
             boolean caseSensitive,
             List<ComputedColumn> computedColumns,
-            TableNameConverter tableNameConverter) {
+            TableNameConverter tableNameConverter,
+            MySqlTableSchemaBuilder schemaBuilder) {
         this.serverTimeZone = serverTimeZone;
         this.caseSensitive = caseSensitive;
         this.computedColumns = computedColumns;
         this.tableNameConverter = tableNameConverter;
+        this.schemaBuilder = schemaBuilder;
     }
 
     @Override
@@ -178,7 +181,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     }
 
     @Override
-    public Optional<Schema> parseNewTable(String databaseName) {
+    public Optional<Schema> parseNewTable() {
         JsonNode historyRecord = payload.get("historyRecord");
         if (historyRecord == null) {
             return Optional.empty();
@@ -191,66 +194,12 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
                 return Optional.empty();
             }
 
-            SQLStatement statement = SQLUtils.parseSingleStatement(ddl, JdbcConstants.MYSQL);
-
-            if (!(statement instanceof MySqlCreateTableStatement)) {
-                return Optional.empty();
-            }
-
-            MySqlCreateTableStatement createTableStatement = (MySqlCreateTableStatement) statement;
-
-            // TODO: add default table config, partitions, and computed column
-            //     for newly added table;
-            MySqlSchema mySqlSchema = buildMySqlSchema(databaseName, createTableStatement);
-            Schema fromMySql =
-                    MySqlActionUtils.buildPaimonSchema(
-                            mySqlSchema,
-                            Collections.emptyList(),
-                            mySqlSchema.getPrimaryKeys(),
-                            computedColumns,
-                            Collections.emptyMap(),
-                            caseSensitive);
-
-            return Optional.of(fromMySql);
-
+            schemaBuilder.init(ddl);
+            return schemaBuilder.build();
         } catch (Exception e) {
             LOG.info("Failed to parse history record for schema changes", e);
             return Optional.empty();
         }
-    }
-
-    private MySqlSchema buildMySqlSchema(String database, MySqlCreateTableStatement statement) {
-        LinkedHashMap<String, Tuple2<DataType, String>> fields = new LinkedHashMap<>();
-
-        List<SQLTableElement> columns = statement.getTableElementList();
-        for (SQLTableElement element : columns) {
-            if (element instanceof SQLColumnDefinition) {
-                SQLColumnDefinition column = (SQLColumnDefinition) element;
-                SQLName name = column.getName();
-                SQLDataType dataType = column.getDataType();
-                List<SQLExpr> arguments = dataType.getArguments();
-                Integer precision = null;
-                Integer scale = null;
-                if (arguments.size() >= 1) {
-                    precision = (int) (((SQLIntegerExpr) arguments.get(0)).getValue());
-                }
-
-                if (arguments.size() >= 2) {
-                    scale = (int) (((SQLIntegerExpr) arguments.get(1)).getValue());
-                }
-
-                SQLCharExpr comment = (SQLCharExpr) column.getComment();
-                fields.put(
-                        name.getSimpleName(),
-                        Tuple2.of(
-                                MySqlTypeUtils.toDataType(
-                                        column.getDataType().getName(), precision, scale),
-                                comment == null ? null : String.valueOf(comment.getValue())));
-            }
-        }
-
-        return new MySqlSchema(
-                database, statement.getTableName(), fields, statement.getPrimaryKeyNames());
     }
 
     @Override
@@ -378,7 +327,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             } else if ("io.debezium.time.ZonedTimestamp".equals(className)) {
                 // MySQL timestamp
 
-                // dispaly value of timestamp is affected by timezone, see
+                // display value of timestamp is affected by timezone, see
                 // https://dev.mysql.com/doc/refman/8.0/en/datetime.html for standard, and
                 // RowDataDebeziumDeserializeSchema#convertToTimestamp in flink-cdc-connector
                 // for implementation

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSchema.java
@@ -40,17 +40,6 @@ public class MySqlSchema {
     private final LinkedHashMap<String, Tuple2<DataType, String>> fields;
     private final List<String> primaryKeys;
 
-    public MySqlSchema(
-            String databaseName,
-            String tableName,
-            LinkedHashMap<String, Tuple2<DataType, String>> fields,
-            List<String> primaryKeys) {
-        this.databaseName = databaseName;
-        this.tableName = tableName;
-        this.fields = fields;
-        this.primaryKeys = primaryKeys;
-    }
-
     public MySqlSchema(DatabaseMetaData metaData, String databaseName, String tableName)
             throws Exception {
         this.databaseName = databaseName;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -234,8 +234,12 @@ public class MySqlSyncDatabaseAction extends ActionBase {
 
         String serverTimeZone = mySqlConfig.get(MySqlSourceOptions.SERVER_TIME_ZONE);
         ZoneId zoneId = serverTimeZone == null ? ZoneId.systemDefault() : ZoneId.of(serverTimeZone);
+        MySqlTableSchemaBuilder schemaBuilder =
+                new MySqlTableSchemaBuilder(tableConfig, caseSensitive);
         EventParser.Factory<String> parserFactory =
-                () -> new MySqlDebeziumJsonEventParser(zoneId, caseSensitive, tableNameConverter);
+                () ->
+                        new MySqlDebeziumJsonEventParser(
+                                zoneId, caseSensitive, tableNameConverter, schemaBuilder);
 
         String database = this.database;
         MySqlDatabaseSyncMode mode = this.mode;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
@@ -37,7 +37,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,30 +44,22 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Schema builder for MySQL cdc. */
-public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder {
+public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder<String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlTableSchemaBuilder.class);
 
     private final Map<String, String> tableConfig;
     private final boolean caseSensitive;
 
-    private String ddl;
-
     public MySqlTableSchemaBuilder(Map<String, String> tableConfig, boolean caseSensitive) {
         this.tableConfig = tableConfig;
         this.caseSensitive = caseSensitive;
     }
 
-    public void init(String ddl) {
-        this.ddl = ddl;
-    }
-
     @Override
-    public Optional<Schema> build() {
-        checkNotNull(ddl, "MySqlTableSchemaBuilder wasn't initialized.");
+    public Optional<Schema> build(String ddl) {
         SQLStatement statement = SQLUtils.parseSingleStatement(ddl, JdbcConstants.MYSQL);
 
         if (!(statement instanceof MySqlCreateTableStatement)) {
@@ -144,14 +135,5 @@ public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder {
         Schema schema = builder.primaryKey(primaryKeys).build();
 
         return Optional.of(schema);
-    }
-
-    public static MySqlTableSchemaBuilder dummyBuilder() {
-        return new MySqlTableSchemaBuilder(Collections.emptyMap(), true) {
-            @Override
-            public Optional<Schema> build() {
-                return Optional.empty();
-            }
-        };
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.mysql;
+
+import org.apache.paimon.flink.sink.cdc.NewTableSchemaBuilder;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataType;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLDataType;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
+import com.alibaba.druid.sql.ast.statement.SQLTableElement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
+import com.alibaba.druid.util.JdbcConstants;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Schema builder for MySQL cdc. */
+public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MySqlTableSchemaBuilder.class);
+
+    private final Map<String, String> tableConfig;
+    private final boolean caseSensitive;
+
+    private String ddl;
+
+    public MySqlTableSchemaBuilder(Map<String, String> tableConfig, boolean caseSensitive) {
+        this.tableConfig = tableConfig;
+        this.caseSensitive = caseSensitive;
+    }
+
+    public void init(String ddl) {
+        this.ddl = ddl;
+    }
+
+    @Override
+    public Optional<Schema> build() {
+        checkNotNull(ddl, "MySqlTableSchemaBuilder wasn't initialized.");
+        SQLStatement statement = SQLUtils.parseSingleStatement(ddl, JdbcConstants.MYSQL);
+
+        if (!(statement instanceof MySqlCreateTableStatement)) {
+            return Optional.empty();
+        }
+
+        MySqlCreateTableStatement createTableStatement = (MySqlCreateTableStatement) statement;
+        String tableName = createTableStatement.getTableName();
+
+        List<String> primaryKeys = createTableStatement.getPrimaryKeyNames();
+        if (primaryKeys.isEmpty()) {
+            LOG.debug(
+                    "Didn't find primary keys from MySQL DDL for table '{}'. "
+                            + "This table won't be synchronized.",
+                    tableName);
+            // TODO: for non-pk tables, we should not handle their records because we haven't
+            // created them here. Fix in 'MySqlDebeziumJsonEventParser'
+            return Optional.empty();
+        }
+
+        List<SQLTableElement> columns = createTableStatement.getTableElementList();
+        LinkedHashMap<String, Tuple2<DataType, String>> fields = new LinkedHashMap<>();
+
+        for (SQLTableElement element : columns) {
+            if (element instanceof SQLColumnDefinition) {
+                SQLColumnDefinition column = (SQLColumnDefinition) element;
+                SQLName name = column.getName();
+                SQLDataType dataType = column.getDataType();
+                List<SQLExpr> arguments = dataType.getArguments();
+                Integer precision = null;
+                Integer scale = null;
+                if (arguments.size() >= 1) {
+                    precision = (int) (((SQLIntegerExpr) arguments.get(0)).getValue());
+                }
+
+                if (arguments.size() >= 2) {
+                    scale = (int) (((SQLIntegerExpr) arguments.get(1)).getValue());
+                }
+
+                SQLCharExpr comment = (SQLCharExpr) column.getComment();
+                fields.put(
+                        name.getSimpleName(),
+                        Tuple2.of(
+                                MySqlTypeUtils.toDataType(
+                                        column.getDataType().getName(), precision, scale),
+                                comment == null ? null : String.valueOf(comment.getValue())));
+            }
+        }
+
+        if (caseSensitive) {
+            LinkedHashMap<String, Tuple2<DataType, String>> tmp = new LinkedHashMap<>();
+            for (Map.Entry<String, Tuple2<DataType, String>> entry : fields.entrySet()) {
+                String fieldName = entry.getKey();
+                checkArgument(
+                        !tmp.containsKey(fieldName.toLowerCase()),
+                        "Duplicate key '%s' in table '%s' appears when converting fields map keys to case-insensitive form.",
+                        fieldName,
+                        tableName);
+                tmp.put(fieldName.toLowerCase(), entry.getValue());
+            }
+            fields = tmp;
+
+            primaryKeys =
+                    primaryKeys.stream().map(String::toLowerCase).collect(Collectors.toList());
+        }
+
+        Schema.Builder builder = Schema.newBuilder();
+        builder.options(tableConfig);
+        for (Map.Entry<String, Tuple2<DataType, String>> entry : fields.entrySet()) {
+            builder.column(entry.getKey(), entry.getValue().f0, entry.getValue().f1);
+        }
+
+        Schema schema = builder.primaryKey(primaryKeys).build();
+
+        return Optional.of(schema);
+    }
+
+    public static MySqlTableSchemaBuilder dummyBuilder() {
+        return new MySqlTableSchemaBuilder(Collections.emptyMap(), true) {
+            @Override
+            public Optional<Schema> build() {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
@@ -118,7 +118,7 @@ public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder {
             }
         }
 
-        if (caseSensitive) {
+        if (!caseSensitive) {
             LinkedHashMap<String, Tuple2<DataType, String>> tmp = new LinkedHashMap<>();
             for (Map.Entry<String, Tuple2<DataType, String>> entry : fields.entrySet()) {
                 String fieldName = entry.getKey();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicTableParsingProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicTableParsingProcessFunction.java
@@ -87,7 +87,7 @@ public class CdcDynamicTableParsingProcessFunction<T> extends ProcessFunction<T,
         String tableName = parser.parseTableName();
 
         // check for newly added table
-        parser.parseNewTable(database)
+        parser.parseNewTable()
                 .ifPresent(
                         schema -> {
                             Identifier identifier =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -59,10 +59,9 @@ public interface EventParser<T> {
     /**
      * Parse newly added table schema from event.
      *
-     * @param databaseName database of the new table
      * @return empty if there is no newly added table
      */
-    default Optional<Schema> parseNewTable(String databaseName) {
+    default Optional<Schema> parseNewTable() {
         return Optional.empty();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 /** Build table schema for newly added table in CDC ingestion. */
 @FunctionalInterface
-public interface NewTableSchemaBuilder extends Serializable {
+public interface NewTableSchemaBuilder<T> extends Serializable {
 
-    Optional<Schema> build();
+    Optional<Schema> build(T source);
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
@@ -18,34 +18,14 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.utils.ObjectUtils;
+import org.apache.paimon.schema.Schema;
 
-import java.util.Collections;
-import java.util.List;
+import java.io.Serializable;
+import java.util.Optional;
 
-/** Testing {@link EventParser} for {@link TestCdcEvent}. */
-public class TestCdcEventParser implements EventParser<TestCdcEvent> {
+/** Build table schema for newly added table in CDC ingestion. */
+@FunctionalInterface
+public interface NewTableSchemaBuilder extends Serializable {
 
-    private TestCdcEvent raw;
-
-    @Override
-    public void setRawEvent(TestCdcEvent raw) {
-        this.raw = raw;
-    }
-
-    @Override
-    public String parseTableName() {
-        return raw.tableName();
-    }
-
-    @Override
-    public List<DataField> parseSchemaChange() {
-        return ObjectUtils.coalesce(raw.updatedDataFields(), Collections.emptyList());
-    }
-
-    @Override
-    public List<CdcRecord> parseRecords() {
-        return ObjectUtils.coalesce(raw.records(), Collections.emptyList());
-    }
+    Optional<Schema> build();
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecord.java
@@ -22,6 +22,7 @@ import org.apache.paimon.types.DataType;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Objects;
 
 /** Compared to {@link CdcMultiplexRecord}, this contains schema information. */
@@ -29,24 +30,35 @@ public class RichCdcMultiplexRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final CdcRecord cdcRecord;
-    private final LinkedHashMap<String, DataType> fieldTypes;
     private final String databaseName;
     private final String tableName;
+    private final LinkedHashMap<String, DataType> fieldTypes;
+    private final List<String> primaryKeys;
+    private final CdcRecord cdcRecord;
 
     public RichCdcMultiplexRecord(
-            CdcRecord cdcRecord,
-            LinkedHashMap<String, DataType> fieldTypes,
             String databaseName,
-            String tableName) {
-        this.cdcRecord = cdcRecord;
-        this.fieldTypes = fieldTypes;
+            String tableName,
+            LinkedHashMap<String, DataType> fieldTypes,
+            List<String> primaryKeys,
+            CdcRecord cdcRecord) {
         this.databaseName = databaseName;
         this.tableName = tableName;
+        this.fieldTypes = fieldTypes;
+        this.primaryKeys = primaryKeys;
+        this.cdcRecord = cdcRecord;
     }
 
     public String tableName() {
         return tableName;
+    }
+
+    public LinkedHashMap<String, DataType> fieldTypes() {
+        return fieldTypes;
+    }
+
+    public List<String> primaryKeys() {
+        return primaryKeys;
     }
 
     public RichCdcRecord toRichCdcRecord() {
@@ -55,7 +67,7 @@ public class RichCdcMultiplexRecord implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(cdcRecord, fieldTypes, databaseName, tableName);
+        return Objects.hash(databaseName, tableName, fieldTypes, primaryKeys, cdcRecord);
     }
 
     @Override
@@ -67,23 +79,26 @@ public class RichCdcMultiplexRecord implements Serializable {
             return false;
         }
         RichCdcMultiplexRecord that = (RichCdcMultiplexRecord) o;
-        return Objects.equals(cdcRecord, that.cdcRecord)
+        return databaseName.equals(that.databaseName)
+                && tableName.equals(that.tableName)
                 && Objects.equals(fieldTypes, that.fieldTypes)
-                && databaseName.equals(that.databaseName)
-                && tableName.equals(that.tableName);
+                && Objects.equals(primaryKeys, that.primaryKeys)
+                && Objects.equals(cdcRecord, that.cdcRecord);
     }
 
     @Override
     public String toString() {
         return "{"
-                + "cdcRecord="
-                + cdcRecord
-                + ", fieldTypes="
-                + fieldTypes
-                + ", databaseName="
+                + "databaseName="
                 + databaseName
                 + ", tableName="
                 + tableName
+                + ", fieldTypes="
+                + fieldTypes
+                + ", primaryKeys="
+                + primaryKeys
+                + ", cdcRecord="
+                + cdcRecord
                 + '}';
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
@@ -41,7 +41,7 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     private static final Logger LOG =
             LoggerFactory.getLogger(RichCdcMultiplexRecordEventParser.class);
 
-    private final RichCdcMultiplexRecordSchemaBuilder schemaBuilder;
+    private final NewTableSchemaBuilder<RichCdcMultiplexRecord> schemaBuilder;
     @Nullable private final Pattern includingPattern;
     @Nullable private final Pattern excludingPattern;
     private final Map<String, RichEventParser> parsers = new HashMap<>();
@@ -55,11 +55,11 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     private RichEventParser currentParser;
 
     public RichCdcMultiplexRecordEventParser() {
-        this(RichCdcMultiplexRecordSchemaBuilder.dummyBuilder(), null, null);
+        this(record -> Optional.empty(), null, null);
     }
 
     public RichCdcMultiplexRecordEventParser(
-            RichCdcMultiplexRecordSchemaBuilder schemaBuilder,
+            NewTableSchemaBuilder<RichCdcMultiplexRecord> schemaBuilder,
             @Nullable Pattern includingPattern,
             @Nullable Pattern excludingPattern) {
         this.schemaBuilder = schemaBuilder;
@@ -100,8 +100,7 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     @Override
     public Optional<Schema> parseNewTable() {
         if (shouldCreateCurrentTable()) {
-            schemaBuilder.init(record);
-            return schemaBuilder.build();
+            return schemaBuilder.build(record);
         }
 
         return Optional.empty();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
@@ -115,15 +115,15 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
             return false;
         }
 
-        boolean shouldSynchronized = true;
+        boolean shouldSynchroniz = true;
         if (includingPattern != null) {
-            shouldSynchronized = includingPattern.matcher(currentTable).matches();
+            shouldSynchroniz = includingPattern.matcher(currentTable).matches();
         }
         if (excludingPattern != null) {
-            shouldSynchronized =
-                    shouldSynchronized && !excludingPattern.matcher(currentTable).matches();
+            shouldSynchroniz =
+                    shouldSynchroniz && !excludingPattern.matcher(currentTable).matches();
         }
-        if (!shouldSynchronized) {
+        if (!shouldSynchroniz) {
             LOG.debug(
                     "Source table {} won't be synchronized because it was excluded. ",
                     currentTable);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
@@ -45,8 +45,8 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     @Nullable private final Pattern includingPattern;
     @Nullable private final Pattern excludingPattern;
     private final Map<String, RichEventParser> parsers = new HashMap<>();
-    private final Set<String> acceptedTables = new HashSet<>();
-    private final Set<String> rejectedTables = new HashSet<>();
+    private final Set<String> includedTables = new HashSet<>();
+    private final Set<String> excludedTables = new HashSet<>();
     private final Set<String> createdTables = new HashSet<>();
 
     private RichCdcMultiplexRecord record;
@@ -108,10 +108,10 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     }
 
     private boolean shouldSynchronizeCurrentTable(List<String> primaryKeys) {
-        if (acceptedTables.contains(currentTable)) {
+        if (includedTables.contains(currentTable)) {
             return true;
         }
-        if (rejectedTables.contains(currentTable)) {
+        if (excludedTables.contains(currentTable)) {
             return false;
         }
 
@@ -127,7 +127,7 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
             LOG.debug(
                     "Source table {} won't be synchronized because it was excluded. ",
                     currentTable);
-            rejectedTables.add(currentTable);
+            excludedTables.add(currentTable);
             return false;
         }
 
@@ -136,11 +136,11 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
                     "Didn't find primary keys from kafka topic's table schemas for table '{}'. "
                             + "This table won't be synchronized.",
                     currentTable);
-            rejectedTables.add(currentTable);
+            excludedTables.add(currentTable);
             return false;
         }
 
-        acceptedTables.add(currentTable);
+        includedTables.add(currentTable);
         return true;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordSchemaBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataType;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Schema builder for {@link RichCdcMultiplexRecord}. */
+public class RichCdcMultiplexRecordSchemaBuilder implements NewTableSchemaBuilder {
+
+    private final Map<String, String> tableConfig;
+
+    private RichCdcMultiplexRecord record;
+
+    public RichCdcMultiplexRecordSchemaBuilder(Map<String, String> tableConfig) {
+        this.tableConfig = tableConfig;
+    }
+
+    public void init(RichCdcMultiplexRecord record) {
+        this.record = record;
+    }
+
+    @Override
+    public Optional<Schema> build() {
+        checkNotNull(record, "CanalTableSchemaBuilder wasn't initialized.");
+
+        Schema.Builder builder = Schema.newBuilder();
+        builder.options(tableConfig);
+
+        for (Map.Entry<String, DataType> entry : record.fieldTypes().entrySet()) {
+            builder.column(entry.getKey(), entry.getValue(), null);
+        }
+
+        Schema schema = builder.primaryKey(record.primaryKeys()).build();
+
+        return Optional.of(schema);
+    }
+
+    public static RichCdcMultiplexRecordSchemaBuilder dummyBuilder() {
+        return new RichCdcMultiplexRecordSchemaBuilder(Collections.emptyMap()) {
+            @Override
+            public Optional<Schema> build() {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordSchemaBuilder.java
@@ -21,31 +21,21 @@ package org.apache.paimon.flink.sink.cdc;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataType;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.paimon.utils.Preconditions.checkNotNull;
-
 /** Schema builder for {@link RichCdcMultiplexRecord}. */
-public class RichCdcMultiplexRecordSchemaBuilder implements NewTableSchemaBuilder {
+public class RichCdcMultiplexRecordSchemaBuilder
+        implements NewTableSchemaBuilder<RichCdcMultiplexRecord> {
 
     private final Map<String, String> tableConfig;
-
-    private RichCdcMultiplexRecord record;
 
     public RichCdcMultiplexRecordSchemaBuilder(Map<String, String> tableConfig) {
         this.tableConfig = tableConfig;
     }
 
-    public void init(RichCdcMultiplexRecord record) {
-        this.record = record;
-    }
-
     @Override
-    public Optional<Schema> build() {
-        checkNotNull(record, "CanalTableSchemaBuilder wasn't initialized.");
-
+    public Optional<Schema> build(RichCdcMultiplexRecord record) {
         Schema.Builder builder = Schema.newBuilder();
         builder.options(tableConfig);
 
@@ -56,14 +46,5 @@ public class RichCdcMultiplexRecordSchemaBuilder implements NewTableSchemaBuilde
         Schema schema = builder.primaryKey(record.primaryKeys()).build();
 
         return Optional.of(schema);
-    }
-
-    public static RichCdcMultiplexRecordSchemaBuilder dummyBuilder() {
-        return new RichCdcMultiplexRecordSchemaBuilder(Collections.emptyMap()) {
-            @Override
-            public Optional<Schema> build() {
-                return Optional.empty();
-            }
-        };
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -18,7 +18,12 @@
 
 package org.apache.paimon.flink.action.cdc.kafka;
 
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.ActionITCaseBase;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
@@ -362,5 +367,14 @@ public abstract class KafkaActionITCaseBase extends ActionITCaseBase {
             }
             Thread.sleep(1000);
         }
+    }
+
+    protected Catalog catalog() {
+        return CatalogFactory.createCatalog(CatalogContext.create(new Path(warehouse)));
+    }
+
+    protected FileStoreTable getFileStoreTable(String tableName) throws Exception {
+        Identifier identifier = Identifier.create(database, tableName);
+        return (FileStoreTable) catalog().getTable(identifier);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
@@ -98,7 +98,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -110,7 +110,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
     }
 
     private void testSchemaEvolutionImpl(String topic, String sourceDir) throws Exception {
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -271,7 +271,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.emptyList(),
                         Collections.singletonList("_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         Collections.emptyMap());
         action.build(env);
@@ -283,7 +283,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
     }
 
     private void testSchemaEvolutionMultipleImpl(String topic) throws Exception {
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -533,7 +533,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                             "_geometrycollection",
                             "_set",
                         });
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
         List<String> expected =
                 Arrays.asList(
                         "+I["
@@ -637,8 +637,6 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
             waitForResult(expected, table, rowType, Arrays.asList("pt", "_id"));
             SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
             schemaManager.commitChanges(SchemaChange.dropColumn("v"));
-            List<DataField> fields = table.schema().fields();
-            int size = fields.size();
         }
     }
 
@@ -675,7 +673,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         UnsupportedOperationException e =
@@ -719,7 +717,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         Exception e = assertThrows(Exception.class, () -> action.build(env), "Expecting Exception");
@@ -771,7 +769,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         IllegalArgumentException e =
@@ -821,7 +819,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -829,7 +827,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
 
         waitJobRunning(client);
 
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -879,7 +877,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -892,7 +890,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
         } catch (Exception e) {
             throw new Exception("Failed to write canal data to Kafka.", e);
         }
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -944,7 +942,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -957,7 +955,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
         } catch (Exception e) {
             throw new Exception("Failed to write canal data to Kafka.", e);
         }
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -1007,7 +1005,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -1020,7 +1018,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
         } catch (Exception e) {
             throw new Exception("Failed to write canal data to Kafka.", e);
         }
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -1072,7 +1070,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                         tableName,
                         Collections.singletonList("pt"),
                         Arrays.asList("pt", "_id"),
-                        Collections.EMPTY_LIST,
+                        Collections.emptyList(),
                         Collections.emptyMap(),
                         tableConfig);
         action.build(env);
@@ -1085,7 +1083,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
         } catch (Exception e) {
             throw new Exception("Failed to write canal data to Kafka.", e);
         }
-        FileStoreTable table = getFileStoreTable();
+        FileStoreTable table = getFileStoreTable(tableName);
 
         RowType rowType =
                 RowType.of(
@@ -1101,11 +1099,5 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                 Arrays.asList(
                         "+I[1, 1, one]", "+I[1, 2, two]", "+I[1, 3, three]", "+I[1, 4, four]");
         waitForResult(expected, table, rowType, primaryKeys);
-    }
-
-    private FileStoreTable getFileStoreTable() throws Exception {
-        Catalog catalog = CatalogFactory.createCatalog(CatalogContext.create(new Path(warehouse)));
-        Identifier identifier = Identifier.create(database, tableName);
-        return (FileStoreTable) catalog.getTable(identifier);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -59,8 +59,8 @@ import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.flink.action.cdc.mysql.MySqlDatabaseSyncMode.SEPARATE;
-import static org.apache.paimon.flink.action.cdc.mysql.MySqlDatabaseSyncMode.UNIFIED;
+import static org.apache.paimon.flink.action.cdc.DatabaseSyncMode.COMBINED;
+import static org.apache.paimon.flink.action.cdc.DatabaseSyncMode.DIVIDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -374,7 +374,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                         null,
                         Collections.emptyMap(),
                         tableConfig,
-                        SEPARATE);
+                        DIVIDED);
         action.build(env);
         JobClient client = env.executeAsync();
         waitJobRunning(client);
@@ -549,7 +549,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                         excludingTables,
                         Collections.emptyMap(),
                         tableConfig,
-                        SEPARATE);
+                        DIVIDED);
         action.build(env);
         JobClient client = env.executeAsync();
         waitJobRunning(client);
@@ -924,7 +924,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                         null,
                         catalogConfig,
                         tableConfig,
-                        UNIFIED);
+                        COMBINED);
         action.build(env);
 
         if (Objects.nonNull(savepointPath)) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently, when Kafka cdc start, the action will read some canal json and try to build schema from them.
In this PR, the action will dynamically find new table and create them.

<!-- What is the purpose of the change -->

### Tests

Original tests.
### API and Format
Remove two Kafka cdc arguments:
schema-init-max-read
ignore-incompatible

### Documentation

<!-- Does this change introduce a new feature -->
Modify doc.
