### PR TITLE
[doc] Use correct parameters for Presto & Trino

### DIFF
--- a/docs/content/engines/presto.md
+++ b/docs/content/engines/presto.md
@@ -124,12 +124,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file.format = 'ORC',
+    file_format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
-    partitioned_by = ARRAY['orderdate'],
+    partitioned_by = ARRAY['order_date'],
     bucket = '2',
-    bucket-key = 'order_key',
-    changelog-producer = 'input'
+    bucket_key = 'order_key',
+    changelog_producer = 'input'
 )
 ```
 
@@ -143,12 +143,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file.format = 'ORC',
+    file_format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
-    partitioned_by = ARRAY['orderdate'],
+    partitioned_by = ARRAY['order_date'],
     bucket = '2',
-    bucket-key = 'order_key',
-    changelog-producer = 'input'
+    bucket_key = 'order_key',
+    changelog_producer = 'input'
 )
 
 ALTER TABLE paimon.test_db.orders ADD COLUMN "shipping_address varchar;

--- a/docs/content/engines/presto.md
+++ b/docs/content/engines/presto.md
@@ -99,7 +99,7 @@ If you are using HDFS, choose one of the following ways to configure your HDFS:
 
 ## Kerberos
 
-You can configure kerberos keytag file when using KERBEROS authentication in the properties.
+You can configure kerberos keytab file when using KERBEROS authentication in the properties.
 
 ```
 security.kerberos.login.principal=hadoop-user
@@ -124,12 +124,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file_format = 'ORC',
+    file.format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
     partitioned_by = ARRAY['orderdate'],
     bucket = '2',
-    bucket_key = 'order_key',
-    changelog_producer = 'input'
+    bucket-key = 'order_key',
+    changelog-producer = 'input'
 )
 ```
 
@@ -143,12 +143,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file_format = 'ORC',
+    file.format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
     partitioned_by = ARRAY['orderdate'],
     bucket = '2',
-    bucket_key = 'order_key',
-    changelog_producer = 'input'
+    bucket-key = 'order_key',
+    changelog-producer = 'input'
 )
 
 ALTER TABLE paimon.test_db.orders ADD COLUMN "shipping_address varchar;

--- a/docs/content/engines/trino.md
+++ b/docs/content/engines/trino.md
@@ -124,7 +124,7 @@ If you are using HDFS, choose one of the following ways to configure your HDFS:
 
 ## Kerberos
 
-You can configure kerberos keytag file when using KERBEROS authentication in the properties.
+You can configure kerberos keytab file when using KERBEROS authentication in the properties.
 
 ```
 security.kerberos.login.principal=hadoop-user

--- a/docs/content/engines/trino.md
+++ b/docs/content/engines/trino.md
@@ -149,12 +149,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file_format = 'ORC',
+    file.format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
     partitioned_by = ARRAY['orderdate'],
     bucket = '2',
-    bucket_key = 'order_key',
-    changelog_producer = 'input'
+    bucket-key = 'order_key',
+    changelog-producer = 'input'
 )
 ```
 
@@ -168,12 +168,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file_format = 'ORC',
+    file.format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
     partitioned_by = ARRAY['orderdate'],
     bucket = '2',
-    bucket_key = 'order_key',
-    changelog_producer = 'input'
+    bucket-key = 'order_key',
+    changelog-producer = 'input'
 )
 
 ALTER TABLE paimon.test_db.orders ADD COLUMN "shipping_address varchar;

--- a/docs/content/engines/trino.md
+++ b/docs/content/engines/trino.md
@@ -149,12 +149,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file.format = 'ORC',
+    file_format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
-    partitioned_by = ARRAY['orderdate'],
+    partitioned_by = ARRAY['order_date'],
     bucket = '2',
-    bucket-key = 'order_key',
-    changelog-producer = 'input'
+    bucket_key = 'order_key',
+    changelog_producer = 'input'
 )
 ```
 
@@ -168,12 +168,12 @@ CREATE TABLE paimon.test_db.orders (
     order_date date
 )
 WITH (
-    file.format = 'ORC',
+    file_format = 'ORC',
     primary_key = ARRAY['order_key','order_date'],
-    partitioned_by = ARRAY['orderdate'],
+    partitioned_by = ARRAY['order_date'],
     bucket = '2',
-    bucket-key = 'order_key',
-    changelog-producer = 'input'
+    bucket_key = 'order_key',
+    changelog_producer = 'input'
 )
 
 ALTER TABLE paimon.test_db.orders ADD COLUMN "shipping_address varchar;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
file.format is defined here
https://github.com/apache/incubator-paimon/blob/41997b2170dcfa32aa867bbc4573989911f05f61/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java#L91
bucket-key
https://github.com/apache/incubator-paimon/blob/41997b2170dcfa32aa867bbc4573989911f05f61/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java#L67
changelog-producer
https://github.com/apache/incubator-paimon/blob/41997b2170dcfa32aa867bbc4573989911f05f61/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java#L373
primary_key & partitioned_by shouldn't be changed 
https://github.com/apache/incubator-paimon-trino/blob/75360d8e0b11cf5026f5219d0c9af02afee2b984/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java#L36




<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
