### PR TITLE
[flink] Fix to  use : instead of -> for operator name

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -150,7 +150,7 @@ public abstract class FlinkSink<T> implements Serializable {
         SingleOutputStreamOperator<Committable> written =
                 input.transform(
                                 (writeOnly ? WRITER_WRITE_ONLY_NAME : WRITER_NAME)
-                                        + " -> "
+                                        + " : "
                                         + table.name(),
                                 new CommittableTypeInfo(),
                                 createWriteOperator(
@@ -186,7 +186,7 @@ public abstract class FlinkSink<T> implements Serializable {
 
         SingleOutputStreamOperator<?> committed =
                 written.transform(
-                                GLOBAL_COMMITTER_NAME + " -> " + table.name(),
+                                GLOBAL_COMMITTER_NAME + " : " + table.name(),
                                 new CommittableTypeInfo(),
                                 new CommitterOperator<>(
                                         streamingCheckpointEnabled,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BucketUnawareCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BucketUnawareCompactSource.java
@@ -125,7 +125,7 @@ public class BucketUnawareCompactSource extends RichSourceFunction<AppendOnlyCom
                 new CompactionTaskTypeInfo(),
                 sourceOperator,
                 false,
-                COMPACTION_COORDINATOR_NAME + " -> " + tableIdentifier,
+                COMPACTION_COORDINATOR_NAME + " : " + tableIdentifier,
                 streaming ? Boundedness.CONTINUOUS_UNBOUNDED : Boundedness.BOUNDED);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose


Ambiguous operator name, we can make it more clearer.
![image](https://github.com/apache/incubator-paimon/assets/18002496/81152ce7-51ab-47f6-a3c7-d831a552ecf8)


<!-- What is the purpose of the change -->
 use : instead of -> for operator name
