### PR TITLE
[flink] support consumer-id for AlignedContinuousFileSplitEnumerator

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -81,6 +81,8 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
 
     private long currentCheckpointId;
 
+    private Long lastConsumedSnapshotId;
+
     private boolean closed;
 
     public AlignedContinuousFileSplitEnumerator(
@@ -98,6 +100,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
         this.alignTimeout = alignTimeout;
         this.lock = new Object();
         this.currentCheckpointId = Long.MIN_VALUE;
+        this.lastConsumedSnapshotId = null;
         this.closed = false;
     }
 
@@ -161,6 +164,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
             assignSplits();
         }
         Preconditions.checkArgument(alignedAssigner.isAligned());
+        lastConsumedSnapshotId = alignedAssigner.minRemainingSnapshotId();
         alignedAssigner.removeFirst();
         currentCheckpointId = checkpointId;
 
@@ -182,6 +186,8 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
         currentCheckpointId = Long.MIN_VALUE;
+        Long nextSnapshot = lastConsumedSnapshotId == null ? null : lastConsumedSnapshotId + 1;
+        scan.notifyCheckpointComplete(nextSnapshot);
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
@@ -114,6 +114,11 @@ public class AlignedSplitAssigner implements SplitAssigner {
                 "The head pending splits is not empty. This is a bug, please file an issue.");
     }
 
+    public Long minRemainingSnapshotId() {
+        PendingSnapshot head = pendingSplitAssignment.peek();
+        return head != null ? head.snapshotId : null;
+    }
+
     private static class PendingSnapshot {
         private final long snapshotId;
         private final boolean isPlaceHolder;


### PR DESCRIPTION


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1793 

<!-- What is the purpose of the change -->
support `consumer-id` for `AlignedContinuousFileSplitEnumerator`.

### Tests

<!-- List UT and IT cases to verify this change -->
Added `org.apache.paimon.flink.source.align.AlignedContinuousFileSplitEnumeratorTest#testScanWithConsumerId` to verify that the `consumer-id` can be updated correctly.

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No