### PR TITLE
[Improve][Flink]Get kafka schema optimization

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/DataFormat.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/DataFormat.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.kafka;
+
+import org.apache.paimon.flink.action.cdc.ComputedColumn;
+import org.apache.paimon.flink.action.cdc.TableNameConverter;
+import org.apache.paimon.flink.action.cdc.kafka.parser.RecordParser;
+import org.apache.paimon.flink.action.cdc.kafka.parser.canal.CanalRecordParser;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions;
+
+import java.util.List;
+
+/** supported formats. */
+public enum DataFormat {
+    CANAL_JSON(CanalRecordParser::new);
+    // Add more data formats here if needed
+
+    private final DataFormatParser parser;
+
+    DataFormat(DataFormatParser parser) {
+        this.parser = parser;
+    }
+
+    public RecordParser createParser(
+            boolean caseSensitive,
+            TableNameConverter tableNameConverter,
+            List<ComputedColumn> computedColumns) {
+        return parser.createParser(caseSensitive, tableNameConverter, computedColumns);
+    }
+
+    public static DataFormat getDataFormat(Configuration kafkaConfig) {
+        String formatStr = kafkaConfig.get(KafkaConnectorOptions.VALUE_FORMAT);
+        try {
+            return DataFormat.valueOf(formatStr.replace("-", "_").toUpperCase());
+        } catch (Exception e) {
+            throw new UnsupportedOperationException(
+                    "This format: " + formatStr + " is not support.");
+        }
+    }
+
+    /** Data format parser. */
+    @FunctionalInterface
+    public interface DataFormatParser {
+        RecordParser createParser(
+                boolean caseSensitive,
+                TableNameConverter tableNameConverter,
+                List<ComputedColumn> computedColumns);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/parser/RecordParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/parser/RecordParser.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.kafka.parser;
+
+import org.apache.paimon.flink.action.cdc.TableNameConverter;
+import org.apache.paimon.flink.action.cdc.kafka.KafkaSchema;
+import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.util.Collector;
+
+import java.util.List;
+
+/** Abstract Class for Parsing Messages with Different Formats. */
+public abstract class RecordParser implements FlatMapFunction<String, RichCdcMultiplexRecord> {
+
+    protected static final String FIELD_TABLE = "table";
+    protected static final String FIELD_DATABASE = "database";
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+    protected final TableNameConverter tableNameConverter;
+    protected JsonNode root;
+    protected String databaseName;
+    protected String tableName;
+
+    protected abstract List<RichCdcMultiplexRecord> extractRecords();
+
+    protected abstract void validateFormat();
+
+    protected abstract String extractString(String key);
+
+    public abstract KafkaSchema getKafkaSchema(String record);
+
+    public RecordParser(TableNameConverter tableNameConverter) {
+        this.tableNameConverter = tableNameConverter;
+    }
+
+    @Override
+    public void flatMap(String value, Collector<RichCdcMultiplexRecord> out) throws Exception {
+        root = objectMapper.readValue(value, JsonNode.class);
+        validateFormat();
+
+        databaseName = extractString(FIELD_DATABASE);
+        tableName = tableNameConverter.convert(extractString(FIELD_TABLE));
+
+        extractRecords().forEach(out::collect);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/parser/canal/CanalFieldParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/parser/canal/CanalFieldParser.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.kafka.canal;
+package org.apache.paimon.flink.action.cdc.kafka.parser.canal;
 
 /** Converts some special types such as enum、set、geometry. */
 public class CanalFieldParser {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. It is not ideal that the `KafkaSchema#getKafkaSchema()` method could potentially execute the `new CanalRecordParser` operation without checking if records are available first. It is recommended to include a check for the presence of records before performing the `new CanalRecordParser` operation.

2. The current configuration for retry attempts and retry intervals seems inappropriate: the number of retry attempts is set at 100, and the retry interval is set at 100 milliseconds. It is suggested to adjust these values to a more reasonable setting, such as 5 retry attempts and a retry interval of 1000 milliseconds. Additionally, implementing an exponential backoff strategy would be beneficial, which progressively increases the retry waiting time with each attempt.

3. It would be more beneficial to utilize an enumeration for determining the canal-json type.

4. Considering that there are several data format types that have not been implemented yet, an additional abstract class called "RecordParser" has been introduced to extend support for OGG CDC, and others.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
