### PR TITLE
[hive] Support use partitioned by to create hive partition table.

### DIFF
--- a/docs/content/how-to/creating-tables.md
+++ b/docs/content/how-to/creating-tables.md
@@ -168,14 +168,14 @@ SET hive.metastore.warehouse.dir=warehouse_path;
 CREATE TABLE MyTable (
     user_id BIGINT,
     item_id BIGINT,
-    behavior STRING,
+    behavior STRING
+) PARTITIONED BY ( 
     dt STRING,
     hh STRING
 )
 STORED BY 'org.apache.paimon.hive.PaimonStorageHandler'
 TBLPROPERTIES (
-    'primary-key' = 'dt,hh,user_id',
-    'partition'='dt,hh'
+    'primary-key' = 'dt,hh,user_id'
 );
 ```
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Support use `partitioned by` to create hive partition table.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
