### PR TITLE
[hotfix] Fix CallStatementParserTest stop and clear spark active session

### DIFF
--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/extensions/CallStatementParserTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/extensions/CallStatementParserTest.java
@@ -51,6 +51,8 @@ public class CallStatementParserTest {
 
     @BeforeEach
     public void startSparkSession() {
+        // Stops and clears active session to avoid loading previous non-stopped session.
+        SparkSession.getActiveSession().orElse(SparkSession::getDefaultSession).get().stop();
         SparkSession.clearActiveSession();
         spark =
                 SparkSession.builder()


### PR DESCRIPTION
### Purpose

Fix `CallStatementParserTest` stop and clear spark active session to avoid loading previous non-stopped session, which causes that the Paimon extension could not load from the active session.
Linked issue: close #1155 

### Tests

- `CallStatementParserTest`

### API and Format

None.

### Documentation

None.