### PR TITLE
[hive] HiveCatalog should throw TableNotExists Exception when table is not a paimon table

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -228,7 +228,7 @@ public class HiveCatalog extends AbstractCatalog {
                                 // tables.
                                 // so we just check the schema file first
                                 return schemaFileExists(identifier)
-                                        && paimonTableExists(identifier, false);
+                                        && paimonTableExists(identifier);
                             })
                     .collect(Collectors.toList());
         } catch (UnknownDBException e) {
@@ -532,15 +532,11 @@ public class HiveCatalog extends AbstractCatalog {
                 dataField.description());
     }
 
-    private boolean paimonTableExists(Identifier identifier) {
-        return paimonTableExists(identifier, true);
-    }
-
     private boolean schemaFileExists(Identifier identifier) {
         return new SchemaManager(fileIO, getDataTableLocation(identifier)).latest().isPresent();
     }
 
-    private boolean paimonTableExists(Identifier identifier, boolean throwException) {
+    private boolean paimonTableExists(Identifier identifier) {
         Table table;
         try {
             table = client.getTable(identifier.getDatabaseName(), identifier.getObjectName());
@@ -552,17 +548,7 @@ public class HiveCatalog extends AbstractCatalog {
                     e);
         }
 
-        boolean isPaimonTable = isPaimonTable(table) || LegacyHiveClasses.isPaimonTable(table);
-        if (!isPaimonTable && throwException) {
-            throw new IllegalArgumentException(
-                    "Table "
-                            + identifier.getFullName()
-                            + " is not a paimon table. It's input format is "
-                            + table.getSd().getInputFormat()
-                            + " and its output format is "
-                            + table.getSd().getOutputFormat());
-        }
-        return isPaimonTable;
+        return isPaimonTable(table) || LegacyHiveClasses.isPaimonTable(table);
     }
 
     private static boolean isPaimonTable(Table table) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -237,7 +237,7 @@ public abstract class HiveCatalogITCaseBase {
             Assert.fail("No exception is thrown");
         } catch (Throwable t) {
             ExceptionUtils.assertThrowableWithMessage(
-                    t, "Table test_db.hive_table is not a paimon table");
+                    t, "Table with identifier 'my_hive.test_db.hive_table' does not exist.");
         }
 
         // alter table
@@ -262,7 +262,8 @@ public abstract class HiveCatalogITCaseBase {
             Assert.fail("No exception is thrown");
         } catch (Throwable t) {
             ExceptionUtils.assertThrowableWithMessage(
-                    t, "Table test_db.hive_table is not a paimon table");
+                    t,
+                    "Table `my_hive`.`test_db`.`hive_table` doesn't exist or is a temporary table.");
         }
     }
 
@@ -334,7 +335,8 @@ public abstract class HiveCatalogITCaseBase {
             Assert.fail("No exception is thrown");
         } catch (Throwable t) {
             ExceptionUtils.assertThrowableWithMessage(
-                    t, "Table test_db.hive_table is not a paimon table");
+                    t,
+                    "Cannot find table '`my_hive`.`test_db`.`hive_table`' in any of the catalogs [default_catalog, my_hive], nor as a temporary table.");
         }
     }
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
