### PR TITLE
[flink]Improve get kafka schema

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
@@ -686,7 +686,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
 
         assertThatThrownBy(() -> action.build(env))
                 .isInstanceOf(Exception.class)
-                .hasMessage("Could not get metadata from server,topic :no_non_ddl_data");
+                .hasMessage("Could not get metadata from server,topic:no_non_ddl_data");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The current configuration for retry attempts and retry intervals seems inappropriate: the number of retry attempts is set at 100, and the retry interval is set at 100 milliseconds. It is suggested to adjust these values to a more reasonable setting, such as 5 retry attempts and a retry interval of 1000 milliseconds. Additionally, implementing an exponential backoff strategy would be beneficial, which progressively increases the retry waiting time with each attempt.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
