### PR TITLE
[common] Fix array copy out of bounds exception in ColumnarArray.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
@@ -116,7 +116,7 @@ public final class ColumnarArray implements InternalArray, DataSetters, Serializ
         if (byteArray.len == byteArray.data.length) {
             return byteArray.data;
         } else {
-            return Arrays.copyOfRange(byteArray.data, byteArray.offset, byteArray.len);
+            return Arrays.copyOfRange(byteArray.data, 0, byteArray.len);
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix array copy out of bounds exception in ColumnarArray.

![44DC13CE-578C-466A-97D2-A15AC99FA98E](https://github.com/apache/incubator-paimon/assets/37063904/e935d5ca-c853-4a73-aa39-5c969bdf8d07)

![A3F3EB15-4171-4616-A8B6-A5D82E1EF400](https://github.com/apache/incubator-paimon/assets/37063904/cce3432f-8077-49c1-879d-8355f990a948)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
