### PR TITLE
[filnk] make kafka sync action to public

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DropPartitionAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DropPartitionAction.java
@@ -33,7 +33,7 @@ public class DropPartitionAction extends TableActionBase {
     private final List<Map<String, String>> partitions;
     private final FileStoreCommit commit;
 
-    DropPartitionAction(
+    public DropPartitionAction(
             String warehouse,
             String databaseName,
             String tableName,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -117,11 +117,11 @@ public class MergeIntoAction extends TableActionBase {
     @Nullable private String notMatchedInsertCondition;
     @Nullable private String notMatchedInsertValues;
 
-    MergeIntoAction(String warehouse, String database, String tableName) {
+    public MergeIntoAction(String warehouse, String database, String tableName) {
         this(warehouse, database, tableName, Collections.emptyMap());
     }
 
-    MergeIntoAction(
+    public MergeIntoAction(
             String warehouse,
             String database,
             String tableName,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseAction.java
@@ -89,7 +89,7 @@ public class KafkaSyncDatabaseAction extends ActionBase {
     @Nullable private final Pattern excludingPattern;
     private final Map<String, String> tableConfig;
 
-    KafkaSyncDatabaseAction(
+    public KafkaSyncDatabaseAction(
             Map<String, String> kafkaConfig,
             String warehouse,
             String database,
@@ -98,7 +98,7 @@ public class KafkaSyncDatabaseAction extends ActionBase {
         this(kafkaConfig, warehouse, database, null, null, null, null, catalogConfig, tableConfig);
     }
 
-    KafkaSyncDatabaseAction(
+    public KafkaSyncDatabaseAction(
             Map<String, String> kafkaConfig,
             String warehouse,
             String database,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncTableAction.java
@@ -88,7 +88,7 @@ public class KafkaSyncTableAction extends ActionBase {
 
     private final Map<String, String> paimonConfig;
 
-    KafkaSyncTableAction(
+    public KafkaSyncTableAction(
             Map<String, String> kafkaConfig,
             String warehouse,
             String database,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

when use flink api to start a flink kafka sync action job  ,  it will throw an `Cannot be accessed from outside package` exception , because it is not public. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
