### PR TITLE
[doc] KAFKA-Paimon Database Sync, Fix multiple topic parameter delimiter

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -341,7 +341,7 @@ Synchronization from multiple Kafka topics to Paimon database.
     --warehouse hdfs:///path/to/warehouse \
     --database test_db \
     --kafka-conf properties.bootstrap.servers=127.0.0.1:9020 \
-    --kafka-conf topic=order,logistic_order,user \
+    --kafka-conf topic=order\;logistic_order\;user \
     --kafka-conf properties.group.id=123456 \
     --kafka-conf value.format=canal-json \
     --catalog-conf metastore=hive \

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSyncDatabaseActionFactory.java
@@ -127,7 +127,7 @@ public class KafkaSyncDatabaseActionFactory implements ActionFactory {
                         + "    --warehouse hdfs:///path/to/warehouse \\\n"
                         + "    --database test_db \\\n"
                         + "    --kafka-conf properties.bootstrap.servers=127.0.0.1:9020 \\\n"
-                        + "    --kafka-conf topic=order,logistic,user \\\n"
+                        + "    --kafka-conf topic=order\\;logistic\\;user \\\n"
                         + "    --kafka-conf properties.group.id=123456 \\\n"
                         + "    --kafka-conf value.format=canal-json \\\n"
                         + "    --catalog-conf metastore=hive \\\n"


### PR DESCRIPTION
fix doc, When the flink configuration class obtains list parameters, follow the `;` split

org.apache.flink.configuration.ConfigurationUtils#convertToList
```
StructuredOptionsSplitter.splitEscaped(rawValue.toString(), ';').stream()
                            .map(s -> convertValue(s, atomicClass))
                            .collect(Collectors.toList());
```