### PR TITLE
[fs] Introduce requiredOptions to FileIOLoader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -259,14 +259,21 @@ public interface FileIO extends Serializable {
         List<IOException> ioExceptionList = new ArrayList<>();
 
         if (loader != null) {
-            Set<String> keys =
+            Set<String> options =
                     config.options().keySet().stream()
                             .map(String::toLowerCase)
                             .collect(Collectors.toSet());
             Set<String> missOptions = new HashSet<>();
-            for (String key : loader.requiredOptions()) {
-                if (!keys.contains(key.toLowerCase())) {
-                    missOptions.add(key);
+            for (String[] keys : loader.requiredOptions()) {
+                boolean found = false;
+                for (String key : keys) {
+                    if (options.contains(key.toLowerCase())) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    missOptions.add(keys[0]);
                 }
             }
             if (missOptions.size() > 0) {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIOLoader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIOLoader.java
@@ -21,7 +21,7 @@ package org.apache.paimon.fs;
 import org.apache.paimon.annotation.Public;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Loader to load {@link FileIO}.
@@ -34,12 +34,12 @@ public interface FileIOLoader {
     String getScheme();
 
     /**
-     * Returns a set of option keys (case-insensitive) that an implementation of this FileIO
-     * requires. Only when these options are included will this FileIO be selected, otherwise it
-     * will fall back to HadoopFileIO or compute engine's own FileIO.
+     * Returns a set of option keys (case-insensitive, key can be written in multiple ways) that an
+     * implementation of this FileIO requires. Only when these options are included will this FileIO
+     * be selected, otherwise it will fall back to HadoopFileIO or compute engine's own FileIO.
      */
-    default Set<String> requiredOptions() {
-        return Collections.emptySet();
+    default List<String[]> requiredOptions() {
+        return Collections.emptyList();
     }
 
     FileIO load(Path path);

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
@@ -48,7 +48,7 @@ public class FileIOTest {
                     .hasMessageContaining("Missing required options are:\n\nRequire1\nreQuire2");
         }
 
-        options.set("Require1", "dummy");
+        options.set("Re-quire1", "dummy");
         options.set("reQuire2", "dummy");
         FileIO fileIO =
                 FileIO.get(

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test {@link FileIO}. */
+public class FileIOTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testRequireOptions() throws IOException {
+        Options options = new Options();
+
+        try {
+            FileIO.get(
+                    new Path("require-options://" + tempDir.toString()),
+                    CatalogContext.create(options));
+            Assertions.fail();
+        } catch (UnsupportedSchemeException e) {
+            assertThat(e.getSuppressed()[0])
+                    .hasMessageContaining("Missing required options are:\n\nRequire1\nreQuire2");
+        }
+
+        options.set("Require1", "dummy");
+        options.set("reQuire2", "dummy");
+        FileIO fileIO =
+                FileIO.get(
+                        new Path("require-options://" + tempDir.toString()),
+                        CatalogContext.create(options));
+        assertThat(fileIO).isInstanceOf(RequireOptionsFileIOLoader.MyFileIO.class);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RequireOptionsFileIOLoader.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RequireOptionsFileIOLoader.java
@@ -20,8 +20,8 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.fs.local.LocalFileIO;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Test {@link FileIOLoader}. */
 public class RequireOptionsFileIOLoader implements FileIOLoader {
@@ -32,10 +32,10 @@ public class RequireOptionsFileIOLoader implements FileIOLoader {
     }
 
     @Override
-    public Set<String> requiredOptions() {
-        Set<String> options = new HashSet<>();
-        options.add("Require1");
-        options.add("reQuire2");
+    public List<String[]> requiredOptions() {
+        List<String[]> options = new ArrayList<>();
+        options.add(new String[] {"Require1", "Re-quire1"});
+        options.add(new String[] {"reQuire2"});
         return options;
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RequireOptionsFileIOLoader.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RequireOptionsFileIOLoader.java
@@ -18,29 +18,32 @@
 
 package org.apache.paimon.fs;
 
-import org.apache.paimon.annotation.Public;
+import org.apache.paimon.fs.local.LocalFileIO;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
-/**
- * Loader to load {@link FileIO}.
- *
- * @since 0.4.0
- */
-@Public
-public interface FileIOLoader {
+/** Test {@link FileIOLoader}. */
+public class RequireOptionsFileIOLoader implements FileIOLoader {
 
-    String getScheme();
-
-    /**
-     * Returns a set of option keys (case-insensitive) that an implementation of this FileIO
-     * requires. Only when these options are included will this FileIO be selected, otherwise it
-     * will fall back to HadoopFileIO or compute engine's own FileIO.
-     */
-    default Set<String> requiredOptions() {
-        return Collections.emptySet();
+    @Override
+    public String getScheme() {
+        return "require-options";
     }
 
-    FileIO load(Path path);
+    @Override
+    public Set<String> requiredOptions() {
+        Set<String> options = new HashSet<>();
+        options.add("Require1");
+        options.add("reQuire2");
+        return options;
+    }
+
+    @Override
+    public FileIO load(Path path) {
+        return new MyFileIO();
+    }
+
+    /** My {@link LocalFileIO} for checking. */
+    public static class MyFileIO extends LocalFileIO {}
 }

--- a/paimon-common/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
+++ b/paimon-common/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.paimon.fs.RequireOptionsFileIOLoader

--- a/paimon-filesystems/paimon-oss/src/main/java/org/apache/paimon/oss/OSSLoader.java
+++ b/paimon-filesystems/paimon-oss/src/main/java/org/apache/paimon/oss/OSSLoader.java
@@ -25,8 +25,8 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PluginFileIO;
 import org.apache.paimon.plugin.PluginLoader;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /** A {@link PluginLoader} to load oss. */
 public class OSSLoader implements FileIOLoader {
@@ -53,11 +53,11 @@ public class OSSLoader implements FileIOLoader {
     }
 
     @Override
-    public Set<String> requiredOptions() {
-        Set<String> options = new HashSet<>();
-        options.add("fs.oss.endpoint");
-        options.add("fs.oss.accessKeyId");
-        options.add("fs.oss.accessKeySecret");
+    public List<String[]> requiredOptions() {
+        List<String[]> options = new ArrayList<>();
+        options.add(new String[] {"fs.oss.endpoint"});
+        options.add(new String[] {"fs.oss.accessKeyId"});
+        options.add(new String[] {"fs.oss.accessKeySecret"});
         return options;
     }
 

--- a/paimon-filesystems/paimon-oss/src/main/java/org/apache/paimon/oss/OSSLoader.java
+++ b/paimon-filesystems/paimon-oss/src/main/java/org/apache/paimon/oss/OSSLoader.java
@@ -25,6 +25,9 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PluginFileIO;
 import org.apache.paimon.plugin.PluginLoader;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /** A {@link PluginLoader} to load oss. */
 public class OSSLoader implements FileIOLoader {
 
@@ -47,6 +50,15 @@ public class OSSLoader implements FileIOLoader {
     @Override
     public String getScheme() {
         return "oss";
+    }
+
+    @Override
+    public Set<String> requiredOptions() {
+        Set<String> options = new HashSet<>();
+        options.add("fs.oss.endpoint");
+        options.add("fs.oss.accessKeyId");
+        options.add("fs.oss.accessKeySecret");
+        return options;
     }
 
     @Override

--- a/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
+++ b/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
@@ -25,8 +25,8 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PluginFileIO;
 import org.apache.paimon.plugin.PluginLoader;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /** A {@link PluginLoader} to load oss. */
 public class S3Loader implements FileIOLoader {
@@ -53,10 +53,10 @@ public class S3Loader implements FileIOLoader {
     }
 
     @Override
-    public Set<String> requiredOptions() {
-        Set<String> options = new HashSet<>();
-        options.add("s3.access-key");
-        options.add("s3.secret-key");
+    public List<String[]> requiredOptions() {
+        List<String[]> options = new ArrayList<>();
+        options.add(new String[] {"s3.access-key", "s3.access.key"});
+        options.add(new String[] {"s3.secret-key", "s3.secret.key"});
         return options;
     }
 

--- a/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
+++ b/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
@@ -25,6 +25,9 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PluginFileIO;
 import org.apache.paimon.plugin.PluginLoader;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /** A {@link PluginLoader} to load oss. */
 public class S3Loader implements FileIOLoader {
 
@@ -47,6 +50,14 @@ public class S3Loader implements FileIOLoader {
     @Override
     public String getScheme() {
         return "s3";
+    }
+
+    @Override
+    public Set<String> requiredOptions() {
+        Set<String> options = new HashSet<>();
+        options.add("s3.access-key");
+        options.add("s3.secret-key");
+        return options;
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, when we put Paimon-s3.jar into the production environment, we must configure s3 related configurations, and fallback FileIO will not be useful.

We can actually make them coexist and introduce the requiredOptions mechanism to use fallback FileIO.

It is not recommended to use `FileIOUtils.checkAccess` here. Accessing real S3FileIO may cause decompression of temporary files and may also cause blockages.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
