### PR TITLE
[hive] extern table remove file by mistake when create table failed

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
@@ -64,7 +64,7 @@ public class PaimonMetaHook implements HiveMetaHook {
     private final Configuration conf;
 
     // paimon table existed before create hive table
-    private Set<Identifier> existingPaimonTable = new HashSet<>();
+    private final Set<Identifier> existingPaimonTable = new HashSet<>();
 
     public PaimonMetaHook(Configuration conf) {
         this.conf = conf;

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
@@ -35,7 +35,6 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -43,8 +42,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hive.metastore.Warehouse.getDnsPath;
@@ -62,6 +63,9 @@ public class PaimonMetaHook implements HiveMetaHook {
     private static final String COMMENT = "comment";
     private final Configuration conf;
 
+    // paimon table existed before create hive table
+    private Set<Identifier> existingPaimonTable = new HashSet<>();
+
     public PaimonMetaHook(Configuration conf) {
         this.conf = conf;
     }
@@ -75,12 +79,12 @@ public class PaimonMetaHook implements HiveMetaHook {
         table.getSd().setInputFormat(PaimonInputFormat.class.getCanonicalName());
         table.getSd().setOutputFormat(PaimonOutputFormat.class.getCanonicalName());
         String location = LocationKeyExtractor.getPaimonLocation(conf, table);
+        Identifier identifier = Identifier.create(table.getDbName(), table.getTableName());
         if (location == null) {
             String warehouse = conf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname);
             org.apache.hadoop.fs.Path hadoopPath =
                     getDnsPath(new org.apache.hadoop.fs.Path(warehouse), conf);
             warehouse = hadoopPath.toUri().toString();
-            Identifier identifier = Identifier.create(table.getDbName(), table.getTableName());
             location = AbstractCatalog.dataTableLocation(warehouse, identifier).toUri().toString();
             table.getSd().setLocation(location);
         }
@@ -97,6 +101,7 @@ public class PaimonMetaHook implements HiveMetaHook {
         SchemaManager schemaManager = new SchemaManager(fileIO, path);
         Optional<TableSchema> tableSchema = schemaManager.latest();
         if (tableSchema.isPresent()) {
+            existingPaimonTable.add(identifier);
             // paimon table already exists
             return;
         }
@@ -143,7 +148,8 @@ public class PaimonMetaHook implements HiveMetaHook {
 
     @Override
     public void rollbackCreateTable(Table table) throws MetaException {
-        if (MetaStoreUtils.isExternalTable(table)) {
+        Identifier identifier = Identifier.create(table.getDbName(), table.getTableName());
+        if (existingPaimonTable.contains(identifier)) {
             return;
         }
 

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
@@ -143,7 +143,7 @@ public class PaimonMetaHook implements HiveMetaHook {
 
     @Override
     public void rollbackCreateTable(Table table) throws MetaException {
-        if (!MetaStoreUtils.isExternalTable(table)) {
+        if (MetaStoreUtils.isExternalTable(table)) {
             return;
         }
 

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
@@ -125,5 +125,4 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
         decomposed.pushedPredicate = (ExprNodeGenericFuncDesc) predicate;
         return decomposed;
     }
-
 }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
@@ -125,4 +125,5 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
         decomposed.pushedPredicate = (ExprNodeGenericFuncDesc) predicate;
         return decomposed;
     }
+
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
@@ -367,6 +367,7 @@ public class CreateTableITCase extends HiveTestBase {
         }
     }
 
+    /** Mock create table failed. */
     public static class MockPaimonMetaHook extends PaimonMetaHook {
 
         public MockPaimonMetaHook(Configuration conf) {
@@ -379,6 +380,7 @@ public class CreateTableITCase extends HiveTestBase {
         }
     }
 
+    /** StorageHanlder with MockPaimonMetaHook. */
     public static class MockPaimonStorageHandler extends PaimonStorageHandler {
         @Override
         public HiveMetaHook getMetaHook() {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
@@ -329,7 +329,9 @@ public class CreateTableITCase extends HiveTestBase {
                 hiveShell.execute(hiveSql);
             } catch (Throwable ignore) {
             } finally {
-                Assertions.assertThat(LocalFileIO.create().exists(tablePath)).isTrue();
+                boolean isPresent =
+                        new SchemaManager(LocalFileIO.create(), tablePath).latest().isPresent();
+                Assertions.assertThat(isPresent).isTrue();
             }
         }
 
@@ -358,7 +360,9 @@ public class CreateTableITCase extends HiveTestBase {
             } finally {
                 Identifier identifier = Identifier.create(DATABASE_TEST, tableName);
                 Path tablePath = AbstractCatalog.dataTableLocation(path, identifier);
-                Assertions.assertThat(LocalFileIO.create().exists(tablePath)).isFalse();
+                boolean isPresent =
+                        new SchemaManager(LocalFileIO.create(), tablePath).latest().isPresent();
+                Assertions.assertThat(isPresent).isFalse();
             }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
When attempting to create a  hive extern table  for an existing Paimon, if the table creation fails, the Paimon table will be deleted, which is not expected.
The pr is for reproduce the problem,and then fix it

### Tests
CreateTableITCase#createExternTableFailing

