### PR TITLE
[common] add option to enable/disable orc dictionary encoding

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -305,6 +305,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Define the default false positive probability for bloom filters.</td>
         </tr>
         <tr>
+            <td><h5>orc.dictionary.key.threshold</h5></td>
+            <td style="word-wrap: break-word;">0.8</td>
+            <td>Double</td>
+            <td>If the number of distinct keys in a dictionary is greater than this fraction of the total number of non-null rows, turn off dictionary encoding. Use 1 to always use dictionary encoding, and use 0 to turn off dictionary encoding.</td>
+        </tr>
+        <tr>
             <td><h5>page-size</h5></td>
             <td style="word-wrap: break-word;">64 kb</td>
             <td>MemorySize</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -106,6 +106,14 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Define the default false positive probability for bloom filters.");
 
+    public static final ConfigOption<Double> ORC_DICTIONARY_ENABLE =
+            key("orc.dictionary.key.threshold")
+                    .doubleType()
+                    .defaultValue(0.8)
+                    .withDescription(
+                            "If the number of distinct keys in a dictionary is greater than this "
+                                    + "fraction of the total number of non-null rows, turn off dictionary encoding. "
+                                    + "Use 1 to always use dictionary encoding, and use 0 to turn off dictionary encoding.");
     public static final ConfigOption<Map<String, String>> FILE_COMPRESSION_PER_LEVEL =
             key("file.compression.per.level")
                     .mapType()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/incubator-paimon/issues/1375

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
