### PR TITLE
[core] Fix Object reusing bug in PartialUpdateMergeFunction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
  *
  * <ul>
  *   <li>Please don't save KeyValue and InternalRow references to the List: the KeyValue of the
- *       first two articles and the InternalRow object inside them are safe, but the reference of
- *       the third article may overwrite the reference of the first article.
+ *       first two objects and the InternalRow object inside them are safe, but the reference of the
+ *       third object may overwrite the reference of the first object.
  *   <li>You can save fields references: fields don't reuse their objects.
  * </ul>
  *

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
@@ -220,7 +220,7 @@ public abstract class SortBufferWriteBufferTestBase {
 
         @Override
         protected List<ReusingTestData> getExpected(List<ReusingTestData> input) {
-            return MergeFunctionTestUtils.getExpectedForAgg(input);
+            return MergeFunctionTestUtils.getExpectedForAggSum(input);
         }
 
         @Override
@@ -246,7 +246,7 @@ public abstract class SortBufferWriteBufferTestBase {
 
         @Override
         protected List<ReusingTestData> getExpected(List<ReusingTestData> input) {
-            return MergeFunctionTestUtils.getExpectedForAgg(input);
+            return MergeFunctionTestUtils.getExpectedForAggSum(input);
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
@@ -94,7 +94,7 @@ public class MergeFunctionTestUtils {
         return expected;
     }
 
-    public static List<ReusingTestData> getExpectedForAgg(List<ReusingTestData> input) {
+    public static List<ReusingTestData> getExpectedForAggSum(List<ReusingTestData> input) {
         input = new ArrayList<>(input);
         Collections.sort(input);
 

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
@@ -67,6 +67,10 @@ public class ReusingTestData implements Comparable<ReusingTestData> {
         assertThat(kv.value().getLong(0)).isEqualTo(value);
     }
 
+    public ReusingTestData copy(long newValue) {
+        return new ReusingTestData(key, sequenceNumber, valueKind, newValue);
+    }
+
     /**
      * String format:
      *

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
@@ -67,10 +67,6 @@ public class ReusingTestData implements Comparable<ReusingTestData> {
         assertThat(kv.value().getLong(0)).isEqualTo(value);
     }
 
-    public ReusingTestData copy(long newValue) {
-        return new ReusingTestData(key, sequenceNumber, valueKind, newValue);
-    }
-
     /**
      * String format:
      *


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- When delete Ignore is enabled
- and the last data of the key is delete
- which occurs in Sink's WriteBuffer

There will be a bug in object reuse.


We should update key reference even the incoming record is a delete record.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Introduce classes in `SortBufferWriteBufferTestBase`:
1. WithPartialUpdateMergeFunctionTest
2. WithAggMergeFunctionTest
3. WithLookupFunctionTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
