### PR TITLE
[test] Fix unstable test: UnawareBucketAppendOnlyTableITCase.testCompactionInStreamingMode

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -197,13 +197,15 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
                         + ") WITH (\n"
                         + "    'connector' = 'datagen',\n"
                         + "    'rows-per-second' = '1',\n"
-                        + "    'number-of-rows' = '4'\n"
+                        + "    'number-of-rows' = '10'\n"
                         + ")");
 
         assertStreamingHasCompact("INSERT INTO append_table SELECT * FROM Orders_in", 60000);
+        // ensure data gen finished
+        Thread.sleep(5000);
 
         List<Row> rows = batchSql("SELECT * FROM append_table");
-        assertThat(rows.size()).isEqualTo(4);
+        assertThat(rows.size()).isEqualTo(10);
     }
 
     @Test


### PR DESCRIPTION

This test is unstable, guess the rows generate too fast, and job start too slow to generate 4 file of 4 rows. So make more rows by datagen.