### PR TITLE
[hive] After Flink changed the table name when using hive metastore, the modified table could not be found.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -382,6 +382,7 @@ public class HiveCatalog extends AbstractCatalog {
 
                 // update location
                 locationHelper.specifyTableLocation(table, toPath.toString());
+                client.alter_table(toTable.getDatabaseName(), toTable.getObjectName(), table);
             }
         } catch (TException e) {
             throw new RuntimeException("Failed to rename table " + fromTable.getFullName(), e);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -368,8 +368,7 @@ public class HiveCatalog extends AbstractCatalog {
             Path fromPath = getDataTableLocation(fromTable);
             if (new SchemaManager(fileIO, fromPath).listAllIds().size() > 0) {
                 // Rename the file system's table directory. Maintain consistency between tables in
-                // the
-                // file system and tables in the Hive Metastore.
+                // the file system and tables in the Hive Metastore.
                 Path toPath = getDataTableLocation(toTable);
                 try {
                     fileIO.rename(fromPath, toPath);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.hive;
 
-import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLock;
 import org.apache.paimon.catalog.Identifier;
@@ -49,7 +48,6 @@ import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.Statement;
 
-import java.io.File;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -504,7 +502,7 @@ public abstract class HiveCatalogITCaseBase {
     public void testRenameTable() throws Exception {
         tEnv.executeSql("CREATE TABLE t1 (a INT)").await();
         tEnv.executeSql("CREATE TABLE t2 (a INT)").await();
-        tEnv.executeSql("INSERT INTO t1 SELECT 1");
+        tEnv.executeSql("INSERT INTO t1 SELECT 1").await();
         // the source table do not exist.
         assertThatThrownBy(() -> tEnv.executeSql("ALTER TABLE t3 RENAME TO t4"))
                 .hasMessage(
@@ -521,21 +519,21 @@ public abstract class HiveCatalogITCaseBase {
                         "Could not execute ALTER TABLE my_hive.test_db.t1 RENAME TO my_hive.test_db.T1");
 
         tEnv.executeSql("ALTER TABLE t1 RENAME TO t3").await();
+
+        // hive read
         List<String> tables = hiveShell.executeQuery("SHOW TABLES");
         assertThat(tables.contains("t3")).isTrue();
         assertThat(tables.contains("t1")).isFalse();
+        List<String> data = hiveShell.executeQuery("SELECT * FROM t3");
+        assertThat(data).containsExactlyInAnyOrder("1");
 
-        Identifier identifier = new Identifier("test_db", "t3");
-        Catalog catalog =
-                ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
-        org.apache.paimon.fs.Path tablePath =
-                ((AbstractCatalog) catalog).getDataTableLocation(identifier);
-        assertThat(tablePath.toString()).isEqualTo(path + "test_db.db" + File.separator + "t3");
+        // flink read
+        List<Row> tablesFromFlink = collect("SHOW TABLES");
+        assertThat(tablesFromFlink).contains(Row.of("t3"));
+        assertThat(tablesFromFlink).doesNotContain(Row.of("t1"));
 
-        // TODO: the hiverunner (4.0) has a bug ,it can not rename the table path correctly ,
-        // we should upgrade it to the 6.0 later ,and  update the test case for query.
-        assertThatThrownBy(() -> tEnv.executeSql("SELECT * FROM t3"))
-                .hasMessageContaining("SQL validation failed. There is no paimond in");
+        List<Row> dataFromFlink = collect("SELECT * FROM t3");
+        assertThat(dataFromFlink).contains(Row.of(1));
     }
 
     @Test


### PR DESCRIPTION
…

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1831

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
HiveCatalogITCaseBase#testRenameTable

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
