### PR TITLE
[Format] dictionary option

### DIFF
--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -218,6 +218,7 @@ There are three main places in Paimon writer that takes up memory:
 * Memory consumed when merging several sorted runs for compaction. Can be adjusted by the `num-sorted-run.compaction-trigger` option to change the number of sorted runs to be merged.
 * If the row is very large, reading too many lines of data at once will consume a lot of memory when making a compaction. Reducing the `read.batch-size` option can alleviate the impact of this case.
 * The memory consumed by writing columnar (ORC, Parquet, etc.) file. Decreasing the `orc.write.batch-size` option can reduce the consumption of memory for ORC format.
+* If files are automatically compaction in the write task, dictionaries for certain large columns can significantly consume memory during compaction. You can disable data dictionaries by using `fields.{fieldName}.dictionary-enable`, or disable dictionaries for all fields using the configuration `format.dictionary-enable`.
 
 If your Flink job does not rely on state, please avoid using managed memory, which you can control with the following Flink parameter:
 ```shell

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -159,6 +159,12 @@ under the License.
             <td>Define different file format for different level, you can add the conf like this: 'file.format.per.level' = '0:avro,3:parquet', if the file format for level is not provided, the default format which set by `file.format` will be used.</td>
         </tr>
         <tr>
+            <td><h5>format.fields-dictionary.enable</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enable or disable the dictionary for Parquet/Orc,'format.fields-dictionary.{fieldName}.enable' can be set to enable or disable the dictionary for a specific column.</td>
+        </tr>
+        <tr>
             <td><h5>full-compaction.delta-commits</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -159,10 +159,10 @@ under the License.
             <td>Define different file format for different level, you can add the conf like this: 'file.format.per.level' = '0:avro,3:parquet', if the file format for level is not provided, the default format which set by `file.format` will be used.</td>
         </tr>
         <tr>
-            <td><h5>format.fields-dictionary.enable</h5></td>
+            <td><h5>format.dictionary-enable</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Enable or disable the dictionary for Parquet/Orc,'format.fields-dictionary.{fieldName}.enable' can be set to enable or disable the dictionary for a specific column.</td>
+            <td>Enable the dictionary for Parquet/Orc,'fields.{fieldName}.dictionary-enable' can be set to enable or disable the dictionary for a specific column.</td>
         </tr>
         <tr>
             <td><h5>full-compaction.delta-commits</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1239,7 +1239,7 @@ public class CoreOptions implements Serializable {
         // set whole table dictionary option
         boolean globalDictionaryEnable = options.get(CoreOptions.FORMAT_FIELDS_DICTIONARY);
 
-        Map<String, Boolean> fieldsDictionaryEnabled = new HashMap<>();
+        Map<String, Boolean> fieldsDictionaryOption = new HashMap<>();
 
         // set field's
         for (String key : options.keySet()) {
@@ -1248,11 +1248,11 @@ public class CoreOptions implements Serializable {
             if (key.startsWith(prefix) && key.endsWith(suffix)) {
                 boolean fieldDictionaryOpt = options.getBoolean(key);
                 String fieldName = key.substring(prefix.length(), key.length() - suffix.length());
-                fieldsDictionaryEnabled.put(fieldName, fieldDictionaryOpt);
+                fieldsDictionaryOption.put(fieldName, fieldDictionaryOpt);
             }
         }
 
-        return new DictionaryOptions(globalDictionaryEnable, fieldsDictionaryEnabled);
+        return new DictionaryOptions(globalDictionaryEnable, fieldsDictionaryOption);
     }
 
     public Map<String, String> commitCallbacks() {

--- a/paimon-common/src/main/java/org/apache/paimon/format/DictionaryOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/DictionaryOptions.java
@@ -57,13 +57,13 @@ public class DictionaryOptions {
         }
 
         // fields dictionary opt
-        Map<String, Boolean> fieldsDicOption = getFieldsDicOptionFromFieldPath(fieldPaths);
+        Map<String, Boolean> fieldsDicOption = getFieldPathDicOptions(fieldPaths);
         result.putAll(fieldsDicOption);
 
         return result;
     }
 
-    public Map<String, Boolean> getFieldsDicOptionFromFieldPath(List<String> fieldPaths) {
+    public Map<String, Boolean> getFieldPathDicOptions(List<String> fieldPaths) {
         Map<String, Boolean> result = new HashMap<>();
 
         Map<String, List<String>> pathsGroupByField =
@@ -75,7 +75,7 @@ public class DictionaryOptions {
                                                         ? path.substring(0, path.indexOf("."))
                                                         : path));
 
-        // Specify the dictionary config for the child paths of the field which has dictionary config.
+        // Specify the dictionary for the child paths of the field which has dictionary config
         for (Map.Entry<String, Boolean> fieldOption : fieldsDicOption.entrySet()) {
             String field = fieldOption.getKey();
             boolean dictionaryConfig = fieldOption.getValue();

--- a/paimon-common/src/main/java/org/apache/paimon/format/DictionaryOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/DictionaryOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** the helper class of specifying the dictionary option for parquet/orc format. */
+public class DictionaryOptions {
+    private final boolean tableDictionaryEnable;
+    private final Map<String, Boolean> fieldsDictionaryEnabled;
+
+    public DictionaryOptions(
+            boolean tableDictionaryEnable, Map<String, Boolean> fieldsDictionaryEnabled) {
+        this.tableDictionaryEnable = tableDictionaryEnable;
+        this.fieldsDictionaryEnabled = fieldsDictionaryEnabled;
+    }
+
+    public List<String> getDictionaryDisabledFields(List<String> fieldNames) {
+        Map<String, Boolean> result = new HashMap<>();
+        for (String fieldName : fieldNames) {
+            result.put(fieldName, tableDictionaryEnable);
+        }
+        result.putAll(fieldsDictionaryEnabled);
+        return result.entrySet().stream()
+                .filter(entry -> !entry.getValue())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    public Map<String, Boolean> getFieldsDictionaryEnabled() {
+        return fieldsDictionaryEnabled;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -26,8 +26,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.types.RowType;
 
-import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
-
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -127,21 +125,5 @@ public abstract class FileFormat {
                         options.removePrefix(formatIdentifier + "."),
                         coreOptions.getDictionaryOptions(),
                         readBatchSize));
-    }
-
-    protected List<String> getAllFieldPath(RowType type) {
-        throw new RuntimeException("Unsupported");
-    }
-
-    protected List<String> getDicDisabledFieldPath(
-            RowType rowType, DictionaryOptions dictionaryOptions) {
-        List<String> disableDictionaryFields = Lists.newArrayList();
-
-        // dictionary option has been set
-        if (dictionaryOptions != null && !dictionaryOptions.isEnableAllFieldsDic()) {
-            List<String> fieldPaths = getAllFieldPath(rowType);
-            disableDictionaryFields.addAll(dictionaryOptions.getDicDisabledFields(fieldPaths));
-        }
-        return disableDictionaryFields;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -26,6 +26,8 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.types.RowType;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
+
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -118,16 +120,21 @@ public abstract class FileFormat {
 
     public static FileFormat getFileFormat(Options options, String formatIdentifier) {
         int readBatchSize = options.get(CoreOptions.READ_BATCH_SIZE);
+        CoreOptions coreOptions = new CoreOptions(options);
         return FileFormat.fromIdentifier(
                 formatIdentifier,
                 new FormatContext(
                         options.removePrefix(formatIdentifier + "."),
-                        options.filterPrefixOptions(CoreOptions.FORMAT_PREFIX + "."),
+                        coreOptions.getDictionaryOptions(),
                         readBatchSize));
     }
 
-    public static List<String> mergeDictionaryOptions(RowType rowType, Options options) {
-        CoreOptions coreOptions = new CoreOptions(options);
-        return coreOptions.getDisableDictionaryFields(rowType.getFieldNames());
+    protected List<String> getDictionaryDisabledFields(
+            RowType type, DictionaryOptions dictionaryOptions) {
+        if (dictionaryOptions != null) {
+            return dictionaryOptions.getDictionaryDisabledFields(type.getFieldNames());
+        } else {
+            return Lists.newArrayList();
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -129,12 +129,19 @@ public abstract class FileFormat {
                         readBatchSize));
     }
 
-    protected List<String> getDictionaryDisabledFields(
-            RowType type, DictionaryOptions dictionaryOptions) {
-        if (dictionaryOptions != null) {
-            return dictionaryOptions.getDictionaryDisabledFields(type.getFieldNames());
-        } else {
-            return Lists.newArrayList();
+    protected List<String> getAllFieldPath(RowType type) {
+        throw new RuntimeException("Unsupported");
+    }
+
+    protected List<String> getDicDisabledFieldPath(
+            RowType rowType, DictionaryOptions dictionaryOptions) {
+        List<String> disableDictionaryFields = Lists.newArrayList();
+
+        // dictionary option has been set
+        if (dictionaryOptions != null && !dictionaryOptions.isEnableAllFieldsDic()) {
+            List<String> fieldPaths = getAllFieldPath(rowType);
+            disableDictionaryFields.addAll(dictionaryOptions.getDicDisabledFields(fieldPaths));
         }
+        return disableDictionaryFields;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -120,6 +120,14 @@ public abstract class FileFormat {
         int readBatchSize = options.get(CoreOptions.READ_BATCH_SIZE);
         return FileFormat.fromIdentifier(
                 formatIdentifier,
-                new FormatContext(options.removePrefix(formatIdentifier + "."), readBatchSize));
+                new FormatContext(
+                        options.removePrefix(formatIdentifier + "."),
+                        options.filterPrefixOptions(CoreOptions.FORMAT_PREFIX + "."),
+                        readBatchSize));
+    }
+
+    public static List<String> mergeDictionaryOptions(RowType rowType, Options options) {
+        CoreOptions coreOptions = new CoreOptions(options);
+        return coreOptions.getDisableDictionaryFields(rowType.getFieldNames());
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
@@ -30,15 +30,26 @@ public interface FileFormatFactory {
     /** the format context. */
     class FormatContext {
         private final Options formatOptions;
+
+        private final Options unifyOptions;
         private final int readBatchSize;
 
         public FormatContext(Options formatOptions, int readBatchSize) {
+            this(formatOptions, new Options(), readBatchSize);
+        }
+
+        public FormatContext(Options formatOptions, Options unifyOptions, int readBatchSize) {
             this.formatOptions = formatOptions;
             this.readBatchSize = readBatchSize;
+            this.unifyOptions = unifyOptions;
         }
 
         public Options formatOptions() {
             return formatOptions;
+        }
+
+        public Options getUnifyOptions() {
+            return unifyOptions;
         }
 
         public int readBatchSize() {

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
@@ -31,25 +31,26 @@ public interface FileFormatFactory {
     class FormatContext {
         private final Options formatOptions;
 
-        private final Options unifyOptions;
+        private final DictionaryOptions dictionaryOptions;
         private final int readBatchSize;
 
         public FormatContext(Options formatOptions, int readBatchSize) {
-            this(formatOptions, new Options(), readBatchSize);
+            this(formatOptions, null, readBatchSize);
         }
 
-        public FormatContext(Options formatOptions, Options unifyOptions, int readBatchSize) {
+        public FormatContext(
+                Options formatOptions, DictionaryOptions dictionaryOptions, int readBatchSize) {
             this.formatOptions = formatOptions;
             this.readBatchSize = readBatchSize;
-            this.unifyOptions = unifyOptions;
+            this.dictionaryOptions = dictionaryOptions;
         }
 
         public Options formatOptions() {
             return formatOptions;
         }
 
-        public Options getUnifyOptions() {
-            return unifyOptions;
+        public DictionaryOptions getDictionaryOptions() {
+            return dictionaryOptions;
         }
 
         public int readBatchSize() {

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -48,7 +48,7 @@ public class Options implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /** Stores the concrete key/value pairs of this configuration object. */
-    private final HashMap<String, String> data;
+    private final Map<String, String> data;
 
     /** Creates a new empty configuration. */
     public Options() {
@@ -152,6 +152,17 @@ public class Options implements Serializable {
         return new Options(newData);
     }
 
+    public synchronized Options filterPrefixOptions(String prefix) {
+        Map<String, String> newData = new HashMap<>();
+        data.forEach(
+                (k, v) -> {
+                    if (k.startsWith(prefix)) {
+                        newData.put(k, v);
+                    }
+                });
+        return new Options(newData);
+    }
+
     public synchronized boolean containsKey(String key) {
         return data.containsKey(key);
     }
@@ -167,6 +178,13 @@ public class Options implements Serializable {
 
     public synchronized boolean getBoolean(String key, boolean defaultValue) {
         return getRawValue(key).map(OptionsUtils::convertToBoolean).orElse(defaultValue);
+    }
+
+    public synchronized boolean getBoolean(String key) {
+        return getRawValue(key)
+                .map(OptionsUtils::convertToBoolean)
+                .orElseThrow(
+                        () -> new IllegalStateException(String.format("%s does not exist", key)));
     }
 
     public synchronized int getInteger(String key, int defaultValue) {

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -152,17 +152,6 @@ public class Options implements Serializable {
         return new Options(newData);
     }
 
-    public synchronized Options filterPrefixOptions(String prefix) {
-        Map<String, String> newData = new HashMap<>();
-        data.forEach(
-                (k, v) -> {
-                    if (k.startsWith(prefix)) {
-                        newData.put(k, v);
-                    }
-                });
-        return new Options(newData);
-    }
-
     public synchronized boolean containsKey(String key) {
         return data.containsKey(key);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -46,5 +47,12 @@ public class ReflectionUtils {
     public static <T> T invokeStaticMethod(Method method, Object... args)
             throws InvocationTargetException, IllegalAccessException {
         return (T) method.invoke(null, args);
+    }
+
+    public static <T> T getFeild(Class<?> sourceClazz, Object sourceObject, String fieldName)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field orcReaderField = sourceClazz.getDeclaredField(fieldName);
+        orcReaderField.setAccessible(true);
+        return (T) orcReaderField.get(sourceObject);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -337,8 +337,7 @@ public class SchemaValidation {
         Set<String> fieldNames = new HashSet<>(schema.fieldNames());
         DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
 
-        Map<String, Boolean> fieldsDictionaryEnabled =
-                dictionaryOptions.getfieldsDictionaryOption();
+        Map<String, Boolean> fieldsDictionaryEnabled = dictionaryOptions.getFieldsDictOption();
         for (String dictionaryField : fieldsDictionaryEnabled.keySet()) {
             if (!fieldNames.contains(dictionaryField)) {
                 throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -338,7 +338,7 @@ public class SchemaValidation {
         DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
 
         Map<String, Boolean> fieldsDictionaryEnabled =
-                dictionaryOptions.getFieldsDictionaryEnabled();
+                dictionaryOptions.getfieldsDictionaryOption();
         for (String dictionaryField : fieldsDictionaryEnabled.keySet()) {
             if (!fieldNames.contains(dictionaryField)) {
                 throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -83,6 +83,8 @@ public class SchemaValidation {
 
         validateStartupMode(options);
 
+        validateFormatDictionaryOpt(schema);
+
         ChangelogProducer changelogProducer = options.changelogProducer();
         if (options.writeMode() == WriteMode.APPEND_ONLY
                 && changelogProducer != ChangelogProducer.NONE) {
@@ -325,6 +327,15 @@ public class SchemaValidation {
 
     private static String concatConfigKeys(List<ConfigOption<?>> configOptions) {
         return configOptions.stream().map(ConfigOption::key).collect(Collectors.joining(","));
+    }
+
+    private static void validateFormatDictionaryOpt(TableSchema schema) {
+        try {
+            CoreOptions coreOptions = new CoreOptions(schema.options());
+            coreOptions.getDisableDictionaryFields(schema.fieldNames());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Format dictionary option valid failed", e);
+        }
     }
 
     private static void validateDefaultValues(TableSchema schema) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -201,6 +201,37 @@ public class SchemaEvolutionTest {
     }
 
     @Test
+    public void testDictionaryFormatValid() {
+        {
+            Map<String, String> option = new HashMap<>();
+            option.put(
+                    String.format(
+                            "%s.%s.%s.%s",
+                            CoreOptions.FORMAT_PREFIX,
+                            CoreOptions.DICTIONARY_PREFIX,
+                            "c",
+                            "enable"),
+                    "true");
+            Schema schema =
+                    new Schema(
+                            RowType.of(
+                                            new DataType[] {
+                                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
+                                                DataTypes.BIGINT()
+                                            },
+                                            new String[] {"a", "b"})
+                                    .getFields(),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            option,
+                            "");
+            assertThatThrownBy(() -> schemaManager.createTable(schema))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasRootCauseMessage("field c not found in table");
+        }
+    }
+
+    @Test
     public void testAddField() throws Exception {
         Schema schema =
                 new Schema(

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -206,11 +206,8 @@ public class SchemaEvolutionTest {
             Map<String, String> option = new HashMap<>();
             option.put(
                     String.format(
-                            "%s.%s.%s.%s",
-                            CoreOptions.FORMAT_PREFIX,
-                            CoreOptions.DICTIONARY_PREFIX,
-                            "c",
-                            "enable"),
+                            "%s.%s.%s",
+                            CoreOptions.FIELDS_PREFIX, "c", CoreOptions.DICTIONARY_PREFIX),
                     "true");
             Schema schema =
                     new Schema(
@@ -227,7 +224,7 @@ public class SchemaEvolutionTest {
                             "");
             assertThatThrownBy(() -> schemaManager.createTable(schema))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasRootCauseMessage("field c not found in table");
+                    .hasMessageContaining("field c not found in table");
         }
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -139,7 +139,10 @@ public class OrcFileFormat extends FileFormat {
         Vectorizer<InternalRow> vectorizer =
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
 
-        return new OrcWriterFactory(vectorizer, orcProperties, writerConf);
+        List<String> fieldsDisableDictionary =
+                mergeDictionaryOptions(type, formatContext.getUnifyOptions());
+
+        return new OrcWriterFactory(vectorizer, orcProperties, writerConf, fieldsDisableDictionary);
     }
 
     private static Properties getOrcProperties(Options options) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -140,9 +140,14 @@ public class OrcFileFormat extends FileFormat {
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
 
         List<String> fieldsDisableDictionary =
-                getDictionaryDisabledFields(type, formatContext.getDictionaryOptions());
+                getDicDisabledFieldPath(type, formatContext.getDictionaryOptions());
 
         return new OrcWriterFactory(vectorizer, orcProperties, writerConf, fieldsDisableDictionary);
+    }
+
+    @Override
+    public List<String> getAllFieldPath(RowType type) {
+        return type.getFieldNames();
     }
 
     private static Properties getOrcProperties(Options options) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -140,7 +140,7 @@ public class OrcFileFormat extends FileFormat {
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
 
         List<String> fieldsDisableDictionary =
-                mergeDictionaryOptions(type, formatContext.getUnifyOptions());
+                getDictionaryDisabledFields(type, formatContext.getDictionaryOptions());
 
         return new OrcWriterFactory(vectorizer, orcProperties, writerConf, fieldsDisableDictionary);
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -20,6 +20,7 @@ package org.apache.paimon.format.orc;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.DictionaryOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -43,6 +44,8 @@ import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Projection;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 
 import org.apache.orc.TypeDescription;
 
@@ -145,9 +148,15 @@ public class OrcFileFormat extends FileFormat {
         return new OrcWriterFactory(vectorizer, orcProperties, writerConf, fieldsDisableDictionary);
     }
 
-    @Override
-    public List<String> getAllFieldPath(RowType type) {
-        return type.getFieldNames();
+    private List<String> getDicDisabledFieldPath(
+            RowType rowType, DictionaryOptions dictionaryOptions) {
+        List<String> disableDictionaryFields = Lists.newArrayList();
+        // dictionary option has been set
+        if (dictionaryOptions != null) {
+            List<String> fieldPaths = rowType.getFieldNames();
+            disableDictionaryFields.addAll(dictionaryOptions.getDisableDicFields(fieldPaths));
+        }
+        return disableDictionaryFields;
     }
 
     private static Properties getOrcProperties(Options options) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormatFactory.java
@@ -38,7 +38,7 @@ public class OrcFileFormatFactory implements FileFormatFactory {
         return new OrcFileFormat(
                 new FormatContext(
                         supplyDefaultOptions(formatContext.formatOptions()),
-                        formatContext.getUnifyOptions(),
+                        formatContext.getDictionaryOptions(),
                         formatContext.readBatchSize()));
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormatFactory.java
@@ -38,6 +38,7 @@ public class OrcFileFormatFactory implements FileFormatFactory {
         return new OrcFileFormat(
                 new FormatContext(
                         supplyDefaultOptions(formatContext.formatOptions()),
+                        formatContext.getUnifyOptions(),
                         formatContext.readBatchSize()));
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -62,19 +62,13 @@ public class ParquetFileFormat extends FileFormat {
 
     @Override
     public FormatWriterFactory createWriterFactory(RowType type) {
-        List<String> disableDictionaryFields = getDisableDictionaryFields(type);
+        List<String> disableDictionaryFields =
+                getDictionaryDisabledFields(type, formatContext.getDictionaryOptions());
         return new ParquetWriterFactory(
                 new RowDataParquetBuilder(
                         type,
                         getParquetConfiguration(formatContext.formatOptions()),
                         disableDictionaryFields));
-    }
-
-    @VisibleForTesting
-    protected List<String> getDisableDictionaryFields(RowType type) {
-        List<String> disableDictionaryFields =
-                mergeDictionaryOptions(type, formatContext.getUnifyOptions());
-        return disableDictionaryFields;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -28,9 +28,15 @@ import org.apache.paimon.format.parquet.writer.RowDataParquetBuilder;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.FieldStatsCollector;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Projection;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,12 +69,54 @@ public class ParquetFileFormat extends FileFormat {
     @Override
     public FormatWriterFactory createWriterFactory(RowType type) {
         List<String> disableDictionaryFields =
-                getDictionaryDisabledFields(type, formatContext.getDictionaryOptions());
+                getDicDisabledFieldPath(type, formatContext.getDictionaryOptions());
         return new ParquetWriterFactory(
                 new RowDataParquetBuilder(
                         type,
                         getParquetConfiguration(formatContext.formatOptions()),
                         disableDictionaryFields));
+    }
+
+    @Override
+    public List<String> getAllFieldPath(RowType type) {
+        List<String> result = new ArrayList<>();
+
+        List<DataField> fields = type.getFields();
+        for (DataField field : fields) {
+            DataType dataType = field.type();
+            if (dataType.getTypeRoot() == DataTypeRoot.ROW) {
+                result.addAll(traversal(Pair.of(field.name(), (RowType) dataType)));
+            } else {
+                result.add(field.name());
+            }
+        }
+
+        return result;
+    }
+
+    public static List<String> traversal(Pair<String, RowType> pathPrefixAndRow) {
+        List<String> result = new ArrayList<>();
+
+        LinkedList<Pair<String, RowType>> queue = new LinkedList<>();
+        queue.offer(pathPrefixAndRow);
+        while (!queue.isEmpty()) {
+            Pair<String, RowType> polled = queue.poll();
+
+            String pathPrefix = polled.getKey();
+            List<DataField> datafields = polled.getValue().getFields();
+            for (DataField dataField : datafields) {
+                DataType dataType = dataField.type();
+                String name = dataField.name();
+                String path = String.format("%s.%s", pathPrefix, name);
+                if (dataType.getTypeRoot() != DataTypeRoot.ROW) {
+                    result.add(path);
+                } else {
+                    queue.offer(Pair.of(path, (RowType) dataType));
+                }
+            }
+        }
+
+        return result;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -62,9 +62,19 @@ public class ParquetFileFormat extends FileFormat {
 
     @Override
     public FormatWriterFactory createWriterFactory(RowType type) {
+        List<String> disableDictionaryFields = getDisableDictionaryFields(type);
         return new ParquetWriterFactory(
                 new RowDataParquetBuilder(
-                        type, getParquetConfiguration(formatContext.formatOptions())));
+                        type,
+                        getParquetConfiguration(formatContext.formatOptions()),
+                        disableDictionaryFields));
+    }
+
+    @VisibleForTesting
+    protected List<String> getDisableDictionaryFields(RowType type) {
+        List<String> disableDictionaryFields =
+                mergeDictionaryOptions(type, formatContext.getUnifyOptions());
+        return disableDictionaryFields;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
@@ -40,7 +40,7 @@ public class ParquetFileFormatFactory implements FileFormatFactory {
         return new ParquetFileFormat(
                 new FormatContext(
                         supplyDefaultOptions(formatContext.formatOptions()),
-                        formatContext.getUnifyOptions(),
+                        formatContext.getDictionaryOptions(),
                         formatContext.readBatchSize()));
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
@@ -40,6 +40,7 @@ public class ParquetFileFormatFactory implements FileFormatFactory {
         return new ParquetFileFormat(
                 new FormatContext(
                         supplyDefaultOptions(formatContext.formatOptions()),
+                        formatContext.getUnifyOptions(),
                         formatContext.readBatchSize()));
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -47,8 +47,12 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 /** Schema converter converts Parquet schema to and from Paimon internal types. */
 public class ParquetSchemaConverter {
 
-    static final String MAP_REPEATED_NAME = "key_value";
-    static final String LIST_ELEMENT_NAME = "element";
+    public static final String MAP_REPEATED_NAME = "key_value";
+    public static final String MAP_KEY_NAME = "key";
+    public static final String MAP_VALUE_NAME = "value";
+    public static final String LIST_ELEMENT_NAME = "element";
+
+    public static final String LIST_REPEATED_NAME = "list";
 
     public static MessageType convertToParquetMessageType(String name, RowType rowType) {
         Type[] types = new Type[rowType.getFieldCount()];
@@ -136,16 +140,16 @@ public class ParquetSchemaConverter {
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", mapType.getKeyType()),
-                        convertToParquetType("value", mapType.getValueType()));
+                        convertToParquetType(MAP_KEY_NAME, mapType.getKeyType()),
+                        convertToParquetType(MAP_VALUE_NAME, mapType.getValueType()));
             case MULTISET:
                 MultisetType multisetType = (MultisetType) type;
                 return ConversionPatterns.mapType(
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", multisetType.getElementType()),
-                        convertToParquetType("value", new IntType(false)));
+                        convertToParquetType(MAP_KEY_NAME, multisetType.getElementType()),
+                        convertToParquetType(MAP_VALUE_NAME, new IntType(false)));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new GroupType(repetition, name, convertToParquetTypes(rowType));

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/RowtypeToFieldPathConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/RowtypeToFieldPathConverter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.LIST_ELEMENT_NAME;
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.LIST_REPEATED_NAME;
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.MAP_KEY_NAME;
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.MAP_REPEATED_NAME;
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.MAP_VALUE_NAME;
+
+/** convert Paimon Row to Parquet FilePath. */
+public class RowtypeToFieldPathConverter {
+    public static List<String> getAllFieldPath(RowType type) {
+        List<String> result = new ArrayList<>();
+
+        LinkedList<Pair<String, DataType>> queue = new LinkedList<>();
+        List<DataField> fields = type.getFields();
+        for (DataField field : fields) {
+            queue.offer(Pair.of(field.name(), field.type()));
+        }
+        while (!queue.isEmpty()) {
+            Pair<String, DataType> polled = queue.poll();
+            String fieldName = polled.getLeft();
+            DataType dataType = polled.getRight();
+
+            if (dataType.getTypeRoot() == DataTypeRoot.ROW) {
+                List<Pair<String, DataType>> pairs =
+                        traversalRowType(fieldName, (RowType) dataType);
+                for (Pair<String, DataType> pair : pairs) {
+                    queue.offer(pair);
+                }
+            } else if (dataType.getTypeRoot() == DataTypeRoot.MAP) {
+                result.add(String.format("%s.%s.%s", fieldName, MAP_REPEATED_NAME, MAP_KEY_NAME));
+                result.add(String.format("%s.%s.%s", fieldName, MAP_REPEATED_NAME, MAP_VALUE_NAME));
+            } else if (dataType.getTypeRoot() == DataTypeRoot.MULTISET) {
+                result.add(String.format("%s.%s.%s", fieldName, MAP_REPEATED_NAME, MAP_KEY_NAME));
+            } else if (dataType.getTypeRoot() == DataTypeRoot.ARRAY) {
+                result.add(
+                        String.format(
+                                "%s.%s.%s", fieldName, LIST_REPEATED_NAME, LIST_ELEMENT_NAME));
+            } else {
+                result.add(fieldName);
+            }
+        }
+        return result;
+    }
+
+    public static List<Pair<String, DataType>> traversalRowType(String prefix, RowType type) {
+        List<Pair<String, DataType>> result = new ArrayList<>();
+
+        LinkedList<Pair<String, RowType>> queue = new LinkedList<>();
+        queue.offer(Pair.of(prefix, type));
+        while (!queue.isEmpty()) {
+            Pair<String, RowType> polled = queue.poll();
+
+            String pathPrefix = polled.getKey();
+            List<DataField> datafields = polled.getValue().getFields();
+            for (DataField dataField : datafields) {
+                DataType dataType = dataField.type();
+                String name = dataField.name();
+                String path = String.format("%s.%s", pathPrefix, name);
+                if (dataType.getTypeRoot() == DataTypeRoot.ROW) {
+                    queue.offer(Pair.of(path, (RowType) dataType));
+                } else {
+                    result.add(Pair.of(path, dataType));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/AbstractColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/AbstractColumnReader.java
@@ -295,4 +295,8 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
      */
     protected abstract void readBatchFromDictionaryIds(
             int rowId, int num, VECTOR column, WritableIntVector dictionaryIds);
+
+    public boolean isCurrentPageDictionaryEncoded() {
+        return isCurrentPageDictionaryEncoded;
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BaseVectorizedColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BaseVectorizedColumnReader.java
@@ -287,4 +287,8 @@ public abstract class BaseVectorizedColumnReader implements ColumnReader<Writabl
             return 0;
         }
     }
+
+    public boolean isCurrentPageDictionaryEncoded() {
+        return isCurrentPageDictionaryEncoded;
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/MapColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/MapColumnReader.java
@@ -17,6 +17,7 @@
 
 package org.apache.paimon.format.parquet.reader;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.columnar.ColumnVector;
 import org.apache.paimon.data.columnar.heap.HeapArrayVector;
 import org.apache.paimon.data.columnar.heap.HeapMapVector;
@@ -60,5 +61,15 @@ public class MapColumnReader implements ColumnReader<WritableColumnVector> {
     @Override
     public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
         readBatch(readNumber, vector);
+    }
+
+    @VisibleForTesting
+    public ArrayColumnReader getKeyReader() {
+        return keyReader;
+    }
+
+    @VisibleForTesting
+    public ArrayColumnReader getValueReader() {
+        return valueReader;
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowColumnReader.java
@@ -17,6 +17,7 @@
 
 package org.apache.paimon.format.parquet.reader;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.columnar.heap.HeapRowVector;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 
@@ -54,5 +55,10 @@ public class RowColumnReader implements ColumnReader<WritableColumnVector> {
                 }
             }
         }
+    }
+
+    @VisibleForTesting
+    public List<ColumnReader> getFieldReaders() {
+        return fieldReaders;
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -94,9 +94,14 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
             parquetRowDataBuilder.withDictionaryEncoding(
                     dictionaryOptions.isTableDictionaryEnable());
             if (dictionaryOptions.hasFieldsDicOption()) {
+                // Convert paimon row To parquet feild paths
                 List<String> allFieldPath = RowtypeToFieldPathConverter.getAllFieldPath(rowType);
+
+                // Get field paths dictionary options
                 Map<String, Boolean> fieldsDicOptions =
-                        dictionaryOptions.getFieldsDicOptionFromFieldPath(allFieldPath);
+                        dictionaryOptions.getFieldPathDicOptions(allFieldPath);
+
+                // Specify field path dictionary options to Parquet
                 for (Map.Entry<String, Boolean> fieldsDicOption : fieldsDicOptions.entrySet()) {
                     parquetRowDataBuilder.withDictionaryEncoding(
                             fieldsDicOption.getKey(), fieldsDicOption.getValue());

--- a/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
@@ -135,30 +135,32 @@ public abstract class AbstractDictionaryReaderWriterTest {
             options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
             CoreOptions coreOptions = new CoreOptions(options);
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
-            List<String> disableDictionaryField =
-                    coreOptions.getDisableDictionaryFields(fieldNames);
-            assertThat(disableDictionaryField).hasSameElementsAs(fieldNames);
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
+            assertThat(dictionaryOptions.getDictionaryDisabledFields(fieldNames))
+                    .hasSameElementsAs(fieldNames);
         }
 
         {
             Options options = new Options();
             options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
-            options.set("format.fields-dictionary.c.enable", "true");
+            options.set("fields.c.dictionary-enable", "true");
             CoreOptions coreOptions = new CoreOptions(options);
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
             List<String> disableDictionaryField =
-                    coreOptions.getDisableDictionaryFields(fieldNames);
+                    dictionaryOptions.getDictionaryDisabledFields(fieldNames);
             assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("a", "b", "d"));
         }
 
         {
             Options options = new Options();
             options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, true);
-            options.set("format.fields-dictionary.c.enable", "false");
+            options.set("fields.c.dictionary-enable", "false");
             CoreOptions coreOptions = new CoreOptions(options);
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
             List<String> disableDictionaryField =
-                    coreOptions.getDisableDictionaryFields(fieldNames);
+                    dictionaryOptions.getDictionaryDisabledFields(fieldNames);
             assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("c"));
         }
     }

--- a/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Case for the read/writer of format. */
+public abstract class AbstractDictionaryReaderWriterTest {
+    private @TempDir java.nio.file.Path tempDir;
+
+    protected Path path;
+    protected RowType rowType;
+
+    @BeforeEach
+    public void before() throws IOException {
+        rowType =
+                RowType.builder()
+                        .field("a0", DataTypes.INT())
+                        .field("a1", DataTypes.TINYINT())
+                        .field("a2", DataTypes.SMALLINT())
+                        .field("a3", DataTypes.BIGINT())
+                        .field("a4", DataTypes.STRING())
+                        .field("a5", DataTypes.DOUBLE())
+                        .field("a6", DataTypes.ARRAY(DataTypes.STRING()))
+                        .field("a7", DataTypes.CHAR(100))
+                        .field("a8", DataTypes.VARCHAR(100))
+                        .field("a9", DataTypes.BOOLEAN())
+                        .field("a10", DataTypes.DATE())
+                        .field("a11", DataTypes.TIME())
+                        .field("a12", DataTypes.TIMESTAMP())
+                        .field("a13", DataTypes.TIMESTAMP_MILLIS())
+                        .field("a14", DataTypes.DECIMAL(3, 3))
+                        .field("a15", DataTypes.BYTES())
+                        .field("a16", DataTypes.FLOAT())
+                        .field("a17", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))
+                        .field("a18", DataTypes.ROW(DataTypes.FIELD(100, "b1", DataTypes.STRING())))
+                        .field("a19", DataTypes.BINARY(100))
+                        .field("a20", DataTypes.VARBINARY(100))
+                        .field("a21", DataTypes.MULTISET(DataTypes.STRING()))
+                        .field("a22", DataTypes.STRING())
+                        .build();
+        FormatWriterFactory writerFactory = getFileFormat().createWriterFactory(rowType);
+        path = new Path(tempDir.toUri().toString(), "1." + getFileFormat().getFormatIdentifier());
+        LocalFileIO localFileIO = LocalFileIO.create();
+        PositionOutputStream out = localFileIO.newOutputStream(path, false);
+        FormatWriter formatWriter = writerFactory.create(out, null);
+
+        for (int i = 0; i < 1024; i++) {
+            GenericRow row = new GenericRow(23);
+            row.setField(0, 1);
+            row.setField(1, (byte) 1);
+            row.setField(2, (short) 1);
+            row.setField(3, 1L);
+            row.setField(4, BinaryString.fromString("a"));
+            row.setField(5, 0.5D);
+            row.setField(6, new GenericArray(new Object[] {BinaryString.fromString("1")}));
+            row.setField(7, BinaryString.fromString("3"));
+            row.setField(8, BinaryString.fromString("3"));
+            row.setField(9, true);
+            row.setField(10, 375);
+            row.setField(11, 100);
+            row.setField(12, Timestamp.fromEpochMillis(1685548953000L));
+            row.setField(13, Timestamp.fromEpochMillis(1685548953000L));
+            row.setField(14, Decimal.fromBigDecimal(new BigDecimal("0.22"), 3, 3));
+            row.setField(15, new byte[] {1, 5, 2});
+            row.setField(16, 0.26F);
+            row.setField(
+                    17,
+                    new GenericMap(
+                            Collections.singletonMap(
+                                    BinaryString.fromString("k"), BinaryString.fromString("v"))));
+            row.setField(18, GenericRow.of(BinaryString.fromString("cc")));
+            row.setField(19, "bb".getBytes());
+            row.setField(20, "aa".getBytes());
+            row.setField(
+                    21,
+                    new GenericMap(Collections.singletonMap(BinaryString.fromString("set"), 1)));
+            row.setField(22, BinaryString.fromString("a"));
+
+            formatWriter.addElement(row);
+        }
+
+        formatWriter.flush();
+        formatWriter.finish();
+        out.close();
+    }
+
+    protected abstract FileFormat getFileFormat();
+
+    @Test
+    public void testFormatDictionaryOpt() {
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+            CoreOptions coreOptions = new CoreOptions(options);
+            List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
+            List<String> disableDictionaryField =
+                    coreOptions.getDisableDictionaryFields(fieldNames);
+            assertThat(disableDictionaryField).hasSameElementsAs(fieldNames);
+        }
+
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+            options.set("format.fields-dictionary.c.enable", "true");
+            CoreOptions coreOptions = new CoreOptions(options);
+            List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
+            List<String> disableDictionaryField =
+                    coreOptions.getDisableDictionaryFields(fieldNames);
+            assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("a", "b", "d"));
+        }
+
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, true);
+            options.set("format.fields-dictionary.c.enable", "false");
+            CoreOptions coreOptions = new CoreOptions(options);
+            List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
+            List<String> disableDictionaryField =
+                    coreOptions.getDisableDictionaryFields(fieldNames);
+            assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("c"));
+        }
+    }
+}

--- a/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractDictionaryReaderWriterTest {
             CoreOptions coreOptions = new CoreOptions(options);
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
             DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
-            assertThat(dictionaryOptions.getDictionaryDisabledFields(fieldNames))
+            assertThat(dictionaryOptions.getDicDisabledFields(fieldNames))
                     .hasSameElementsAs(fieldNames);
         }
 
@@ -148,7 +148,7 @@ public abstract class AbstractDictionaryReaderWriterTest {
             DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
             List<String> disableDictionaryField =
-                    dictionaryOptions.getDictionaryDisabledFields(fieldNames);
+                    dictionaryOptions.getDicDisabledFields(fieldNames);
             assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("a", "b", "d"));
         }
 
@@ -160,7 +160,7 @@ public abstract class AbstractDictionaryReaderWriterTest {
             DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
             List<String> fieldNames = Lists.newArrayList("a", "b", "c", "d");
             List<String> disableDictionaryField =
-                    dictionaryOptions.getDictionaryDisabledFields(fieldNames);
+                    dictionaryOptions.getDicDisabledFields(fieldNames);
             assertThat(disableDictionaryField).hasSameElementsAs(Lists.newArrayList("c"));
         }
     }

--- a/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractDictionaryReaderWriterTest {
     private @TempDir java.nio.file.Path tempDir;
 
     protected Path path;
-    protected RowType rowType;
+    private RowType rowType;
 
     @BeforeEach
     public void before() throws IOException {

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.format.orc;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.AbstractDictionaryReaderWriterTest;
+import org.apache.paimon.format.DictionaryOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -38,6 +39,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT Case for the read/writer of orc. */
 public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWriterTest {
@@ -56,7 +60,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
     }
 
     @Test
-    public void testWriterFormatOpt() {
+    public void testOrcWriterOpt() {
         OrcWriterFactory writerFactory =
                 (OrcWriterFactory) getFileFormat().createWriterFactory(rowType);
         OrcFile.WriterOptions writerOptions = writerFactory.getWriterOptions();
@@ -64,7 +68,8 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
         ArrayList<String> expected =
                 Lists.newArrayList(
                         "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
-                        "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19", "a20", "a21");
+                        "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19", "a20", "a21",
+                        "a23");
         Assertions.assertThat(Arrays.asList(directEncodingColumns)).hasSameElementsAs(expected);
     }
 
@@ -85,7 +90,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
     }
 
     @Test
-    public void testReadFormatDictionary()
+    public void testFormatDictionaryIT()
             throws IOException, NoSuchFieldException, ClassNotFoundException,
                     IllegalAccessException {
         TreeReaderFactory.TreeReader[] child = getReaderChild();
@@ -101,15 +106,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
 
         // DataTypes.ARRAY(DataTypes.STRING())
         {
-            TreeReaderFactory.StringTreeReader elementReader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.ListTreeReader.class, child[6], "elementReader");
-
-            TreeReaderFactory.TreeReader reader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StringTreeReader.class, elementReader, "reader");
-            Assertions.assertThat(reader)
-                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+            assertDirectEncodeArray(child[6]);
         }
 
         // DataTypes.CHAR(100)
@@ -132,57 +129,139 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
 
         // DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())
         {
-            TreeReaderFactory.TreeReader keyReader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.MapTreeReader.class, child[17], "keyReader");
-            TreeReaderFactory.TreeReader valueReader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.MapTreeReader.class, child[17], "valueReader");
-
-            TreeReaderFactory.TreeReader reader1 =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
-
-            TreeReaderFactory.TreeReader reader2 =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StringTreeReader.class, valueReader, "reader");
-            Assertions.assertThat(reader1)
-                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
-            Assertions.assertThat(reader2)
-                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+            assertDirectEncodeMap(child[17]);
         }
 
-        //        DataTypes.ROW(DataTypes.FIELD(100, "b1", DataTypes.STRING()))
+        // DataTypes.ROW(DataTypes.FIELD(100, "b1", DataTypes.STRING()))
         {
-            TreeReaderFactory.TreeReader[] fields =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StructTreeReader.class, child[18], "fields");
-            TreeReaderFactory.TreeReader reader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StringTreeReader.class, fields[0], "reader");
-            Assertions.assertThat(reader)
-                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+            assertDirectEncodeRow(child[18]);
         }
 
-        //        DataTypes.MULTISET(DataTypes.STRING())
+        // DataTypes.MULTISET(DataTypes.STRING())
         {
-            TreeReaderFactory.TreeReader keyReader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.MapTreeReader.class, child[21], "keyReader");
-            TreeReaderFactory.TreeReader strReader =
-                    ReflectionUtils.getFeild(
-                            TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
-
-            Assertions.assertThat(strReader)
-                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+            assertDirectEncodeMultiSet(child[21]);
         }
-        // enable dictionary
+
+        // Enable string dictionary
         {
             TreeReaderFactory.TreeReader reader =
                     ReflectionUtils.getFeild(
                             TreeReaderFactory.StringTreeReader.class, child[22], "reader");
             Assertions.assertThat(reader)
                     .isInstanceOf(TreeReaderFactory.StringDictionaryTreeReader.class);
+        }
+
+        // Complex Nested Feilds:  Row<Row<Map<String,String>,Arrary,Set<String>>>
+        {
+            TreeReaderFactory.StructTreeReader reader =
+                    (TreeReaderFactory.StructTreeReader) child[23];
+
+            TreeReaderFactory.StructTreeReader childReader =
+                    (TreeReaderFactory.StructTreeReader) reader.getChildReaders()[0];
+
+            assertDirectEncodeMap(childReader.getChildReaders()[0]);
+            assertDirectEncodeArray(childReader.getChildReaders()[1]);
+            assertDirectEncodeMultiSet(childReader.getChildReaders()[2]);
+        }
+    }
+
+    private static void assertDirectEncodeArray(TreeReaderFactory.TreeReader child)
+            throws NoSuchFieldException, IllegalAccessException {
+        TreeReaderFactory.StringTreeReader elementReader =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.ListTreeReader.class, child, "elementReader");
+
+        TreeReaderFactory.TreeReader reader =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.StringTreeReader.class, elementReader, "reader");
+        Assertions.assertThat(reader).isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+    }
+
+    private static void assertDirectEncodeMap(TreeReaderFactory.TreeReader child)
+            throws NoSuchFieldException, IllegalAccessException {
+        TreeReaderFactory.TreeReader keyReader =
+                ReflectionUtils.getFeild(TreeReaderFactory.MapTreeReader.class, child, "keyReader");
+        TreeReaderFactory.TreeReader valueReader =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.MapTreeReader.class, child, "valueReader");
+
+        TreeReaderFactory.TreeReader reader1 =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
+
+        TreeReaderFactory.TreeReader reader2 =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.StringTreeReader.class, valueReader, "reader");
+        Assertions.assertThat(reader1).isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        Assertions.assertThat(reader2).isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+    }
+
+    private static void assertDirectEncodeRow(TreeReaderFactory.TreeReader child)
+            throws NoSuchFieldException, IllegalAccessException {
+        TreeReaderFactory.TreeReader[] fields =
+                ReflectionUtils.getFeild(TreeReaderFactory.StructTreeReader.class, child, "fields");
+        TreeReaderFactory.TreeReader reader =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.StringTreeReader.class, fields[0], "reader");
+        Assertions.assertThat(reader).isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+    }
+
+    private static void assertDirectEncodeMultiSet(TreeReaderFactory.TreeReader child)
+            throws NoSuchFieldException, IllegalAccessException {
+        TreeReaderFactory.TreeReader keyReader =
+                ReflectionUtils.getFeild(TreeReaderFactory.MapTreeReader.class, child, "keyReader");
+        TreeReaderFactory.TreeReader strReader =
+                ReflectionUtils.getFeild(
+                        TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
+
+        Assertions.assertThat(strReader)
+                .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+    }
+
+    @Test
+    public void testDictionaryOpt() {
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+            CoreOptions coreOptions = new CoreOptions(options);
+            List<String> fieldNames =
+                    org.apache.paimon.shade.guava30.com.google.common.collect.Lists.newArrayList(
+                            "a", "b", "c", "d");
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
+            assertThat(dictionaryOptions.mergeFieldsDictionaryOpt(fieldNames).keySet())
+                    .hasSameElementsAs(fieldNames);
+        }
+
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+            options.set("fields.c.dictionary-enable", "true");
+            CoreOptions coreOptions = new CoreOptions(options);
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
+            List<String> fieldNames =
+                    org.apache.paimon.shade.guava30.com.google.common.collect.Lists.newArrayList(
+                            "a", "b", "c", "d");
+            List<String> disableDictionaryField = dictionaryOptions.getDisableDicFields(fieldNames);
+            assertThat(disableDictionaryField)
+                    .hasSameElementsAs(
+                            org.apache.paimon.shade.guava30.com.google.common.collect.Lists
+                                    .newArrayList("a", "b", "d"));
+        }
+
+        {
+            Options options = new Options();
+            options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, true);
+            options.set("fields.c.dictionary-enable", "false");
+            CoreOptions coreOptions = new CoreOptions(options);
+            DictionaryOptions dictionaryOptions = coreOptions.getDictionaryOptions();
+            List<String> fieldNames =
+                    org.apache.paimon.shade.guava30.com.google.common.collect.Lists.newArrayList(
+                            "a", "b", "c", "d");
+            List<String> disableDictionaryField = dictionaryOptions.getDisableDicFields(fieldNames);
+            assertThat(disableDictionaryField)
+                    .hasSameElementsAs(
+                            org.apache.paimon.shade.guava30.com.google.common.collect.Lists
+                                    .newArrayList("c"));
         }
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
@@ -47,7 +47,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
         Options options = new Options();
         options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
         // a22 enable dictionary
-        options.set("format.fields-dictionary.a22.enable", "true");
+        options.set("fields.a22.dictionary-enable", "true");
         fileFormat = FileFormat.getFileFormat(options, "orc");
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
@@ -62,7 +62,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
     @Test
     public void testOrcWriterOpt() {
         OrcWriterFactory writerFactory =
-                (OrcWriterFactory) getFileFormat().createWriterFactory(rowType);
+                (OrcWriterFactory) getFileFormat().createWriterFactory(getRowType());
         OrcFile.WriterOptions writerOptions = writerFactory.getWriterOptions();
         String[] directEncodingColumns = writerOptions.getDirectEncodingColumns().split(",");
         ArrayList<String> expected =
@@ -76,7 +76,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
     private TreeReaderFactory.TreeReader[] getReaderChild()
             throws IOException, ClassNotFoundException, NoSuchFieldException,
                     IllegalAccessException {
-        FormatReaderFactory readerFactory = fileFormat.createReaderFactory(rowType);
+        FormatReaderFactory readerFactory = fileFormat.createReaderFactory(getRowType());
         RecordReader<InternalRow> reader = readerFactory.createReader(LocalFileIO.create(), path);
 
         Class<?> vectorizedReaderClass =
@@ -90,7 +90,7 @@ public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWrite
     }
 
     @Test
-    public void testFormatDictionaryIT()
+    public void testFormatDictionaryReader()
             throws IOException, NoSuchFieldException, ClassNotFoundException,
                     IllegalAccessException {
         TreeReaderFactory.TreeReader[] child = getReaderChild();

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.orc;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.AbstractDictionaryReaderWriterTest;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.ReflectionUtils;
+
+import org.apache.orc.OrcFile;
+import org.apache.orc.impl.RecordReaderImpl;
+import org.apache.orc.impl.TreeReaderFactory;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/** IT Case for the read/writer of orc. */
+public class OrcDictionaryReaderWriterTest extends AbstractDictionaryReaderWriterTest {
+    protected final FileFormat fileFormat;
+
+    public OrcDictionaryReaderWriterTest() {
+        Options options = new Options();
+        options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+        // a22 enable dictionary
+        options.set("format.fields-dictionary.a22.enable", "true");
+        fileFormat = FileFormat.getFileFormat(options, "orc");
+    }
+
+    public FileFormat getFileFormat() {
+        return fileFormat;
+    }
+
+    @Test
+    public void testWriterFormatOpt() {
+        OrcWriterFactory writerFactory =
+                (OrcWriterFactory) getFileFormat().createWriterFactory(rowType);
+        OrcFile.WriterOptions writerOptions = writerFactory.getWriterOptions();
+        String[] directEncodingColumns = writerOptions.getDirectEncodingColumns().split(",");
+        ArrayList<String> expected =
+                Lists.newArrayList(
+                        "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+                        "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19", "a20", "a21");
+        Assertions.assertThat(Arrays.asList(directEncodingColumns)).hasSameElementsAs(expected);
+    }
+
+    private TreeReaderFactory.TreeReader[] getReaderChild()
+            throws IOException, ClassNotFoundException, NoSuchFieldException,
+                    IllegalAccessException {
+        FormatReaderFactory readerFactory = fileFormat.createReaderFactory(rowType);
+        RecordReader<InternalRow> reader = readerFactory.createReader(LocalFileIO.create(), path);
+
+        Class<?> vectorizedReaderClass =
+                Class.forName("org.apache.paimon.format.orc.OrcReaderFactory$OrcVectorizedReader");
+        RecordReaderImpl orcReader =
+                ReflectionUtils.getFeild(vectorizedReaderClass, reader, "orcReader");
+
+        TreeReaderFactory.StructTreeReader structTreeReader =
+                ReflectionUtils.getFeild(RecordReaderImpl.class, orcReader, "reader");
+        return structTreeReader.getChildReaders();
+    }
+
+    @Test
+    public void testReadFormatDictionary()
+            throws IOException, NoSuchFieldException, ClassNotFoundException,
+                    IllegalAccessException {
+        TreeReaderFactory.TreeReader[] child = getReaderChild();
+
+        // DataTypes.STRING()
+        {
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, child[4], "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        // DataTypes.ARRAY(DataTypes.STRING())
+        {
+            TreeReaderFactory.StringTreeReader elementReader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.ListTreeReader.class, child[6], "elementReader");
+
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, elementReader, "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        // DataTypes.CHAR(100)
+        {
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, child[7], "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        // DataTypes.VARCHAR(100)
+        {
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, child[8], "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        // DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())
+        {
+            TreeReaderFactory.TreeReader keyReader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.MapTreeReader.class, child[17], "keyReader");
+            TreeReaderFactory.TreeReader valueReader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.MapTreeReader.class, child[17], "valueReader");
+
+            TreeReaderFactory.TreeReader reader1 =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
+
+            TreeReaderFactory.TreeReader reader2 =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, valueReader, "reader");
+            Assertions.assertThat(reader1)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+            Assertions.assertThat(reader2)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        //        DataTypes.ROW(DataTypes.FIELD(100, "b1", DataTypes.STRING()))
+        {
+            TreeReaderFactory.TreeReader[] fields =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StructTreeReader.class, child[18], "fields");
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, fields[0], "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+
+        //        DataTypes.MULTISET(DataTypes.STRING())
+        {
+            TreeReaderFactory.TreeReader keyReader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.MapTreeReader.class, child[21], "keyReader");
+            TreeReaderFactory.TreeReader strReader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, keyReader, "reader");
+
+            Assertions.assertThat(strReader)
+                    .isInstanceOf(TreeReaderFactory.StringDirectTreeReader.class);
+        }
+        // enable dictionary
+        {
+            TreeReaderFactory.TreeReader reader =
+                    ReflectionUtils.getFeild(
+                            TreeReaderFactory.StringTreeReader.class, child[22], "reader");
+            Assertions.assertThat(reader)
+                    .isInstanceOf(TreeReaderFactory.StringDictionaryTreeReader.class);
+        }
+    }
+}

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetDictionaryReaderWriterTest.java
@@ -50,7 +50,7 @@ import java.util.List;
 
 /** IT Case for the read/writer of parquet. */
 public class ParquetDictionaryReaderWriterTest extends AbstractDictionaryReaderWriterTest {
-    private MockParquetFormat fileFormat;
+    private ParquetFileFormat fileFormat;
 
     public ParquetDictionaryReaderWriterTest() {
         Options options = new Options();
@@ -61,22 +61,12 @@ public class ParquetDictionaryReaderWriterTest extends AbstractDictionaryReaderW
         FileFormatFactory.FormatContext formatContext =
                 new FileFormatFactory.FormatContext(
                         options.removePrefix("parquet."), coreOptions.getDictionaryOptions(), 1024);
-        MockParquetFormat mockParquetFormat = new MockParquetFormat(formatContext);
-        fileFormat = mockParquetFormat;
+        fileFormat = new ParquetFileFormat(formatContext);
     }
 
     @Override
     protected FileFormat getFileFormat() {
         return fileFormat;
-    }
-
-    @Test
-    public void testWriterFormatOpt() {
-        ArrayList<String> expected =
-                Lists.newArrayList(
-                        "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
-                        "a12", "a13", "a14", "a15", "a16", "a17", "a18.b1", "a19", "a20", "a21");
-        Assertions.assertThat(fileFormat.disableDictionaryPaths).hasSameElementsAs(expected);
     }
 
     @Test
@@ -271,14 +261,6 @@ public class ParquetDictionaryReaderWriterTest extends AbstractDictionaryReaderW
                             "d.g.key_value.key",
                             "d.g.key_value.value");
             Assertions.assertThat(allFieldPath).hasSameElementsAs(expected);
-        }
-    }
-
-    class MockParquetFormat extends ParquetFileFormat {
-        private List<String> disableDictionaryPaths;
-
-        public MockParquetFormat(FileFormatFactory.FormatContext formatContext) {
-            super(formatContext);
         }
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetDictionaryReaderWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetDictionaryReaderWriterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.AbstractDictionaryReaderWriterTest;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FormatWriterFactory;
+import org.apache.paimon.format.parquet.writer.ParquetBulkWriter;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.RowType;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** IT Case for the read/writer of parquet. */
+public class ParquetDictionaryReaderWriterTest extends AbstractDictionaryReaderWriterTest {
+    private MockParquetFormat fileFormat;
+
+    public ParquetDictionaryReaderWriterTest() {
+        Options options = new Options();
+        options.set(CoreOptions.FORMAT_FIELDS_DICTIONARY, false);
+        // a22 enable dictionary
+        options.set("format.fields-dictionary.a22.enable", "true");
+        FileFormatFactory.FormatContext formatContext =
+                new FileFormatFactory.FormatContext(
+                        options.removePrefix("parquet."),
+                        options.filterPrefixOptions(CoreOptions.FORMAT_PREFIX + "."),
+                        1024);
+        MockParquetFormat mockParquetFormat = new MockParquetFormat(formatContext);
+        fileFormat = mockParquetFormat;
+    }
+
+    @Override
+    protected FileFormat getFileFormat() {
+        return fileFormat;
+    }
+
+    @Test
+    public void testWriterFormatOpt() {
+        ArrayList<String> expected =
+                Lists.newArrayList(
+                        "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+                        "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19", "a20", "a21");
+        Assertions.assertThat(fileFormat.disableDictionaryFields).hasSameElementsAs(expected);
+    }
+
+    @Test
+    public void test() throws IOException {
+        FormatWriterFactory writerFactory = fileFormat.createWriterFactory(rowType);
+        Assertions.assertThat(writerFactory).isInstanceOf(ParquetWriterFactory.class);
+
+        LocalFileIO localFileIO = LocalFileIO.create();
+        ParquetBulkWriter formatWriter =
+                (ParquetBulkWriter)
+                        writerFactory.create(
+                                localFileIO.newOutputStream(
+                                        new Path(path.getParent(), "2.parquet"), false),
+                                null);
+        ParquetReaderFactory readerFactory =
+                (ParquetReaderFactory) fileFormat.createReaderFactory(rowType);
+        RecordReader<InternalRow> reader = readerFactory.createReader(LocalFileIO.create(), path);
+        System.out.println(reader);
+    }
+
+    class MockParquetFormat extends ParquetFileFormat {
+        private List<String> disableDictionaryFields;
+
+        public MockParquetFormat(FileFormatFactory.FormatContext formatContext) {
+            super(formatContext);
+        }
+
+        @Override
+        protected List<String> getDisableDictionaryFields(RowType type) {
+            disableDictionaryFields = super.getDisableDictionaryFields(type);
+            return disableDictionaryFields;
+        }
+    }
+}


### PR DESCRIPTION
close #1375 
add two  format options to enable dictionary for ORC/PARQUET

1.  format.dictionary-enable
2.  fields.{fieldName}.dictionary-enable
### test
paimon-format/src/test/java/org/apache/paimon/format/AbstractDictionaryReaderWriterTest.java
paimon-format/src/test/java/org/apache/paimon/format/orc/OrcDictionaryReaderWriterTest.java
paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetDictionaryReaderWriterTest.java