### PR TITLE
[hive] Map object inspector should normalize map key properly before search value

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonDateObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonDateObjectInspector.java
@@ -66,6 +66,8 @@ public class PaimonDateObjectInspector extends AbstractPrimitiveJavaObjectInspec
         }
         if (value instanceof Date) {
             return DateTimeUtils.toInternal((Date) value);
+        } else if (value instanceof DateWritable) {
+            return (((DateWritable) value).getDays());
         } else {
             return DateTimeUtils.toInternal((LocalDate) value);
         }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonDecimalObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonDecimalObjectInspector.java
@@ -65,6 +65,9 @@ public class PaimonDecimalObjectInspector extends AbstractPrimitiveJavaObjectIns
             return null;
         }
 
+        if (o instanceof HiveDecimalWritable) {
+            o = ((HiveDecimalWritable) o).getHiveDecimal();
+        }
         BigDecimal result = ((HiveDecimal) o).bigDecimalValue();
         // during the HiveDecimal to BigDecimal conversion the scale is lost, when the value is 0
         result = result.setScale(scale());

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonMapObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonMapObjectInspector.java
@@ -70,7 +70,11 @@ public class PaimonMapObjectInspector implements MapObjectInspector {
         InternalArray valueArrayData = mapData.valueArray();
         for (int i = 0; i < mapData.size(); i++) {
             Object k = keyGetter.getElementOrNull(keyArrayData, i);
-            if (Objects.equals(k, key)) {
+            Object normalizedSearchKey = key;
+            if (keyObjectInspector instanceof WriteableObjectInspector) {
+                normalizedSearchKey = ((WriteableObjectInspector) keyObjectInspector).convert(key);
+            }
+            if (Objects.equals(k, normalizedSearchKey)) {
                 return valueGetter.getElementOrNull(valueArrayData, i);
             }
         }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspector.java
@@ -66,6 +66,8 @@ public class PaimonTimestampObjectInspector extends AbstractPrimitiveJavaObjectI
         }
         if (value instanceof java.sql.Timestamp) {
             return Timestamp.fromSQLTimestamp((java.sql.Timestamp) value);
+        } else if (value instanceof TimestampWritable) {
+            return Timestamp.fromSQLTimestamp(((TimestampWritable) value).getTimestamp());
         } else {
             return Timestamp.fromLocalDateTime((LocalDateTime) value);
         }


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1552 

<!-- What is the purpose of the change -->
Currently, Hive external table cannot handle map type. It is because the `PaimonMapObjectInspector` haven't convert paimon map key and hive map key to the same comparble type. This PR fix it.

### Tests

<!-- List UT and IT cases to verify this change -->
`PaimonStorageHandlerITCase#testMapKey`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
