### PR TITLE
[core] Fix that tag auto creation cannot work after restarting job

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -107,7 +107,8 @@ public class TagAutoCreation {
                     firstNonNull(snapshotManager.earliestSnapshotId(), FIRST_SNAPSHOT_ID);
         } else {
             Snapshot lastTag = tags.lastKey();
-            this.nextSnapshot = lastTag.id() + 1;
+            // avoid that job restarts and is initialized to expired snapshot
+            this.nextSnapshot = Math.max(snapshotManager.earliestSnapshotId(), lastTag.id()) + 1;
 
             LocalDateTime time = periodHandler.tagToTime(tags.get(lastTag));
             this.nextTag = periodHandler.nextTagTime(time);

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -115,14 +115,18 @@ public class TagAutoCreation {
     }
 
     public void run() {
-        // avoid snapshot has been expired
-        nextSnapshot = Math.max(snapshotManager.earliestSnapshotId(), nextSnapshot);
         while (true) {
             if (snapshotManager.snapshotExists(nextSnapshot)) {
                 tryToTag(snapshotManager.snapshot(nextSnapshot));
                 nextSnapshot++;
             } else {
-                break;
+                // avoid snapshot has been expired
+                Long earliest = snapshotManager.earliestSnapshotId();
+                if (earliest != null && earliest > nextSnapshot) {
+                    nextSnapshot = earliest;
+                } else {
+                    break;
+                }
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -107,8 +107,7 @@ public class TagAutoCreation {
                     firstNonNull(snapshotManager.earliestSnapshotId(), FIRST_SNAPSHOT_ID);
         } else {
             Snapshot lastTag = tags.lastKey();
-            // avoid that job restarts and is initialized to expired snapshot
-            this.nextSnapshot = Math.max(snapshotManager.earliestSnapshotId(), lastTag.id()) + 1;
+            this.nextSnapshot = lastTag.id() + 1;
 
             LocalDateTime time = periodHandler.tagToTime(tags.get(lastTag));
             this.nextTag = periodHandler.nextTagTime(time);
@@ -116,6 +115,8 @@ public class TagAutoCreation {
     }
 
     public void run() {
+        // avoid snapshot has been expired
+        nextSnapshot = Math.max(snapshotManager.earliestSnapshotId(), nextSnapshot);
         while (true) {
             if (snapshotManager.snapshotExists(nextSnapshot)) {
                 tryToTag(snapshotManager.snapshot(nextSnapshot));

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
@@ -35,6 +35,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import static org.apache.paimon.CoreOptions.SINK_WATERMARK_TIME_ZONE;
+import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
+import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MIN;
 import static org.apache.paimon.CoreOptions.TAG_AUTOMATIC_CREATION;
 import static org.apache.paimon.CoreOptions.TAG_CREATION_DELAY;
 import static org.apache.paimon.CoreOptions.TAG_CREATION_PERIOD;
@@ -50,6 +52,8 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
         options.set(TAG_NUM_RETAINED_MAX, 3);
+        options.set(SNAPSHOT_NUM_RETAINED_MIN, 1);
+        options.set(SNAPSHOT_NUM_RETAINED_MAX, 1);
         FileStoreTable table = this.table.copy(options.toMap());
         TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
         TagManager tagManager = table.store().newTagManager();
@@ -72,9 +76,14 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-18 12", "2023-07-18 13", "2023-07-18 14");
 
-        // test restore
+        // test restore after snapshot expiration
+        // first trigger snapshot expiration
+        commit.commit(new ManifestCommittable(5, utcMills("2023-07-18T15:01:00")));
+        commit.commit(new ManifestCommittable(6, utcMills("2023-07-18T15:02:00")));
+
+        // then restore and check tags
         commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
-        commit.commit(new ManifestCommittable(5, utcMills("2023-07-18T16:00:00")));
+        commit.commit(new ManifestCommittable(7, utcMills("2023-07-18T16:00:00")));
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-18 13", "2023-07-18 14", "2023-07-18 15");
     }

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
@@ -52,8 +52,6 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
         options.set(TAG_NUM_RETAINED_MAX, 3);
-        options.set(SNAPSHOT_NUM_RETAINED_MIN, 1);
-        options.set(SNAPSHOT_NUM_RETAINED_MAX, 1);
         FileStoreTable table = this.table.copy(options.toMap());
         TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
         TagManager tagManager = table.store().newTagManager();
@@ -76,14 +74,21 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-18 12", "2023-07-18 13", "2023-07-18 14");
 
-        // test restore after snapshot expiration
-        // first trigger snapshot expiration
+        // test restore with snapshot expiration
         commit.commit(new ManifestCommittable(5, utcMills("2023-07-18T15:01:00")));
         commit.commit(new ManifestCommittable(6, utcMills("2023-07-18T15:02:00")));
 
-        // then restore and check tags
-        commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
-        commit.commit(new ManifestCommittable(7, utcMills("2023-07-18T16:00:00")));
+        Options expireSetting = new Options();
+        expireSetting.set(SNAPSHOT_NUM_RETAINED_MIN, 1);
+        expireSetting.set(SNAPSHOT_NUM_RETAINED_MAX, 1);
+        commit = table.copy(expireSetting.toMap()).newCommit(commitUser).ignoreEmptyCommit(false);
+
+        // trigger snapshot expiration
+        commit.commit(new ManifestCommittable(7, utcMills("2023-07-18T15:03:00")));
+        commit.commit(new ManifestCommittable(8, utcMills("2023-07-18T15:04:00")));
+
+        // check tags
+        commit.commit(new ManifestCommittable(9, utcMills("2023-07-18T16:00:00")));
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-18 13", "2023-07-18 14", "2023-07-18 15");
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
After restarting job, the `TagAutoCreation` may be initialized to expired snapshot. 

<!-- What is the purpose of the change -->

### Tests

`TagAutoCreationTest#testTag`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
