### PR TITLE
[core] Remove append-only.assert-disorder

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -652,15 +652,6 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Consumer id for recording the offset of consumption in the storage.");
 
-    @Deprecated
-    @ExcludeFromDocumentation("For compatibility with older versions")
-    public static final ConfigOption<Boolean> APPEND_ONLY_ASSERT_DISORDER =
-            key("append-only.assert-disorder")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Should assert disorder files, this just for compatibility with older versions.");
-
     public static final ConfigOption<Integer> FULL_COMPACTION_DELTA_COMMITS =
             key("full-compaction.delta-commits")
                     .intType()

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import static org.apache.paimon.CoreOptions.APPEND_ONLY_ASSERT_DISORDER;
 import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
 
 /** {@link FileStoreWrite} for {@link AppendOnlyFileStore}. */
@@ -65,7 +64,6 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
     private final int compactionMinFileNum;
     private final int compactionMaxFileNum;
     private final boolean commitForceCompact;
-    private final boolean assertDisorder;
     private final String fileCompression;
     private final FieldStatsCollector.Factory[] statsCollectors;
 
@@ -94,7 +92,6 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
         this.compactionMaxFileNum = options.compactionMaxFileNum();
         this.commitForceCompact = options.commitForceCompact();
         this.skipCompaction = options.writeOnly();
-        this.assertDisorder = options.toConfiguration().get(APPEND_ONLY_ASSERT_DISORDER);
         this.fileCompression = options.fileCompression();
         this.statsCollectors =
                 StatsCollectorFactories.createStatsFactories(options, rowType.getFieldNames());
@@ -120,8 +117,7 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<InternalRow
                                 compactionMinFileNum,
                                 compactionMaxFileNum,
                                 targetFileSize,
-                                compactRewriter(partition, bucket),
-                                assertDisorder);
+                                compactRewriter(partition, bucket));
 
         return new AppendOnlyWriter(
                 fileIO,

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
@@ -46,7 +46,7 @@ public class AppendOnlySplitGenerator implements SplitGenerator {
     @Override
     public List<List<DataFileMeta>> splitForBatch(List<DataFileMeta> input) {
         List<DataFileMeta> files = new ArrayList<>(input);
-        files.sort(fileComparator(false));
+        files.sort(fileComparator());
         Function<DataFileMeta, Long> weightFunc = file -> Math.max(file.fileSize(), openFileCost);
         return BinPacking.packForOrdered(files, weightFunc, targetSplitSize);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyCompactManagerTest.java
@@ -24,14 +24,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 import static org.apache.paimon.io.DataFileTestUtils.newFile;
-import static org.apache.paimon.table.source.SplitGeneratorTest.newFileFromSequence;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link AppendOnlyCompactManager}. */
 public class AppendOnlyCompactManagerTest {
@@ -194,42 +191,6 @@ public class AppendOnlyCompactManagerTest {
                 Collections.singletonList(newFile(2621L, 2630L)));
     }
 
-    @Test
-    public void testAppendOverlap() {
-        Comparator<DataFileMeta> comparator = AppendOnlyCompactManager.fileComparator(true);
-        assertThatThrownBy(
-                        () ->
-                                comparator.compare(
-                                        newFileFromSequence("1", 11, 0, 20),
-                                        newFileFromSequence("2", 13, 20, 30)))
-                .hasMessageContaining(
-                        "There should no overlap in append files, but Range1(0, 20), Range2(20, 30)");
-
-        assertThatThrownBy(
-                        () ->
-                                comparator.compare(
-                                        newFileFromSequence("1", 11, 20, 30),
-                                        newFileFromSequence("2", 13, 0, 20)))
-                .hasMessageContaining(
-                        "There should no overlap in append files, but Range1(20, 30), Range2(0, 20)");
-
-        assertThatThrownBy(
-                        () ->
-                                comparator.compare(
-                                        newFileFromSequence("1", 11, 0, 30),
-                                        newFileFromSequence("2", 13, 10, 20)))
-                .hasMessageContaining(
-                        "There should no overlap in append files, but Range1(0, 30), Range2(10, 20)");
-
-        assertThatThrownBy(
-                        () ->
-                                comparator.compare(
-                                        newFileFromSequence("1", 11, 10, 20),
-                                        newFileFromSequence("2", 13, 0, 30)))
-                .hasMessageContaining(
-                        "There should no overlap in append files, but Range1(10, 20), Range2(0, 30)");
-    }
-
     private void innerTest(
             List<DataFileMeta> toCompactBeforePick,
             boolean expectedPresent,
@@ -245,8 +206,8 @@ public class AppendOnlyCompactManagerTest {
                         minFileNum,
                         maxFileNum,
                         targetFileSize,
-                        null, // not used
-                        false);
+                        null // not used
+                        );
         Optional<List<DataFileMeta>> actual = manager.pickCompactBefore();
         assertThat(actual.isPresent()).isEqualTo(expectedPresent);
         if (expectedPresent) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -305,8 +305,7 @@ public class AppendOnlyWriterTest {
                                 compactBefore.isEmpty()
                                         ? Collections.emptyList()
                                         : Collections.singletonList(
-                                                generateCompactAfter(compactBefore)),
-                        false);
+                                                generateCompactAfter(compactBefore)));
         AppendOnlyWriter writer =
                 new AppendOnlyWriter(
                         LocalFileIO.create(),

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -72,8 +72,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         10,
                         SCHEMA,
                         0,
-                        new AppendOnlyCompactManager(
-                                null, toCompact, 4, 10, 10, null, false), // not used
+                        new AppendOnlyCompactManager(null, toCompact, 4, 10, 10, null), // not used
                         false,
                         dataFilePathFactory,
                         null,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
There could overlap in append files, if the users have multiple write jobs.

So we can not check by default.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
