### PR TITLE
[hotfix] Fix that MySQL sync-database action parses table prefix incorrectly

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionFactory.java
@@ -53,7 +53,7 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
                 .mergeShards(
                         !params.has("merge-shards")
                                 || Boolean.parseBoolean(params.get("merge-shards")))
-                .withTablePrefix(params.get("table-suffix"))
+                .withTablePrefix(params.get("table-prefix"))
                 .withTableSuffix(params.get("table-suffix"))
                 .includingTables(params.get("including-tables"))
                 .excludingTables(params.get("excluding-tables"))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
