### PR TITLE
[core][test] fix SORT_ENGIN#MIN_HEAP is not tested issue.

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -135,6 +135,7 @@ public abstract class MergeTreeTestBase {
         configuration.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         configuration.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
         configuration.set(CoreOptions.TARGET_FILE_SIZE, new MemorySize(targetFileSize));
+        configuration.set(CoreOptions.SORT_ENGINE, getSortEngine());
         options = new CoreOptions(configuration);
         RowType keyType = new RowType(singletonList(new DataField(0, "k", new IntType())));
         RowType valueType = new RowType(singletonList(new DataField(0, "v", new IntType())));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

[core][test] fix SORT_ENGIN#MIN_HEAP is not tested issue.
<!-- Linking this pull request to the issue -->
Linked issue: close #1655 

<!-- What is the purpose of the change -->

### Tests

`MergeTreeTestWithMinHeap` can work correctly.

### API and Format

No.

### Documentation

No.
