### PR TITLE
[improve] add system table to show all table configs in `sys.all_table_options`

### DIFF
--- a/docs/content/how-to/system-tables.md
+++ b/docs/content/how-to/system-tables.md
@@ -26,7 +26,9 @@ under the License.
 
 # System Tables
 
-System tables contain metadata and information about each table, such as the snapshots created and the options in use. Users can access system tables with batch queries.
+## Table Specified System Table
+
+Table specified system tables contain metadata and information about each table, such as the snapshots created and the options in use. Users can access system tables with batch queries.
 
 Currently, Flink, Spark and Trino supports querying system tables.
 
@@ -35,7 +37,7 @@ In some cases, the table name needs to be enclosed with back quotes to avoid syn
 SELECT * FROM my_catalog.my_db.`MyTable$snapshots`;
 ```
 
-## Snapshots Table
+### Snapshots Table
 
 You can query the snapshot history information of the table through snapshots table, including the record count occurred in the snapshot.
 
@@ -55,7 +57,7 @@ SELECT * FROM MyTable$snapshots;
 
 By querying the snapshots table, you can know the commit and expiration information about that table and time travel through the data.
 
-## Schemas Table
+### Schemas Table
 
 You can query the historical schemas of the table through schemas table.
 
@@ -82,7 +84,7 @@ SELECT s.snapshot_id, t.schema_id, t.fields
     ON s.schema_id=t.schema_id where s.snapshot_id=100;
 ```
 
-## Options Table
+### Options Table
 
 You can query the table's option information which is specified from the DDL through options table. The options not shown will be the default value. You can take reference to  [Configuration].
 
@@ -99,7 +101,7 @@ SELECT * FROM MyTable$options;
 */
 ```
 
-## Audit log Table
+### Audit log Table
 
 If you need to audit the changelog of the table, you can use the `audit_log` system table. Through `audit_log` table, you can get the `rowkind` column when you get the incremental data of the table. You can use this column for
 filtering and other operations to complete the audit.
@@ -128,7 +130,7 @@ SELECT * FROM MyTable$audit_log;
 */
 ```
 
-## Files Table
+### Files Table
 You can query the files of the table with specific snapshot.
 
 ```
@@ -158,7 +160,7 @@ SELECT * FROM MyTable$files /*+ OPTIONS('scan.snapshot-id'='1') */;
 3 rows in set
 ```
 
-## Tags Table
+### Tags Table
 
 You can query the tag history information of the table through tags table, including which snapshots are the tags based on
 and some historical information of the snapshots. You can also get all tag names and time travel to a specific tag data by name.
@@ -177,7 +179,7 @@ SELECT * FROM MyTable$tags;
 */
 ```
 
-## Consumers Table
+### Consumers Table
 
 You can query all consumers which contains next snapshot.
 
@@ -195,7 +197,7 @@ SELECT * FROM MyTable$consumers;
 */
 ```
 
-## Manifests Table
+### Manifests Table
 
 You can query all manifest files contained in the latest snapshot of the current table.
 
@@ -210,3 +212,35 @@ SELECT * FROM MyTable$manifests;
 +--------------------------------+-------------+------------------+-------------------+---------------+
 */
 ```
+
+## Global System Table
+
+Global system tables contain the statistical information of all the tables exists in paimon. For convenient of searching, we create a reference system database called `sys`.
+We can display all the global system tables by sql in flink:
+```sql
+USE sys;
+SHOW TABLES;
+```
+
+### ALL Options Table
+This table is similar to [Options Table]({{< ref "how-to/system-tables#options-table" >}}), but it shows all the table options is all database.
+
+```sql
+SELECT * FROM sys.all_table_options;
+
+/*
++---------------+--------------------------------+--------------------------------+------------------+
+| database_name |                     table_name |                            key |            value |
++---------------+--------------------------------+--------------------------------+------------------+
+|         my_db |                    Orders_orc  |                         bucket |               -1 |
+|         my_db |                        Orders2 |                         bucket |               -1 |
+|         my_db |                        Orders2 |                     write-mode |      append-only |
+|         my_db |                        Orders2 |               sink.parallelism |                7 |
+|         my_db |                   StockAnalyze |                     write-mode |       change-log |
+|         my_db2|                      OrdersSum |                         bucket |                1 |
+|         my_db2|                      OrdersSum |                     write-mode |       change-log |
++---------------+--------------------------------+--------------------------------+------------------+
+7 rows in set
+*/
+```
+

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -40,7 +40,7 @@ public abstract class AbstractCatalog implements Catalog {
 
     public static final String DB_SUFFIX = ".db";
     protected static final String TABLE_DEFAULT_OPTION_PREFIX = "table-default.";
-    protected static final List<String> globalTables =
+    protected static final List<String> GLOBAL_TABLES =
             Arrays.asList(AllTableOptionsTable.ALL_TABLE_OPTIONS);
 
     protected final FileIO fileIO;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -42,8 +42,7 @@ public interface Catalog extends AutoCloseable {
     String DEFAULT_DATABASE = "default";
 
     String SYSTEM_TABLE_SPLITTER = "$";
-
-    String SYSTEM_GLOBAL_TABLE = "system";
+    String SYSTEM_DATABASE_NAME = "sys";
 
     /**
      * Get lock factory from catalog. Lock is used to support multiple concurrent writes on the
@@ -270,6 +269,15 @@ public interface Catalog extends AutoCloseable {
 
         public String database() {
             return database;
+        }
+    }
+
+    /** Exception for trying to operate on a system database. */
+    class ProcessSystemDatabaseException extends IllegalArgumentException {
+        private static final String MSG = "Can't do operation on system database.";
+
+        public ProcessSystemDatabaseException() {
+            super(MSG);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -43,6 +43,8 @@ public interface Catalog extends AutoCloseable {
 
     String SYSTEM_TABLE_SPLITTER = "$";
 
+    String SYSTEM_GLOBAL_TABLE = "system";
+
     /**
      * Get lock factory from catalog. Lock is used to support multiple concurrent writes on the
      * object store.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -111,7 +111,7 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         if (isSystemDatabase(databaseName)) {
-            return globalTables;
+            return GLOBAL_TABLES;
         }
         if (!databaseExists(databaseName)) {
             throw new DatabaseNotExistException(databaseName);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -66,12 +66,18 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public boolean databaseExists(String databaseName) {
+        if (isSystemDatabase(databaseName)) {
+            return true;
+        }
         return uncheck(() -> fileIO.exists(databasePath(databaseName)));
     }
 
     @Override
     public void createDatabase(String name, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException {
+        if (isSystemDatabase(name)) {
+            throw new ProcessSystemDatabaseException();
+        }
         if (databaseExists(name)) {
             if (ignoreIfExists) {
                 return;
@@ -84,6 +90,9 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
             throws DatabaseNotExistException, DatabaseNotEmptyException {
+        if (isSystemDatabase(name)) {
+            throw new ProcessSystemDatabaseException();
+        }
         if (!databaseExists(name)) {
             if (ignoreIfNotExists) {
                 return;
@@ -101,6 +110,9 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
+        if (isSystemDatabase(databaseName)) {
+            return globalTables;
+        }
         if (!databaseExists(databaseName)) {
             throw new DatabaseNotExistException(databaseName);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -51,15 +51,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.paimon.catalog.Catalog.SYSTEM_GLOBAL_TABLE;
-import static org.apache.paimon.catalog.Catalog.SYSTEM_TABLE_SPLITTER;
-
 /**
  * This is a system table to display all the database-table properties.
  *
  * <pre>
  *  For example:
- *     If we select * from system$all_table_options, we will get
+ *     If we select * from sys.all_table_options, we will get
  *     databasename       tablename       key      value
  *         default           test0         a         b
  *         my_db             test1         c         d
@@ -82,7 +79,7 @@ public class AllTableOptionsTable implements ReadonlyTable {
 
     @Override
     public String name() {
-        return SYSTEM_GLOBAL_TABLE + SYSTEM_TABLE_SPLITTER + ALL_TABLE_OPTIONS;
+        return ALL_TABLE_OPTIONS;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.ReadonlyTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.ReadOnceTableScan;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.ProjectedRow;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.paimon.catalog.Catalog.SYSTEM_GLOBAL_TABLE;
+import static org.apache.paimon.catalog.Catalog.SYSTEM_TABLE_SPLITTER;
+
+/**
+ * This is a system table to display all the database-table properties.
+ *
+ * <pre>
+ *  For example:
+ *     If we select * from system$all_table_options, we will get
+ *     databasename       tablename       key      value
+ *         default           test0         a         b
+ *         my_db             test1         c         d
+ *          ...               ...         ...       ...
+ *     We can write sql to fetch the information we need.
+ * </pre>
+ */
+public class AllTableOptionsTable implements ReadonlyTable {
+
+    public static final String ALL_TABLE_OPTIONS = "all_table_options";
+
+    private final FileIO fileIO;
+    private final Map<String, Map<String, Path>> allTablePaths;
+
+    public AllTableOptionsTable(FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
+        // allTablePath is the map of  <database, <table_name, properties>>
+        this.fileIO = fileIO;
+        this.allTablePaths = allTablePaths;
+    }
+
+    @Override
+    public String name() {
+        return SYSTEM_GLOBAL_TABLE + SYSTEM_TABLE_SPLITTER + ALL_TABLE_OPTIONS;
+    }
+
+    @Override
+    public RowType rowType() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "database_name", new VarCharType(VarCharType.MAX_LENGTH)));
+        fields.add(new DataField(1, "table_name", new VarCharType(VarCharType.MAX_LENGTH)));
+        fields.add(new DataField(2, "key", new VarCharType(VarCharType.MAX_LENGTH)));
+        fields.add(new DataField(3, "value", new VarCharType(VarCharType.MAX_LENGTH)));
+        return new RowType(fields);
+    }
+
+    @Override
+    public List<String> primaryKeys() {
+        return Collections.singletonList("table_name");
+    }
+
+    @Override
+    public InnerTableScan newScan() {
+        return new AllTableOptionsScan();
+    }
+
+    @Override
+    public InnerTableRead newRead() {
+        return new AllTableOptionsRead(fileIO);
+    }
+
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new AllTableOptionsTable(fileIO, allTablePaths);
+    }
+
+    private class AllTableOptionsScan extends ReadOnceTableScan {
+
+        @Override
+        public InnerTableScan withFilter(Predicate predicate) {
+            return this;
+        }
+
+        @Override
+        public Plan innerPlan() {
+            return () -> Collections.singletonList(new AllTableSplit(fileIO, allTablePaths));
+        }
+    }
+
+    private static class AllTableSplit implements Split {
+
+        private static final long serialVersionUID = 1L;
+
+        private final FileIO fileIO;
+        private final Map<String, Map<String, Path>> allTablePaths;
+
+        private AllTableSplit(FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
+            this.fileIO = fileIO;
+            this.allTablePaths = allTablePaths;
+        }
+
+        @Override
+        public long rowCount() {
+            return options(fileIO, allTablePaths).values().stream()
+                    .flatMap(t -> t.values().stream())
+                    .reduce(0, (a, b) -> a + b.size(), Integer::sum);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            AllTableSplit that = (AllTableSplit) o;
+            return Objects.equals(allTablePaths, that.allTablePaths);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(allTablePaths);
+        }
+    }
+
+    private static class AllTableOptionsRead implements InnerTableRead {
+
+        private final FileIO fileIO;
+        private int[][] projection;
+
+        public AllTableOptionsRead(FileIO fileIO) {
+            this.fileIO = fileIO;
+        }
+
+        @Override
+        public InnerTableRead withFilter(Predicate predicate) {
+            return this;
+        }
+
+        @Override
+        public InnerTableRead withProjection(int[][] projection) {
+            this.projection = projection;
+            return this;
+        }
+
+        @Override
+        public TableRead withIOManager(IOManager ioManager) {
+            return this;
+        }
+
+        @Override
+        public RecordReader<InternalRow> createReader(Split split) throws IOException {
+            if (!(split instanceof AllTableSplit)) {
+                throw new IllegalArgumentException("Unsupported split: " + split.getClass());
+            }
+            Map<String, Map<String, Path>> location = ((AllTableSplit) split).allTablePaths;
+            Iterator<InternalRow> rows = toRow(options(fileIO, location));
+            if (projection != null) {
+                rows =
+                        Iterators.transform(
+                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+            }
+            return new IteratorRecordReader<>(rows);
+        }
+
+        private Iterator<InternalRow> toRow(Map<String, Map<String, Map<String, String>>> option) {
+            List<InternalRow> rows = new ArrayList<>();
+            for (Map.Entry<String, Map<String, Map<String, String>>> entry0 : option.entrySet()) {
+                String database = entry0.getKey();
+                for (Map.Entry<String, Map<String, String>> entry1 : entry0.getValue().entrySet()) {
+                    String tableName = entry1.getKey();
+                    for (Map.Entry<String, String> entry2 : entry1.getValue().entrySet()) {
+                        String key = entry2.getKey();
+                        String value = entry2.getValue();
+                        rows.add(
+                                GenericRow.of(
+                                        BinaryString.fromString(database),
+                                        BinaryString.fromString(tableName),
+                                        BinaryString.fromString(key),
+                                        BinaryString.fromString(value)));
+                    }
+                }
+            }
+            return rows.iterator();
+        }
+    }
+
+    private static Map<String, Map<String, Map<String, String>>> options(
+            FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
+        Map<String, Map<String, Map<String, String>>> allOptions = new HashMap<>();
+        for (Map.Entry<String, Map<String, Path>> entry0 : allTablePaths.entrySet()) {
+            Map<String, Map<String, String>> m0 =
+                    allOptions.computeIfAbsent(entry0.getKey(), k -> new HashMap<>());
+            for (Map.Entry<String, Path> entry1 : entry0.getValue().entrySet()) {
+                Map<String, String> options =
+                        new SchemaManager(fileIO, entry1.getValue())
+                                .latest()
+                                .orElseThrow(() -> new RuntimeException("Table not exists."))
+                                .options();
+                m0.put(entry1.getKey(), options);
+            }
+        }
+        return allOptions;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -25,6 +25,9 @@ import org.apache.paimon.table.Table;
 
 import javax.annotation.Nullable;
 
+import java.util.Map;
+
+import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
 import static org.apache.paimon.table.system.AuditLogTable.AUDIT_LOG;
 import static org.apache.paimon.table.system.ConsumersTable.CONSUMERS;
 import static org.apache.paimon.table.system.FilesTable.FILES;
@@ -57,6 +60,17 @@ public class SystemTableLoader {
                 return new TagsTable(fileIO, location);
             case CONSUMERS:
                 return new ConsumersTable(fileIO, location);
+            default:
+                return null;
+        }
+    }
+
+    @Nullable
+    public static Table loadGlobal(
+            String type, FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
+        switch (type.toLowerCase()) {
+            case ALL_TABLE_OPTIONS:
+                return new AllTableOptionsTable(fileIO, allTablePaths);
             default:
                 return null;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -67,8 +67,8 @@ public class SystemTableLoader {
 
     @Nullable
     public static Table loadGlobal(
-            String type, FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
-        switch (type.toLowerCase()) {
+            String tableName, FileIO fileIO, Map<String, Map<String, Path>> allTablePaths) {
+        switch (tableName.toLowerCase()) {
             case ALL_TABLE_OPTIONS:
                 return new AllTableOptionsTable(fileIO, allTablePaths);
             default:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -496,6 +496,9 @@ public class FlinkCatalog extends AbstractCatalog {
     }
 
     private static void validateAlterTable(CatalogTable ct1, CatalogTable ct2) {
+        if (ct1 instanceof SystemCatalogTable) {
+            throw new UnsupportedOperationException("Can't alter system table.");
+        }
         org.apache.flink.table.api.TableSchema ts1 = ct1.getSchema();
         org.apache.flink.table.api.TableSchema ts2 = ct2.getSchema();
         boolean pkEquality = false;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -104,21 +104,22 @@ public class CatalogTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testDropSystemDatabase() {
-        assertThatCode( ()->
-        sql("DROP DATABASE sys")).hasRootCauseMessage("Can't do operation on system database.");
+        assertThatCode(() -> sql("DROP DATABASE sys"))
+                .hasRootCauseMessage("Can't do operation on system database.");
     }
 
     @Test
     public void testCreateSystemDatabase() {
-        assertThatCode( ()->
-                sql("CREATE DATABASE sys")).hasRootCauseMessage("Can't do operation on system database.");
+        assertThatCode(() -> sql("CREATE DATABASE sys"))
+                .hasRootCauseMessage("Can't do operation on system database.");
     }
 
     @Test
     public void testChangeTableInSystemDatabase() {
         sql("USE sys");
-        assertThatCode( ()->
-        sql("ALTER TABLE all_table_options SET ('bucket-num' = '5')")).hasRootCauseMessage("Can't alter system table.");;
+        assertThatCode(() -> sql("ALTER TABLE all_table_options SET ('bucket-num' = '5')"))
+                .hasRootCauseMessage("Can't alter system table.");
+        ;
     }
 
     @Test
@@ -315,23 +316,23 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                         + ")");
 
         assertThatThrownBy(
-                () ->
-                        sql(
-                                "CREATE TABLE t_pk_not_exist_as WITH ('primary-key' = 'aaa') AS SELECT * FROM t_pk_not_exist"))
+                        () ->
+                                sql(
+                                        "CREATE TABLE t_pk_not_exist_as WITH ('primary-key' = 'aaa') AS SELECT * FROM t_pk_not_exist"))
                 .hasRootCauseMessage("Primary key column '[aaa]' is not defined in the schema.");
 
         // primary key in option and DDL.
         assertThatThrownBy(
-                () ->
-                        sql(
-                                "CREATE TABLE t_pk_ddl_option ("
-                                        + "user_id BIGINT,"
-                                        + "item_id BIGINT,"
-                                        + "behavior STRING,"
-                                        + "dt STRING,"
-                                        + "hh STRING,"
-                                        + "PRIMARY KEY (dt, hh, user_id) NOT ENFORCED"
-                                        + ") WITH ('primary-key' = 'dt')"))
+                        () ->
+                                sql(
+                                        "CREATE TABLE t_pk_ddl_option ("
+                                                + "user_id BIGINT,"
+                                                + "item_id BIGINT,"
+                                                + "behavior STRING,"
+                                                + "dt STRING,"
+                                                + "hh STRING,"
+                                                + "PRIMARY KEY (dt, hh, user_id) NOT ENFORCED"
+                                                + ") WITH ('primary-key' = 'dt')"))
                 .hasRootCauseMessage(
                         "Cannot define primary key on DDL and table options at the same time.");
 
@@ -346,22 +347,22 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                         + ") PARTITIONED BY (dt, hh) ");
 
         assertThatThrownBy(
-                () ->
-                        sql(
-                                "CREATE TABLE t_partition_not_exist_as WITH ('partition' = 'aaa') AS SELECT * FROM t_partition_not_exist"))
+                        () ->
+                                sql(
+                                        "CREATE TABLE t_partition_not_exist_as WITH ('partition' = 'aaa') AS SELECT * FROM t_partition_not_exist"))
                 .hasRootCauseMessage("Partition column '[aaa]' is not defined in the schema.");
 
         // partition in option and DDL.
         assertThatThrownBy(
-                () ->
-                        sql(
-                                "CREATE TABLE t_partition_ddl_option ("
-                                        + "user_id BIGINT,"
-                                        + "item_id BIGINT,"
-                                        + "behavior STRING,"
-                                        + "dt STRING,"
-                                        + "hh STRING"
-                                        + ") PARTITIONED BY (dt, hh)  WITH ('partition' = 'dt')"))
+                        () ->
+                                sql(
+                                        "CREATE TABLE t_partition_ddl_option ("
+                                                + "user_id BIGINT,"
+                                                + "item_id BIGINT,"
+                                                + "behavior STRING,"
+                                                + "dt STRING,"
+                                                + "hh STRING"
+                                                + ") PARTITIONED BY (dt, hh)  WITH ('partition' = 'dt')"))
                 .hasRootCauseMessage(
                         "Cannot define partition on DDL and table options at the same time.");
     }
@@ -369,9 +370,9 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     @Test
     public void testConflictOption() {
         assertThatThrownBy(
-                () ->
-                        sql(
-                                "CREATE TABLE T (a INT) WITH ('write-mode' = 'append-only', 'changelog-producer' = 'input')"))
+                        () ->
+                                sql(
+                                        "CREATE TABLE T (a INT) WITH ('write-mode' = 'append-only', 'changelog-producer' = 'input')"))
                 .getRootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage(
@@ -480,31 +481,31 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                         // value count table use all fields as min/max key
                                         ? "[23, 2, 24, 25, 26],[27, 2, 28, 29, 30]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        // append only table has no min/max key
-                                        ? ","
-                                        // with key table use primary key trimmed partition
-                                        : "[23],[27]")),
+                                                // append only table has no min/max key
+                                                ? ","
+                                                // with key table use primary key trimmed partition
+                                                : "[23],[27]")),
                         String.format(
                                 "[1],0,orc,0,0,2,%s,{a=0, bb=0, dd=2, f=2, p=0},{a=1, bb=2, dd=null, f=null, p=1},{a=3, bb=4, dd=null, f=null, p=1}",
                                 StringUtils.endsWith(tableName, "VALUE_COUNT")
                                         ? "[1, 1, 2, S1],[3, 1, 4, S2]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        ? ","
-                                        : "[1],[3]")),
+                                                ? ","
+                                                : "[1],[3]")),
                         String.format(
                                 "[1],0,orc,1,0,2,%s,{a=0, bb=0, dd=0, f=0, p=0},{a=5, bb=6, dd=7, f=9, p=1},{a=10, bb=11, dd=12, f=14, p=1}",
                                 StringUtils.endsWith(tableName, "VALUE_COUNT")
                                         ? "[5, 1, 6, S3, 7, 8, 9],[10, 1, 11, S4, 12, 13, 14]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        ? ","
-                                        : "[5],[10]")),
+                                                ? ","
+                                                : "[5],[10]")),
                         String.format(
                                 "[1],0,orc,2,0,2,%s,{a=0, bb=0, dd=0, f=0, p=0},{a=15, bb=16, dd=17, f=18, p=1},{a=19, bb=20, dd=21, f=22, p=1}",
                                 StringUtils.endsWith(tableName, "VALUE_COUNT")
                                         ? "[15, 1, 16, 17, 18],[19, 1, 20, 21, 22]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        ? ","
-                                        : "[15],[19]")));
+                                                ? ","
+                                                : "[15],[19]")));
 
         // Get files with snapshot id 2
         List<Row> rows2 =
@@ -524,15 +525,15 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                 StringUtils.endsWith(tableName, "VALUE_COUNT")
                                         ? "[1, 1, 2, S1],[3, 1, 4, S2]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        ? ","
-                                        : "[1],[3]")),
+                                                ? ","
+                                                : "[1],[3]")),
                         String.format(
                                 "[1],0,orc,1,0,2,%s,{a=0, b=0, c=0, d=0, e=0, f=0, p=0},{a=5, b=6, c=S3, d=7, e=8, f=9, p=1},{a=10, b=11, c=S4, d=12, e=13, f=14, p=1}",
                                 StringUtils.endsWith(tableName, "VALUE_COUNT")
                                         ? "[5, 1, 6, S3, 7, 8, 9],[10, 1, 11, S4, 12, 13, 14]"
                                         : (StringUtils.endsWith(tableName, "APPEND_ONLY")
-                                        ? ","
-                                        : "[5],[10]")));
+                                                ? ","
+                                                : "[5],[10]")));
     }
 
     @Nonnull
@@ -542,17 +543,17 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                         v ->
                                 StringUtils.join(
                                         new Object[] {
-                                                v.getField(0),
-                                                v.getField(1),
-                                                v.getField(3),
-                                                v.getField(4),
-                                                v.getField(5),
-                                                v.getField(6),
-                                                v.getField(8),
-                                                v.getField(9),
-                                                v.getField(10),
-                                                v.getField(11),
-                                                v.getField(12)
+                                            v.getField(0),
+                                            v.getField(1),
+                                            v.getField(3),
+                                            v.getField(4),
+                                            v.getField(5),
+                                            v.getField(6),
+                                            v.getField(8),
+                                            v.getField(9),
+                                            v.getField(10),
+                                            v.getField(11),
+                                            v.getField(12)
                                         },
                                         ","))
                 .collect(Collectors.toList());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -87,6 +87,19 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testOptionsTable2() throws Exception {
+        sql("CREATE TABLE T (a INT, b INT) with ('a.aa.aaa'='val1', 'b.bb.bbb'='val2')");
+        sql("ALTER TABLE T SET ('c.cc.ccc' = 'val3')");
+
+        List<Row> result = sql("SELECT * FROM system$all_table_options");
+        assertThat(result)
+                .containsExactly(
+                        Row.of("default", "T", "a.aa.aaa", "val1"),
+                        Row.of("default", "T", "b.bb.bbb", "val2"),
+                        Row.of("default", "T", "c.cc.ccc", "val3"));
+    }
+
+    @Test
     public void testCreateSystemTable() {
         assertThatThrownBy(() -> sql("CREATE TABLE T$snapshots (a INT, b INT)"))
                 .hasRootCauseMessage(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -119,7 +119,6 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         sql("USE sys");
         assertThatCode(() -> sql("ALTER TABLE all_table_options SET ('bucket-num' = '5')"))
                 .hasRootCauseMessage("Can't alter system table.");
-        ;
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -171,6 +171,9 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     public boolean databaseExists(String databaseName) {
+        if (isSystemDatabase(databaseName)) {
+            return true;
+        }
         try {
             client.getDatabase(databaseName);
             return true;
@@ -185,6 +188,9 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public void createDatabase(String name, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException {
+        if (isSystemDatabase(name)) {
+            throw new ProcessSystemDatabaseException();
+        }
         try {
             client.createDatabase(convertToDatabase(name));
 
@@ -201,6 +207,9 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
             throws DatabaseNotExistException, DatabaseNotEmptyException {
+        if (isSystemDatabase(name)) {
+            throw new ProcessSystemDatabaseException();
+        }
         try {
             if (!cascade && client.getAllTables(name).size() > 0) {
                 throw new DatabaseNotEmptyException(name);
@@ -219,6 +228,9 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
+        if (isSystemDatabase(databaseName)) {
+            return globalTables;
+        }
         try {
             return client.getAllTables(databaseName).stream()
                     .filter(

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -229,7 +229,7 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         if (isSystemDatabase(databaseName)) {
-            return globalTables;
+            return GLOBAL_TABLES;
         }
         try {
             return client.getAllTables(databaseName).stream()


### PR DESCRIPTION
add system table system$all_table_options to enable config search

sql:
```
SELECT * FROM sys.all_table_options
```

add built-in system "sys"
sql:
```
USE sys;
SHOW TABLES;
```
will result in:
all_table_options

We will add more system table in the future