### PR TITLE
[hive] HiveCatalog supports TIME type by converting time to string

### DIFF
--- a/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
+++ b/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
@@ -37,6 +37,7 @@ import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
@@ -170,6 +171,11 @@ public class HiveTypeUtils {
         @Override
         public TypeInfo visit(DateType dateType) {
             return TypeInfoFactory.dateTypeInfo;
+        }
+
+        @Override
+        public TypeInfo visit(TimeType timeType) {
+            return TypeInfoFactory.stringTypeInfo;
         }
 
         @Override

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.VarCharType;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -34,6 +35,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Factory to create {@link ObjectInspector}s according to the given {@link DataType}. */
 public class PaimonObjectInspectorFactory {
@@ -67,6 +70,10 @@ public class PaimonObjectInspectorFactory {
                 }
             case DATE:
                 return new PaimonDateObjectInspector();
+            case TIME_WITHOUT_TIME_ZONE:
+                TimeType timeType = (TimeType) logicalType;
+                checkArgument(timeType.getPrecision() <= 3, "TIME type precision must be <= 3.");
+                return new PaimonTimeObjectInspector();
             case TIMESTAMP_WITHOUT_TIME_ZONE:
                 return new PaimonTimestampObjectInspector();
             case ARRAY:

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspector.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.hive.objectinspector;
 
-import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
@@ -48,7 +47,7 @@ public class PaimonTimeObjectInspector extends AbstractPrimitiveJavaObjectInspec
     }
 
     @Override
-    public BinaryString convert(Object value) {
-        return value == null ? null : BinaryString.fromString(getPrimitiveJavaObject(value));
+    public Integer convert(Object value) {
+        return value == null ? null : DateTimeUtils.parseTime((String) value);
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspector.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.objectinspector;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.utils.DateTimeUtils;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+/** {@link AbstractPrimitiveJavaObjectInspector} for TIME type. */
+public class PaimonTimeObjectInspector extends AbstractPrimitiveJavaObjectInspector
+        implements StringObjectInspector, WriteableObjectInspector {
+
+    public PaimonTimeObjectInspector() {
+        super(TypeInfoFactory.stringTypeInfo);
+    }
+
+    @Override
+    public String getPrimitiveJavaObject(Object o) {
+        if (o == null) {
+            return null;
+        }
+        return DateTimeUtils.toLocalTime((int) o).toString();
+    }
+
+    @Override
+    public Text getPrimitiveWritableObject(Object o) {
+        return o == null ? null : new Text(getPrimitiveJavaObject(o));
+    }
+
+    @Override
+    public BinaryString convert(Object value) {
+        return value == null ? null : BinaryString.fromString(getPrimitiveJavaObject(value));
+    }
+}

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/RandomGenericRowDataGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/RandomGenericRowDataGenerator.java
@@ -57,6 +57,7 @@ public class RandomGenericRowDataGenerator {
                     DataTypes.STRING(),
                     DataTypes.VARBINARY(Integer.MAX_VALUE),
                     DataTypes.DATE(),
+                    DataTypes.TIME(),
                     DataTypes.TIMESTAMP(3),
                     DataTypes.ARRAY(DataTypes.BIGINT()),
                     DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()));
@@ -77,6 +78,7 @@ public class RandomGenericRowDataGenerator {
                     "string",
                     "binary",
                     "date",
+                    "time",
                     "timestamp",
                     "array<bigint>",
                     "map<string,int>");
@@ -97,6 +99,7 @@ public class RandomGenericRowDataGenerator {
                     "f_string",
                     "f_binary",
                     "f_date",
+                    "f_time",
                     "f_timestamp",
                     "f_list_long",
                     "f_map_string_int");
@@ -117,6 +120,7 @@ public class RandomGenericRowDataGenerator {
                     "comment_string",
                     "comment_binary",
                     "comment_date",
+                    "comment_time",
                     "comment_timestamp",
                     "comment_list_long",
                     "comment_map_string_int");
@@ -166,6 +170,7 @@ public class RandomGenericRowDataGenerator {
                         BinaryString.fromString(randomString(100)),
                         randomBytes,
                         random.nextInt(10000),
+                        random.nextInt(86400),
                         Timestamp.fromEpochMillis(random.nextLong(Integer.MAX_VALUE)),
                         new GenericArray(randomLongArray),
                         new GenericMap(randomMap));

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/RandomGenericRowDataGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/RandomGenericRowDataGenerator.java
@@ -78,7 +78,7 @@ public class RandomGenericRowDataGenerator {
                     "string",
                     "binary",
                     "date",
-                    "time",
+                    "string",
                     "timestamp",
                     "array<bigint>",
                     "map<string,int>");

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonInternalRowObjectInspectorTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonInternalRowObjectInspectorTest.java
@@ -59,6 +59,7 @@ public class PaimonInternalRowObjectInspectorTest {
                         ObjectInspector.Category.PRIMITIVE,
                         ObjectInspector.Category.PRIMITIVE,
                         ObjectInspector.Category.PRIMITIVE,
+                        ObjectInspector.Category.PRIMITIVE,
                         ObjectInspector.Category.LIST,
                         ObjectInspector.Category.MAP);
 
@@ -97,6 +98,7 @@ public class PaimonInternalRowObjectInspectorTest {
                                         "f_string:string",
                                         "f_binary:binary",
                                         "f_date:date",
+                                        "f_time:string",
                                         "f_timestamp:timestamp",
                                         "f_list_long:array<bigint>",
                                         "f_map_string_int:map<string,int>"))

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspectorTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonTimeObjectInspectorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.objectinspector;
+
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PaimonTimeObjectInspector}. */
+public class PaimonTimeObjectInspectorTest {
+
+    @Test
+    public void testCategoryAndClass() {
+        PaimonTimeObjectInspector oi = new PaimonTimeObjectInspector();
+
+        assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+        assertThat(oi.getPrimitiveCategory())
+                .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
+
+        assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
+        assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
+    }
+
+    @Test
+    public void testGetPrimitiveJavaObject() {
+        PaimonTimeObjectInspector oi = new PaimonTimeObjectInspector();
+
+        int input = 1;
+        assertThat(oi.getPrimitiveJavaObject(input)).isEqualTo("00:00:00.001");
+        assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    }
+
+    @Test
+    public void testGetPrimitiveWritableObject() {
+        PaimonTimeObjectInspector oi = new PaimonTimeObjectInspector();
+
+        int input = 86_399_000;
+        assertThat(oi.getPrimitiveWritableObject(input).toString()).isEqualTo("23:59:59");
+        assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

`PaimonStorageHandlerITCase#testTime`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
