### PR TITLE
[flink][test] fix unstable testRandomCdcEventsDynamicBucket.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcSourceFunction.java
@@ -52,7 +52,7 @@ public class TestCdcSourceFunction extends RichParallelSourceFunction<TestCdcEve
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-        numRecordsPerCheckpoint = events.size() / ThreadLocalRandom.current().nextInt(10, 20);
+        numRecordsPerCheckpoint = events.size() / ThreadLocalRandom.current().nextInt(10, 20) + 1;
         recordsThisCheckpoint = new AtomicInteger(0);
 
         remainingEventsCount =


### PR DESCRIPTION


### Purpose

[flink][test] fix unstable testRandomCdcEventsDynamicBucket. 

Linked issue: close #1645 

<!-- What is the purpose of the change -->

### Tests

Current `FlinkCdcSyncDatabaseSinkITCase. testRandomCdcEventsDynamicBucket` can cover this.

### API and Format

No.

### Documentation

No.
