### PR TITLE
[flink] Fetching schema in Kafka table synchronization should first seek to beginningOffsets

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchema.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +100,8 @@ public class KafkaSchema {
         }
         int firstPartition =
                 partitionInfos.stream().map(PartitionInfo::partition).sorted().findFirst().get();
-        Collection<TopicPartition> topicPartitions = Collections.singletonList(new TopicPartition(topic, firstPartition));
+        Collection<TopicPartition> topicPartitions =
+                Collections.singletonList(new TopicPartition(topic, firstPartition));
         consumer.assign(topicPartitions);
 
         Map<TopicPartition, Long> beginningOffsets = consumer.beginningOffsets(topicPartitions);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchema.java
@@ -103,12 +103,7 @@ public class KafkaSchema {
         Collection<TopicPartition> topicPartitions =
                 Collections.singletonList(new TopicPartition(topic, firstPartition));
         consumer.assign(topicPartitions);
-
-        Map<TopicPartition, Long> beginningOffsets = consumer.beginningOffsets(topicPartitions);
-        for (TopicPartition tp : topicPartitions) {
-            Long offset = beginningOffsets.get(tp);
-            consumer.seek(tp, offset);
-        }
+        consumer.seekToBeginning(topicPartitions);
 
         return consumer;
     }


### PR DESCRIPTION
…chema otherwise perhaps can NOT fetch records in little traffic case

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->
[flink]
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: when run kafka sync table action it throws can NOT get metadata of topic error

<!-- What is the purpose of the change -->
Seek to beginningOffsets and enlarge poll duration when fetch kafka schema otherwise perhaps can NOT fetch records in little traffic case

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
NO
### Documentation

<!-- Does this change introduce a new feature -->
