### PR TITLE
[flink] Refactor Flink sink metrics by introducing CommitterMetrics

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -22,6 +22,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -39,8 +40,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             throws IOException;
 
     /** Commits the given {@link GlobalCommitT}. */
-    void commit(List<GlobalCommitT> globalCommittables, OperatorIOMetricGroup metricGroup)
-            throws IOException, InterruptedException;
+    void commit(List<GlobalCommitT> globalCommittables) throws IOException, InterruptedException;
 
     /**
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link
@@ -49,4 +49,11 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
     int filterAndCommit(List<GlobalCommitT> globalCommittables) throws IOException;
 
     Map<Long, List<CommitT>> groupByCheckpoint(Collection<CommitT> committables);
+
+    /** Factory to create {@link Committer}. */
+    interface Factory<CommitT, GlobalCommitT> extends Serializable {
+
+        Committer<CommitT, GlobalCommitT> create(
+                String commitUser, OperatorIOMetricGroup metricGroup);
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterMetrics.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterMetrics.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+
+/** Flink metrics for {@link Committer}. */
+public class CommitterMetrics {
+
+    private static final String SINK_METRIC_GROUP = "sink";
+
+    private final Counter numBytesOutCounter;
+    private final Counter numRecordsOutCounter;
+
+    public CommitterMetrics(OperatorIOMetricGroup metricGroup) {
+        MetricGroup sinkMetricGroup = metricGroup.addGroup(SINK_METRIC_GROUP);
+
+        numBytesOutCounter = metricGroup.getNumBytesOutCounter();
+        sinkMetricGroup.counter(MetricNames.IO_NUM_BYTES_OUT, numBytesOutCounter);
+        sinkMetricGroup.meter(MetricNames.IO_NUM_BYTES_OUT_RATE, new MeterView(numBytesOutCounter));
+
+        numRecordsOutCounter = metricGroup.getNumRecordsOutCounter();
+        sinkMetricGroup.counter(MetricNames.IO_NUM_RECORDS_OUT, numRecordsOutCounter);
+        sinkMetricGroup.meter(
+                MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOutCounter));
+    }
+
+    public void increaseNumBytesOut(long numBytesOut) {
+        numBytesOutCounter.inc(numBytesOut);
+    }
+
+    public void increaseNumRecordsOut(long numRecordsOut) {
+        numRecordsOutCounter.inc(numRecordsOut);
+    }
+
+    @VisibleForTesting
+    public Counter getNumBytesOutCounter() {
+        return numBytesOutCounter;
+    }
+
+    @VisibleForTesting
+    public Counter getNumRecordsOutCounter() {
+        return numRecordsOutCounter;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -17,8 +17,6 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.utils.SerializableFunction;
-
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -65,7 +63,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     /** Group the committable by the checkpoint id. */
     protected final NavigableMap<Long, GlobalCommitT> committablesPerCheckpoint;
 
-    private final SerializableFunction<String, Committer<CommitT, GlobalCommitT>> committerFactory;
+    private final Committer.Factory<CommitT, GlobalCommitT> committerFactory;
 
     private final CommittableStateManager<GlobalCommitT> committableStateManager;
 
@@ -84,7 +82,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     public CommitterOperator(
             boolean streamingCheckpointEnabled,
             String initialCommitUser,
-            SerializableFunction<String, Committer<CommitT, GlobalCommitT>> committerFactory,
+            Committer.Factory<CommitT, GlobalCommitT> committerFactory,
             CommittableStateManager<GlobalCommitT> committableStateManager) {
         this.streamingCheckpointEnabled = streamingCheckpointEnabled;
         this.initialCommitUser = initialCommitUser;
@@ -107,7 +105,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
         // parallelism of commit operator is always 1, so commitUser will never be null
-        committer = committerFactory.apply(commitUser);
+        committer = committerFactory.create(commitUser, getMetricGroup().getIOMetricGroup());
 
         committableStateManager.initializeState(context, committer);
     }
@@ -156,7 +154,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     private void commitUpToCheckpoint(long checkpointId) throws Exception {
         NavigableMap<Long, GlobalCommitT> headMap =
                 committablesPerCheckpoint.headMap(checkpointId, true);
-        committer.commit(committables(headMap), getMetricGroup().getIOMetricGroup());
+        committer.commit(committables(headMap));
         headMap.clear();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.table.data.RowData;
@@ -41,9 +40,10 @@ public class CompactorSink extends FlinkSink<RowData> {
     }
 
     @Override
-    protected SerializableFunction<String, Committer<Committable, ManifestCommittable>>
-            createCommitterFactory(boolean streamingCheckpointEnabled) {
-        return user -> new StoreCommitter(table.newCommit(user));
+    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
+            boolean streamingCheckpointEnabled) {
+        return (user, metricGroup) ->
+                new StoreCommitter(table.newCommit(user), new CommitterMetrics(metricGroup));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -24,7 +24,6 @@ import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -235,8 +234,8 @@ public abstract class FlinkSink<T> implements Serializable {
     protected abstract OneInputStreamOperator<T, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser);
 
-    protected abstract SerializableFunction<String, Committer<Committable, ManifestCommittable>>
-            createCommitterFactory(boolean streamingCheckpointEnabled);
+    protected abstract Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
+            boolean streamingCheckpointEnabled);
 
     protected abstract CommittableStateManager<ManifestCommittable> createCommittableStateManager();
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
-import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -49,9 +48,10 @@ public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionT
     }
 
     @Override
-    protected SerializableFunction<String, Committer<Committable, ManifestCommittable>>
-            createCommitterFactory(boolean streamingCheckpointEnabled) {
-        return s -> new StoreCommitter(table.newCommit(s));
+    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
+            boolean streamingCheckpointEnabled) {
+        return (s, metricGroup) ->
+                new StoreCommitter(table.newCommit(s), new CommitterMetrics(metricGroup));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -459,7 +459,11 @@ class StoreMultiCommitterTest {
                 new CommitterOperator<>(
                         true,
                         initialCommitUser,
-                        user -> new StoreMultiCommitter(initialCommitUser, catalogLoader),
+                        (user, metricGroup) ->
+                                new StoreMultiCommitter(
+                                        catalogLoader,
+                                        initialCommitUser,
+                                        new CommitterMetrics(metricGroup)),
                         new RestoreAndFailCommittableStateManager<>(
                                 () ->
                                         new VersionedSerializerWrapper<>(
@@ -473,7 +477,11 @@ class StoreMultiCommitterTest {
                 new CommitterOperator<>(
                         true,
                         initialCommitUser,
-                        user -> new StoreMultiCommitter(initialCommitUser, catalogLoader),
+                        (user, metricGroup) ->
+                                new StoreMultiCommitter(
+                                        catalogLoader,
+                                        initialCommitUser,
+                                        new CommitterMetrics(metricGroup)),
                         new CommittableStateManager<WrappedManifestCommittable>() {
                             @Override
                             public void initializeState(


### PR DESCRIPTION
### Purpose

This PR refactors Flink sink metrics by introducing the `CommitterMetrics` class. All Flink related metrics are now managed by this class.

This PR also introduces a `sink` metric group for users to quickly find out number of bytes and records written by sink.

### Tests

Existing tests should cover the changes.

### API and Format

No.

### Documentation

No.
