### PR TITLE
[build] Disable shading of test jar by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -608,7 +608,7 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <shadeTestJar>true</shadeTestJar>
+                            <shadeTestJar>false</shadeTestJar>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
                             <!-- Filters MUST be appended; merging filters does not work properly, see MSHADE-305 -->


### PR DESCRIPTION
### Purpose

Currently there are many modules which don't have test classes but still produce test jars (for example, `paimon-oss-impl`). Because these modules don't have test classes, maven will have to download test jars from apache repository which is extremely slow.

This PR disables shading of test jar by default to speed up building.

### Tests

Existing tests should cover this change.

### API and Format

No.

### Documentation

No.
