### PR TITLE
[hotfix] Clean up the redundant code of the method of obtaining timestamp type precision.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -27,7 +27,6 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DecimalType;
-import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -135,16 +135,6 @@ public class TypeUtils {
         }
     }
 
-    public static int timestampPrecision(DataType type) {
-        if (type instanceof TimestampType) {
-            return ((TimestampType) type).getPrecision();
-        } else if (type instanceof LocalZonedTimestampType) {
-            return ((LocalZonedTimestampType) type).getPrecision();
-        }
-
-        throw new UnsupportedOperationException("Unsupported type: " + type);
-    }
-
     public static boolean isPrimitive(DataType type) {
         return isPrimitive(type.getTypeRoot());
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkArrayData.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkArrayData.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
 
@@ -35,7 +36,6 @@ import org.apache.spark.unsafe.types.UTF8String;
 
 import static org.apache.paimon.spark.SparkInternalRow.fromPaimon;
 import static org.apache.paimon.utils.InternalRowUtils.copyArray;
-import static org.apache.paimon.utils.TypeUtils.timestampPrecision;
 
 /** Spark {@link ArrayData} to wrap Paimon {@link InternalArray}. */
 public class SparkArrayData extends ArrayData {
@@ -117,7 +117,7 @@ public class SparkArrayData extends ArrayData {
     }
 
     private long getTimestampMicros(int ordinal) {
-        return fromPaimon(array.getTimestamp(ordinal, timestampPrecision(elementType)));
+        return fromPaimon(array.getTimestamp(ordinal, DataTypeChecks.getPrecision(elementType)));
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
-
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
@@ -32,6 +31,7 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
+
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
@@ -23,14 +23,15 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
-
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
@@ -40,7 +41,6 @@ import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import static org.apache.paimon.utils.InternalRowUtils.copyInternalRow;
-import static org.apache.paimon.utils.TypeUtils.timestampPrecision;
 
 /** Spark {@link org.apache.spark.sql.catalyst.InternalRow} to wrap {@link InternalRow}. */
 public class SparkInternalRow extends org.apache.spark.sql.catalyst.InternalRow {
@@ -114,7 +114,7 @@ public class SparkInternalRow extends org.apache.spark.sql.catalyst.InternalRow 
 
     private long getTimestampMicros(int ordinal) {
         DataType type = rowType.getTypeAt(ordinal);
-        return fromPaimon(row.getTimestamp(ordinal, timestampPrecision(type)));
+        return fromPaimon(row.getTimestamp(ordinal, DataTypeChecks.getPrecision(type)));
     }
 
     @Override


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Clean up the redundant code of the method of obtaining timestamp type precision.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
