### PR TITLE
[build] Support storing the commit ID and branch name inside the JAR, when building a JAR package with Paimon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,11 +305,32 @@ under the License.
                 <version>2.4</version><!--$NO-MVN-MAN-VER$-->
                 <configuration>
                     <archive>
+                        <manifestEntries>
+                            <SCM-Revision>${git.commit.id}</SCM-Revision>
+                            <SCM-Branch>${git.branch}</SCM-Branch>
+                        </manifestEntries>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
[build] Support storing the commit ID and branch name inside the JAR, when building a JAR package with Paimon

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1820 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
