### PR TITLE
[flink] Add local merge operator for Flink

### DIFF
--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -163,6 +163,18 @@ One can easily see that too many sorted runs will result in poor query performan
 
 Compaction will become less frequent when `num-sorted-run.compaction-trigger` becomes larger, thus improving writing performance. However, if this value becomes too large, more memory and CPU time will be needed when querying the table. This is a trade-off between writing and query performance.
 
+## Local Merging
+
+If your job suffers from primary key data skew
+(for example, you want to count the number of views for each pages in a website,
+and some particular pages are very popular among the users),
+you can set `'local-merge-buffer-size'` so that input records will be buffered and merged
+before they're shuffled by bucket and written into sink.
+This is particularly useful when the same primary key is updated frequently between snapshots.
+
+The buffer will be flushed when it is full. We recommend starting with `64 mb`
+when you are faced with data skew but don't know where to start adjusting buffer size.
+
 ## File Format
 
 If you want to achieve ultimate compaction performance, you can consider using row storage file format AVRO.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -177,6 +177,13 @@ under the License.
             <td>Read incremental changes between start timestamp (exclusive) and end timestamp, for example, 't1,t2' means changes between timestamp t1 and timestamp t2.</td>
         </tr>
         <tr>
+            <td><h5>local-merge-buffer-size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Local merge will buffer and merge input records before they're shuffled by bucket and written into sink. The buffer will be flushed when it is full.
+Mainly to resolve data skew on primary keys. We recommend starting with 64 mb when trying out this feature.</td>
+        </tr>
+        <tr>
             <td><h5>local-sort.max-num-file-handles</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -39,18 +39,6 @@ under the License.
             <td>The log system used to keep changes of the table.<br /><br />Possible values:<br /><ul><li>"none": No log system, the data is written only to file store, and the streaming read will be directly read from the file store.</li></ul><ul><li>"kafka": Kafka log system, the data is double written to file store and kafka, and the streaming read will be read from kafka. If streaming read from file, configures streaming-read-mode to file.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>lookup.async</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to enable async lookup join.</td>
-        </tr>
-        <tr>
-            <td><h5>lookup.async-thread-number</h5></td>
-            <td style="word-wrap: break-word;">16</td>
-            <td>Integer</td>
-            <td>The thread number for lookup async.</td>
-        </tr>
-        <tr>
             <td><h5>log.system.partitions</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
@@ -61,6 +49,18 @@ under the License.
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
             <td>The number of replication of the log system. If log system is kafka, this is kafka replicationFactor.</td>
+        </tr>
+        <tr>
+            <td><h5>lookup.async</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable async lookup join.</td>
+        </tr>
+        <tr>
+            <td><h5>lookup.async-thread-number</h5></td>
+            <td style="word-wrap: break-word;">16</td>
+            <td>Integer</td>
+            <td>The thread number for lookup async.</td>
         </tr>
         <tr>
             <td><h5>scan.infer-parallelism</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -834,6 +834,17 @@ public class CoreOptions implements Serializable {
                                     + " the value should be the user configured local time zone. The option value is either a full name"
                                     + " such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-08:00'.");
 
+    public static final ConfigOption<MemorySize> LOCAL_MERGE_BUFFER_SIZE =
+            key("local-merge-buffer-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Local merge will buffer and merge input records "
+                                    + "before they're shuffled by bucket and written into sink. "
+                                    + "The buffer will be flushed when it is full.\n"
+                                    + "Mainly to resolve data skew on primary keys. "
+                                    + "We recommend starting with 64 mb when trying out this feature.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1238,6 +1249,14 @@ public class CoreOptions implements Serializable {
 
     public int orcWriteBatch() {
         return options.getInteger(ORC_WRITE_BATCH_SIZE.key(), ORC_WRITE_BATCH_SIZE.defaultValue());
+    }
+
+    public boolean localMergeEnabled() {
+        return options.get(LOCAL_MERGE_BUFFER_SIZE) != null;
+    }
+
+    public long localMergeBufferSize() {
+        return options.get(LOCAL_MERGE_BUFFER_SIZE).getBytes();
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/src/main/java/org/apache/paimon/schema/TableSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/TableSchema.java
@@ -229,6 +229,10 @@ public class TableSchema implements Serializable {
         return projectedLogicalRowType(trimmedPrimaryKeys());
     }
 
+    public RowType logicalPrimaryKeysType() {
+        return projectedLogicalRowType(primaryKeys());
+    }
+
     public List<DataField> trimmedPrimaryKeysFields() {
         return projectedDataFields(trimmedPrimaryKeys());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -27,12 +27,8 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ManifestCacheFilter;
-import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.paimon.mergetree.compact.FirstRowMergeFunction;
 import org.apache.paimon.mergetree.compact.LookupMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
-import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
-import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.Lock;
@@ -48,17 +44,14 @@ import org.apache.paimon.table.source.KeyValueTableRead;
 import org.apache.paimon.table.source.MergeTreeSplitGenerator;
 import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.table.source.ValueContentRowDataRecordIterator;
-import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.predicate.PredicateBuilder.and;
 import static org.apache.paimon.predicate.PredicateBuilder.pickTransformFieldMapping;
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
-import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode with primary keys. */
 public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
@@ -90,36 +83,11 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
             RowType rowType = tableSchema.logicalRowType();
             Options conf = Options.fromMap(tableSchema.options());
             CoreOptions options = new CoreOptions(conf);
-            CoreOptions.MergeEngine mergeEngine = options.mergeEngine();
-            KeyValueFieldsExtractor extractor = ChangelogWithKeyKeyValueFieldsExtractor.EXTRACTOR;
+            KeyValueFieldsExtractor extractor =
+                    ChangelogWithKeyTableUtils.ChangelogWithKeyKeyValueFieldsExtractor.EXTRACTOR;
 
-            MergeFunctionFactory<KeyValue> mfFactory;
-
-            switch (mergeEngine) {
-                case DEDUPLICATE:
-                    mfFactory = DeduplicateMergeFunction.factory();
-                    break;
-                case PARTIAL_UPDATE:
-                    mfFactory = PartialUpdateMergeFunction.factory(conf, rowType);
-                    break;
-                case AGGREGATE:
-                    mfFactory =
-                            AggregateMergeFunction.factory(
-                                    conf,
-                                    tableSchema.fieldNames(),
-                                    rowType.getFieldTypes(),
-                                    tableSchema.primaryKeys());
-                    break;
-                case FIRST_ROW:
-                    mfFactory =
-                            FirstRowMergeFunction.factory(
-                                    new RowType(extractor.keyFields(tableSchema)), rowType);
-                    break;
-                default:
-                    throw new UnsupportedOperationException(
-                            "Unsupported merge engine: " + mergeEngine);
-            }
-
+            MergeFunctionFactory<KeyValue> mfFactory =
+                    ChangelogWithKeyTableUtils.createMergeFunctionFactory(tableSchema);
             if (options.changelogProducer() == ChangelogProducer.LOOKUP) {
                 mfFactory =
                         LookupMergeFunction.wrap(
@@ -134,39 +102,14 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                             tableSchema.crossPartitionUpdate(),
                             options,
                             tableSchema.logicalPartitionType(),
-                            addKeyNamePrefix(tableSchema.logicalBucketKeyType()),
+                            ChangelogWithKeyTableUtils.addKeyNamePrefix(
+                                    tableSchema.logicalBucketKeyType()),
                             new RowType(extractor.keyFields(tableSchema)),
                             rowType,
                             extractor,
                             mfFactory);
         }
         return lazyStore;
-    }
-
-    private static RowType addKeyNamePrefix(RowType type) {
-        // add prefix to avoid conflict with value
-        return new RowType(
-                type.getFields().stream()
-                        .map(
-                                f ->
-                                        new DataField(
-                                                f.id(),
-                                                KEY_FIELD_PREFIX + f.name(),
-                                                f.type(),
-                                                f.description()))
-                        .collect(Collectors.toList()));
-    }
-
-    private static List<DataField> addKeyNamePrefix(List<DataField> keyFields) {
-        return keyFields.stream()
-                .map(
-                        f ->
-                                new DataField(
-                                        f.id(),
-                                        KEY_FIELD_PREFIX + f.name(),
-                                        f.type(),
-                                        f.description()))
-                .collect(Collectors.toList());
     }
 
     @Override
@@ -260,24 +203,5 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                             record.row().getRowKind(),
                             record.row());
                 });
-    }
-
-    static class ChangelogWithKeyKeyValueFieldsExtractor implements KeyValueFieldsExtractor {
-        private static final long serialVersionUID = 1L;
-
-        static final ChangelogWithKeyKeyValueFieldsExtractor EXTRACTOR =
-                new ChangelogWithKeyKeyValueFieldsExtractor();
-
-        private ChangelogWithKeyKeyValueFieldsExtractor() {}
-
-        @Override
-        public List<DataField> keyFields(TableSchema schema) {
-            return addKeyNamePrefix(schema.trimmedPrimaryKeysFields());
-        }
-
-        @Override
-        public List<DataField> valueFields(TableSchema schema) {
-            return schema.fields();
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyTableUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.paimon.mergetree.compact.FirstRowMergeFunction;
+import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
+import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
+import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.KeyValueFieldsExtractor;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
+
+/** Utils for creating changelog table with primary keys. */
+public class ChangelogWithKeyTableUtils {
+
+    public static RowType addKeyNamePrefix(RowType type) {
+        return new RowType(addKeyNamePrefix(type.getFields()));
+    }
+
+    public static List<DataField> addKeyNamePrefix(List<DataField> keyFields) {
+        return keyFields.stream()
+                .map(
+                        f ->
+                                new DataField(
+                                        f.id(),
+                                        KEY_FIELD_PREFIX + f.name(),
+                                        f.type(),
+                                        f.description()))
+                .collect(Collectors.toList());
+    }
+
+    public static MergeFunctionFactory<KeyValue> createMergeFunctionFactory(
+            TableSchema tableSchema) {
+        RowType rowType = tableSchema.logicalRowType();
+        Options conf = Options.fromMap(tableSchema.options());
+        CoreOptions options = new CoreOptions(conf);
+        CoreOptions.MergeEngine mergeEngine = options.mergeEngine();
+        KeyValueFieldsExtractor extractor = ChangelogWithKeyKeyValueFieldsExtractor.EXTRACTOR;
+
+        switch (mergeEngine) {
+            case DEDUPLICATE:
+                return DeduplicateMergeFunction.factory();
+            case PARTIAL_UPDATE:
+                return PartialUpdateMergeFunction.factory(conf, rowType);
+            case AGGREGATE:
+                return AggregateMergeFunction.factory(
+                        conf,
+                        tableSchema.fieldNames(),
+                        rowType.getFieldTypes(),
+                        tableSchema.primaryKeys());
+            case FIRST_ROW:
+                return FirstRowMergeFunction.factory(
+                        new RowType(extractor.keyFields(tableSchema)), rowType);
+            default:
+                throw new UnsupportedOperationException("Unsupported merge engine: " + mergeEngine);
+        }
+    }
+
+    static class ChangelogWithKeyKeyValueFieldsExtractor implements KeyValueFieldsExtractor {
+        private static final long serialVersionUID = 1L;
+
+        static final ChangelogWithKeyKeyValueFieldsExtractor EXTRACTOR =
+                new ChangelogWithKeyKeyValueFieldsExtractor();
+
+        private ChangelogWithKeyKeyValueFieldsExtractor() {}
+
+        @Override
+        public List<DataField> keyFields(TableSchema schema) {
+            return addKeyNamePrefix(schema.trimmedPrimaryKeysFields());
+        }
+
+        @Override
+        public List<DataField> valueFields(TableSchema schema) {
+            return schema.fields();
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.sink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO;
@@ -237,7 +239,12 @@ public class SequenceGeneratorTest {
     }
 
     private SequenceGenerator getGenerator(String field) {
-        return new SequenceGenerator(field, ALL_DATA_TYPE);
+        return getGenerator(field, Collections.emptyList());
+    }
+
+    private SequenceGenerator getGenerator(
+            String field, List<CoreOptions.SequenceAutoPadding> paddings) {
+        return new SequenceGenerator(field, ALL_DATA_TYPE, paddings);
     }
 
     private void assertUnsupportedDatatype(String field) {
@@ -246,8 +253,7 @@ public class SequenceGeneratorTest {
     }
 
     private long generateWithPaddingOnSecond(String field) {
-        return getGenerator(field)
-                .generateWithPadding(row, Collections.singletonList(SECOND_TO_MICRO));
+        return getGenerator(field, Collections.singletonList(SECOND_TO_MICRO)).generate(row);
     }
 
     private long getSecondFromGeneratedWithPadding(long generated) {
@@ -255,22 +261,17 @@ public class SequenceGeneratorTest {
     }
 
     private long generateWithPaddingOnMillis(String field) {
-        return getGenerator(field)
-                .generateWithPadding(row, Collections.singletonList(MILLIS_TO_MICRO));
+        return getGenerator(field, Collections.singletonList(MILLIS_TO_MICRO)).generate(row);
     }
 
     private long generateWithPaddingOnRowKind(long sequence, RowKind rowKind) {
-        return getGenerator("_bigint")
-                .generateWithPadding(
-                        GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence),
-                        Collections.singletonList(ROW_KIND_FLAG));
+        return getGenerator("_bigint", Collections.singletonList(ROW_KIND_FLAG))
+                .generate(GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence));
     }
 
     private long generateWithPaddingOnMicrosAndRowKind(long sequence, RowKind rowKind) {
-        return getGenerator("_bigint")
-                .generateWithPadding(
-                        GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence),
-                        Arrays.asList(MILLIS_TO_MICRO, ROW_KIND_FLAG));
+        return getGenerator("_bigint", Arrays.asList(MILLIS_TO_MICRO, ROW_KIND_FLAG))
+                .generate(GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence));
     }
 
     private long getMillisFromGeneratedWithPadding(long generated) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -69,29 +69,41 @@ public class FlinkSinkBuilder {
     }
 
     public DataStreamSink<?> build() {
+        DataStream<RowData> input = this.input;
+        if (table.coreOptions().localMergeEnabled() && table.schema().primaryKeys().size() > 0) {
+            input =
+                    input.forward()
+                            .transform(
+                                    "local merge",
+                                    input.getType(),
+                                    new LocalMergeOperator(table.schema()))
+                            .setParallelism(input.getParallelism());
+        }
+
         BucketMode bucketMode = table.bucketMode();
         switch (bucketMode) {
             case FIXED:
-                return buildForFixedBucket();
+                return buildForFixedBucket(input);
             case DYNAMIC:
-                return buildDynamicBucketSink(false);
+                return buildDynamicBucketSink(input, false);
             case GLOBAL_DYNAMIC:
-                return buildDynamicBucketSink(true);
+                return buildDynamicBucketSink(input, true);
             case UNAWARE:
-                return buildUnawareBucketSink();
+                return buildUnawareBucketSink(input);
             default:
                 throw new UnsupportedOperationException("Unsupported bucket mode: " + bucketMode);
         }
     }
 
-    private DataStreamSink<?> buildDynamicBucketSink(boolean globalIndex) {
+    private DataStreamSink<?> buildDynamicBucketSink(
+            DataStream<RowData> input, boolean globalIndex) {
         checkArgument(logSinkFunction == null, "Dynamic bucket mode can not work with log system.");
         return globalIndex
                 ? new GlobalDynamicBucketSink(table, overwritePartition).build(input, parallelism)
                 : new RowDynamicBucketSink(table, overwritePartition).build(input, parallelism);
     }
 
-    private DataStreamSink<?> buildForFixedBucket() {
+    private DataStreamSink<?> buildForFixedBucket(DataStream<RowData> input) {
         DataStream<RowData> partitioned =
                 partition(
                         input,
@@ -101,7 +113,7 @@ public class FlinkSinkBuilder {
         return sink.sinkFrom(partitioned);
     }
 
-    private DataStreamSink<?> buildUnawareBucketSink() {
+    private DataStreamSink<?> buildUnawareBucketSink(DataStream<RowData> input) {
         checkArgument(
                 table instanceof AppendOnlyFileStoreTable,
                 "Unaware bucket mode only works with append-only table for now.");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.CodeGenUtils;
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.codegen.RecordComparator;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.memory.HeapMemorySegmentPool;
+import org.apache.paimon.mergetree.SortBufferWriteBuffer;
+import org.apache.paimon.mergetree.compact.MergeFunction;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.ChangelogWithKeyTableUtils;
+import org.apache.paimon.table.sink.SequenceGenerator;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.KeyComparatorSupplier;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * {@link AbstractStreamOperator} which buffer input record and apply merge function when the buffer
+ * is full. Mainly to resolve data skew on primary keys.
+ */
+public class LocalMergeOperator extends AbstractStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput {
+
+    private static final long serialVersionUID = 1L;
+
+    TableSchema schema;
+
+    private transient Projection keyProjection;
+    private transient RecordComparator keyComparator;
+
+    private transient long recordCount;
+    private transient SequenceGenerator sequenceGenerator;
+    private transient MergeFunction<KeyValue> mergeFunction;
+
+    private transient SortBufferWriteBuffer buffer;
+    private transient long currentWatermark;
+
+    private transient FlinkRowData reusedRowData;
+    private transient boolean endOfInput;
+
+    public LocalMergeOperator(TableSchema schema) {
+        Preconditions.checkArgument(
+                schema.primaryKeys().size() > 0,
+                "LocalMergeOperator currently only support tables with primary keys");
+        this.schema = schema;
+        setChainingStrategy(ChainingStrategy.ALWAYS);
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+
+        RowType keyType =
+                ChangelogWithKeyTableUtils.addKeyNamePrefix(schema.logicalPrimaryKeysType());
+        RowType valueType = schema.logicalRowType();
+        CoreOptions options = new CoreOptions(schema.options());
+
+        keyProjection =
+                CodeGenUtils.newProjection(
+                        schema.logicalRowType(), schema.projection(schema.primaryKeys()));
+        keyComparator = new KeyComparatorSupplier(keyType).get();
+
+        recordCount = 0;
+        sequenceGenerator = SequenceGenerator.create(schema, options);
+        mergeFunction = ChangelogWithKeyTableUtils.createMergeFunctionFactory(schema).create();
+
+        buffer =
+                new SortBufferWriteBuffer(
+                        keyType,
+                        valueType,
+                        new HeapMemorySegmentPool(
+                                options.localMergeBufferSize(), options.pageSize()),
+                        false,
+                        options.localSortMaxNumFileHandles(),
+                        null);
+        currentWatermark = Long.MIN_VALUE;
+
+        reusedRowData = new FlinkRowData(null);
+        endOfInput = false;
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> record) throws Exception {
+        recordCount++;
+        InternalRow row = new FlinkRowWrapper(record.getValue());
+
+        RowKind rowKind = row.getRowKind();
+        // row kind must be INSERT when it is divided into key and value
+        row.setRowKind(RowKind.INSERT);
+
+        InternalRow key = keyProjection.apply(row);
+        long sequenceNumber =
+                sequenceGenerator == null ? recordCount : sequenceGenerator.generate(row);
+        if (!buffer.put(sequenceNumber, rowKind, key, row)) {
+            flushBuffer();
+            if (!buffer.put(sequenceNumber, rowKind, key, row)) {
+                // change row kind back
+                row.setRowKind(rowKind);
+                output.collect(record);
+            }
+        }
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        // don't emit watermark immediately, emit them after flushing buffer
+        currentWatermark = mark.getTimestamp();
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        if (!endOfInput) {
+            flushBuffer();
+        }
+        // no records are expected to emit after endOfInput
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        endOfInput = true;
+        flushBuffer();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (buffer != null) {
+            buffer.clear();
+        }
+
+        super.close();
+    }
+
+    private void flushBuffer() throws Exception {
+        if (buffer.size() == 0) {
+            return;
+        }
+
+        buffer.forEach(
+                keyComparator,
+                mergeFunction,
+                null,
+                kv -> {
+                    InternalRow row = kv.value();
+                    row.setRowKind(kv.valueKind());
+                    output.collect(new StreamRecord<>(reusedRowData.replace(row)));
+                });
+        buffer.clear();
+
+        if (currentWatermark != Long.MIN_VALUE) {
+            super.processWatermark(new Watermark(currentWatermark));
+            // each watermark should only be emitted once
+            currentWatermark = Long.MIN_VALUE;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Local merge aims to resolve data skew on primary keys. If your job suffers from primary key data skew (for example, you want to count the number of views for each pages in a website, and some particular pages are very popular among the users), you can use local merge so that input records will be buffered and merged before they're shuffled by bucket and written into sink. This is particularly useful when the same primary key is updated frequently between snapshots.

This PR implements local merge operator for Flink.

### Tests

* `ChangelogWithKeyFileStoreTableITCase` now randomly runs with local merge.

### API and Format

No.

### Documentation

Yes. Document is also updated.
