### PR TITLE
[hotfix][core] Multiple-writers doc url path is error in Exception messages

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -877,7 +877,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         "2. Multiple jobs are writing into the same partition at the same time "
                                 + "(you'll probably see different base commit user and current commit user below).",
                         "   You can use "
-                                + "https://paimon.apache.org/docs/master/maintenance/write-performance/#dedicated-compaction-job "
+                                + "https://paimon.apache.org/docs/master/maintenance/multiple-writers/#dedicated-compaction-job "
                                 + "to support multiple writing.",
                         "3. You're recovering from an old savepoint, or you're creating multiple jobs from a savepoint.",
                         "   The job will fail continuously in this scenario to protect metadata from corruption.",


### PR DESCRIPTION
### Purpose
Multiple-writers doc url path is error in Exception messages，Might not be updated to latest url，cause misunderstanding

Earlier： https://paimon.apache.org/docs/master/maintenance/write-performance/#dedicated-compaction-job
Newest：https://paimon.apache.org/docs/master/maintenance/multiple-writers/#dedicated-compaction-job

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
