### PR TITLE
[core] Refactor StreamTableScan interface to spark streaming read

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -32,6 +32,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.FieldStatsArraySerializer;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Filter;
@@ -72,7 +73,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private Snapshot specifiedSnapshot = null;
     private Filter<Integer> bucketFilter = null;
     private List<ManifestFileMeta> specifiedManifests = null;
-    private ScanKind scanKind = ScanKind.ALL;
+    private ScanMode scanMode = ScanMode.ALL;
     private Filter<Integer> levelFilter = null;
 
     private ManifestCacheFilter manifestCacheFilter = null;
@@ -169,8 +170,8 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     }
 
     @Override
-    public FileStoreScan withKind(ScanKind scanKind) {
-        this.scanKind = scanKind;
+    public FileStoreScan withKind(ScanMode scanMode) {
+        this.scanMode = scanMode;
         return this;
     }
 
@@ -205,6 +206,11 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             @Override
             public Long snapshotId() {
                 return readSnapshot == null ? null : readSnapshot.id();
+            }
+
+            @Override
+            public ScanMode scanMode() {
+                return scanMode;
             }
 
             @Override
@@ -274,7 +280,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     }
 
     private List<ManifestFileMeta> readManifests(Snapshot snapshot) {
-        switch (scanKind) {
+        switch (scanMode) {
             case ALL:
                 return snapshot.dataManifests(manifestList);
             case DELTA:
@@ -294,7 +300,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                                 "Incremental scan does not accept %s snapshot",
                                 snapshot.commitKind()));
             default:
-                throw new UnsupportedOperationException("Unknown scan kind " + scanKind.name());
+                throw new UnsupportedOperationException("Unknown scan kind " + scanMode.name());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -26,6 +26,7 @@ import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.Filter;
 
 import javax.annotation.Nullable;
@@ -55,7 +56,7 @@ public interface FileStoreScan {
 
     FileStoreScan withManifestList(List<ManifestFileMeta> manifests);
 
-    FileStoreScan withKind(ScanKind scanKind);
+    FileStoreScan withKind(ScanMode scanMode);
 
     FileStoreScan withLevelFilter(Filter<Integer> levelFilter);
 
@@ -76,6 +77,8 @@ public interface FileStoreScan {
          */
         @Nullable
         Long snapshotId();
+
+        ScanMode scanMode();
 
         /** Result {@link ManifestEntry} files. */
         List<ManifestEntry> files();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataFilePlan.java
@@ -38,10 +38,9 @@ public class DataFilePlan implements TableScan.Plan {
         return new ArrayList<>(splits);
     }
 
-    public static DataFilePlan fromResult(StartingScanner.Result result) {
-        return new DataFilePlan(
-                result instanceof StartingScanner.ScannedResult
-                        ? ((StartingScanner.ScannedResult) result).splits()
-                        : Collections.emptyList());
+    public static TableScan.Plan fromResult(StartingScanner.Result result) {
+        return result instanceof StartingScanner.ScannedResult
+                ? ((StartingScanner.ScannedResult) result).plan()
+                : new DataFilePlan(Collections.emptyList());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
@@ -52,7 +52,7 @@ public class InnerTableScanImpl extends AbstractInnerTableScan {
     }
 
     @Override
-    public DataFilePlan plan() {
+    public TableScan.Plan plan() {
         if (startingScanner == null) {
             startingScanner = createStartingScanner(false);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/RichPlan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/RichPlan.java
@@ -18,38 +18,30 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.annotation.Public;
+
 import javax.annotation.Nullable;
 
-import java.util.Collections;
-import java.util.List;
+/**
+ * Rich Plan of scan.
+ *
+ * @since 0.6.0
+ */
+@Public
+public interface RichPlan extends TableScan.Plan {
 
-/** This is used to distinguish the case where the snapshot does not exist and the plan is empty. */
-public class SnapshotNotExistPlan implements RichPlan {
-    public static final SnapshotNotExistPlan INSTANCE = new SnapshotNotExistPlan();
-
-    private SnapshotNotExistPlan() {
-        // private
-    }
-
-    @Override
-    public List<Split> splits() {
-        return Collections.emptyList();
-    }
-
+    /** Current watermark for consumed snapshot. */
     @Nullable
-    @Override
-    public Long watermark() {
-        return null;
-    }
+    Long watermark();
 
+    /**
+     * Snapshot id of this plan.
+     *
+     * @return null if the table is empty.
+     */
     @Nullable
-    @Override
-    public Long snapshotId() {
-        return null;
-    }
+    Long snapshotId();
 
-    @Override
-    public ScanMode scanMode() {
-        throw new UnsupportedOperationException();
-    }
+    /** Scan which part of the snapshot. */
+    ScanMode scanMode();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ScanMode.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ScanMode.java
@@ -16,14 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.operation;
+package org.apache.paimon.table.source;
 
-/** Scan which part of the snapshot. */
-public enum ScanKind {
+import org.apache.paimon.annotation.Public;
+
+/**
+ * Scan which part of the snapshot.
+ *
+ * @since 0.6.0
+ */
+@Public
+public enum ScanMode {
+
     /** Scan complete data files of a snapshot. */
     ALL,
+
     /** Only scan newly changed files of a snapshot. */
     DELTA,
+
     /** Only scan changelog files of a snapshot. */
     CHANGELOG
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/StreamTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/StreamTableScan.java
@@ -33,13 +33,15 @@ import javax.annotation.Nullable;
 @Public
 public interface StreamTableScan extends TableScan, Restorable<Long> {
 
-    /** Current watermark for consumed snapshot. */
-    @Nullable
-    Long watermark();
+    @Override
+    RichPlan plan();
 
     /** Restore from checkpoint next snapshot id. */
     @Override
     void restore(@Nullable Long nextSnapshotId);
+
+    /** Restore from checkpoint next snapshot id with scan kind. */
+    void restore(@Nullable Long nextSnapshotId, ScanMode scanMode);
 
     /** Checkpoint to return next snapshot id. */
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactedStartingScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
@@ -49,7 +49,7 @@ public class CompactedStartingScanner implements StartingScanner {
         }
 
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshotId).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(startingSnapshotId).read());
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +49,6 @@ public class CompactionChangelogFollowUpScanner implements FollowUpScanner {
 
     @Override
     public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).read();
+        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +49,6 @@ public class ContinuousAppendAndCompactFollowUpScanner implements FollowUpScanne
 
     @Override
     public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +45,6 @@ public class ContinuousCompactorFollowUpScanner implements FollowUpScanner {
 
     @Override
     public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotFullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotFullStartingScanner.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
 /**
@@ -41,6 +41,6 @@ public class ContinuousFromSnapshotFullStartingScanner implements StartingScanne
         }
         long ceiledSnapshotId = Math.max(snapshotId, earliestSnapshotId);
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(ceiledSnapshotId).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(ceiledSnapshotId).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +45,6 @@ public class DeltaFollowUpScanner implements FollowUpScanner {
 
     @Override
     public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withKind(ScanKind.DELTA).withSnapshot(snapshotId).read();
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FullStartingScanner.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
@@ -38,6 +38,6 @@ public class FullStartingScanner implements StartingScanner {
             return new NoSnapshot();
         }
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshotId).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(startingSnapshotId).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +45,6 @@ public class InputChangelogFollowUpScanner implements FollowUpScanner {
 
     @Override
     public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withKind(ScanKind.CHANGELOG).withSnapshot(snapshotId).read();
+        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshotId).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -21,16 +21,14 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.RichPlan;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
-import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.SnapshotManager;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -49,7 +47,7 @@ public interface SnapshotReader {
 
     SnapshotReader withFilter(Predicate predicate);
 
-    SnapshotReader withKind(ScanKind scanKind);
+    SnapshotReader withMode(ScanMode scanMode);
 
     SnapshotReader withLevelFilter(Filter<Integer> levelFilter);
 
@@ -69,17 +67,7 @@ public interface SnapshotReader {
     List<BinaryRow> partitions();
 
     /** Result plan of this scan. */
-    interface Plan extends TableScan.Plan {
-
-        @Nullable
-        Long watermark();
-
-        /**
-         * Snapshot id of this plan, return null if the table is empty or the manifest list is
-         * specified.
-         */
-        @Nullable
-        Long snapshotId();
+    interface Plan extends RichPlan {
 
         /** Result splits. */
         List<Split> splits();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StartingScanner.java
@@ -22,8 +22,6 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.utils.SnapshotManager;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 
 /** Helper class for the first planning of {@link TableScan}. */
@@ -38,33 +36,28 @@ public interface StartingScanner {
     class NoSnapshot implements Result {}
 
     static ScannedResult fromPlan(SnapshotReader.Plan plan) {
-        return new ScannedResult(plan.snapshotId(), plan.watermark(), (List) plan.splits());
+        return new ScannedResult(plan);
     }
 
     /** Result with scanned snapshot. Next snapshot should be the current snapshot plus 1. */
     class ScannedResult implements Result {
-        private final long currentSnapshotId;
-        @Nullable private final Long currentWatermark;
-        private final List<DataSplit> splits;
 
-        public ScannedResult(
-                long currentSnapshotId, @Nullable Long currentWatermark, List<DataSplit> splits) {
-            this.currentSnapshotId = currentSnapshotId;
-            this.currentWatermark = currentWatermark;
-            this.splits = splits;
+        private final SnapshotReader.Plan plan;
+
+        public ScannedResult(SnapshotReader.Plan plan) {
+            this.plan = plan;
         }
 
         public long currentSnapshotId() {
-            return currentSnapshotId;
-        }
-
-        @Nullable
-        public Long currentWatermark() {
-            return currentWatermark;
+            return plan.snapshotId();
         }
 
         public List<DataSplit> splits() {
-            return splits;
+            return (List) plan.splits();
+        }
+
+        public SnapshotReader.Plan plan() {
+            return plan;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
 /**
@@ -40,6 +40,6 @@ public class StaticFromSnapshotStartingScanner implements StartingScanner {
             return new NoSnapshot();
         }
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(snapshotId).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(snapshotId).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -40,6 +40,6 @@ public class StaticFromTagStartingScanner implements StartingScanner {
         Snapshot snapshot = tagManager.taggedSnapshot(tagName);
 
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(snapshot).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(snapshot).read());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.ScanKind;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ public class StaticFromTimestampStartingScanner implements StartingScanner {
             return new NoSnapshot();
         }
         return StartingScanner.fromPlan(
-                snapshotReader.withKind(ScanKind.ALL).withSnapshot(startingSnapshot.id()).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(startingSnapshot.id()).read());
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -27,7 +27,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -40,6 +39,8 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.InnerStreamTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.RichPlan;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.table.source.TableRead;
@@ -225,8 +226,8 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
             return this;
         }
 
-        public SnapshotReader withKind(ScanKind scanKind) {
-            snapshotReader.withKind(scanKind);
+        public SnapshotReader withMode(ScanMode scanMode) {
+            snapshotReader.withMode(scanMode);
             return this;
         }
 
@@ -307,7 +308,7 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public Plan plan() {
+        public RichPlan plan() {
             return streamScan.plan();
         }
 
@@ -322,15 +323,14 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
             return streamScan.checkpoint();
         }
 
-        @Nullable
-        @Override
-        public Long watermark() {
-            return streamScan.watermark();
-        }
-
         @Override
         public void restore(@Nullable Long nextSnapshotId) {
             streamScan.restore(nextSnapshotId);
+        }
+
+        @Override
+        public void restore(@Nullable Long nextSnapshotId, ScanMode scanMode) {
+            streamScan.restore(nextSnapshotId, scanMode);
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -39,7 +39,6 @@ import org.apache.paimon.operation.FileStoreCommitImpl;
 import org.apache.paimon.operation.FileStoreExpireImpl;
 import org.apache.paimon.operation.FileStoreRead;
 import org.apache.paimon.operation.FileStoreScan;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReaderIterator;
@@ -47,6 +46,7 @@ import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CommitIncrement;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -339,8 +339,8 @@ public class TestFileStore extends KeyValueFileStore {
                             .withKind(
                                     options.changelogProducer()
                                                     == CoreOptions.ChangelogProducer.NONE
-                                            ? ScanKind.DELTA
-                                            : ScanKind.CHANGELOG)
+                                            ? ScanMode.DELTA
+                                            : ScanMode.CHANGELOG)
                             .withSnapshot(snapshotId)
                             .plan()
                             .files();

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -25,7 +25,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -38,6 +37,7 @@ import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
@@ -213,7 +213,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("+101|11", "+102|12"));
@@ -231,7 +231,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         List<Split> splits =
                 toSplits(
                         table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
+                                .withMode(ScanMode.DELTA)
                                 .withFilter(predicate)
                                 .read()
                                 .dataSplits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogValueCountFileStoreTableTest.java
@@ -24,7 +24,6 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFilePathFactory;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -34,6 +33,7 @@ import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.RowKind;
@@ -109,7 +109,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -130,7 +130,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("-100|10", "+101|11"));
@@ -148,7 +148,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         List<Split> splits =
                 toSplits(
                         table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
+                                .withMode(ScanMode.DELTA)
                                 .withFilter(predicate)
                                 .read()
                                 .dataSplits());
@@ -203,7 +203,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
         // check that no data file is produced
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         assertThat(splits).isEmpty();
         // check that no changelog file is produced
         Path bucketPath = DataFilePathFactory.bucketPath(table.location(), "1", 0);

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
@@ -20,10 +20,10 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.WriteMode;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.RowType;
@@ -153,7 +153,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
                     // filter with "b" = 15 in schema0
@@ -174,7 +174,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
 
@@ -212,7 +212,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
                     // filter with "kt" = 116 in schema0
@@ -230,7 +230,7 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -28,7 +28,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -48,6 +47,7 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
@@ -253,7 +253,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -273,7 +273,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits =
-                toSplits(table.newSnapshotReader().withKind(ScanKind.DELTA).read().dataSplits());
+                toSplits(table.newSnapshotReader().withMode(ScanMode.DELTA).read().dataSplits());
         TableRead read = table.newRead().withProjection(PROJECTION);
 
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
@@ -292,7 +292,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         List<Split> splits =
                 toSplits(
                         table.newSnapshotReader()
-                                .withKind(ScanKind.DELTA)
+                                .withMode(ScanMode.DELTA)
                                 .withFilter(predicate)
                                 .read()
                                 .dataSplits());
@@ -328,7 +328,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
+                        table.newSnapshotReader().withMode(ScanMode.CHANGELOG).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -377,7 +377,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         List<Split> splits =
                 toSplits(
-                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
+                        table.newSnapshotReader().withMode(ScanMode.CHANGELOG).read().dataSplits());
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
@@ -400,7 +400,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
+                        table.newSnapshotReader().withMode(ScanMode.CHANGELOG).read().dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("+I 1|30|130|binary|varbinary|mapKey:mapVal|multiset");
         assertThat(getResult(read, splits, binaryRow(2), 0, CHANGELOG_ROW_TO_STRING))
@@ -426,7 +426,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         splits =
                 toSplits(
-                        table.newSnapshotReader().withKind(ScanKind.CHANGELOG).read().dataSplits());
+                        table.newSnapshotReader().withMode(ScanMode.CHANGELOG).read().dataSplits());
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
                 .containsExactlyInAnyOrder(
                         "-D 1|20|120|binary|varbinary|mapKey:mapVal|multiset",
@@ -709,7 +709,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(1, 20, 200L));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        SnapshotReader snapshotReader = table.newSnapshotReader().withKind(ScanKind.DELTA);
+        SnapshotReader snapshotReader = table.newSnapshotReader().withMode(ScanMode.DELTA);
         List<DataSplit> splits0 = snapshotReader.read().dataSplits();
         assertThat(splits0).hasSize(1);
         assertThat(splits0.get(0).dataFiles()).hasSize(1);

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileDataFilterTestBase.java
@@ -19,12 +19,12 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.IsNull;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataTypes;
@@ -341,7 +341,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
                     TableRead read = table.newRead();
@@ -359,7 +359,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
 
@@ -384,7 +384,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
                     // project "c", "b", "pt" in schema0
@@ -400,7 +400,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
 
@@ -424,7 +424,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
                     // filter with "b" = 15 in schema0
@@ -442,7 +442,7 @@ public abstract class FileDataFilterTestBase extends SchemaEvolutionTableTestBas
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
-                                            .withKind(ScanKind.DELTA)
+                                            .withMode(ScanMode.DELTA)
                                             .read()
                                             .dataSplits());
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -22,7 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.operation.ScanKind;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamTableCommit;
@@ -76,13 +75,13 @@ public class StartupModeTest extends ScannerTestBase {
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -96,20 +95,20 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withMode(ScanMode.ALL).read().splits());
         assertThat(secondPlan.splits()).isEmpty();
 
         // write next data
         writeAndCommit(4, rowData(1, 10, 103L));
         TableScan.Plan thirdPlan = dataTableScan.plan();
         assertThat(thirdPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -135,13 +134,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = readTable.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -159,15 +158,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.ALL).read().splits());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(5).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(5).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(4).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(4).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -184,13 +183,13 @@ public class StartupModeTest extends ScannerTestBase {
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -212,7 +211,7 @@ public class StartupModeTest extends ScannerTestBase {
         assertThat(firstPlan.splits()).isEmpty();
         // ceiled up to the earliest snapshot id = 2
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
@@ -232,15 +231,15 @@ public class StartupModeTest extends ScannerTestBase {
         TableScan.Plan secondPlan = dataTableScan.plan();
 
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.ALL).read().splits());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();
         TableScan.Plan plan = batchScan.plan();
         assertThat(plan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.ALL).read().splits());
     }
 
     @Test
@@ -260,9 +259,9 @@ public class StartupModeTest extends ScannerTestBase {
 
         // ceiled up to the earliest snapshot id = 2
         assertThat(firstPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(2).withKind(ScanKind.ALL).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.ALL).read().splits());
         assertThat(secondPlan.splits())
-                .isEqualTo(snapshotReader.withSnapshot(3).withKind(ScanKind.DELTA).read().splits());
+                .isEqualTo(snapshotReader.withSnapshot(3).withMode(ScanMode.DELTA).read().splits());
 
         // batch mode
         TableScan batchScan = table.newScan();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
@@ -22,6 +22,7 @@ import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.RichPlan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 
@@ -180,12 +181,13 @@ public class MonitorFunction extends RichSourceFunction<Split>
                     return;
                 }
                 try {
-                    List<Split> splits = scan.plan().splits();
+                    RichPlan plan = scan.plan();
+                    List<Split> splits = plan.splits();
                     isEmpty = splits.isEmpty();
                     splits.forEach(ctx::collect);
 
                     if (emitSnapshotWatermark) {
-                        Long watermark = scan.watermark();
+                        Long watermark = plan.watermark();
                         if (watermark != null) {
                             ctx.emitWatermark(new Watermark(watermark));
                         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -21,12 +21,13 @@ package org.apache.paimon.flink.source;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.BucketMode;
-import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.RichPlan;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
-import org.apache.paimon.table.source.TableScan;
 
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
@@ -200,7 +201,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(0, "test-host");
         context.registerReader(1, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         MockScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -216,7 +217,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 4; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
         context.triggerAllActions();
 
         // assign to task 0
@@ -269,7 +270,7 @@ public class ContinuousFileSplitEnumeratorTest {
                 new TestingSplitEnumeratorContext<>(3);
         context.registerReader(0, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         StreamTableScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -284,7 +285,7 @@ public class ContinuousFileSplitEnumeratorTest {
         long snapshot = 0;
         List<DataSplit> splits = new ArrayList<>();
         splits.add(createDataSplit(snapshot, 1, Collections.emptyList()));
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
         context.triggerAllActions();
 
         // assign to task 0
@@ -296,7 +297,7 @@ public class ContinuousFileSplitEnumeratorTest {
 
         splits.clear();
         splits.add(createDataSplit(snapshot, 2, Collections.emptyList()));
-        results.put(2L, new DataFilePlan(splits));
+        results.put(2L, new MockPlan(splits));
         context.triggerAllActions();
 
         // assign to task 0
@@ -315,7 +316,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(2, "test-host");
         context.registerReader(3, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         StreamTableScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -332,7 +333,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 100; i++) {
             splits.add(createDataSplit(snapshot, 0, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
         context.triggerAllActions();
 
         // assign to task 0
@@ -378,7 +379,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(2, "test-host");
         context.registerReader(3, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         MockScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -407,7 +408,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 100; i++) {
             splits.add(createDataSplit(snapshot, 0, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
         // trigger assign task 0 and task 1 will get their assignment
         context.triggerAllActions();
 
@@ -436,7 +437,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(0, "test-host");
         context.registerReader(1, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         StreamTableScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -453,7 +454,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 4; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
         context.triggerAllActions();
 
         // assign to task 0
@@ -477,7 +478,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(0, "test-host");
         context.registerReader(1, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         StreamTableScan scan = new MockScan(results);
         ContinuousFileSplitEnumerator enumerator =
                 new Builder()
@@ -495,7 +496,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 4; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
 
         context.registeredReaders().remove(1);
         // assign to task 0
@@ -510,7 +511,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(0, "test-host");
         context.registerReader(1, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         MockScan scan = new MockScan(results);
         scan.allowEnd(false);
         ContinuousFileSplitEnumerator enumerator =
@@ -527,7 +528,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 4; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
 
         // request directly
         enumerator.handleSplitRequest(0, "test-host");
@@ -555,7 +556,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(2, "test-host");
         context.registerReader(3, "test-host");
 
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         MockScan scan = new MockScan(results);
         scan.allowEnd(false);
         ContinuousFileSplitEnumerator enumerator =
@@ -574,7 +575,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 0; i < 2; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(1L, new DataFilePlan(splits));
+        results.put(1L, new MockPlan(splits));
 
         // will not trigger scan here
         enumerator.handleSplitRequest(0, "test-host");
@@ -602,7 +603,7 @@ public class ContinuousFileSplitEnumeratorTest {
         for (int i = 2; i < 4; i++) {
             splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
         }
-        results.put(2L, new DataFilePlan(splits));
+        results.put(2L, new MockPlan(splits));
         // because blockScanByRequest = false, so this request will trigger scan
         enumerator.handleSplitRequest(2, "test-host");
         context.getExecutorService().triggerAllNonPeriodicTasks();
@@ -620,7 +621,7 @@ public class ContinuousFileSplitEnumeratorTest {
         context.getExecutorService().triggerAllNonPeriodicTasks();
         splits.clear();
         splits.add(createDataSplit(snapshot, 7, Collections.emptyList()));
-        results.put(3L, new DataFilePlan(splits));
+        results.put(3L, new MockPlan(splits));
 
         // this won't trigger scan, cause blockScanByRequest = true
         enumerator.handleSplitRequest(3, "test-host");
@@ -647,13 +648,13 @@ public class ContinuousFileSplitEnumeratorTest {
         context.registerReader(0, "test-host");
 
         // prepare test data
-        TreeMap<Long, TableScan.Plan> results = new TreeMap<>();
+        TreeMap<Long, RichPlan> results = new TreeMap<>();
         Map<Long, List<DataSplit>> expectedResults = new HashMap<>(4);
         StreamTableScan scan = new MockScan(results);
         for (int i = 1; i <= 4; i++) {
             List<DataSplit> dataSplits =
                     Collections.singletonList(createDataSplit(i, 0, Collections.emptyList()));
-            results.put((long) i, new DataFilePlan(dataSplits));
+            results.put((long) i, new MockPlan(dataSplits));
             expectedResults.put((long) i, dataSplits);
         }
 
@@ -787,20 +788,51 @@ public class ContinuousFileSplitEnumeratorTest {
         }
     }
 
+    private static class MockPlan implements RichPlan {
+
+        private final List<DataSplit> splits;
+
+        public MockPlan(List<DataSplit> splits) {
+            this.splits = splits;
+        }
+
+        @Nullable
+        @Override
+        public Long watermark() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nullable
+        @Override
+        public Long snapshotId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScanMode scanMode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Split> splits() {
+            return (List) splits;
+        }
+    }
+
     private static class MockScan implements StreamTableScan {
 
-        private final TreeMap<Long, Plan> results;
+        private final TreeMap<Long, RichPlan> results;
         private @Nullable Long nextSnapshotId;
         private boolean allowEnd = true;
 
-        public MockScan(TreeMap<Long, Plan> results) {
+        public MockScan(TreeMap<Long, RichPlan> results) {
             this.results = results;
             this.nextSnapshotId = null;
         }
 
         @Override
-        public Plan plan() {
-            Map.Entry<Long, Plan> planEntry = results.pollFirstEntry();
+        public RichPlan plan() {
+            Map.Entry<Long, RichPlan> planEntry = results.pollFirstEntry();
             if (planEntry == null) {
                 if (allowEnd) {
                     throw new EndOfScanException();
@@ -825,14 +857,11 @@ public class ContinuousFileSplitEnumeratorTest {
         @Override
         public void notifyCheckpointComplete(@Nullable Long nextSnapshot) {}
 
-        @Nullable
-        @Override
-        public Long watermark() {
-            return null;
-        }
-
         @Override
         public void restore(Long state) {}
+
+        @Override
+        public void restore(@Nullable Long nextSnapshotId, ScanMode scanMode) {}
 
         public void allowEnd(boolean allowEnd) {
             this.allowEnd = allowEnd;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.table.source.snapshot.SnapshotReaderImpl;
 
@@ -57,6 +58,11 @@ public class FileStoreSourceSplitGeneratorTest {
                     @Override
                     public Long snapshotId() {
                         return 1L;
+                    }
+
+                    @Override
+                    public ScanMode scanMode() {
+                        return ScanMode.ALL;
                     }
 
                     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, the interface exposed by StreamTableScan is only suitable for Flink, and Spark does not save the returned splits. It needs to read the current snapshot again during failover, but currently only returns nextSnapshotId.

This PR includes the current snapshotId in the returned plan and returns ScanMode to resolve the full stage restore.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
