### PR TITLE
[bug]  fix bug: Stream read snapshot slow while reading from history, waiting for time interval to trigger stream scan

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -122,7 +122,8 @@ public class ContinuousFileSplitEnumerator
 
     @Override
     public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
-        assignAndScanIfNeeded(subtaskId);
+        readersAwaitingSplit.add(subtaskId);
+        doHandleSplitRequest(subtaskId);
     }
 
     @Override
@@ -189,8 +190,7 @@ public class ContinuousFileSplitEnumerator
         assignSplits();
     }
 
-    private void assignAndScanIfNeeded(int taskId) {
-        readersAwaitingSplit.add(taskId);
+    private void doHandleSplitRequest(int taskId) {
         assignSplits();
         // if current task assigned no split, we check conditions to scan one more time
         if (readersAwaitingSplit.contains(taskId)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -169,7 +169,9 @@ public class ContinuousFileSplitEnumerator
             return;
         }
 
-        nextSnapshotId = planWithNextSnapshotId.nextSnapshotId;
+        if (nextSnapshotId == null || planWithNextSnapshotId.nextSnapshotId > nextSnapshotId) {
+            nextSnapshotId = planWithNextSnapshotId.nextSnapshotId;
+        }
         TableScan.Plan plan = planWithNextSnapshotId.plan;
         if (plan.equals(SnapshotNotExistPlan.INSTANCE)) {
             hasReadLatest = true;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -185,7 +185,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
     // ------------------------------------------------------------------------
 
     @Override
-    protected PlanWithNextSnapshotId scanNextSnapshot() {
+    protected synchronized PlanWithNextSnapshotId scanNextSnapshot() {
         if (pendingPlans.remainingCapacity() > 0) {
             PlanWithNextSnapshotId scannedPlan = super.scanNextSnapshot();
             if (!(scannedPlan.plan() instanceof SnapshotNotExistPlan)) {
@@ -199,7 +199,8 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
     }
 
     @Override
-    protected void processDiscoveredSplits(PlanWithNextSnapshotId ignore, Throwable error) {
+    protected synchronized void processDiscoveredSplits(
+            PlanWithNextSnapshotId ignore, Throwable error) {
         if (error != null) {
             if (error instanceof EndOfScanException) {
                 // finished

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -185,7 +185,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
     // ------------------------------------------------------------------------
 
     @Override
-    protected synchronized PlanWithNextSnapshotId scanNextSnapshot() {
+    protected PlanWithNextSnapshotId scanNextSnapshot() {
         if (pendingPlans.remainingCapacity() > 0) {
             PlanWithNextSnapshotId scannedPlan = super.scanNextSnapshot();
             if (!(scannedPlan.plan() instanceof SnapshotNotExistPlan)) {
@@ -199,8 +199,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
     }
 
     @Override
-    protected synchronized void processDiscoveredSplits(
-            PlanWithNextSnapshotId ignore, Throwable error) {
+    protected void processDiscoveredSplits(PlanWithNextSnapshotId ignore, Throwable error) {
         if (error != null) {
             if (error instanceof EndOfScanException) {
                 // finished

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -598,7 +598,7 @@ public class ContinuousFileSplitEnumeratorTest {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
         results.put(2L, new DataFilePlan(splits));
-        // cause latestSnapshot = false, so this request will trigger scan
+        // because latestSnapshot = false, so this request will trigger scan
         enumerator.handleSplitRequest(2, "test-host");
         enumerator.handleSplitRequest(3, "test-host");
         assignments = context.getSplitAssignments();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -603,7 +603,7 @@ public class ContinuousFileSplitEnumeratorTest {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
         results.put(2L, new DataFilePlan(splits));
-        // because latestSnapshot = false, so this request will trigger scan
+        // because blockScanByRequest = false, so this request will trigger scan
         enumerator.handleSplitRequest(2, "test-host");
         context.getExecutorService().triggerAllNonPeriodicTasks();
         enumerator.handleSplitRequest(3, "test-host");
@@ -615,22 +615,22 @@ public class ContinuousFileSplitEnumeratorTest {
         assignedSplits = assignments.get(3).getAssignedSplits();
         assertThat(toDataSplits(assignedSplits)).containsExactly(splits.get(1));
 
-        // this will trigger scan, and then set latestSnapshot = true
+        // this will trigger scan, and then set blockScanByRequest = true
         enumerator.handleSplitRequest(3, "test-host");
         context.getExecutorService().triggerAllNonPeriodicTasks();
         splits.clear();
         splits.add(createDataSplit(snapshot, 7, Collections.emptyList()));
         results.put(3L, new DataFilePlan(splits));
 
-        // this won't trigger scan, cause latestSnapshot = true
+        // this won't trigger scan, cause blockScanByRequest = true
         enumerator.handleSplitRequest(3, "test-host");
         context.getExecutorService().triggerAllNonPeriodicTasks();
         assignments = context.getSplitAssignments();
         assignedSplits = assignments.get(3).getAssignedSplits();
         assertThat(toDataSplits(assignedSplits)).doesNotContain(splits.get(0));
 
-        // forcely set latestSnapshot = false, so the split request below will trigger scan
-        enumerator.hasReadLatest = false;
+        // forcely set blockScanByRequest = false, so the split request below will trigger scan
+        enumerator.blockScanByRequest = false;
         // trigger scan here
         enumerator.handleSplitRequest(3, "test-host");
         context.getExecutorService().triggerAllNonPeriodicTasks();


### PR DESCRIPTION
Stream read too slow, tasks will wait time interval to trigger snapshot scan. 
Every request will trigger a snapshot scan immediately (on if the last scan hasn't reach the latest one).