### PR TITLE
[test] fix test problem: libc++abi: pure virtual function called

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
@@ -67,6 +67,7 @@ public class RocksDBListStateTest {
         listState.add(key, row("1"));
         assertThat(getString(listState.get(key))).containsExactlyInAnyOrder("1", "2,3", "1");
         assertThat(listState.get(row("bbb"))).isEmpty();
+        factory.close();
     }
 
     public GenericRow row(String value) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerTest.java
@@ -170,6 +170,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
         assigner.process(GenericRowData.of(2, 4, 4));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0, 0, 0);
         output.clear();
+        assigner.close();
     }
 
     @Test
@@ -194,5 +195,6 @@ public class GlobalIndexAssignerTest extends TableTestBase {
         assigner.process(GenericRowData.of(2, 4, 4));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0, 0, 0);
         output.clear();
+        assigner.close();
     }
 }


### PR DESCRIPTION
Test always fails because some error called: pure virtual function called.

Track it, found the root cause is: "Java: Finalizer" Thread collapse while gc the rocksdb object.

crash stack:
![image](https://github.com/apache/incubator-paimon/assets/41894543/9dde8039-cf09-480a-b568-edc52bb5e9b9)

rocksdb related issue:
https://github.com/facebook/rocksdb/issues/649