### PR TITLE
[core] Introduce row time flag sequence.auto-padding

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -360,3 +360,6 @@ padding for row kind flag, which will automatically distinguish between -U (-D) 
 2. Insufficient precision: If the provided `sequence.field` doesn't meet the precision, like a rough second or
 millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision
 of sequence number will be made up to microsecond by system.
+
+3. Composite pattern: for example, "second-to-micro,row-kind-flag", first, add the micro to the second, and then
+pad the row kind flag.

--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -330,19 +330,8 @@ changelog for the same record.
 By default, the primary key table determines the merge order according to the input order (the last input record will be the last to merge). However, in distributed computing,
 there will be some cases that lead to data disorder. At this time, you can use a time field as `sequence.field`, for example:
 
-{{< hint info >}}
-When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged. 
-For -U and +U, their sequence-fields must be different.
-
-If the provided `sequence.field` doesn't meet the precision, like a rough second or millisecond, you can set
-`sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision of sequence number will
-be made up to microsecond by system. 
-{{< /hint >}}
-
 {{< tabs "sequence.field" >}}
-
 {{< tab "Flink" >}}
-
 ```sql
 CREATE TABLE MyTable (
     pk BIGINT PRIMARY KEY NOT ENFORCED,
@@ -353,9 +342,21 @@ CREATE TABLE MyTable (
     'sequence.field' = 'dt'
 );
 ```
-
 {{< /tab >}}
-
 {{< /tabs >}}
 
 The record with the largest `sequence.field` value will be the last to merge, regardless of the input order.
+
+**Sequence Auto Padding**:
+
+When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged.
+For -U and +U, their sequence-fields must be different. If you cannot meet this requirement, Paimon provides
+option to automatically pad the sequence field for you.
+
+1. `'sequence.auto-padding' = 'row-kind-flag'`: If you are using same value for -U and +U, just like "`op_ts`"
+(the time that the change was made in the database) in Mysql Binlog. It is recommended to use the automatic
+padding for row kind flag, which will automatically distinguish between -U (-D) and +U (+I).
+
+2. Insufficient precision: If the provided `sequence.field` doesn't meet the precision, like a rough second or
+millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision
+of sequence number will be made up to microsecond by system.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -422,7 +422,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>sequence.auto-padding</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
-            <td>Specify the way of padding precision up to micro-second if the provided sequence field is used to indicate "time" but doesn't meet the precise.<br /><br />Possible values:<ul><li>"none": No padding for sequence field.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
+            <td>Specify the way of padding precision up to micro-second if the provided sequence field is used to indicate "time" but doesn't meet the precise.<br /><br />Possible values:<ul><li>"none": No padding for sequence field.</li><li>"row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence.field</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -420,9 +420,9 @@ This config option does not affect the default filesystem metastore.</td>
         </tr>
         <tr>
             <td><h5>sequence.auto-padding</h5></td>
-            <td style="word-wrap: break-word;">none</td>
-            <td><p>Enum</p></td>
-            <td>Specify the way of padding precision up to micro-second if the provided sequence field is used to indicate "time" but doesn't meet the precise.<br /><br />Possible values:<ul><li>"none": No padding for sequence field.</li><li>"row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>"second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>"millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li></ul></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the way of padding precision, if the provided sequence field is used to indicate "time" but doesn't meet the precise.<ul><li>You can specific:</li><li>1. "row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>2. "second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>3. "millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li><li>4. Composite pattern: for example, "second-to-micro,row-kind-flag".</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence.field</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1628,6 +1628,9 @@ public class CoreOptions implements Serializable {
     /** Specifies the way of making up time precision for sequence field. */
     public enum SequenceAutoPadding implements DescribedEnum {
         NONE("none", "No padding for sequence field."),
+        ROW_KIND_FLAG(
+                "row-kind-flag",
+                "Pads a bit flag to indicate whether it is retract (0) or add (1) message."),
         SECOND_TO_MICRO(
                 "second-to-micro",
                 "Pads the sequence field that indicates time with precision of seconds to micro-second."),

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -26,6 +26,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.options.OptionsUtils;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
@@ -1670,6 +1671,10 @@ public class CoreOptions implements Serializable {
         @Override
         public InlineElement getDescription() {
             return text(description);
+        }
+
+        public static SequenceAutoPadding fromString(String s) {
+            return OptionsUtils.convertToEnum(s, SequenceAutoPadding.class);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -250,7 +250,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         .orElse(null);
         final List<SequenceAutoPadding> sequenceAutoPadding =
                 store().options().sequenceAutoPadding().stream()
-                        .map(SequenceAutoPadding::valueOf)
+                        .map(SequenceAutoPadding::fromString)
                         .collect(Collectors.toList());
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -179,7 +179,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                             conf.set(CoreOptions.SEQUENCE_FIELD, "sec");
                             conf.set(
                                     CoreOptions.SEQUENCE_AUTO_PADDING,
-                                    CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO);
+                                    CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO.toString());
                         },
                         rowType);
         StreamTableWrite write = table.newWrite(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.table.sink;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
@@ -34,10 +33,13 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.paimon.CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO;
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.ROW_KIND_FLAG;
+import static org.apache.paimon.CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -227,6 +229,11 @@ public class SequenceGeneratorTest {
                 Timestamp.fromLocalDateTime(LocalDateTime.parse("5000-01-01T00:00:00")).toMicros();
         assertThat(generateWithPaddingOnRowKind(maxMicros, RowKind.INSERT))
                 .isEqualTo(191235168000000001L);
+
+        assertThat(generateWithPaddingOnMicrosAndRowKind(1L, RowKind.INSERT))
+                .isBetween(2001L, 3999L);
+        assertThat(generateWithPaddingOnMicrosAndRowKind(1L, RowKind.UPDATE_BEFORE))
+                .isBetween(2000L, 3998L);
     }
 
     private SequenceGenerator getGenerator(String field) {
@@ -240,7 +247,7 @@ public class SequenceGeneratorTest {
 
     private long generateWithPaddingOnSecond(String field) {
         return getGenerator(field)
-                .generateWithPadding(row, CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO);
+                .generateWithPadding(row, Collections.singletonList(SECOND_TO_MICRO));
     }
 
     private long getSecondFromGeneratedWithPadding(long generated) {
@@ -249,13 +256,21 @@ public class SequenceGeneratorTest {
 
     private long generateWithPaddingOnMillis(String field) {
         return getGenerator(field)
-                .generateWithPadding(row, CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO);
+                .generateWithPadding(row, Collections.singletonList(MILLIS_TO_MICRO));
     }
 
     private long generateWithPaddingOnRowKind(long sequence, RowKind rowKind) {
         return getGenerator("_bigint")
                 .generateWithPadding(
-                        GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence), ROW_KIND_FLAG);
+                        GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence),
+                        Collections.singletonList(ROW_KIND_FLAG));
+    }
+
+    private long generateWithPaddingOnMicrosAndRowKind(long sequence, RowKind rowKind) {
+        return getGenerator("_bigint")
+                .generateWithPadding(
+                        GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence),
+                        Arrays.asList(MILLIS_TO_MICRO, ROW_KIND_FLAG));
     }
 
     private long getMillisFromGeneratedWithPadding(long generated) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR adds `'sequence.auto-padding' = 'row-kind-flag'`, full documentation for **Sequence Auto Padding** is:

When the record is updated or deleted, the `sequence.field` must become larger and cannot remain unchanged.
For -U and +U, their sequence-fields must be different. If you cannot meet this requirement, Paimon provides
option to automatically pad the sequence field for you.

1. `'sequence.auto-padding' = 'row-kind-flag'`: If you are using same value for -U and +U, just like "`op_ts`"
(the time that the change was made in the database) in Mysql Binlog. It is recommended to use the automatic
padding for row kind flag, which will automatically distinguish between -U (-D) and +U (+I).

2. Insufficient precision: If the provided `sequence.field` doesn't meet the precision, like a rough second or
millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision
of sequence number will be made up to microsecond by system.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
