### PR TITLE
[core] Partial update supports retraction with sequence group

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -80,7 +80,9 @@ For streaming queries, `partial-update` merge engine must be used together with 
 {{< /hint >}}
 
 {{< hint info >}}
-Partial cannot receive `DELETE` messages because the behavior cannot be defined. You can configure `partial-update.ignore-delete` to ignore `DELETE` messages.
+By default, Partial update can not accept delete records, you can choose one of the following solutions:
+- Configure 'partial-update.ignore-delete' to ignore delete records.
+- Configure 'sequence-group's to retract partial columns.
 {{< /hint >}}
 
 #### Sequence Group

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -104,7 +104,7 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                             "By default, Partial update can not accept delete records,"
                                     + " you can choose one of the following solutions:",
                             "1. Configure 'partial-update.ignore-delete' to ignore delete records.",
-                            "2. Configure 'sequence-group' to retract partial columns.");
+                            "2. Configure 'sequence-group's to retract partial columns.");
 
             throw new IllegalArgumentException(msg);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -78,6 +78,16 @@ public class PartialUpdateMergeFunctionTest {
         validate(func, 1, 2, 2, 2, 1, 1, 1);
         add(func, 1, 3, 3, 1, 3, 3, 3);
         validate(func, 1, 2, 2, 2, 3, 3, 3);
+
+        // delete
+        add(func, RowKind.DELETE, 1, 1, 1, 3, 1, 1, null);
+        validate(func, 1, null, null, 3, 3, 3, 3);
+        add(func, RowKind.DELETE, 1, 1, 1, 3, 1, 1, 4);
+        validate(func, 1, null, null, 3, null, null, 4);
+        add(func, 1, 4, 4, 4, 5, 5, 5);
+        validate(func, 1, 4, 4, 4, 5, 5, 5);
+        add(func, RowKind.DELETE, 1, 1, 1, 6, 1, 1, 6);
+        validate(func, 1, null, null, 6, null, null, 6);
     }
 
     @Test
@@ -283,9 +293,12 @@ public class PartialUpdateMergeFunctionTest {
     }
 
     private void add(MergeFunction<KeyValue> function, Integer... f) {
+        add(function, RowKind.INSERT, f);
+    }
+
+    private void add(MergeFunction<KeyValue> function, RowKind rowKind, Integer... f) {
         function.add(
-                new KeyValue()
-                        .replace(GenericRow.of(1), sequence++, RowKind.INSERT, GenericRow.of(f)));
+                new KeyValue().replace(GenericRow.of(1), sequence++, rowKind, GenericRow.of(f)));
     }
 
     private void validate(MergeFunction<KeyValue> function, Integer... f) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
By default, Partial update can not accept delete records, you can choose one of the following solutions:
1. Configure 'partial-update.ignore-delete' to ignore delete records.
2. Configure 'sequence-group' to retract partial columns.

Sequence group delete corresponding fields.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
