### PR TITLE
[Flink] Support numBytesSend metrics for paimon sink

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -39,7 +39,8 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             throws IOException;
 
     /** Commits the given {@link GlobalCommitT}. */
-    void commit(List<GlobalCommitT> globalCommittables, OperatorIOMetricGroup metricGroup) throws IOException, InterruptedException;
+    void commit(List<GlobalCommitT> globalCommittables, OperatorIOMetricGroup metricGroup)
+            throws IOException, InterruptedException;
 
     /**
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -19,6 +19,8 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -37,7 +39,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             throws IOException;
 
     /** Commits the given {@link GlobalCommitT}. */
-    void commit(List<GlobalCommitT> globalCommittables) throws IOException, InterruptedException;
+    void commit(List<GlobalCommitT> globalCommittables, OperatorIOMetricGroup metricGroup) throws IOException, InterruptedException;
 
     /**
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -154,7 +154,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     private void commitUpToCheckpoint(long checkpointId) throws Exception {
         NavigableMap<Long, GlobalCommitT> headMap =
                 committablesPerCheckpoint.headMap(checkpointId, true);
-        committer.commit(committables(headMap));
+        committer.commit(committables(headMap), getMetricGroup().getIOMetricGroup());
         headMap.clear();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -95,7 +95,12 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
         for (ManifestCommittable committable : committables) {
             List<CommitMessage> commitMessages = committable.fileCommittables();
             for (CommitMessage commitMessage : commitMessages) {
-                long dataFileSizeInc = ((CommitMessageImpl) commitMessage).newFilesIncrement().newFiles().stream().mapToLong(f -> f.fileSize()).reduce(Long::sum).getAsLong();
+                long dataFileSizeInc =
+                        ((CommitMessageImpl) commitMessage)
+                                .newFilesIncrement().newFiles().stream()
+                                        .mapToLong(f -> f.fileSize())
+                                        .reduce(Long::sum)
+                                        .getAsLong();
                 bytesSend += dataFileSizeInc;
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -66,8 +66,8 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public void commit(List<ManifestCommittable> committables, OperatorIOMetricGroup metricGroup)
             throws IOException, InterruptedException {
-        metricGroup.getNumBytesOutCounter().inc(calcDataBytesSend(committables));
         commit.commitMultiple(committables);
+        metricGroup.getNumBytesOutCounter().inc(calcDataBytesSend(committables));
     }
 
     @Override
@@ -100,7 +100,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
                                 .newFilesIncrement().newFiles().stream()
                                         .mapToLong(f -> f.fileSize())
                                         .reduce(Long::sum)
-                                        .getAsLong();
+                                        .orElse(0);
                 bytesSend += dataFileSizeInc;
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -99,26 +99,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
                 long dataFileSizeInc =
                         calcTotalFileSize(
                                 ((CommitMessageImpl) commitMessage).newFilesIncrement().newFiles());
-                long changelogFileSizeInc =
-                        calcTotalFileSize(
-                                ((CommitMessageImpl) commitMessage)
-                                        .newFilesIncrement()
-                                        .changelogFiles());
-                long compactedDataFileSizeInc =
-                        calcTotalFileSize(
-                                ((CommitMessageImpl) commitMessage)
-                                        .compactIncrement()
-                                        .compactAfter());
-                long compactedChangelogFileSizeInc =
-                        calcTotalFileSize(
-                                ((CommitMessageImpl) commitMessage)
-                                        .compactIncrement()
-                                        .compactAfter());
-                bytesSend +=
-                        dataFileSizeInc
-                                + changelogFileSizeInc
-                                + compactedDataFileSizeInc
-                                + compactedChangelogFileSizeInc;
+                bytesSend += dataFileSizeInc;
             }
         }
         return bytesSend;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -26,6 +26,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class StoreMultiCommitter
     }
 
     @Override
-    public void commit(List<WrappedManifestCommittable> committables)
+    public void commit(List<WrappedManifestCommittable> committables, OperatorIOMetricGroup metricGroup)
             throws IOException, InterruptedException {
 
         // key by table id
@@ -94,7 +95,7 @@ public class StoreMultiCommitter
             Identifier tableId = entry.getKey();
             List<ManifestCommittable> committableList = entry.getValue();
             StoreCommitter committer = getStoreCommitter(tableId);
-            committer.commit(committableList);
+            committer.commit(committableList, metricGroup);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -85,7 +85,8 @@ public class StoreMultiCommitter
     }
 
     @Override
-    public void commit(List<WrappedManifestCommittable> committables, OperatorIOMetricGroup metricGroup)
+    public void commit(
+            List<WrappedManifestCommittable> committables, OperatorIOMetricGroup metricGroup)
             throws IOException, InterruptedException {
 
         // key by table id

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -342,10 +343,11 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
             manifestCommittable.addFileCommittable(commitMessage);
         }
         write.close();
-        assertThat(
-                        StoreCommitter.calcDataBytesSend(
-                                new ArrayList<>(Arrays.asList(manifestCommittable))))
-                .isEqualTo(275);
+        Tuple2<Long, Long> numBytesAndRecords =
+                StoreCommitter.calcDataBytesAndRecordsSend(
+                        new ArrayList<>(Arrays.asList(manifestCommittable)));
+        assertThat(numBytesAndRecords.f0).isEqualTo(275);
+        assertThat(numBytesAndRecords.f1).isEqualTo(2);
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -342,7 +342,10 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
             manifestCommittable.addFileCommittable(commitMessage);
         }
         write.close();
-        assertThat(StoreCommitter.calcDataBytesSend(new ArrayList<>(Arrays.asList(manifestCommittable)))).isEqualTo(275);
+        assertThat(
+                        StoreCommitter.calcDataBytesSend(
+                                new ArrayList<>(Arrays.asList(manifestCommittable))))
+                .isEqualTo(275);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1737 

Update counter when commit with committables, the value is the size of data files. The counter metric is already registered by flink.