### PR TITLE
[flink] fix rename table error in sync action

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -384,8 +384,8 @@ Synchronization from multiple Kafka topics to Paimon database.
 
 ## Schema Change Evolution
 
-Cdc Ingestion supports a limited number of schema changes. Currently, the framework can not drop columns, so the
-behaviors of `DROP` will be ignored, `RENAME` will add a new column. Currently supported schema changes includes:
+Cdc Ingestion supports a limited number of schema changes. Currently, the framework can not rename table, drop columns, so the
+behaviors of `RENAME TABLE` and `DROP COLUMN` will be ignored, `RENAME COLUMN` will add a new column. Currently supported schema changes includes:
 
 * Adding columns.
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
@@ -38,7 +38,6 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -93,12 +92,12 @@ public class MultiTableUpdatedDataFieldsProcessFunction
                         });
 
         if (Objects.isNull(schemaManager)) {
-            throw new IOException("Failed to get schema manager for table " + tableId);
-        }
-
-        for (SchemaChange schemaChange :
-                extractSchemaChanges(schemaManager, updatedDataFields.f1)) {
-            applySchemaChange(schemaManager, schemaChange, tableId);
+            LOG.error("Failed to get schema manager for table " + tableId);
+        } else {
+            for (SchemaChange schemaChange :
+                    extractSchemaChanges(schemaManager, updatedDataFields.f1)) {
+                applySchemaChange(schemaManager, schemaChange, tableId);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/incubator-paimon/issues/1659

I fixed it ,the result is : 
During the data synchronization,  we rename a table,  the old table will stop data synchronization , the new table will not be synchronized either.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
