### PR TITLE
[flink][mysql-cdc] MySQL CDC supports convert TIME type to STRING type when using Hive catalog

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -438,6 +438,11 @@ behaviors of `RENAME TABLE` and `DROP COLUMN` will be ignored, `RENAME COLUMN` w
 
 {{< generated/compute_column >}}
 
+## Special Data Type Conversions
+1. TINYINT(1) type in MySQL would be converted to Boolean by default. If you want to store number in it like MySQL, you 
+can specify that `--mysql-conf mysql.converter.tinyint1-to-bool=false`, then the column will be mapped to TINYINT in paimon table.
+2. Hive catalog doesn't support TIME type, so TIME type will be converted to STRING.
+
 ## FAQ
 1. Chinese characters in records ingested from MySQL are garbled.
 * Try to set `env.java.opts: -Dfile.encoding=UTF-8` in `flink-conf.yaml`

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -63,7 +63,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--mysql-conf</h5></td>
-        <td>The configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options">document</a> for a complete list of configurations. <br> Furthermore, TINYINT(1) type in MySQL would be converted to Boolean by default. If you want to store number (-128~127) in it, you can specify the config 'mysql.converter.tinyint1-to-bool' to false, then the column will be mapped to TINYINT in paimon table.</td>
+        <td>The configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options">document</a> for a complete list of configurations.</td>
     </tr>
     <tr>
         <td><h5>--catalog-conf</h5></td>

--- a/docs/layouts/shortcodes/generated/mysql_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_table.html
@@ -51,7 +51,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--mysql-conf</h5></td>
-        <td>The configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options">document</a> for a complete list of configurations. <br> Furthermore, TINYINT(1) type in MySQL would be converted to Boolean by default. If you want to store number in it like MySQL, you can specify the config 'mysql.converter.tinyint1-to-bool' to false, then the column will be mapped to TINYINT in paimon table.</td>
+        <td>The configuration for Flink CDC MySQL table sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#connector-options">document</a> for a complete list of configurations.</td>
     </tr>
     <tr>
         <td><h5>--catalog-conf</h5></td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/SpecialCastRules.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/SpecialCastRules.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc;
+
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+import static org.apache.paimon.flink.action.cdc.mysql.MySqlTypeUtils.TIME;
+import static org.apache.paimon.flink.action.cdc.mysql.MySqlTypeUtils.TINYINT;
+
+/** Utility class that holds some special MySQL type to Paimon type cast rules . */
+public class SpecialCastRules implements Serializable {
+
+    /**
+     * MySQL haven't boolean type, it uses tinyint(1) to represents boolean type user should not use
+     * tinyint(1) to store number although jdbc url parameter tinyInt1isBit=false can help change
+     * the return value, it's not a general way. mybatis and mysql-connector-java map tinyint(1) to
+     * boolean by default, we behave the same way by default. To store number (-128~127), we can set
+     * the parameter tinyInt1ToByte (option 'mysql.converter.tinyint1-to-bool') to false, then
+     * tinyint(1) will be mapped to TinyInt.
+     */
+    private final boolean castTinyInt1ToBool;
+
+    /** Hive doesn't support TIME, so here convert it into STRING type. */
+    private final boolean castTimeToString;
+
+    public SpecialCastRules(boolean castTinyInt1ToBool, boolean castTimeToString) {
+        this.castTinyInt1ToBool = castTinyInt1ToBool;
+        this.castTimeToString = castTimeToString;
+    }
+
+    public static SpecialCastRules defaultRules() {
+        return new SpecialCastRules(true, false);
+    }
+
+    public DataType cast(String type, @Nullable Integer length) {
+        switch (type) {
+            case TINYINT:
+                return castTinyInt1ToBool && length != null && length == 1
+                        ? DataTypes.BOOLEAN()
+                        : DataTypes.TINYINT();
+
+            case TIME:
+                return castTimeToString ? DataTypes.STRING() : DataTypes.TIME();
+            default:
+                throw new IllegalArgumentException("No special cast rule for type: " + type);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.action.cdc.mysql;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.cdc.ComputedColumn;
+import org.apache.paimon.flink.action.cdc.SpecialCastRules;
 import org.apache.paimon.flink.action.cdc.mysql.schema.MySqlSchema;
 import org.apache.paimon.flink.action.cdc.mysql.schema.MySqlSchemasInfo;
 import org.apache.paimon.flink.action.cdc.mysql.schema.MySqlTableInfo;
@@ -107,7 +108,8 @@ public class MySqlActionUtils {
     static MySqlSchemasInfo getMySqlTableInfos(
             Configuration mySqlConfig,
             Predicate<String> monitorTablePredication,
-            List<Identifier> excludedTables)
+            List<Identifier> excludedTables,
+            SpecialCastRules specialCastRules)
             throws Exception {
         Pattern databasePattern =
                 Pattern.compile(mySqlConfig.get(MySqlSourceOptions.DATABASE_NAME));
@@ -127,7 +129,7 @@ public class MySqlActionUtils {
                                                 metaData,
                                                 databaseName,
                                                 tableName,
-                                                mySqlConfig.get(MYSQL_CONVERTER_TINYINT1_BOOL));
+                                                specialCastRules);
                                 Identifier identifier = Identifier.create(databaseName, tableName);
                                 if (monitorTablePredication.test(tableName)) {
                                     mySqlSchemasInfo.addSchema(identifier, mySqlSchema);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlDebeziumJsonEventParser.java
@@ -25,6 +25,7 @@ package org.apache.paimon.flink.action.cdc.mysql;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.cdc.ComputedColumn;
+import org.apache.paimon.flink.action.cdc.SpecialCastRules;
 import org.apache.paimon.flink.action.cdc.TableNameConverter;
 import org.apache.paimon.flink.sink.cdc.CdcRecord;
 import org.apache.paimon.flink.sink.cdc.EventParser;
@@ -88,7 +89,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
     @Nullable private final Pattern excludingPattern;
     private final Set<String> includedTables = new HashSet<>();
     private final Set<String> excludedTables = new HashSet<>();
-    private final boolean convertTinyint1ToBool;
+    private final SpecialCastRules specialCastRules;
 
     private JsonNode root;
     private JsonNode payload;
@@ -100,7 +101,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             ZoneId serverTimeZone,
             boolean caseSensitive,
             List<ComputedColumn> computedColumns,
-            boolean convertTinyint1ToBool) {
+            SpecialCastRules specialCastRules) {
         this(
                 serverTimeZone,
                 caseSensitive,
@@ -109,7 +110,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
                 ddl -> Optional.empty(),
                 null,
                 null,
-                convertTinyint1ToBool);
+                specialCastRules);
     }
 
     public MySqlDebeziumJsonEventParser(
@@ -119,7 +120,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             NewTableSchemaBuilder<JsonNode> schemaBuilder,
             @Nullable Pattern includingPattern,
             @Nullable Pattern excludingPattern,
-            boolean convertTinyint1ToBool) {
+            SpecialCastRules specialCastRules) {
         this(
                 serverTimeZone,
                 caseSensitive,
@@ -128,7 +129,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
                 schemaBuilder,
                 includingPattern,
                 excludingPattern,
-                convertTinyint1ToBool);
+                specialCastRules);
     }
 
     public MySqlDebeziumJsonEventParser(
@@ -139,7 +140,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
             NewTableSchemaBuilder<JsonNode> schemaBuilder,
             @Nullable Pattern includingPattern,
             @Nullable Pattern excludingPattern,
-            boolean convertTinyint1ToBool) {
+            SpecialCastRules specialCastRules) {
         this.serverTimeZone = serverTimeZone;
         this.caseSensitive = caseSensitive;
         this.computedColumns = computedColumns;
@@ -147,7 +148,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
         this.schemaBuilder = schemaBuilder;
         this.includingPattern = includingPattern;
         this.excludingPattern = excludingPattern;
-        this.convertTinyint1ToBool = convertTinyint1ToBool;
+        this.specialCastRules = specialCastRules;
     }
 
     @Override
@@ -211,7 +212,7 @@ public class MySqlDebeziumJsonEventParser implements EventParser<String> {
                             column.get("typeName").asText(),
                             length == null ? null : length.asInt(),
                             scale == null ? null : scale.asInt(),
-                            convertTinyint1ToBool);
+                            specialCastRules);
             if (column.get("optional").asBoolean()) {
                 type = type.nullable();
             } else {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTableSchemaBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.action.cdc.mysql;
 
+import org.apache.paimon.flink.action.cdc.SpecialCastRules;
 import org.apache.paimon.flink.sink.cdc.NewTableSchemaBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataType;
@@ -32,7 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.flink.action.cdc.mysql.MySqlActionUtils.MYSQL_CONVERTER_TINYINT1_BOOL;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Schema builder for MySQL cdc. */
@@ -40,10 +40,15 @@ public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder<JsonNode> 
 
     private final Map<String, String> tableConfig;
     private final boolean caseSensitive;
+    private final SpecialCastRules specialCastRules;
 
-    public MySqlTableSchemaBuilder(Map<String, String> tableConfig, boolean caseSensitive) {
+    public MySqlTableSchemaBuilder(
+            Map<String, String> tableConfig,
+            boolean caseSensitive,
+            SpecialCastRules specialCastRules) {
         this.tableConfig = tableConfig;
         this.caseSensitive = caseSensitive;
+        this.specialCastRules = specialCastRules;
     }
 
     @Override
@@ -63,7 +68,7 @@ public class MySqlTableSchemaBuilder implements NewTableSchemaBuilder<JsonNode> 
                                     element.get("typeExpression").asText(),
                                     precision,
                                     scale,
-                                    MYSQL_CONVERTER_TINYINT1_BOOL.defaultValue())
+                                    specialCastRules)
                             .copy(element.get("optional").asBoolean()));
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/schema/MySqlSchema.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/schema/MySqlSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.action.cdc.mysql.schema;
 
+import org.apache.paimon.flink.action.cdc.SpecialCastRules;
 import org.apache.paimon.flink.action.cdc.mysql.MySqlTypeUtils;
 import org.apache.paimon.flink.sink.cdc.UpdatedDataFieldsProcessFunction;
 import org.apache.paimon.types.DataType;
@@ -49,7 +50,7 @@ public class MySqlSchema {
             DatabaseMetaData metaData,
             String databaseName,
             String tableName,
-            boolean convertTinyintToBool)
+            SpecialCastRules specialCastRules)
             throws SQLException {
         LinkedHashMap<String, Pair<DataType, String>> fields = new LinkedHashMap<>();
         try (ResultSet rs = metaData.getColumns(databaseName, null, tableName, null)) {
@@ -70,7 +71,7 @@ public class MySqlSchema {
                         fieldName,
                         Pair.of(
                                 MySqlTypeUtils.toDataType(
-                                        fieldType, precision, scale, convertTinyintToBool),
+                                        fieldType, precision, scale, specialCastRules),
                                 fieldComment));
             }
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -856,10 +856,10 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
 
     @Test
     @Timeout(60)
-    public void testTinyInt1Convert() throws Exception {
+    public void testSpecialCastRules() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
         mySqlConfig.put("database-name", DATABASE_NAME);
-        mySqlConfig.put("table-name", "test_tinyint1_convert");
+        mySqlConfig.put("table-name", "test_special_cast_rules");
         mySqlConfig.put("mysql.converter.tinyint1-to-bool", "false");
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -878,109 +878,66 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         Collections.emptyList(),
                         Collections.emptyMap(),
                         Collections.emptyMap());
-        action.build(env);
-        JobClient client = env.executeAsync();
-        waitJobRunning(client);
-
-        try (Statement statement = getStatement()) {
-            statement.execute("USE " + DATABASE_NAME);
-            statement.executeUpdate(
-                    "INSERT INTO test_tinyint1_convert VALUES (1, '2021-09-15 15:00:10', 21)");
-            statement.executeUpdate(
-                    "INSERT INTO test_tinyint1_convert VALUES (2, '2023-03-23 16:00:20', 42)");
-
-            FileStoreTable table = getFileStoreTable();
-            RowType rowType =
-                    RowType.of(
-                            new DataType[] {
-                                DataTypes.INT().notNull(),
-                                DataTypes.TIMESTAMP(0),
-                                DataTypes.TINYINT()
-                            },
-                            new String[] {"pk", "_datetime", "_tinyint1"});
-            List<String> expected =
-                    Arrays.asList(
-                            "+I[1, 2021-09-15T15:00:10, 21]", "+I[2, 2023-03-23T16:00:20, 42]");
-            waitForResult(expected, table, rowType, Collections.singletonList("pk"));
-        }
-    }
-
-    @Test
-    @Timeout(60)
-    public void testSchemaEvolutionWithTinyint1Convert() throws Exception {
-        Map<String, String> mySqlConfig = getBasicMySqlConfig();
-        mySqlConfig.put("database-name", "paimon_sync_table_tinyint");
-        mySqlConfig.put("table-name", "schema_evolution_3");
-        mySqlConfig.put("mysql.converter.tinyint1-to-bool", "false");
-
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(2);
-        env.enableCheckpointing(1000);
-        env.setRestartStrategy(RestartStrategies.noRestart());
-
-        Map<String, String> tableConfig = getBasicTableConfig();
-        MySqlSyncTableAction action =
-                new MySqlSyncTableAction(
-                        mySqlConfig,
-                        warehouse,
-                        database,
-                        tableName,
-                        Collections.singletonList("pt"),
-                        Arrays.asList("pt", "_id"),
-                        Collections.singletonMap(
-                                CatalogOptions.METASTORE.key(), "test-alter-table"),
-                        tableConfig);
+        action.setCastTimeToString(true);
         action.build(env);
         JobClient client = env.executeAsync();
         waitJobRunning(client);
 
         checkTableSchema(
-                "[{\"id\":0,\"name\":\"pt\",\"type\":\"INT NOT NULL\",\"description\":\"primary\"},{\"id\":1,\"name\":\"_id\",\"type\":\"INT NOT NULL\",\"description\":\"_id\"},{\"id\":2,\"name\":\"v1\",\"type\":\"VARCHAR(10)\",\"description\":\"v1\"}]");
+                "[{\"id\":0,\"name\":\"pk\",\"type\":\"INT NOT NULL\",\"description\":\"\"},"
+                        + "{\"id\":1,\"name\":\"_tinyint1\",\"type\":\"TINYINT\",\"description\":\"\"},"
+                        + "{\"id\":2,\"name\":\"_time\",\"type\":\"STRING\",\"description\":\"\"}]");
 
         try (Statement statement = getStatement()) {
-            testSchemaEvolutionImplWithTinyIntConvert(statement);
+            statement.execute("USE " + DATABASE_NAME);
+            statement.executeUpdate(
+                    "INSERT INTO test_special_cast_rules VALUES (1, 1, '00:01'), (2, 20, '00:02:03')");
+
+            FileStoreTable table = getFileStoreTable();
+            RowType rowType =
+                    RowType.of(
+                            new DataType[] {
+                                DataTypes.INT().notNull(), DataTypes.TINYINT(), DataTypes.STRING()
+                            },
+                            new String[] {"pk", "_tinyint1", "_time"});
+            waitForResult(
+                    Arrays.asList("+I[1, 1, 00:01]", "+I[2, 20, 00:02:03]"),
+                    table,
+                    rowType,
+                    Collections.singletonList("pk"));
+
+            // test schema evolution
+            // add TINYINT(1) and TIME column
+            statement.executeUpdate(
+                    "ALTER TABLE test_special_cast_rules ADD COLUMN _new_tinyint1 TINYINT(1)");
+            statement.executeUpdate(
+                    "ALTER TABLE test_special_cast_rules ADD COLUMN _new_time TIME");
+            statement.executeUpdate(
+                    "INSERT INTO test_special_cast_rules VALUES (3, 30, '00:00:00', 1, '12:21:30.001'), (4, 40, '00:00:00', 40, '23:59:59')");
+
+            rowType =
+                    RowType.of(
+                            new DataType[] {
+                                DataTypes.INT().notNull(),
+                                DataTypes.TINYINT(),
+                                DataTypes.STRING(),
+                                DataTypes.TINYINT(),
+                                DataTypes.STRING()
+                            },
+                            new String[] {
+                                "pk", "_tinyint1", "_time", "_new_tinyint1", "_new_time"
+                            });
+            waitForResult(
+                    Arrays.asList(
+                            "+I[1, 1, 00:01, NULL, NULL]",
+                            "+I[2, 20, 00:02:03, NULL, NULL]",
+                            // note that MySQL time precision is to second
+                            "+I[3, 30, 00:00, 1, 12:21:30]",
+                            "+I[4, 40, 00:00, 40, 23:59:59]"),
+                    table,
+                    rowType,
+                    Collections.singletonList("pk"));
         }
-    }
-
-    private void testSchemaEvolutionImplWithTinyIntConvert(Statement statement) throws Exception {
-        FileStoreTable table = getFileStoreTable();
-        statement.executeUpdate("USE paimon_sync_table_tinyint");
-
-        statement.executeUpdate("INSERT INTO schema_evolution_3 VALUES (1, 1, 'one')");
-        statement.executeUpdate(
-                "INSERT INTO schema_evolution_3 VALUES (1, 2, 'two'), (2, 4, 'four')");
-        RowType rowType =
-                RowType.of(
-                        new DataType[] {
-                            DataTypes.INT().notNull(),
-                            DataTypes.INT().notNull(),
-                            DataTypes.VARCHAR(10)
-                        },
-                        new String[] {"pt", "_id", "v1"});
-        List<String> primaryKeys = Arrays.asList("pt", "_id");
-        List<String> expected = Arrays.asList("+I[1, 1, one]", "+I[1, 2, two]", "+I[2, 4, four]");
-        waitForResult(expected, table, rowType, primaryKeys);
-
-        statement.executeUpdate("ALTER TABLE schema_evolution_3 ADD COLUMN v2 TINYINT(1)");
-        statement.executeUpdate(
-                "INSERT INTO schema_evolution_3 VALUES (2, 3, 'three', 30), (1, 5, 'five', 50)");
-        rowType =
-                RowType.of(
-                        new DataType[] {
-                            DataTypes.INT().notNull(),
-                            DataTypes.INT().notNull(),
-                            DataTypes.VARCHAR(10),
-                            DataTypes.TINYINT()
-                        },
-                        new String[] {"pt", "_id", "v1", "v2"});
-        expected =
-                Arrays.asList(
-                        "+I[1, 1, one, NULL]",
-                        "+I[1, 2, two, NULL]",
-                        "+I[2, 3, three, 30]",
-                        "+I[2, 4, four, NULL]",
-                        "+I[1, 5, five, 50]");
-        waitForResult(expected, table, rowType, primaryKeys);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/sync_table_setup.sql
@@ -274,25 +274,15 @@ CREATE TABLE test_computed_column (
     PRIMARY KEY (pk)
 );
 
-CREATE TABLE test_tinyint1_convert (
+-- ################################################################################
+--  testSpecialCastRules
+-- ################################################################################
+
+CREATE TABLE test_special_cast_rules (
     pk INT,
-    _datetime DATETIME,
     _tinyint1 TINYINT(1),
+    _time TIME,
     PRIMARY KEY (pk)
-);
-
--- ################################################################################
---  testSchemaEvolutionWithTinyint1Convert
--- ################################################################################
-
-CREATE DATABASE paimon_sync_table_tinyint;
-USE paimon_sync_table_tinyint;
-
-CREATE TABLE schema_evolution_3 (
-    pt INT comment  'primary',
-    _id INT comment  '_id',
-    v1 VARCHAR(10) comment  'v1',
-    PRIMARY KEY (_id)
 );
 
 -- ################################################################################


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This is because Hive doesn't support TIME.

<!-- What is the purpose of the change -->

### Tests
`MySqlSyncTableActionITCase#testSpecialCastRules`

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
Refactor cdc doc
