### PR TITLE
[core][test] fix the issue that testPrepareCommitRecycleReference runs unstable.

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -467,7 +467,11 @@ public abstract class MergeTreeTestBase {
                     rewriter);
         }
 
-        protected CompactResult obtainCompactResult() throws ExecutionException {
+        protected CompactResult obtainCompactResult()
+                throws InterruptedException, ExecutionException {
+            if (taskFuture != null && !taskFuture.isDone()) {
+                taskFuture.get();
+            }
             OutOfMemoryError outOfMemoryError = new OutOfMemoryError();
             throw new ExecutionException("mock", outOfMemoryError);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

[core][test] fix the issue that testPrepareCommitRecycleReference runs unstable.

<!-- Linking this pull request to the issue -->
Linked issue: close #1653 

<!-- What is the purpose of the change -->

### Tests

Currently `testPrepareCommitRecycleReference` can work stable.

### API and Format

No.

### Documentation

No.
