### PR TITLE
[core] AddPartitionCommitCallback should only be created for partitioned table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -270,7 +270,8 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     private List<CommitCallback> createCommitCallbacks() {
         List<CommitCallback> callbacks = new ArrayList<>(loadCommitCallbacks());
         if (coreOptions().partitionedTableInMetastore()
-                && catalogEnvironment.metastoreClientFactory() != null) {
+                && catalogEnvironment.metastoreClientFactory() != null
+                && tableSchema.partitionKeys().size() > 0) {
             callbacks.add(
                     new AddPartitionCommitCallback(
                             catalogEnvironment.metastoreClientFactory().create()));

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -831,6 +831,24 @@ public abstract class HiveCatalogITCaseBase {
                         "ptb=3b/pta=3");
     }
 
+    @Test
+    public void testAddPartitionsToMetastoreForUnpartitionedTable() throws Exception {
+        tEnv.executeSql(
+                String.join(
+                        "\n",
+                        "CREATE TABLE t (",
+                        "    k INT,",
+                        "    v BIGINT,",
+                        "    PRIMARY KEY (k) NOT ENFORCED",
+                        ") WITH (",
+                        "    'bucket' = '2',",
+                        "    'metastore.partitioned-table' = 'true'",
+                        ")"));
+        tEnv.executeSql("INSERT INTO t VALUES (1, 10), (2, 20)").await();
+        assertThat(hiveShell.executeQuery("SELECT * FROM t ORDER BY k"))
+                .containsExactlyInAnyOrder("1\t10", "2\t20");
+    }
+
     protected List<Row> collect(String sql) throws Exception {
         List<Row> result = new ArrayList<>();
         try (CloseableIterator<Row> it = tEnv.executeSql(sql).collect()) {


### PR DESCRIPTION
### Purpose

Currently when creating `AddPartitionCommitCallback`, we forget to check whether the table is a partitioned table. This PR fixes the issue.

### Tests

* `HiveCatalogITCaseBase#testAddPartitionsToMetastoreForUnpartitionedTable`.

### API and Format

No.

### Documentation

No.
