### PR TITLE
[core] Add expiration cleanup limit

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -194,6 +194,11 @@ public class CoreOptions implements Serializable {
                     .defaultValue(Duration.ofHours(1))
                     .withDescription("The maximum time of completed snapshots to retain.");
 
+    public static final ConfigOption<Integer> SNAPSHOT_CLEAN_LIMIT =
+            key("snapshot.clean-limit")
+                    .intType()
+                    .defaultValue(200)
+                    .withDescription("The maximum quantity of snapshots to be cleared at once.");
     public static final ConfigOption<Duration> CONTINUOUS_DISCOVERY_INTERVAL =
             key("continuous.discovery-interval")
                     .durationType()
@@ -933,6 +938,9 @@ public class CoreOptions implements Serializable {
         return options.get(SNAPSHOT_TIME_RETAINED);
     }
 
+    public Integer snapshotCleanLimit() {
+        return options.get(SNAPSHOT_CLEAN_LIMIT);
+    }
     public int manifestMergeMinCount() {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -174,6 +174,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.snapshotNumRetainMin(),
                 options.snapshotNumRetainMax(),
                 options.snapshotTimeRetain().toMillis(),
+                options.snapshotCleanLimit(),
                 snapshotManager(),
                 newSnapshotDeletion(),
                 newTagManager());

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -132,10 +132,12 @@ public class TestFileStore extends KeyValueFileStore {
 
     public FileStoreExpireImpl newExpire(
             int numRetainedMin, int numRetainedMax, long millisRetained) {
+        int cleanLimit = options.snapshotCleanLimit();
         return new FileStoreExpireImpl(
                 numRetainedMin,
                 numRetainedMax,
                 millisRetained,
+                cleanLimit,
                 snapshotManager(),
                 newSnapshotDeletion(),
                 new TagManager(fileIO, options.path()));


### PR DESCRIPTION
### Purpose

<!-- What is the purpose of the change -->
【common】add parameters for cleaning limits
【core】limit bulk deletions when snapshots expire

after the consumer group expires, a large number of snapshots will be deleted. In severe cases, it may cause continuous checkpoint timeout and affect the running of tasks. Therefore, we need to limit the number of deleted snapshots to make the whole process smoother.

### Tests

No

### API and Format

No

### Documentation

No
