### PR TITLE
[Improve][Doc][Flink]Improve some small content

### DIFF
--- a/docs/content/engines/hive.md
+++ b/docs/content/engines/hive.md
@@ -202,7 +202,7 @@ CREATE TABLE hive_test_table(
     a INT COMMENT 'The a field',
     b STRING COMMENT 'The b field'
 )
-STORED BY 'org.apache.paimon.hive.PaimonStorageHandler'
+STORED BY 'org.apache.paimon.hive.PaimonStorageHandler';
 ```
 
 ## Hive SQL: access Paimon Tables by External Table

--- a/docs/content/how-to/altering-tables.md
+++ b/docs/content/how-to/altering-tables.md
@@ -315,7 +315,7 @@ The following SQL changes comment of column `buy_count` to `buy count`.
 {{< tab "Flink" >}}
 
 ```sql
-ALTER TABLE my_table MODIFY buy_count BIGINT COMMENT 'buy count'
+ALTER TABLE my_table MODIFY buy_count BIGINT COMMENT 'buy count';
 ```
 
 {{< /tab >}}
@@ -451,7 +451,7 @@ The following SQL drops the watermark of table `my_table`.
 {{< tab "Flink" >}}
 
 ```sql
-ALTER TABLE my_table DROP WATERMARK
+ALTER TABLE my_table DROP WATERMARK;
 ```
 
 {{< /tab >}}

--- a/docs/content/how-to/creating-tables.md
+++ b/docs/content/how-to/creating-tables.md
@@ -362,7 +362,7 @@ CREATE TABLE MyTablePk (
       dt STRING,
       hh STRING,
       PRIMARY KEY (dt, hh, user_id) NOT ENFORCED
-) ;
+);
 CREATE TABLE MyTablePkAs WITH ('primary-key' = 'dt,hh') AS SELECT * FROM MyTablePk;
 
 
@@ -453,7 +453,7 @@ CREATE TABLE MyTable (
     dt STRING,
     hh STRING,
     PRIMARY KEY (dt, hh, user_id) NOT ENFORCED
-) ;
+);
 
 CREATE TABLE MyTableLike LIKE MyTable;
 ```

--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -139,7 +139,7 @@ SELECT * FROM t;
 SET paimon.scan.timestamp-millis=null;
     
 -- read tag 'my-tag'
-set paimon.scan.tag-name=my-tag:
+set paimon.scan.tag-name=my-tag;
 SELECT * FROM t;
 set paimon.scan.tag-name=null;
 ```
@@ -235,7 +235,7 @@ You can also do streaming read without the snapshot data, you can use `latest` s
 {{< tab "Flink" >}}
 ```sql
 -- Continuously reads latest changes without producing a snapshot at the beginning.
-SELECT * FROM t /*+ OPTIONS('scan.mode' = 'latest') */
+SELECT * FROM t /*+ OPTIONS('scan.mode' = 'latest') */;
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -245,7 +245,7 @@ SELECT * FROM t /*+ OPTIONS('scan.mode' = 'latest') */
 If you only want to process data for today and beyond, you can do so with partitioned filters:
 
 ```sql
-SELECT * FROM t WHERE dt > '2023-06-26'
+SELECT * FROM t WHERE dt > '2023-06-26';
 ```
 
 If it's not a partitioned table, or you can't filter by partition, you can use Time travel's stream read.
@@ -348,7 +348,7 @@ CREATE TABLE orders (
     order_id BIGINT,
     .....,
     PRIMARY KEY (catalog_id, order_id) NOT ENFORCED -- composite primary key
-)
+);
 ```
 
 The query obtains a good acceleration by specifying a range filter for

--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -33,7 +33,7 @@ be specified by value expressions or result from a query.
 ## Syntax
 
 ```sql
-INSERT { INTO | OVERWRITE } table_identifier [ part_spec ] [ column_list ] { value_expr | query }
+INSERT { INTO | OVERWRITE } table_identifier [ part_spec ] [ column_list ] { value_expr | query };
 ```
 - part_spec
 
@@ -103,7 +103,7 @@ Other engines will throw respective exception to announce this. We can use funct
 turn a nullable column into a non-null column to escape exception:
 
 ```sql
-INSERT INTO A key1 SELECT COALESCE(key2, <non-null expression>) FROM B
+INSERT INTO A key1 SELECT COALESCE(key2, <non-null expression>) FROM B;
 ```
 
 ## Applying Records/Changes to Tables
@@ -195,7 +195,7 @@ You can use `INSERT OVERWRITE` to purge tables by inserting empty value.
 {{< tab "Flink" >}}
 
 ```sql
-INSERT OVERWRITE MyTable /*+ OPTIONS('dynamic-partition-overwrite'='false') */ SELECT * FROM MyTable WHERE false
+INSERT OVERWRITE MyTable /*+ OPTIONS('dynamic-partition-overwrite'='false') */ SELECT * FROM MyTable WHERE false;
 ```
 
 {{< /tab >}}
@@ -217,7 +217,7 @@ Currently, Paimon supports two ways to purge partitions.
 ```sql
 -- Syntax
 INSERT OVERWRITE MyTable /*+ OPTIONS('dynamic-partition-overwrite'='false') */ 
-PARTITION (key1 = value1, key2 = value2, ...) SELECT selectSpec FROM MyTable WHERE false
+PARTITION (key1 = value1, key2 = value2, ...) SELECT selectSpec FROM MyTable WHERE false;
 
 -- The following SQL is an example:
 -- table definition
@@ -229,11 +229,11 @@ CREATE TABLE MyTable (
 
 -- you can use
 INSERT OVERWRITE MyTable /*+ OPTIONS('dynamic-partition-overwrite'='false') */ 
-PARTITION (k0 = 0) SELECT k1, v FROM MyTable WHERE false
+PARTITION (k0 = 0) SELECT k1, v FROM MyTable WHERE false;
 
 -- or
 INSERT OVERWRITE MyTable /*+ OPTIONS('dynamic-partition-overwrite'='false') */ 
-PARTITION (k0 = 0, k1 = 0) SELECT v FROM MyTable WHERE false
+PARTITION (k0 = 0, k1 = 0) SELECT v FROM MyTable WHERE false;
 ```
 
 {{< /tab >}}

--- a/docs/content/maintenance/rescale-bucket.md
+++ b/docs/content/maintenance/rescale-bucket.md
@@ -34,13 +34,13 @@ scan the data with the old bucket number and hash the record according to the cu
 ## Rescale Overwrite
 ```sql
 -- rescale number of total buckets
-ALTER TABLE table_identifier SET ('bucket' = '...')
+ALTER TABLE table_identifier SET ('bucket' = '...');
 
 -- reorganize data layout of table/partition
 INSERT OVERWRITE table_identifier [PARTITION (part_spec)]
 SELECT ... 
 FROM table_identifier
-[WHERE part_spec]
+[WHERE part_spec];
 ``` 
 
 Please note that

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.logical.RowType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -120,12 +121,17 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
                     .getFamilies()
                     .contains(LogicalTypeFamily.CHARACTER_STRING)) {
                 String sqlPattern =
-                        extractLiteral(fieldRefExpr.getOutputDataType(), children.get(1))
+                        Objects.requireNonNull(
+                                        extractLiteral(
+                                                fieldRefExpr.getOutputDataType(), children.get(1)))
                                 .toString();
                 String escape =
                         children.size() <= 2
                                 ? null
-                                : extractLiteral(fieldRefExpr.getOutputDataType(), children.get(2))
+                                : Objects.requireNonNull(
+                                                extractLiteral(
+                                                        fieldRefExpr.getOutputDataType(),
+                                                        children.get(2)))
                                         .toString();
                 String escapedSqlPattern = sqlPattern;
                 boolean allowQuick = false;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -181,7 +182,7 @@ public class MySqlSyncTableAction extends ActionBase {
                                 .collect(Collectors.toList());
                 List<String> fieldNames = table.schema().fieldNames();
                 checkArgument(
-                        fieldNames.containsAll(computedFields),
+                        new HashSet<>(fieldNames).containsAll(computedFields),
                         " Exists Table should contain all computed columns %s, but are %s.",
                         computedFields,
                         fieldNames);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/kafka/KafkaLogDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/kafka/KafkaLogDeserializationSchema.java
@@ -36,6 +36,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import javax.annotation.Nullable;
 
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 /** A {@link KafkaDeserializationSchema} for the table with primary key in log store. */
@@ -125,7 +126,7 @@ public class KafkaLogDeserializationSchema implements KafkaDeserializationSchema
         Collector<RowData> collector = projectCollector.project(underCollector);
 
         if (primaryKey.length > 0 && record.value() == null) {
-            RowData key = primaryKeyDeserializer.deserialize(record.key());
+            RowData key = Objects.requireNonNull(primaryKeyDeserializer).deserialize(record.key());
             GenericRowData value = new GenericRowData(RowKind.DELETE, fieldCount);
             for (int i = 0; i < primaryKey.length; i++) {
                 value.setField(primaryKey[i], keyFieldGetters[i].getFieldOrNull(key));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -146,7 +146,7 @@ public abstract class FlinkSink<T> implements Serializable {
                                 .get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
 
-        Boolean writeOnly = table.coreOptions().writeOnly();
+        boolean writeOnly = table.coreOptions().writeOnly();
         SingleOutputStreamOperator<Committable> written =
                 input.transform(
                                 (writeOnly ? WRITER_WRITE_ONLY_NAME : WRITER_NAME)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 /** A {@link PrepareCommitOperator} to write {@link RowData}. Record schema is fixed. */
 public class RowDataStoreWriteOperator extends TableWriteOperator<RowData> {
@@ -184,7 +185,7 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<RowData> {
 
         if (logCallback != null) {
             try {
-                logSinkFunction.flush();
+                Objects.requireNonNull(logSinkFunction).flush();
             } catch (Exception e) {
                 throw new IOException(e);
             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -66,7 +66,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     }
 
     @Override
-    public int filterAndCommit(List<ManifestCommittable> globalCommittables) throws IOException {
+    public int filterAndCommit(List<ManifestCommittable> globalCommittables) {
         return commit.filterAndCommitMultiple(globalCommittables);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
@@ -92,6 +92,11 @@ public class UpdatedDataFieldsProcessFunction extends ProcessFunction<List<DataF
     }
 
     private List<SchemaChange> extractSchemaChanges(List<DataField> updatedDataFields) {
+        return getSchemaChanges(updatedDataFields, schemaManager);
+    }
+
+    public static List<SchemaChange> getSchemaChanges(
+            List<DataField> updatedDataFields, SchemaManager schemaManager) {
         RowType oldRowType = schemaManager.latest().get().logicalRowType();
         Map<String, DataField> oldFields = new HashMap<>();
         for (DataField oldField : oldRowType.getFields()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 
@@ -89,7 +90,10 @@ public class FileStoreSourceSplitReader
             nextBatch = currentFirstBatch;
             currentFirstBatch = null;
         } else {
-            nextBatch = reachLimit() ? null : currentReader.recordReader().readBatch();
+            nextBatch =
+                    reachLimit()
+                            ? null
+                            : Objects.requireNonNull(currentReader).recordReader().readBatch();
         }
         if (nextBatch == null) {
             pool.recycler().recycle(iterator);
@@ -179,7 +183,8 @@ public class FileStoreSourceSplitReader
 
     private void seek(long toSkip) throws IOException {
         while (true) {
-            RecordIterator<InternalRow> nextBatch = currentReader.recordReader().readBatch();
+            RecordIterator<InternalRow> nextBatch =
+                    Objects.requireNonNull(currentReader).recordReader().readBatch();
             if (nextBatch == null) {
                 throw new RuntimeException(
                         String.format(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -220,8 +220,9 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
         PlanWithNextSnapshotId nextPlan = pendingPlans.poll();
         if (nextPlan != null) {
             nextSnapshotId = nextPlan.nextSnapshotId();
+            Objects.requireNonNull(nextSnapshotId);
             TableScan.Plan plan = nextPlan.plan();
-            if (plan.splits().isEmpty() && nextSnapshotId != null) {
+            if (plan.splits().isEmpty()) {
                 addSplits(
                         Collections.singletonList(
                                 new FileStoreSourceSplit(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ArrayBlockingQueue;
 
@@ -155,7 +156,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
                 }
             }
             PlanWithNextSnapshotId pendingPlan = pendingPlans.poll();
-            addSplits(splitGenerator.createSplits(pendingPlan.plan()));
+            addSplits(splitGenerator.createSplits(Objects.requireNonNull(pendingPlan).plan()));
             nextSnapshotId = pendingPlan.nextSnapshotId();
             assignSplits();
         }
@@ -220,7 +221,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
         if (nextPlan != null) {
             nextSnapshotId = nextPlan.nextSnapshotId();
             TableScan.Plan plan = nextPlan.plan();
-            if (plan.splits().isEmpty()) {
+            if (plan.splits().isEmpty() && nextSnapshotId != null) {
                 addSplits(
                         Collections.singletonList(
                                 new FileStoreSourceSplit(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/CheckpointEvent.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/CheckpointEvent.java
@@ -20,8 +20,6 @@ package org.apache.paimon.flink.source.align;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 
-import javax.annotation.Nonnull;
-
 import java.util.Objects;
 
 /**
@@ -32,13 +30,12 @@ public class CheckpointEvent implements SourceEvent {
 
     private static final long serialVersionUID = 1L;
 
-    @Nonnull private final long checkpointId;
+    private final long checkpointId;
 
     public CheckpointEvent(long checkpointId) {
         this.checkpointId = checkpointId;
     }
 
-    @Nonnull
     public long getCheckpointId() {
         return checkpointId;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
1. Ensure uniformity of semicolon termination for SQL statements within the document.

2. Refactor the logic inside `getSchemaChanges` into a separate method to eliminate redundancy.

3. some method invocations may result in 'NullPointerException'. It would be more appropriate to perform null checks beforehand instead of waiting for the invocation to trigger it.

4. Be cautious about unboxing 'nextSnapshotId', as it may lead to 'java.lang.NullPointerException'.

5. Note that '@Nonnull' annotation cannot be used on members of primitive types.

6. Improve the performance of `list.containsAll(collection)` by wrapping 'fieldNames' in a `HashSet` constructor.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
