### PR TITLE
[flink][mysql-cdc] Map MySQL BINARY to Paimon VARBINARY and fix parse of MySQL BIT(N) value

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -605,6 +605,8 @@ you can specify type mapping option `tinyint1-not-bool`, then the column will be
 3. You can use type mapping option `to-string` to map all MySQL data type to STRING.
 4. MySQL BIT(1) type will be mapped to Boolean.
 5. When using Hive catalog, MySQL TIME type will be mapped to STRING.
+6. MySQL BINARY will be mapped to Paimon VARBINARY. This is because the binary value is passed as bytes in binlog, so it 
+should be mapped to byte type (BYTES or VARBINARY). We choose VARBINARY because it can retain the length information.
 
 ## FAQ
 1. Chinese characters in records ingested from MySQL are garbled.

--- a/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
@@ -143,6 +143,21 @@ public class StringUtils {
     }
 
     /**
+     * Given an array of bytes it will convert the bytes to a binary (0-1) string representation of
+     * the bytes.
+     *
+     * @param bytes the bytes to be converted
+     * @return binary string representation of the byte array
+     */
+    public static String bytesToBinaryString(final byte[] bytes) {
+        StringBuilder result = new StringBuilder();
+        for (byte b : bytes) {
+            result.append(String.format("%8s", Integer.toBinaryString(b & 0xFF)).replace(' ', '0'));
+        }
+        return result.toString();
+    }
+
+    /**
      * Creates a random string with a length within the given interval. The string contains only
      * characters that can be represented as a single code point.
      *

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -32,7 +32,9 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +52,14 @@ public class TypeUtils {
     }
 
     public static Object castFromString(String s, DataType type) {
+        return castFromStringInternal(s, type, false);
+    }
+
+    public static Object castFromCdcValueString(String s, DataType type) {
+        return castFromStringInternal(s, type, true);
+    }
+
+    private static Object castFromStringInternal(String s, DataType type, boolean isCdcValue) {
         BinaryString str = BinaryString.fromString(s);
         switch (type.getTypeRoot()) {
             case CHAR:
@@ -65,7 +75,9 @@ public class TypeUtils {
             case BOOLEAN:
                 return BinaryStringUtils.toBoolean(str);
             case BINARY:
-                return s.getBytes();
+                return isCdcValue
+                        ? Base64.getDecoder().decode(s)
+                        : s.getBytes(StandardCharsets.UTF_8);
             case VARBINARY:
                 int binaryLength = DataTypeChecks.getLength(type);
                 byte[] bytes = s.getBytes();

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -80,7 +80,7 @@ public class TypeUtils {
                         : s.getBytes(StandardCharsets.UTF_8);
             case VARBINARY:
                 int binaryLength = DataTypeChecks.getLength(type);
-                byte[] bytes = s.getBytes();
+                byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
                 if (bytes.length > binaryLength) {
                     throw new IllegalArgumentException(
                             String.format(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -24,11 +24,9 @@
 package org.apache.paimon.flink.action.cdc.mysql;
 
 import org.apache.paimon.flink.action.cdc.TypeMapping;
-import org.apache.paimon.types.BinaryType;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.TimestampType;
-import org.apache.paimon.types.VarBinaryType;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -279,14 +277,9 @@ public class MySqlTypeUtils {
             case MULTIPOLYGON:
             case GEOMETRYCOLLECTION:
                 return DataTypes.STRING();
+                // MySQL BINARY and VARBINARY are stored as bytes in JSON
             case BINARY:
-                return length == null || length == 0
-                        ? DataTypes.BINARY(BinaryType.DEFAULT_LENGTH)
-                        : DataTypes.BINARY(length);
             case VARBINARY:
-                return length == null || length == 0
-                        ? DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH)
-                        : DataTypes.VARBINARY(length);
             case TINYBLOB:
             case BLOB:
             case MEDIUMBLOB:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -279,13 +279,12 @@ public class MySqlTypeUtils {
             case GEOMETRYCOLLECTION:
                 return DataTypes.STRING();
                 // MySQL BINARY and VARBINARY are stored as bytes in JSON. We convert them to
-                // DataTypes.VARBINARY to remain the length information
+                // DataTypes.VARBINARY to retain the length information
             case BINARY:
             case VARBINARY:
                 return length == null || length == 0
                         ? DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH)
                         : DataTypes.VARBINARY(length);
-
             case TINYBLOB:
             case BLOB:
             case MEDIUMBLOB:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -27,6 +27,7 @@ import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.VarBinaryType;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -277,9 +278,14 @@ public class MySqlTypeUtils {
             case MULTIPOLYGON:
             case GEOMETRYCOLLECTION:
                 return DataTypes.STRING();
-                // MySQL BINARY and VARBINARY are stored as bytes in JSON
+                // MySQL BINARY and VARBINARY are stored as bytes in JSON. We convert them to
+                // DataTypes.VARBINARY to remain the length information
             case BINARY:
             case VARBINARY:
+                return length == null || length == 0
+                        ? DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH)
+                        : DataTypes.VARBINARY(length);
+
             case TINYBLOB:
             case BLOB:
             case MEDIUMBLOB:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /** A data change message from the CDC source. */
 @Experimental
@@ -35,10 +36,16 @@ public class CdcRecord implements Serializable {
     private RowKind kind;
 
     private final Map<String, String> fields;
+    private final Set<String> encodedFields;
 
     public CdcRecord(RowKind kind, Map<String, String> fields) {
+        this(kind, fields, Collections.emptySet());
+    }
+
+    public CdcRecord(RowKind kind, Map<String, String> fields, Set<String> encodedFields) {
         this.kind = kind;
         this.fields = fields;
+        this.encodedFields = encodedFields;
     }
 
     public CdcRecord setRowKind(RowKind kind) {
@@ -56,6 +63,10 @@ public class CdcRecord implements Serializable {
 
     public Map<String, String> fields() {
         return fields;
+    }
+
+    public boolean encoded(String fieldName) {
+        return encodedFields.contains(fieldName);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
@@ -25,7 +25,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /** A data change message from the CDC source. */
 @Experimental
@@ -36,16 +35,10 @@ public class CdcRecord implements Serializable {
     private RowKind kind;
 
     private final Map<String, String> fields;
-    private final Set<String> encodedFields;
 
     public CdcRecord(RowKind kind, Map<String, String> fields) {
-        this(kind, fields, Collections.emptySet());
-    }
-
-    public CdcRecord(RowKind kind, Map<String, String> fields, Set<String> encodedFields) {
         this.kind = kind;
         this.fields = fields;
-        this.encodedFields = encodedFields;
     }
 
     public CdcRecord setRowKind(RowKind kind) {
@@ -63,10 +56,6 @@ public class CdcRecord implements Serializable {
 
     public Map<String, String> fields() {
         return fields;
-    }
-
-    public boolean encoded(String fieldName) {
-        return encodedFields.contains(fieldName);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
@@ -427,7 +427,7 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                             DataTypes.STRING(), // _text
                             DataTypes.STRING(), // _mediumtext
                             DataTypes.STRING(), // _longtext
-                            DataTypes.BINARY(10), // _bin
+                            DataTypes.VARBINARY(10), // _bin
                             DataTypes.VARBINARY(20), // _varbin
                             DataTypes.BYTES(), // _tinyblob
                             DataTypes.BYTES(), // _blob

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
@@ -111,7 +111,6 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
 
     // --------------------------------------- all-to-string ---------------------------------------
 
-    // TODO: test BIT(n) after fix bit type
     @Test
     @Timeout(60)
     public void testReadAllTypes() throws Exception {
@@ -126,7 +125,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
                         .withTypeMapping(new TypeMapping(Collections.singleton(TO_STRING)));
         runActionWithDefaultEnv(action);
 
-        int allTypeNums = 76;
+        int allTypeNums = 77;
         DataType[] types =
                 IntStream.range(0, allTypeNums)
                         .mapToObj(i -> DataTypes.STRING())
@@ -141,6 +140,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
                             "_id",
                             "pt",
                             "_bit1",
+                            "_bit",
                             "_tinyint1",
                             "_boolean",
                             "_bool",
@@ -220,7 +220,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
                 Arrays.asList(
                         "+I["
                                 + "1, 1.1, "
-                                + "true, "
+                                + "true, 0000000000000000000000000000000000000000000000000000011111000111, "
                                 + "1, 1, 0, 1, 2, 3, "
                                 + "1000, 2000, 3000, "
                                 + "100000, 200000, 300000, "
@@ -260,7 +260,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
                                 + "]",
                         "+I["
                                 + "2, 2.2, "
-                                + "NULL, "
+                                + "NULL, NULL, "
                                 + "NULL, NULL, NULL, NULL, NULL, NULL, "
                                 + "NULL, NULL, NULL, "
                                 + "NULL, NULL, NULL, "

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -402,8 +402,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                             DataTypes.STRING(), // _text
                             DataTypes.STRING(), // _mediumtext
                             DataTypes.STRING(), // _longtext
-                            DataTypes.BYTES(), // _bin
-                            DataTypes.BYTES(), // _varbin
+                            DataTypes.VARBINARY(10), // _bin
+                            DataTypes.VARBINARY(20), // _varbin
                             DataTypes.BYTES(), // _tinyblob
                             DataTypes.BYTES(), // _blob
                             DataTypes.BYTES(), // _mediumblob

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -402,8 +402,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                             DataTypes.STRING(), // _text
                             DataTypes.STRING(), // _mediumtext
                             DataTypes.STRING(), // _longtext
-                            DataTypes.BINARY(10), // _bin
-                            DataTypes.VARBINARY(20), // _varbin
+                            DataTypes.BYTES(), // _bin
+                            DataTypes.BYTES(), // _varbin
                             DataTypes.BYTES(), // _tinyblob
                             DataTypes.BYTES(), // _blob
                             DataTypes.BYTES(), // _mediumblob

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -502,11 +502,15 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                             "_set",
                         });
         FileStoreTable table = getFileStoreTable();
+        // BIT(64) data: 0B11111000111 -> 0B00000111_11000111
+        String bits =
+                Arrays.toString(
+                        new byte[] {0, 0, 0, 0, 0, 0, (byte) 0B00000111, (byte) 0B11000111});
         List<String> expected =
                 Arrays.asList(
                         "+I["
                                 + "1, 1.1, "
-                                + "true, [-17, -65, -67, 7, 0, 0, 0, 0, 0, 0], "
+                                + String.format("true, %s, ", bits)
                                 + "true, true, false, 1, 2, 3, "
                                 + "1000, 2000, 3000, "
                                 + "100000, 200000, 300000, "

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/type_mapping_test_setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/type_mapping_test_setup.sql
@@ -51,7 +51,7 @@ CREATE TABLE all_types_table (
     pt DECIMAL(2, 1),
     -- BIT
     _bit1 BIT,
-    -- _bit BIT(64), TODO
+    _bit BIT(64),
     -- TINYINT
     _tinyint1 TINYINT(1),
     _boolean BOOLEAN,
@@ -152,7 +152,7 @@ CREATE TABLE all_types_table (
 INSERT INTO all_types_table VALUES (
     1, 1.1,
     -- BIT
-    1, -- B'11111000111', TODO
+    1, B'11111000111',
     -- TINYINT
     true, true, false, 1, 2, 3,
     -- SMALLINT
@@ -208,7 +208,7 @@ INSERT INTO all_types_table VALUES (
     'a,b'
 ), (
     2, 2.2,
-    NULL,
+    NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL,
     NULL, NULL, NULL,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
1. Binary value is passed as bytes, so we should map the MySQL Binary to byte type. I choose VARBINARY because it can retain the length information.

2. Current parse of BIT(N) is incorrect. The value is of little endian form, and shouldn't be stored by Java String.
Fix:
1. convert bytes to normal form;
2. encode the value to String using Base64 

### Tests

<!-- List UT and IT cases to verify this change -->
`MySqlCdcDataTypeModeITCase#testReadAllTypes`
`MySqlSyncTableActionITCase#testAllTypes`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
