### PR TITLE
[core] Optimize First row merge engine with lookup

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -216,15 +216,12 @@ For streaming queries, `aggregation` merge engine must be used together with `lo
 
 ### First Row
 
-By specifying `'merge-engine' = 'first-row'`, users can keep the first row of the same primary key. It differs from the `deduplicate` merge engine that in the `first-row` merge engine, it will generate insert only changelog. 
+By specifying `'merge-engine' = 'first-row'`, users can keep the first row of the same primary key. It differs from the
+`deduplicate` merge engine that in the `first-row` merge engine, it will generate insert only changelog. 
 
-{{< hint info >}}
-For streaming queries, `first-row` merge engine must be used together with `lookup` or `full-compaction` [changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}).
-{{< /hint >}}
-
-{{< hint info >}}
-Currently, only the first row of insert order supported, so you can not specify `sequence.field` for this merge engine. And also not accept `DELETE` and `UPDATE_BEFORE` message.
-{{< /hint>}}
+1. `first-row` merge engine must be used together with `lookup` [changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}).
+2. You can not specify `sequence.field`.
+3. Not accept `DELETE` and `UPDATE_BEFORE` message.
 
 ## Changelog Producers
 

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BiFunctionWithIOE.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BiFunctionWithIOE.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.IOException;
+
+/** A bi function with {@link IOException}. */
+@FunctionalInterface
+public interface BiFunctionWithIOE<T, U, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     */
+    R apply(T t, U u) throws IOException;
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -157,6 +157,18 @@ public class KeyValueFileReaderFactory {
             applyProjection();
         }
 
+        public Builder copyWithoutProjection() {
+            return new Builder(
+                    fileIO,
+                    schemaManager,
+                    schemaId,
+                    keyType,
+                    valueType,
+                    formatDiscover,
+                    pathFactory,
+                    extractor);
+        }
+
         public Builder withKeyProjection(int[][] projection) {
             keyProjection = projection;
             applyProjection();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/ContainsLevels.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/ContainsLevels.java
@@ -19,18 +19,14 @@
 package org.apache.paimon.mergetree;
 
 import org.apache.paimon.KeyValue;
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.RowCompactedSerializer;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.DataOutputSerializer;
 import org.apache.paimon.lookup.LookupStoreFactory;
 import org.apache.paimon.lookup.LookupStoreReader;
 import org.apache.paimon.lookup.LookupStoreWriter;
-import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.IOFunction;
@@ -52,24 +48,24 @@ import java.util.function.Supplier;
 
 import static org.apache.paimon.mergetree.LookupUtils.fileKibiBytes;
 
-/** Provide lookup by key. */
-public class LookupLevels implements Levels.DropFileCallback, Closeable {
+/** Provide contains key. */
+public class ContainsLevels implements Levels.DropFileCallback, Closeable {
+
+    private static final byte[] EMPTY_VALUE = new byte[] {};
 
     private final Levels levels;
     private final Comparator<InternalRow> keyComparator;
     private final RowCompactedSerializer keySerializer;
-    private final RowCompactedSerializer valueSerializer;
     private final IOFunction<DataFileMeta, RecordReader<KeyValue>> fileReaderFactory;
     private final Supplier<File> localFileFactory;
     private final LookupStoreFactory lookupStoreFactory;
 
-    private final Cache<String, LookupFile> lookupFiles;
+    private final Cache<String, ContainsFile> containsFiles;
 
-    public LookupLevels(
+    public ContainsLevels(
             Levels levels,
             Comparator<InternalRow> keyComparator,
             RowType keyType,
-            RowType valueType,
             IOFunction<DataFileMeta, RecordReader<KeyValue>> fileReaderFactory,
             Supplier<File> localFileFactory,
             LookupStoreFactory lookupStoreFactory,
@@ -78,11 +74,10 @@ public class LookupLevels implements Levels.DropFileCallback, Closeable {
         this.levels = levels;
         this.keyComparator = keyComparator;
         this.keySerializer = new RowCompactedSerializer(keyType);
-        this.valueSerializer = new RowCompactedSerializer(valueType);
         this.fileReaderFactory = fileReaderFactory;
         this.localFileFactory = localFileFactory;
         this.lookupStoreFactory = lookupStoreFactory;
-        this.lookupFiles =
+        this.containsFiles =
                 CacheBuilder.newBuilder()
                         .expireAfterAccess(fileRetention)
                         .maximumWeight(maxDiskSize.getKibiBytes())
@@ -92,53 +87,37 @@ public class LookupLevels implements Levels.DropFileCallback, Closeable {
         levels.addDropFileCallback(this);
     }
 
-    @VisibleForTesting
-    Cache<String, LookupFile> lookupFiles() {
-        return lookupFiles;
-    }
-
     @Override
     public void notifyDropFile(String file) {
-        lookupFiles.invalidate(file);
+        containsFiles.invalidate(file);
+    }
+
+    public boolean contains(InternalRow key, int startLevel) throws IOException {
+        Boolean result = LookupUtils.lookup(levels, key, startLevel, this::contains);
+        return result != null && result;
     }
 
     @Nullable
-    public KeyValue lookup(InternalRow key, int startLevel) throws IOException {
-        return LookupUtils.lookup(levels, key, startLevel, this::lookup);
+    private Boolean contains(InternalRow key, SortedRun level) throws IOException {
+        return LookupUtils.lookup(keyComparator, key, level, this::contains);
     }
 
-    @Nullable
-    private KeyValue lookup(InternalRow key, SortedRun level) throws IOException {
-        return LookupUtils.lookup(keyComparator, key, level, this::lookup);
-    }
-
-    @Nullable
-    private KeyValue lookup(InternalRow key, DataFileMeta file) throws IOException {
-        LookupFile lookupFile;
+    private boolean contains(InternalRow key, DataFileMeta file) throws IOException {
+        ContainsFile containsFile;
         try {
-            lookupFile = lookupFiles.get(file.fileName(), () -> createLookupFile(file));
+            containsFile = containsFiles.get(file.fileName(), () -> createContainsFile(file));
         } catch (ExecutionException e) {
             throw new IOException(e);
         }
-        byte[] keyBytes = keySerializer.serializeToBytes(key);
-        byte[] valueBytes = lookupFile.get(keyBytes);
-        if (valueBytes == null) {
-            return null;
-        }
-        InternalRow value = valueSerializer.deserialize(valueBytes);
-        long sequenceNumber = MemorySegment.wrap(valueBytes).getLong(valueBytes.length - 9);
-        RowKind rowKind = RowKind.fromByteValue(valueBytes[valueBytes.length - 1]);
-        return new KeyValue()
-                .replace(key, sequenceNumber, rowKind, value)
-                .setLevel(lookupFile.remoteFile().level());
+        return containsFile.get(keySerializer.serializeToBytes(key)) != null;
     }
 
-    private int fileWeigh(String file, LookupFile lookupFile) {
-        return fileKibiBytes(lookupFile.localFile);
+    private int fileWeigh(String file, ContainsFile containsFile) {
+        return fileKibiBytes(containsFile.localFile);
     }
 
-    private void removalCallback(RemovalNotification<String, LookupFile> notification) {
-        LookupFile reader = notification.getValue();
+    private void removalCallback(RemovalNotification<String, ContainsFile> notification) {
+        ContainsFile reader = notification.getValue();
         if (reader != null) {
             try {
                 reader.close();
@@ -148,25 +127,19 @@ public class LookupLevels implements Levels.DropFileCallback, Closeable {
         }
     }
 
-    private LookupFile createLookupFile(DataFileMeta file) throws IOException {
+    private ContainsFile createContainsFile(DataFileMeta file) throws IOException {
         File localFile = localFileFactory.get();
         if (!localFile.createNewFile()) {
             throw new IOException("Can not create new file: " + localFile);
         }
         try (LookupStoreWriter kvWriter = lookupStoreFactory.createWriter(localFile);
                 RecordReader<KeyValue> reader = fileReaderFactory.apply(file)) {
-            DataOutputSerializer valueOut = new DataOutputSerializer(32);
             RecordReader.RecordIterator<KeyValue> batch;
             KeyValue kv;
             while ((batch = reader.readBatch()) != null) {
                 while ((kv = batch.next()) != null) {
                     byte[] keyBytes = keySerializer.serializeToBytes(kv.key());
-                    valueOut.clear();
-                    valueOut.write(valueSerializer.serializeToBytes(kv.value()));
-                    valueOut.writeLong(kv.sequenceNumber());
-                    valueOut.writeByte(kv.valueKind().toByteValue());
-                    byte[] valueBytes = valueOut.getCopyOfBuffer();
-                    kvWriter.put(keyBytes, valueBytes);
+                    kvWriter.put(keyBytes, EMPTY_VALUE);
                 }
                 batch.releaseBatch();
             }
@@ -175,33 +148,27 @@ public class LookupLevels implements Levels.DropFileCallback, Closeable {
             throw e;
         }
 
-        return new LookupFile(localFile, file, lookupStoreFactory.createReader(localFile));
+        return new ContainsFile(localFile, lookupStoreFactory.createReader(localFile));
     }
 
     @Override
     public void close() throws IOException {
-        lookupFiles.invalidateAll();
+        containsFiles.invalidateAll();
     }
 
-    private static class LookupFile implements Closeable {
+    private static class ContainsFile implements Closeable {
 
         private final File localFile;
-        private final DataFileMeta remoteFile;
         private final LookupStoreReader reader;
 
-        public LookupFile(File localFile, DataFileMeta remoteFile, LookupStoreReader reader) {
+        public ContainsFile(File localFile, LookupStoreReader reader) {
             this.localFile = localFile;
-            this.remoteFile = remoteFile;
             this.reader = reader;
         }
 
         @Nullable
         public byte[] get(byte[] key) throws IOException {
             return reader.lookup(key);
-        }
-
-        public DataFileMeta remoteFile() {
-            return remoteFile;
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.utils.BiFunctionWithIOE;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/** Utils for lookup. */
+public class LookupUtils {
+
+    public static <T> T lookup(
+            Levels levels,
+            InternalRow key,
+            int startLevel,
+            BiFunctionWithIOE<InternalRow, SortedRun, T> lookup)
+            throws IOException {
+        if (startLevel == 0) {
+            throw new IllegalArgumentException("Start level can not be zero.");
+        }
+
+        T result = null;
+        for (int i = startLevel; i < levels.numberOfLevels(); i++) {
+            SortedRun level = levels.runOfLevel(i);
+            result = lookup.apply(key, level);
+            if (result != null) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    public static <T> T lookup(
+            Comparator<InternalRow> keyComparator,
+            InternalRow target,
+            SortedRun level,
+            BiFunctionWithIOE<InternalRow, DataFileMeta, T> lookup)
+            throws IOException {
+        List<DataFileMeta> files = level.files();
+        int left = 0;
+        int right = files.size() - 1;
+
+        // binary search restart positions to find the restart position immediately before the
+        // targetKey
+        while (left < right) {
+            int mid = (left + right) / 2;
+
+            if (keyComparator.compare(files.get(mid).maxKey(), target) < 0) {
+                // Key at "mid.max" is < "target".  Therefore all
+                // files at or before "mid" are uninteresting.
+                left = mid + 1;
+            } else {
+                // Key at "mid.max" is >= "target".  Therefore all files
+                // after "mid" are uninteresting.
+                right = mid;
+            }
+        }
+
+        int index = right;
+
+        // if the index is now pointing to the last file, check if the largest key in the block is
+        // than the target key.  If so, we need to seek beyond the end of this file
+        if (index == files.size() - 1
+                && keyComparator.compare(files.get(index).maxKey(), target) < 0) {
+            index++;
+        }
+
+        // if files does not have a next, it means the key does not exist in this level
+        return index < files.size() ? lookup.apply(target, files.get(index)) : null;
+    }
+
+    public static int fileKibiBytes(File file) {
+        long kibiBytes = file.length() >> 10;
+        if (kibiBytes > Integer.MAX_VALUE) {
+            throw new RuntimeException(
+                    "Lookup file is too big: " + MemorySize.ofKibiBytes(kibiBytes));
+        }
+        return (int) kibiBytes;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -62,6 +62,23 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
 
     protected abstract MergeFunctionWrapper<ChangelogResult> createMergeWrapper(int outputLevel);
 
+    protected boolean rewriteLookupChangelog(int outputLevel, List<List<SortedRun>> sections) {
+        if (outputLevel == 0) {
+            return false;
+        }
+
+        for (List<SortedRun> runs : sections) {
+            for (SortedRun run : runs) {
+                for (DataFileMeta file : run.files()) {
+                    if (file.level() == 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     @Override
     public CompactResult rewrite(
             int outputLevel, boolean dropDelete, List<List<SortedRun>> sections) throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
@@ -93,8 +94,8 @@ public class FirstRowMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter
         containsLevels.close();
     }
 
-    private static class FistRowMergeFunctionWrapper
-            implements MergeFunctionWrapper<ChangelogResult> {
+    @VisibleForTesting
+    static class FistRowMergeFunctionWrapper implements MergeFunctionWrapper<ChangelogResult> {
 
         private final Filter<InternalRow> contains;
         private final FirstRowMergeFunction mergeFunction;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapper.java
@@ -41,7 +41,6 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
     private final int maxLevel;
     private final RecordEqualiser valueEqualiser;
     private final boolean changelogRowDeduplicate;
-    private final boolean isFirstRow;
 
     // only full compaction will write files into maxLevel, see UniversalCompaction class
     private KeyValue topLevelKv;
@@ -62,7 +61,6 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
                 "Value count merge function does not need to produce changelog from full compaction. "
                         + "Please set changelog producer to 'input'.");
         this.mergeFunction = mergeFunction;
-        this.isFirstRow = mergeFunction instanceof FirstRowMergeFunction;
         this.maxLevel = maxLevel;
         this.valueEqualiser = valueEqualiser;
         this.changelogRowDeduplicate = changelogRowDeduplicate;
@@ -110,10 +108,6 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
                     reusedResult.addChangelog(replace(reusedAfter, RowKind.INSERT, merged));
                 }
             } else {
-                // For first row, we should just return old value. And produce no changelog.
-                if (isFirstRow) {
-                    return reusedResult.setResultIfNotRetract(merged);
-                }
                 if (merged == null || !isAdd(merged)) {
                     reusedResult.addChangelog(replace(reusedBefore, RowKind.DELETE, topLevelKv));
                 } else if (!changelogRowDeduplicate

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -53,7 +53,6 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
     private final KeyValue reusedAfter = new KeyValue();
     private final RecordEqualiser valueEqualiser;
     private final boolean changelogRowDeduplicate;
-    private final boolean isFirstRow;
 
     public LookupChangelogMergeFunctionWrapper(
             MergeFunctionFactory<KeyValue> mergeFunctionFactory,
@@ -66,7 +65,6 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
                 "Merge function should be a LookupMergeFunction, but is %s, there is a bug.",
                 mergeFunction.getClass().getName());
         this.mergeFunction = (LookupMergeFunction) mergeFunction;
-        this.isFirstRow = this.mergeFunction.isFirstRow;
         this.mergeFunction2 = mergeFunctionFactory.create();
         this.lookup = lookup;
         this.valueEqualiser = valueEqualiser;
@@ -100,9 +98,7 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
         // 2. With level 0, with the latest high level, return changelog
         if (highLevel != null) {
             // For first row, we should just return old value. And produce no changelog.
-            if (!isFirstRow) {
-                setChangelog(highLevel, result);
-            }
+            setChangelog(highLevel, result);
             return reusedResult.setResult(result);
         }
 
@@ -114,9 +110,7 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
             mergeFunction2.add(highLevel);
             mergeFunction2.add(result);
             result = mergeFunction2.getResult();
-            if (!isFirstRow) {
-                setChangelog(highLevel, result);
-            }
+            setChangelog(highLevel, result);
         } else {
             setChangelog(null, result);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -35,12 +35,14 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
 import org.apache.paimon.lookup.hash.HashLookupStoreFactory;
+import org.apache.paimon.mergetree.ContainsLevels;
 import org.apache.paimon.mergetree.Levels;
 import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.MergeTreeWriter;
 import org.apache.paimon.mergetree.compact.CompactRewriter;
 import org.apache.paimon.mergetree.compact.CompactStrategy;
+import org.apache.paimon.mergetree.compact.FirstRowMergeTreeCompactRewriter;
 import org.apache.paimon.mergetree.compact.FullChangelogMergeTreeCompactRewriter;
 import org.apache.paimon.mergetree.compact.LookupCompaction;
 import org.apache.paimon.mergetree.compact.LookupMergeTreeCompactRewriter;
@@ -218,6 +220,18 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         valueEqualiserSupplier.get(),
                         options.changelogRowDeduplicate());
             case LOOKUP:
+                if (options.mergeEngine() == CoreOptions.MergeEngine.FIRST_ROW) {
+                    ContainsLevels containsLevels = createContainsLevels(levels, readerFactory);
+                    return new FirstRowMergeTreeCompactRewriter(
+                            containsLevels,
+                            readerFactory,
+                            writerFactory,
+                            keyComparator,
+                            mfFactory,
+                            mergeSorter,
+                            valueEqualiserSupplier.get(),
+                            options.changelogRowDeduplicate());
+                }
                 LookupLevels lookupLevels = createLookupLevels(levels, readerFactory);
                 return new LookupMergeTreeCompactRewriter(
                         lookupLevels,
@@ -245,6 +259,27 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 keyComparatorSupplier.get(),
                 keyType,
                 valueType,
+                file ->
+                        readerFactory.createRecordReader(
+                                file.schemaId(), file.fileName(), file.level()),
+                () -> ioManager.createChannel().getPathFile(),
+                new HashLookupStoreFactory(
+                        cacheManager,
+                        options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR)),
+                options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_FILE_RETENTION),
+                options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE));
+    }
+
+    private ContainsLevels createContainsLevels(
+            Levels levels, KeyValueFileReaderFactory readerFactory) {
+        if (ioManager == null) {
+            throw new RuntimeException(
+                    "Can not use lookup, there is no temp disk directory to use.");
+        }
+        return new ContainsLevels(
+                levels,
+                keyComparatorSupplier.get(),
+                keyType,
                 file ->
                         readerFactory.createRecordReader(
                                 file.schemaId(), file.fileName(), file.level()),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -221,7 +221,12 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         options.changelogRowDeduplicate());
             case LOOKUP:
                 if (options.mergeEngine() == CoreOptions.MergeEngine.FIRST_ROW) {
-                    ContainsLevels containsLevels = createContainsLevels(levels, readerFactory);
+                    KeyValueFileReaderFactory keyOnlyReader =
+                            readerFactoryBuilder
+                                    .copyWithoutProjection()
+                                    .withValueProjection(new int[0][])
+                                    .build(partition, bucket);
+                    ContainsLevels containsLevels = createContainsLevels(levels, keyOnlyReader);
                     return new FirstRowMergeTreeCompactRewriter(
                             containsLevels,
                             readerFactory,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapperTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapperTestBase.java
@@ -20,9 +20,7 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
-import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
-import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,17 +38,13 @@ public abstract class FullChangelogMergeFunctionWrapperTestBase {
     private static final int MAX_LEVEL = 3;
 
     private static final RecordEqualiser EQUALISER =
-            (RecordEqualiser) (row1, row2) -> row1.getInt(0) == row2.getInt(0);
+            (row1, row2) -> row1.getInt(0) == row2.getInt(0);
 
     protected FullChangelogMergeFunctionWrapper wrapper;
 
     protected abstract MergeFunction<KeyValue> createMergeFunction();
 
     protected abstract boolean changelogRowDeduplicate();
-
-    protected List<List<KeyValue>> getInputKvs() {
-        return INPUT_KVS;
-    }
 
     @BeforeEach
     public void beforeEach() {
@@ -113,10 +107,9 @@ public abstract class FullChangelogMergeFunctionWrapperTestBase {
 
     @Test
     public void testFullChangelogMergeFunctionWrapper() {
-        List<List<KeyValue>> inputs = getInputKvs();
-        for (int i = 0; i < inputs.size(); i++) {
+        for (int i = 0; i < INPUT_KVS.size(); i++) {
             wrapper.reset();
-            List<KeyValue> kvs = inputs.get(i);
+            List<KeyValue> kvs = INPUT_KVS.get(i);
             kvs.forEach(kv -> wrapper.add(kv));
             ChangelogResult actualResult = wrapper.getResult();
             List<KeyValue> expectedChangelogs = new ArrayList<>();
@@ -220,115 +213,6 @@ public abstract class FullChangelogMergeFunctionWrapperTestBase {
         @Override
         protected boolean changelogRowDeduplicate() {
             return true;
-        }
-    }
-
-    /** Test for {@link FirstRowMergeFunction} with {@link FullChangelogMergeFunctionWrapper}. */
-    public static class FirstRowMergeFunctionTest
-            extends FullChangelogMergeFunctionWrapperTestBase {
-
-        private static final List<List<KeyValue>> INPUT_KVS =
-                Arrays.asList(
-                        // only 1 insert record, not from top level
-                        Collections.singletonList(
-                                new KeyValue()
-                                        .replace(row(1), 1, RowKind.INSERT, row(1))
-                                        .setLevel(0)),
-                        // only 1 delete record, not from top level
-                        Collections.singletonList(
-                                new KeyValue()
-                                        .replace(row(2), 2, RowKind.DELETE, row(0))
-                                        .setLevel(0)),
-                        // only 1 insert record, from top level
-                        Collections.singletonList(
-                                new KeyValue()
-                                        .replace(row(3), 3, RowKind.INSERT, row(3))
-                                        .setLevel(MAX_LEVEL)),
-                        // multiple records, none from top level
-                        Arrays.asList(
-                                new KeyValue()
-                                        .replace(row(4), 4, RowKind.INSERT, row(3))
-                                        .setLevel(0),
-                                new KeyValue()
-                                        .replace(row(4), 5, RowKind.INSERT, row(-3))
-                                        .setLevel(0)),
-                        // multiple records, one from top level
-                        Arrays.asList(
-                                new KeyValue()
-                                        .replace(row(6), 8, RowKind.INSERT, row(3))
-                                        .setLevel(MAX_LEVEL),
-                                new KeyValue()
-                                        .replace(row(6), 9, RowKind.INSERT, row(-3))
-                                        .setLevel(0)),
-                        Arrays.asList(
-                                new KeyValue()
-                                        .replace(row(8), 14, RowKind.INSERT, row(3))
-                                        .setLevel(MAX_LEVEL),
-                                new KeyValue()
-                                        .replace(row(8), 15, RowKind.INSERT, row(3))
-                                        .setLevel(0)));
-
-        @Override
-        protected List<List<KeyValue>> getInputKvs() {
-            return INPUT_KVS;
-        }
-
-        private final List<KeyValue> expectedBefore =
-                Arrays.asList(
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        changelogRowDeduplicate()
-                                ? null
-                                : new KeyValue()
-                                        .replace(row(8), 14, RowKind.UPDATE_BEFORE, row(3)));
-
-        private final List<KeyValue> expectedAfter =
-                Arrays.asList(
-                        new KeyValue().replace(row(1), 1, RowKind.INSERT, row(1)),
-                        null,
-                        null,
-                        new KeyValue().replace(row(4), 4, RowKind.INSERT, row(3)),
-                        null,
-                        changelogRowDeduplicate()
-                                ? null
-                                : new KeyValue().replace(row(8), 15, RowKind.UPDATE_AFTER, row(3)));
-
-        private final List<KeyValue> expectedResult =
-                Arrays.asList(
-                        new KeyValue().replace(row(1), 1, RowKind.INSERT, row(1)),
-                        null,
-                        new KeyValue().replace(row(3), 3, RowKind.INSERT, row(3)),
-                        new KeyValue().replace(row(4), 4, RowKind.INSERT, row(3)),
-                        new KeyValue().replace(row(6), 8, RowKind.INSERT, row(3)),
-                        new KeyValue().replace(row(8), 14, RowKind.INSERT, row(3)));
-
-        @Override
-        protected MergeFunction<KeyValue> createMergeFunction() {
-            return new FirstRowMergeFunction(
-                    RowType.of(DataTypes.INT()), RowType.of(DataTypes.INT()));
-        }
-
-        @Override
-        protected boolean changelogRowDeduplicate() {
-            return true;
-        }
-
-        @Override
-        protected KeyValue getExpectedBefore(int idx) {
-            return expectedBefore.get(idx);
-        }
-
-        @Override
-        protected KeyValue getExpectedAfter(int idx) {
-            return expectedAfter.get(idx);
-        }
-
-        @Override
-        protected KeyValue getExpectedResult(int idx) {
-            return expectedResult.get(idx);
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -160,9 +160,10 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
 
         @Override
         protected MergeFunction<KeyValue> createMergeFunction() {
-            return new FirstRowMergeFunction(
-                    new RowType(Lists.list(new DataField(0, "f0", new IntType()))),
-                    new RowType(Lists.list(new DataField(1, "f1", new BigIntType()))));
+            RowType keyType = new RowType(Lists.list(new DataField(0, "f0", new IntType())));
+            RowType valueType = new RowType(Lists.list(new DataField(1, "f1", new BigIntType())));
+            return new LookupMergeFunction(
+                    new FirstRowMergeFunction(keyType, valueType), keyType, valueType);
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -195,6 +195,32 @@ public class UniversalCompactionTest {
                 .isEqualTo(new long[] {27});
     }
 
+    @Test
+    public void testLookup() {
+        LookupCompaction compaction = new LookupCompaction(new UniversalCompaction(25, 1, 3));
+
+        // level 0 to max level
+        Optional<CompactUnit> pick = compaction.pick(3, level0(1, 2, 2, 2));
+        assertThat(pick.isPresent()).isTrue();
+        long[] results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
+        assertThat(results).isEqualTo(new long[] {1, 2, 2, 2});
+        assertThat(pick.get().outputLevel()).isEqualTo(2);
+
+        // level 0 force pick
+        pick = compaction.pick(3, Arrays.asList(level(0, 1), level(1, 2), level(2, 2)));
+        assertThat(pick.isPresent()).isTrue();
+        results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
+        assertThat(results).isEqualTo(new long[] {1, 2, 2});
+        assertThat(pick.get().outputLevel()).isEqualTo(2);
+
+        // level 0 to empty level
+        pick = compaction.pick(3, Arrays.asList(level(0, 1), level(2, 2)));
+        assertThat(pick.isPresent()).isTrue();
+        results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
+        assertThat(results).isEqualTo(new long[] {1});
+        assertThat(pick.get().outputLevel()).isEqualTo(1);
+    }
+
     private List<LevelSortedRun> createLevels(int... levels) {
         List<LevelSortedRun> runs = new ArrayList<>();
         for (int size : levels) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBState.java
@@ -23,8 +23,9 @@ import org.apache.paimon.data.serializer.Serializer;
 import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataOutputSerializer;
 
-import org.apache.paimon.shade.guava30.com.google.common.cache.Cache;
-import org.apache.paimon.shade.guava30.com.google.common.cache.CacheBuilder;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
@@ -70,7 +71,11 @@ public abstract class RocksDBState<CacheV> {
         this.valueInputView = new DataInputDeserializer();
         this.valueOutputView = new DataOutputSerializer(32);
         this.writeOptions = new WriteOptions().setDisableWAL(true);
-        this.cache = CacheBuilder.newBuilder().maximumSize(lruCacheSize).build();
+        this.cache =
+                Caffeine.newBuilder()
+                        .maximumSize(lruCacheSize)
+                        .executor(MoreExecutors.directExecutor())
+                        .build();
     }
 
     protected byte[] serializeKey(InternalRow key) throws IOException {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -72,8 +72,11 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow;
 import static org.apache.paimon.CoreOptions.BUCKET;
+import static org.apache.paimon.CoreOptions.CHANGELOG_PRODUCER;
+import static org.apache.paimon.CoreOptions.ChangelogProducer.LOOKUP;
 import static org.apache.paimon.CoreOptions.MERGE_ENGINE;
 import static org.apache.paimon.CoreOptions.MergeEngine.DEDUPLICATE;
+import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
 import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST;
 import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_TARGET_SIZE;
 import static org.apache.paimon.CoreOptions.WRITE_MODE;
@@ -1482,6 +1485,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         Map<String, String> options = new HashMap<>();
         options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
         options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        if (mergeEngine == FIRST_ROW) {
+            options.put(CHANGELOG_PRODUCER.key(), LOOKUP.toString());
+        }
         String table =
                 createTable(
                         Arrays.asList(
@@ -1576,6 +1582,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         options.put(
                 CoreOptions.FIELDS_PREFIX + ".rate." + CoreOptions.DEFAULT_VALUE_SUFFIX, "1000");
         options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        if (mergeEngine == FIRST_ROW) {
+            options.put(CHANGELOG_PRODUCER.key(), LOOKUP.toString());
+        }
         String table =
                 createTable(
                         Arrays.asList(
@@ -1656,6 +1665,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         Map<String, String> options = new HashMap<>();
         options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
         options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        if (mergeEngine == FIRST_ROW) {
+            options.put(CHANGELOG_PRODUCER.key(), LOOKUP.toString());
+        }
         String table =
                 createTable(
                         Arrays.asList(
@@ -1746,6 +1758,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         Map<String, String> options = new HashMap<>();
         options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
         options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        if (mergeEngine == FIRST_ROW) {
+            options.put(CHANGELOG_PRODUCER.key(), LOOKUP.toString());
+        }
         String table =
                 createTable(
                         Arrays.asList(
@@ -1824,6 +1839,9 @@ public class ReadWriteTableITCase extends AbstractTestBase {
         Map<String, String> options = new HashMap<>();
         options.put(WRITE_MODE.key(), WriteMode.CHANGE_LOG.toString());
         options.put(MERGE_ENGINE.key(), mergeEngine.toString());
+        if (mergeEngine == FIRST_ROW) {
+            options.put(CHANGELOG_PRODUCER.key(), LOOKUP.toString());
+        }
         String table =
                 createTable(
                         Arrays.asList(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce `ContainsLevels` to optimize first row.

And first row only works with lookup changelog-producer.

Benifit:

1. One is to generate a changelog through contains, which should be highly efficient. It only reads keys and does not read the entire row of data.
2. The second one is that there is data at the upper level, and the output of data at the lower level is directly null. After merging, it is directly deleted

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
