### PR TITLE
[core] Paimon catalog support immutable options

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>data-lineage</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether save the data lineage information or not, by default is false.</td>
+        </tr>
+        <tr>
             <td><h5>fs.allow-hadoop-fallback</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
@@ -61,6 +67,12 @@ under the License.
             <td style="word-wrap: break-word;">"filesystem"</td>
             <td>String</td>
             <td>Metastore of paimon catalog, supports filesystem and hive.</td>
+        </tr>
+        <tr>
+            <td><h5>table-lineage</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether save the table lineage information or not, by default is false.</td>
         </tr>
         <tr>
             <td><h5>table.type</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.options;
 
+import org.apache.paimon.annotation.Documentation;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.TextElement;
 import org.apache.paimon.table.TableType;
@@ -78,6 +79,7 @@ public class CatalogOptions {
                     .withDescription(
                             "Allow to fallback to hadoop File IO when no file io found for the scheme.");
 
+    @Documentation.Immutable
     public static final ConfigOption<String> LINEAGE_META =
             key("lineage-meta")
                     .stringType()
@@ -97,4 +99,18 @@ public class CatalogOptions {
                                             TextElement.text(
                                                     "\"custom\": You can implement LineageMetaFactory and LineageMeta to store lineage information in customized storage."))
                                     .build());
+
+    @Documentation.Immutable
+    public static final ConfigOption<Boolean> TABLE_LINEAGE =
+            key("table-lineage")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether save the table lineage information or not, by default is false.");
+
+    @Documentation.Immutable
+    public static final ConfigOption<Boolean> DATA_LINEAGE =
+            key("data-lineage")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether save the data lineage information or not, by default is false.");
 }

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -23,7 +23,10 @@ import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.TextElement;
 import org.apache.paimon.table.TableType;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.paimon.options.ConfigOptions.key;
 
@@ -115,4 +118,20 @@ public class CatalogOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Whether save the data lineage information or not, by default is false.");
+
+    public static Set<String> getImmutableOptionKeys() {
+        final Field[] fields = CatalogOptions.class.getFields();
+        final Set<String> immutableKeys = new HashSet<>(fields.length);
+        for (Field field : fields) {
+            if (ConfigOption.class.isAssignableFrom(field.getType())
+                    && field.getAnnotation(Documentation.Immutable.class) != null) {
+                try {
+                    immutableKeys.add(((ConfigOption<?>) field.get(CatalogOptions.class)).key());
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return immutableKeys;
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -105,12 +105,14 @@ public class CatalogOptions {
             key("table-lineage")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Whether save the table lineage information or not, by default is false.");
+                    .withDescription(
+                            "Whether save the table lineage information or not, by default is false.");
 
     @Documentation.Immutable
     public static final ConfigOption<Boolean> DATA_LINEAGE =
             key("data-lineage")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Whether save the data lineage information or not, by default is false.");
+                    .withDescription(
+                            "Whether save the data lineage information or not, by default is false.");
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -23,6 +23,7 @@ import org.apache.paimon.factories.Factory;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.utils.Preconditions;
 
@@ -92,7 +93,7 @@ public interface CatalogFactory extends Factory {
             CatalogOptionsManager catalogOptionsManager =
                     new CatalogOptionsManager(fileIO, new Path(warehouse));
             Map<String, String> immutableOptions =
-                    immutableOptions(context, CatalogOptionsManager.IMMUTABLE_CATALOG_OPTION_KEYS);
+                    immutableOptions(context, CatalogOptions.getImmutableOptionKeys());
             if (fileIO.exists(catalogOptionsManager.getCatalogOptionPath())) {
                 Map<String, String> originImmutableOptions =
                         catalogOptionsManager.immutableOptions();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -23,11 +23,16 @@ import org.apache.paimon.factories.Factory;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
+import static org.apache.paimon.catalog.CatalogOptionsManager.validateCatalogOptions;
 import static org.apache.paimon.options.CatalogOptions.METASTORE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -82,10 +87,26 @@ public interface CatalogFactory extends Factory {
             } else {
                 fileIO.mkdirs(warehousePath);
             }
+
+            // persist immutable catalog options
+            CatalogOptionsManager catalogOptionsManager = new CatalogOptionsManager(fileIO, new Path(warehouse));
+            Map<String, String> immutableOptions = immutableOptions(context, CatalogOptionsManager.IMMUTABLE_CATALOG_OPTION_KEYS);
+            if (fileIO.exists(catalogOptionsManager.getCatalogOptionPath())) {
+                Map<String, String> originImmutableOptions = catalogOptionsManager.immutableOptions();
+                validateCatalogOptions(Options.fromMap(originImmutableOptions), Options.fromMap(immutableOptions));
+            } else {
+                catalogOptionsManager.saveImmutableOptions(immutableOptions);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
 
         return catalogFactory.create(fileIO, warehousePath, context);
+    }
+
+    static Map<String, String> immutableOptions(CatalogContext context, Set<String> immutableCatalogOptionKeys) {
+        Map<String, String> immutableOptions = new HashMap<>();
+        context.options().keySet().stream().filter(key -> immutableCatalogOptionKeys.contains(key)).forEach(key -> immutableOptions.put(key, context.options().get(key)));
+        return immutableOptions;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -89,11 +89,15 @@ public interface CatalogFactory extends Factory {
             }
 
             // persist immutable catalog options
-            CatalogOptionsManager catalogOptionsManager = new CatalogOptionsManager(fileIO, new Path(warehouse));
-            Map<String, String> immutableOptions = immutableOptions(context, CatalogOptionsManager.IMMUTABLE_CATALOG_OPTION_KEYS);
+            CatalogOptionsManager catalogOptionsManager =
+                    new CatalogOptionsManager(fileIO, new Path(warehouse));
+            Map<String, String> immutableOptions =
+                    immutableOptions(context, CatalogOptionsManager.IMMUTABLE_CATALOG_OPTION_KEYS);
             if (fileIO.exists(catalogOptionsManager.getCatalogOptionPath())) {
-                Map<String, String> originImmutableOptions = catalogOptionsManager.immutableOptions();
-                validateCatalogOptions(Options.fromMap(originImmutableOptions), Options.fromMap(immutableOptions));
+                Map<String, String> originImmutableOptions =
+                        catalogOptionsManager.immutableOptions();
+                validateCatalogOptions(
+                        Options.fromMap(originImmutableOptions), Options.fromMap(immutableOptions));
             } else {
                 catalogOptionsManager.saveImmutableOptions(immutableOptions);
             }
@@ -104,9 +108,12 @@ public interface CatalogFactory extends Factory {
         return catalogFactory.create(fileIO, warehousePath, context);
     }
 
-    static Map<String, String> immutableOptions(CatalogContext context, Set<String> immutableCatalogOptionKeys) {
+    static Map<String, String> immutableOptions(
+            CatalogContext context, Set<String> immutableCatalogOptionKeys) {
         Map<String, String> immutableOptions = new HashMap<>();
-        context.options().keySet().stream().filter(key -> immutableCatalogOptionKeys.contains(key)).forEach(key -> immutableOptions.put(key, context.options().get(key)));
+        context.options().keySet().stream()
+                .filter(key -> immutableCatalogOptionKeys.contains(key))
+                .forEach(key -> immutableOptions.put(key, context.options().get(key)));
         return immutableOptions;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
@@ -35,12 +35,12 @@ import static org.apache.paimon.options.CatalogOptions.DATA_LINEAGE;
 import static org.apache.paimon.options.CatalogOptions.LINEAGE_META;
 import static org.apache.paimon.options.CatalogOptions.TABLE_LINEAGE;
 
-/**
- * Manage read and write of immutable {@link org.apache.paimon.options.CatalogOptions}.
- * */
+/** Manage read and write of immutable {@link org.apache.paimon.options.CatalogOptions}. */
 public class CatalogOptionsManager {
     private static final String OPTIONS = "options";
-    public static final Set<String> IMMUTABLE_CATALOG_OPTION_KEYS = new HashSet<>(Arrays.asList(LINEAGE_META.key(), TABLE_LINEAGE.key(), DATA_LINEAGE.key()));
+    public static final Set<String> IMMUTABLE_CATALOG_OPTION_KEYS =
+            new HashSet<>(
+                    Arrays.asList(LINEAGE_META.key(), TABLE_LINEAGE.key(), DATA_LINEAGE.key()));
     private final FileIO fileIO;
     private final Path warehouse;
 
@@ -73,22 +73,25 @@ public class CatalogOptionsManager {
      * @param originImmutableOptions the origin persisted immutable catalog options
      * @param newImmutableOptions the new immutable catalog options
      */
-    public static void validateCatalogOptions(Options originImmutableOptions, Options newImmutableOptions) {
-        // Only open data-lineage without open table-lineage is not supported, data-lineage is depend on table-lineage.
+    public static void validateCatalogOptions(
+            Options originImmutableOptions, Options newImmutableOptions) {
+        // Only open data-lineage without open table-lineage is not supported, data-lineage is
+        // depend on table-lineage.
         if (newImmutableOptions.get(DATA_LINEAGE) && !newImmutableOptions.get(TABLE_LINEAGE)) {
             throw new UnsupportedOperationException(
                     String.format(
                             "Can not open %s without %s opened, please set both of them to TRUE or remove %s.",
-                            CatalogOptions.DATA_LINEAGE.key(), CatalogOptions.TABLE_LINEAGE.key(), CatalogOptions.DATA_LINEAGE.key()));
+                            CatalogOptions.DATA_LINEAGE.key(),
+                            CatalogOptions.TABLE_LINEAGE.key(),
+                            CatalogOptions.DATA_LINEAGE.key()));
         }
 
         // check immutable catalog options
         if (originImmutableOptions != null && !originImmutableOptions.equals(newImmutableOptions)) {
             throw new IllegalStateException(
                     String.format(
-                            "The immutable catalog options changed, origin options are %s, new options are %s.", originImmutableOptions, newImmutableOptions
-                    )
-            );
+                            "The immutable catalog options changed, origin options are %s, new options are %s.",
+                            originImmutableOptions, newImmutableOptions));
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.options.CatalogOptions.DATA_LINEAGE;
+import static org.apache.paimon.options.CatalogOptions.LINEAGE_META;
+import static org.apache.paimon.options.CatalogOptions.TABLE_LINEAGE;
+
+/**
+ * Manage read and write of immutable {@link org.apache.paimon.options.CatalogOptions}.
+ * */
+public class CatalogOptionsManager {
+    private static final String OPTIONS = "options";
+    public static final Set<String> IMMUTABLE_CATALOG_OPTION_KEYS = new HashSet<>(Arrays.asList(LINEAGE_META.key(), TABLE_LINEAGE.key(), DATA_LINEAGE.key()));
+    private final FileIO fileIO;
+    private final Path warehouse;
+
+    public CatalogOptionsManager(FileIO fileIO, Path warehouse) {
+        this.fileIO = fileIO;
+        this.warehouse = warehouse;
+    }
+
+    boolean saveImmutableOptions(Map<String, String> immutableOptions) throws IOException {
+        Path catalogOptionPath = getCatalogOptionPath();
+        return fileIO.writeFileUtf8(catalogOptionPath, JsonSerdeUtil.toJson(immutableOptions));
+    }
+
+    /** Read immutable catalog options. */
+    Map<String, String> immutableOptions() {
+        try {
+            return JsonSerdeUtil.fromJson(fileIO.readFileUtf8(getCatalogOptionPath()), Map.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public Path getCatalogOptionPath() {
+        return new Path(warehouse + "/options/" + OPTIONS);
+    }
+
+    /**
+     * Validate the {@link org.apache.paimon.options.CatalogOptions}.
+     *
+     * @param originImmutableOptions the origin persisted immutable catalog options
+     * @param newImmutableOptions the new immutable catalog options
+     */
+    public static void validateCatalogOptions(Options originImmutableOptions, Options newImmutableOptions) {
+        // Only open data-lineage without open table-lineage is not supported, data-lineage is depend on table-lineage.
+        if (newImmutableOptions.get(DATA_LINEAGE) && !newImmutableOptions.get(TABLE_LINEAGE)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Can not open %s without %s opened, please set both of them to TRUE or remove %s.",
+                            CatalogOptions.DATA_LINEAGE.key(), CatalogOptions.TABLE_LINEAGE.key(), CatalogOptions.DATA_LINEAGE.key()));
+        }
+
+        // check immutable catalog options
+        if (originImmutableOptions != null && !originImmutableOptions.equals(newImmutableOptions)) {
+            throw new IllegalStateException(
+                    String.format(
+                            "The immutable catalog options changed, origin options are %s, new options are %s.", originImmutableOptions, newImmutableOptions
+                    )
+            );
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
@@ -91,7 +91,7 @@ public class CatalogOptionsManager {
             throw new IllegalStateException(
                     String.format(
                             "The immutable catalog options changed, origin options are %s, new options are %s.",
-                            originImmutableOptions, newImmutableOptions));
+                            originImmutableOptions.toMap(), newImmutableOptions.toMap()));
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogOptionsManager.java
@@ -26,21 +26,14 @@ import org.apache.paimon.utils.JsonSerdeUtil;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static org.apache.paimon.options.CatalogOptions.DATA_LINEAGE;
-import static org.apache.paimon.options.CatalogOptions.LINEAGE_META;
 import static org.apache.paimon.options.CatalogOptions.TABLE_LINEAGE;
 
 /** Manage read and write of immutable {@link org.apache.paimon.options.CatalogOptions}. */
 public class CatalogOptionsManager {
     private static final String OPTIONS = "options";
-    public static final Set<String> IMMUTABLE_CATALOG_OPTION_KEYS =
-            new HashSet<>(
-                    Arrays.asList(LINEAGE_META.key(), TABLE_LINEAGE.key(), DATA_LINEAGE.key()));
     private final FileIO fileIO;
     private final Path warehouse;
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
@@ -35,9 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-/**
- * Tests for {@link CatalogOptionsManager}.
- * */
+/** Tests for {@link CatalogOptionsManager}. */
 public class CatalogOptionsManagerTest {
     @TempDir static java.nio.file.Path tempDir;
     private static Options withImmutableOptions = new Options();
@@ -47,6 +45,7 @@ public class CatalogOptionsManagerTest {
     private static CatalogContext catalogContext;
 
     private static FileIO fileIO;
+
     @BeforeAll
     public static void beforeAll() throws IOException {
         withImmutableOptions.set(TABLE_LINEAGE, true);
@@ -66,62 +65,99 @@ public class CatalogOptionsManagerTest {
     public void testSaveImmutableCatalogOptions() throws IOException {
         String warehouse = tempDir.toString();
 
-        CatalogOptionsManager catalogOptionsManager = new CatalogOptionsManager(fileIO, new Path(warehouse));
+        CatalogOptionsManager catalogOptionsManager =
+                new CatalogOptionsManager(fileIO, new Path(warehouse));
         CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
         assertThat(fileIO.exists(catalogOptionsManager.getCatalogOptionPath()));
-        assertThat(withImmutableOptions.toMap()).containsAllEntriesOf(catalogOptionsManager.immutableOptions());
+        assertThat(withImmutableOptions.toMap())
+                .containsAllEntriesOf(catalogOptionsManager.immutableOptions());
     }
 
     @Test
     public void testCatalogOptionsValidate() {
         Options newImmutableCatalogOptions = new Options();
-        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        assertDoesNotThrow(
+                () ->
+                        CatalogOptionsManager.validateCatalogOptions(
+                                null, newImmutableCatalogOptions));
         newImmutableCatalogOptions.set(TABLE_LINEAGE, true);
-        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        assertDoesNotThrow(
+                () ->
+                        CatalogOptionsManager.validateCatalogOptions(
+                                null, newImmutableCatalogOptions));
         newImmutableCatalogOptions.set(DATA_LINEAGE, true);
-        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        assertDoesNotThrow(
+                () ->
+                        CatalogOptionsManager.validateCatalogOptions(
+                                null, newImmutableCatalogOptions));
         newImmutableCatalogOptions.set(TABLE_LINEAGE, false);
-        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions))
+        assertThatThrownBy(
+                        () ->
+                                CatalogOptionsManager.validateCatalogOptions(
+                                        null, newImmutableCatalogOptions))
                 .isInstanceOf(UnsupportedOperationException.class);
         newImmutableCatalogOptions.set(TABLE_LINEAGE, true);
 
         Options originImmutableCatalogOptions = new Options();
-        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions))
+        assertThatThrownBy(
+                        () ->
+                                CatalogOptionsManager.validateCatalogOptions(
+                                        originImmutableCatalogOptions, newImmutableCatalogOptions))
                 .isInstanceOf(IllegalStateException.class);
         originImmutableCatalogOptions.set(TABLE_LINEAGE, true);
-        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions))
+        assertThatThrownBy(
+                        () ->
+                                CatalogOptionsManager.validateCatalogOptions(
+                                        originImmutableCatalogOptions, newImmutableCatalogOptions))
                 .isInstanceOf(IllegalStateException.class);
         originImmutableCatalogOptions.set(DATA_LINEAGE, true);
-        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions));
+        assertDoesNotThrow(
+                () ->
+                        CatalogOptionsManager.validateCatalogOptions(
+                                originImmutableCatalogOptions, newImmutableCatalogOptions));
     }
 
     @Test
     public void testCreatingCatalogWithConflictOptions() throws IOException {
-        // session1: without immutable options, session2: with immutable options, throw IllegalStateException
+        // session1: without immutable options, session2: with immutable options, throw
+        // IllegalStateException
         CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions));
-        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)))
+        assertThatThrownBy(
+                        () ->
+                                CatalogFactory.createCatalog(
+                                        CatalogContext.create(withImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
         cleanCatalogDir();
 
         // session1: without immutable options, session2: without immutable options, succeeded
         CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions));
-        assertDoesNotThrow(() -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)));
+        assertDoesNotThrow(
+                () -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)));
         cleanCatalogDir();
 
         // session1: with immutable options, session2: with the same immutable options, succeeded
         CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
-        assertDoesNotThrow(() -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)));
+        assertDoesNotThrow(
+                () -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)));
         cleanCatalogDir();
 
-        // session1: with immutable options, session2: with different immutable options, throw IllegalStateException
+        // session1: with immutable options, session2: with different immutable options, throw
+        // IllegalStateException
         CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
-        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withPartOfImmutableOptions)))
+        assertThatThrownBy(
+                        () ->
+                                CatalogFactory.createCatalog(
+                                        CatalogContext.create(withPartOfImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
         cleanCatalogDir();
 
-        // session1: with immutable options, session2: without immutable options, throw IllegalStateException
+        // session1: with immutable options, session2: without immutable options, throw
+        // IllegalStateException
         CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
-        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)))
+        assertThatThrownBy(
+                        () ->
+                                CatalogFactory.createCatalog(
+                                        CatalogContext.create(withoutImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
         cleanCatalogDir();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 
 import static org.apache.paimon.options.CatalogOptions.DATA_LINEAGE;
+import static org.apache.paimon.options.CatalogOptions.LINEAGE_META;
 import static org.apache.paimon.options.CatalogOptions.TABLE_LINEAGE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -166,6 +168,13 @@ public class CatalogOptionsManagerTest {
                                         CatalogContext.create(withoutImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
         cleanCatalog();
+    }
+
+    @Test
+    public void testCatalogImmutableOptionKeys() {
+        assertThat(CatalogOptions.getImmutableOptionKeys())
+                .containsExactlyInAnyOrder(
+                        LINEAGE_META.key(), TABLE_LINEAGE.key(), DATA_LINEAGE.key());
     }
 
     private static void cleanCatalog() throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,6 +60,11 @@ public class CatalogOptionsManagerTest {
 
         catalogContext = CatalogContext.create(withoutImmutableOptions);
         fileIO = FileIO.get(new Path(tempDir.toString()), catalogContext);
+    }
+
+    @AfterEach
+    public void afterEach() throws IOException {
+        cleanCatalog();
     }
 
     @Test
@@ -127,19 +133,19 @@ public class CatalogOptionsManagerTest {
                                 CatalogFactory.createCatalog(
                                         CatalogContext.create(withImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
-        cleanCatalogDir();
+        cleanCatalog();
 
         // session1: without immutable options, session2: without immutable options, succeeded
         CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions));
         assertDoesNotThrow(
                 () -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)));
-        cleanCatalogDir();
+        cleanCatalog();
 
         // session1: with immutable options, session2: with the same immutable options, succeeded
         CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
         assertDoesNotThrow(
                 () -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)));
-        cleanCatalogDir();
+        cleanCatalog();
 
         // session1: with immutable options, session2: with different immutable options, throw
         // IllegalStateException
@@ -149,7 +155,7 @@ public class CatalogOptionsManagerTest {
                                 CatalogFactory.createCatalog(
                                         CatalogContext.create(withPartOfImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
-        cleanCatalogDir();
+        cleanCatalog();
 
         // session1: with immutable options, session2: without immutable options, throw
         // IllegalStateException
@@ -159,10 +165,10 @@ public class CatalogOptionsManagerTest {
                                 CatalogFactory.createCatalog(
                                         CatalogContext.create(withoutImmutableOptions)))
                 .isInstanceOf(IllegalStateException.class);
-        cleanCatalogDir();
+        cleanCatalog();
     }
 
-    private static void cleanCatalogDir() throws IOException {
+    private static void cleanCatalog() throws IOException {
         fileIO.delete(new Path(tempDir.toString()), true);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogOptionsManagerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+
+import static org.apache.paimon.options.CatalogOptions.DATA_LINEAGE;
+import static org.apache.paimon.options.CatalogOptions.TABLE_LINEAGE;
+import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Tests for {@link CatalogOptionsManager}.
+ * */
+public class CatalogOptionsManagerTest {
+    @TempDir static java.nio.file.Path tempDir;
+    private static Options withImmutableOptions = new Options();
+    private static Options withoutImmutableOptions = new Options();
+    private static Options withPartOfImmutableOptions = new Options();
+
+    private static CatalogContext catalogContext;
+
+    private static FileIO fileIO;
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        withImmutableOptions.set(TABLE_LINEAGE, true);
+        withImmutableOptions.set(DATA_LINEAGE, true);
+        withImmutableOptions.set(WAREHOUSE, tempDir.toString());
+
+        withoutImmutableOptions.set(WAREHOUSE, tempDir.toString());
+
+        withPartOfImmutableOptions.set(TABLE_LINEAGE, true);
+        withPartOfImmutableOptions.set(WAREHOUSE, tempDir.toString());
+
+        catalogContext = CatalogContext.create(withoutImmutableOptions);
+        fileIO = FileIO.get(new Path(tempDir.toString()), catalogContext);
+    }
+
+    @Test
+    public void testSaveImmutableCatalogOptions() throws IOException {
+        String warehouse = tempDir.toString();
+
+        CatalogOptionsManager catalogOptionsManager = new CatalogOptionsManager(fileIO, new Path(warehouse));
+        CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
+        assertThat(fileIO.exists(catalogOptionsManager.getCatalogOptionPath()));
+        assertThat(withImmutableOptions.toMap()).containsAllEntriesOf(catalogOptionsManager.immutableOptions());
+    }
+
+    @Test
+    public void testCatalogOptionsValidate() {
+        Options newImmutableCatalogOptions = new Options();
+        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        newImmutableCatalogOptions.set(TABLE_LINEAGE, true);
+        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        newImmutableCatalogOptions.set(DATA_LINEAGE, true);
+        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions));
+        newImmutableCatalogOptions.set(TABLE_LINEAGE, false);
+        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(null, newImmutableCatalogOptions))
+                .isInstanceOf(UnsupportedOperationException.class);
+        newImmutableCatalogOptions.set(TABLE_LINEAGE, true);
+
+        Options originImmutableCatalogOptions = new Options();
+        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions))
+                .isInstanceOf(IllegalStateException.class);
+        originImmutableCatalogOptions.set(TABLE_LINEAGE, true);
+        assertThatThrownBy(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions))
+                .isInstanceOf(IllegalStateException.class);
+        originImmutableCatalogOptions.set(DATA_LINEAGE, true);
+        assertDoesNotThrow(() -> CatalogOptionsManager.validateCatalogOptions(originImmutableCatalogOptions, newImmutableCatalogOptions));
+    }
+
+    @Test
+    public void testCreatingCatalogWithConflictOptions() throws IOException {
+        // session1: without immutable options, session2: with immutable options, throw IllegalStateException
+        CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions));
+        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)))
+                .isInstanceOf(IllegalStateException.class);
+        cleanCatalogDir();
+
+        // session1: without immutable options, session2: without immutable options, succeeded
+        CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions));
+        assertDoesNotThrow(() -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)));
+        cleanCatalogDir();
+
+        // session1: with immutable options, session2: with the same immutable options, succeeded
+        CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
+        assertDoesNotThrow(() -> CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions)));
+        cleanCatalogDir();
+
+        // session1: with immutable options, session2: with different immutable options, throw IllegalStateException
+        CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
+        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withPartOfImmutableOptions)))
+                .isInstanceOf(IllegalStateException.class);
+        cleanCatalogDir();
+
+        // session1: with immutable options, session2: without immutable options, throw IllegalStateException
+        CatalogFactory.createCatalog(CatalogContext.create(withImmutableOptions));
+        assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(withoutImmutableOptions)))
+                .isInstanceOf(IllegalStateException.class);
+        cleanCatalogDir();
+    }
+
+    private static void cleanCatalogDir() throws IOException {
+        fileIO.delete(new Path(tempDir.toString()), true);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: subtask of #1481 

As PIP-5 said, to support `table-lineage` and `data-lineage` catalog options which are immutable, paimon should persist the immutable catalog options when creating catalog. This pr support to read / write the immutable catalog options and support validation on the IMMUTABLE catalog options.