### PR TITLE
[flink][mysql-cdc] All FileStoreWrites generated in database synchronization job should use the same compaction executor service

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/utils/CommonTestUtils.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/CommonTestUtils.java
@@ -80,6 +80,11 @@ public class CommonTestUtils {
         assertThatThrownBy(code::call).isInstanceOf(expected).hasMessageContaining(msg);
     }
 
+    public static void waitUtil(Supplier<Boolean> condition, Duration timeout, Duration pause)
+            throws TimeoutException, InterruptedException {
+        waitUtil(condition, timeout, pause, "Failed to wait for condition to be true.");
+    }
+
     /**
      * Wait util the given condition is met or timeout.
      *

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -70,6 +70,7 @@ public abstract class AbstractFileStoreWrite<T>
     protected final Map<BinaryRow, Map<Integer, WriterContainer<T>>> writers;
 
     private ExecutorService lazyCompactExecutor;
+    private boolean closeCompactExecutorWhenLeaving = true;
     private boolean ignorePreviousFiles = false;
     protected boolean isStreamingMode = false;
 
@@ -104,6 +105,7 @@ public abstract class AbstractFileStoreWrite<T>
 
     public void withCompactExecutor(ExecutorService compactExecutor) {
         this.lazyCompactExecutor = compactExecutor;
+        this.closeCompactExecutorWhenLeaving = false;
     }
 
     @Override
@@ -235,7 +237,7 @@ public abstract class AbstractFileStoreWrite<T>
             }
         }
         writers.clear();
-        if (lazyCompactExecutor != null) {
+        if (lazyCompactExecutor != null && closeCompactExecutorWhenLeaving) {
             lazyCompactExecutor.shutdownNow();
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -102,6 +102,10 @@ public abstract class AbstractFileStoreWrite<T>
         this.ignorePreviousFiles = ignorePreviousFiles;
     }
 
+    public void withCompactExecutor(ExecutorService compactExecutor) {
+        this.lazyCompactExecutor = compactExecutor;
+    }
+
     @Override
     public void write(BinaryRow partition, int bucket, T data) throws Exception {
         WriterContainer<T> container = getWriterWrapper(partition, bucket);
@@ -353,6 +357,11 @@ public abstract class AbstractFileStoreWrite<T>
                             new ExecutorThreadFactory(
                                     Thread.currentThread().getName() + "-compaction"));
         }
+        return lazyCompactExecutor;
+    }
+
+    @VisibleForTesting
+    public ExecutorService getCompactExecutor() {
         return lazyCompactExecutor;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -31,6 +31,7 @@ import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.utils.Restorable;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static org.apache.paimon.utils.Preconditions.checkState;
 
@@ -83,6 +84,11 @@ public class TableWriteImpl<T>
 
     public TableWriteImpl<T> withMemoryPoolFactory(MemoryPoolFactory memoryPoolFactory) {
         write.withMemoryPoolFactory(memoryPoolFactory);
+        return this;
+    }
+
+    public TableWriteImpl<T> withCompactExecutor(ExecutorService compactExecutor) {
+        write.withCompactExecutor(compactExecutor);
         return this;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManagerImpl;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -148,6 +150,10 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
         }
     }
 
+    public void withCompactExecutor(ExecutorService compactExecutor) {
+        write.withCompactExecutor(compactExecutor);
+    }
+
     @Override
     public SinkRecord write(InternalRow rowData) throws Exception {
         return write.writeAndReturn(rowData);
@@ -222,5 +228,10 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
         write.close();
         write = newTableWrite(newTable);
         write.restore((List) states);
+    }
+
+    @VisibleForTesting
+    public TableWriteImpl<?> getWrite() {
+        return write;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -210,6 +210,9 @@ public class CdcRecordStoreMultiWriteOperator
         for (StoreSinkWrite write : writes.values()) {
             write.close();
         }
+        if (compactExecutor != null) {
+            compactExecutor.shutdownNow();
+        }
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink.cdc;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.GenericRow;
@@ -25,12 +26,14 @@ import org.apache.paimon.flink.sink.MultiTableCommittable;
 import org.apache.paimon.flink.sink.PrepareCommitOperator;
 import org.apache.paimon.flink.sink.StateUtils;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.ExecutorThreadFactory;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -42,6 +45,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.flink.sink.cdc.CdcRecordStoreWriteOperator.RETRY_SLEEP_TIME;
@@ -61,12 +66,12 @@ public class CdcRecordStoreMultiWriteOperator
     private final Catalog.Loader catalogLoader;
 
     private MemoryPoolFactory memoryPoolFactory;
-
-    protected Catalog catalog;
-    protected Map<Identifier, FileStoreTable> tables;
-    protected StoreSinkWriteState state;
-    protected Map<Identifier, StoreSinkWrite> writes;
-    protected String commitUser;
+    private Catalog catalog;
+    private Map<Identifier, FileStoreTable> tables;
+    private StoreSinkWriteState state;
+    private Map<Identifier, StoreSinkWrite> writes;
+    private String commitUser;
+    private ExecutorService compactExecutor;
 
     public CdcRecordStoreMultiWriteOperator(
             Catalog.Loader catalogLoader,
@@ -96,6 +101,10 @@ public class CdcRecordStoreMultiWriteOperator
         state = new StoreSinkWriteState(context, (tableName, partition, bucket) -> true);
         tables = new HashMap<>();
         writes = new HashMap<>();
+        compactExecutor =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ExecutorThreadFactory(
+                                Thread.currentThread().getName() + "-CdcMultiWrite-Compaction"));
     }
 
     @Override
@@ -107,8 +116,6 @@ public class CdcRecordStoreMultiWriteOperator
         Identifier tableId = Identifier.create(databaseName, tableName);
 
         FileStoreTable table = getTable(tableId);
-
-        // TODO set executor service to write
 
         // all table write should share one write buffer so that writers can preempt memory
         // from those of other tables
@@ -133,6 +140,8 @@ public class CdcRecordStoreMultiWriteOperator
                                         state,
                                         getContainingTask().getEnvironment().getIOManager(),
                                         memoryPoolFactory));
+
+        ((StoreSinkWriteImpl) write).withCompactExecutor(compactExecutor);
 
         Optional<GenericRow> optionalConverted =
                 toGenericRow(record.record(), table.schema().fields());
@@ -218,5 +227,20 @@ public class CdcRecordStoreMultiWriteOperator
                             .collect(Collectors.toList()));
         }
         return committables;
+    }
+
+    @VisibleForTesting
+    public Map<Identifier, FileStoreTable> tables() {
+        return tables;
+    }
+
+    @VisibleForTesting
+    public Map<Identifier, StoreSinkWrite> writes() {
+        return writes;
+    }
+
+    @VisibleForTesting
+    public String commitUser() {
+        return commitUser;
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
`CdcRecordStoreMultiWriteOperatorTest#testUsingTheSameCompactExecutor`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
