### PR TITLE
[ci] Try to fix "ExecutionException Error occurred in starting fork"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,7 @@ under the License.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                     <forkCount>${flink.forkCount}</forkCount>
                     <reuseForks>${flink.reuseForks}</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
@@ -460,7 +461,6 @@ under the License.
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <forkCount>0</forkCount>
                             <includes>
                                 <include>${test.unit.pattern}</include>
                             </includes>
@@ -474,7 +474,6 @@ under the License.
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <forkCount>0</forkCount>
                             <includes>
                                 <include>**/*.*</include>
                             </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,6 @@ under the License.
                             <excludes>
                                 <exclude>${test.unit.pattern}</exclude>
                             </excludes>
-                            <reuseForks>false</reuseForks>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,7 @@ under the License.
                             <goal>test</goal>
                         </goals>
                         <configuration>
+                            <forkCount>0</forkCount>
                             <includes>
                                 <include>${test.unit.pattern}</include>
                             </includes>
@@ -473,12 +474,14 @@ under the License.
                             <goal>test</goal>
                         </goals>
                         <configuration>
+                            <forkCount>0</forkCount>
                             <includes>
                                 <include>**/*.*</include>
                             </includes>
                             <excludes>
                                 <exclude>${test.unit.pattern}</exclude>
                             </excludes>
+                            <reuseForks>false</reuseForks>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR aim to resolve below exception in CI:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test (default-test) on project paimon-flink-common: There are test failures.
Error:  
Error:  Please refer to /home/runner/work/incubator-paimon/incubator-paimon/paimon-flink/paimon-flink-common/target/surefire-reports for the individual test results.
Error:  Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
Error:  ExecutionException Error occurred in starting fork, check output in log
Error:  org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException Error occurred in starting fork, check output in log
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.awaitResultsDone(ForkStarter.java:532)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.runSuitesForkOnceMultiple(ForkStarter.java:405)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:321)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:266)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1314)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1159)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:932)
Error:  	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:370)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:351)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:215)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:171)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:163)
Error:  	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
Error:  	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:210)
Error:  	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:195)
Error:  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
Error:  	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
Error:  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
Error:  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
Error:  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
Error:  	at java.lang.Thread.run(Thread.java:750)
Error:  Caused by: org.apache.maven.surefire.booter.SurefireBooterForkException: Error occurred in starting fork, check output in log
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:662)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.access$700(ForkStarter.java:121)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter$1.call(ForkStarter.java:393)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter$1.call(ForkStarter.java:370)
Error:  	... 4 more
Error:  -> [Help 1]
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
