### PR TITLE
[checkstyle] Forbid directly using guava in checkstyle

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -184,6 +184,11 @@ This file is based on the checkstyle file of Apache Beam.
 
 		-->
 
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use paimon-shaded-guava instead."/>
+		</module>
+
 		<module name="RedundantImport">
 			<!-- Checks for redundant import statements. -->
 			<property name="severity" value="error"/>


### PR DESCRIPTION
### Purpose

Paimon provides paimon-shaded-guava to avoid class conflicts. We should enforce the developers to use this shaded guava by adding a rule in checkstyle.

### Tests

No tests for this change.

### API and Format

No.

### Documentation

No.
