### PR TITLE
[flink] Remove auto-create for Flink External Table

### DIFF
--- a/docs/content/how-to/creating-tables.md
+++ b/docs/content/how-to/creating-tables.md
@@ -593,9 +593,7 @@ CREATE TABLE MyTable (
     PRIMARY KEY (dt, hh, user_id) NOT ENFORCED
 ) WITH (
     'connector' = 'paimon',
-    'path' = 'hdfs:///path/to/table',
-    'auto-create' = 'true' -- this table property creates table files for an empty table if table path does not exist
-                           -- currently only supported by Flink
+    'path' = 'hdfs:///path/to/table'
 );
 ```
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -27,12 +27,6 @@ under the License.
     </thead>
     <tbody>
         <tr>
-            <td><h5>auto-create</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to create underlying storage when reading and writing the table.</td>
-        </tr>
-        <tr>
             <td><h5>bucket</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -482,13 +482,6 @@ public class CoreOptions implements Serializable {
                     .defaultValue("debezium-json")
                     .withDescription("Specify the message format of log system.");
 
-    public static final ConfigOption<Boolean> AUTO_CREATE =
-            key("auto-create")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Whether to create underlying storage when reading and writing the table.");
-
     public static final ConfigOption<Boolean> STREAMING_READ_OVERWRITE =
             key("streaming-read-overwrite")
                     .booleanType()

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -62,7 +62,7 @@ public class FileStoreTableFactory {
                                         new IllegalArgumentException(
                                                 "Schema file not found in location "
                                                         + tablePath
-                                                        + ". Please create table first."));
+                                                        + ". Please create table by Paimon catalog first."));
         return create(
                 fileIO,
                 tablePath,

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -103,7 +103,7 @@ public class HiveSchema {
                 throw new IllegalArgumentException(
                         "Schema file not found in location "
                                 + location
-                                + ". Please create table first.");
+                                + ". Please create table by Paimon catalog first.");
             }
             // Paimon external table can read schema from the specified location
             return new HiveSchema(new RowType(tableSchema.get().fields()));

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
@@ -63,7 +63,7 @@ public class CreateTableITCase extends HiveTestBase {
                 .hasRootCauseMessage(
                         "Schema file not found in location file:"
                                 + path
-                                + ". Please create table first.");
+                                + ". Please create table by Paimon catalog first.");
     }
 
     @Test

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -61,7 +61,7 @@ public class HiveTableSchemaTest {
                 .withMessage(
                         "Schema file not found in location "
                                 + tempDir.toString()
-                                + ". Please create table first.");
+                                + ". Please create table by Paimon catalog first.");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
`auto-create` often makes the situation very chaotic, with users unsure when the tables were created and what options were used.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
