### PR TITLE
[flink] upgrade to flink cdc 2.4

### DIFF
--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
     <properties>
         <flink.version>1.17.1</flink.version>
-        <flink.cdc.version>2.3.0</flink.cdc.version>
+        <flink.cdc.version>2.4.0</flink.cdc.version>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
         <geometry.version>2.2.0</geometry.version>
         <druid.version>1.2.15</druid.version>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -31,10 +31,10 @@ import com.ververica.cdc.connectors.mysql.source.MySqlSourceBuilder;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffsetBuilder;
-import com.ververica.cdc.connectors.mysql.table.JdbcUrlUtils;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.table.DebeziumOptions;
+import com.ververica.cdc.debezium.utils.JdbcUrlUtils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -60,13 +60,6 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class MySqlActionUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlActionUtils.class);
-    public static final ConfigOption<Boolean> SCAN_NEWLY_ADDED_TABLE_ENABLED =
-            ConfigOptions.key("scan.newly-added-table.enabled")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether capture the scan the newly added tables or not, by default is true.");
-
     public static final ConfigOption<Boolean> MYSQL_CONVERTER_TINYINT1_BOOL =
             ConfigOptions.key("mysql.converter.tinyint1-to-bool")
                     .booleanType()
@@ -287,13 +280,7 @@ public class MySqlActionUtils {
         JsonDebeziumDeserializationSchema schema =
                 new JsonDebeziumDeserializationSchema(true, customConverterConfigs);
 
-        boolean scanNewlyAddedTables = mySqlConfig.get(SCAN_NEWLY_ADDED_TABLE_ENABLED);
-
-        return sourceBuilder
-                .deserializer(schema)
-                .includeSchemaChanges(true)
-                .scanNewlyAddedTableEnabled(scanNewlyAddedTables)
-                .build();
+        return sourceBuilder.deserializer(schema).includeSchemaChanges(true).build();
     }
 
     private static void validateMySqlConfig(Configuration mySqlConfig) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

flink cdc 2.4 has a bug , for new added table in the runtime ,we can get the table ,but we can not get the data of the new table, i check it , it is caused by `scanNewlyAddedTables ` param, so I remove it , then all test case passed, I think it meets all our current scenario

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
