### PR TITLE
[core] support querying the manifest of the specified snapshot.

### DIFF
--- a/docs/content/how-to/system-tables.md
+++ b/docs/content/how-to/system-tables.md
@@ -197,16 +197,30 @@ SELECT * FROM MyTable$consumers;
 
 ## Manifests Table
 
-You can query all manifest files contained in the latest snapshot of the current table.
+You can query all manifest files contained in the latest snapshot or the specified snapshot of the current table.
 
 ```sql
+-- Query the manifest of latest snapshot
 SELECT * FROM MyTable$manifests;
 
 /*
 +--------------------------------+-------------+------------------+-------------------+---------------+
 |                      file_name |   file_size |  num_added_files | num_deleted_files |     schema_id |
 +--------------------------------+-------------+------------------+-------------------+---------------+
+| manifest-f4dcab43-ef6b-4713... |        12365|               40 |                 0 |             0 |
 | manifest-f4dcab43-ef6b-4713... |        1648 |                1 |                 0 |             0 |
 +--------------------------------+-------------+------------------+-------------------+---------------+
+2 rows in set
+*/
+
+-- You can also query the manifest with specified snapshot
+SELECT * FROM MyTable$manifests /*+ OPTIONS('scan.snapshot-id'='1') */;
+/*
++--------------------------------+-------------+------------------+-------------------+---------------+
+|                      file_name |   file_size |  num_added_files | num_deleted_files |     schema_id |
++--------------------------------+-------------+------------------+-------------------+---------------+
+| manifest-f4dcab43-ef6b-4713... |        12365|               40 |                 0 |             0 |
++--------------------------------+-------------+------------------+-------------------+---------------+
+1 rows in set
 */
 ```

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link ManifestsTable}. */
+public class ManifestsTableTest extends TableTestBase {
+
+    private Table table;
+    private ManifestsTable manifestsTable;
+    private SnapshotManager snapshotManager;
+    private ManifestList manifestList;
+
+    @BeforeEach
+    public void before() throws Exception {
+        Identifier identifier = identifier("T");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("pk", DataTypes.INT())
+                        .column("pt", DataTypes.INT())
+                        .column("col1", DataTypes.INT())
+                        .partitionKeys("pt")
+                        .primaryKey("pk", "pt")
+                        .option(CoreOptions.CHANGELOG_PRODUCER.key(), "input")
+                        .build();
+        catalog.createTable(identifier, schema, true);
+        table = catalog.getTable(identifier);
+        manifestsTable = (ManifestsTable) catalog.getTable(identifier("T$manifests"));
+
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, "T"));
+        snapshotManager = new SnapshotManager(fileIO, tablePath);
+
+        ManifestList.Factory factory =
+                new ManifestList.Factory(
+                        fileIO,
+                        FileFormat.fromIdentifier(
+                                CoreOptions.MANIFEST_FORMAT.defaultValue().toString(),
+                                new Options()),
+                        new FileStorePathFactory(tablePath),
+                        null);
+        manifestList = factory.create();
+
+        // snapshot 1: append
+        write(table, GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 1));
+
+        // snapshot 2: append
+        write(table, GenericRow.of(2, 1, 1), GenericRow.of(2, 2, 1));
+    }
+
+    @Test
+    public void testReadManifestsFromLatest() throws Exception {
+        List<InternalRow> expectedRow = getExceptedResult(2L);
+        List<InternalRow> result = read(manifestsTable);
+        assertThat(result).containsExactlyElementsOf(expectedRow);
+    }
+
+    @Test
+    public void testReadManifestsFromSpecifiedSnapshot() throws Exception {
+        List<InternalRow> expectedRow = getExceptedResult(1L);
+        manifestsTable =
+                (ManifestsTable)
+                        manifestsTable.copy(
+                                Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        List<InternalRow> result = read(manifestsTable);
+        assertThat(result).containsExactlyElementsOf(expectedRow);
+    }
+
+    @Test
+    public void testReadManifestsFromNotExistSnapshot() throws Exception {
+        manifestsTable =
+                (ManifestsTable)
+                        manifestsTable.copy(
+                                Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
+        List<InternalRow> result = read(manifestsTable);
+        assertThat(result).isEmpty();
+    }
+
+    private List<InternalRow> getExceptedResult(long snapshotId) {
+        if (!snapshotManager.snapshotExists(snapshotId)) {
+            return Collections.emptyList();
+        }
+
+        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
+        List<ManifestFileMeta> allManifestMeta = snapshot.allManifests(manifestList);
+
+        List<InternalRow> expectedRow = new ArrayList<>();
+        for (ManifestFileMeta manifestFileMeta : allManifestMeta) {
+            expectedRow.add(
+                    GenericRow.of(
+                            BinaryString.fromString(manifestFileMeta.fileName()),
+                            manifestFileMeta.fileSize(),
+                            manifestFileMeta.numAddedFiles(),
+                            manifestFileMeta.numDeletedFiles(),
+                            manifestFileMeta.schemaId()));
+        }
+        return expectedRow;
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1666 

<!-- What is the purpose of the change -->
[core] support querying the manifest of the specified snapshot.

### Tests

Added `org.apache.paimon.table.system.ManifestsTableTest` to verify correctness.

### API and Format

No.

### Documentation

No.
