### PR TITLE
[build] Try to minimize paimon-common jar

### DIFF
--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -287,6 +287,7 @@ under the License.
                                     <shadedPattern>org.apache.paimon.shade.it.unimi.dsi.fastutil</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <minimizeJar>true</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Now, paimon-common.jar is too big, about 26 MB.
We should minimize it, actually, the root reason is `fastutil`, it is very big.

I am trying to add minimizeJar to shade plugin. After, the jar is 3 MB.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
