### PR TITLE
[hive] After flink creates hive external partition table, using hive to read data cannot find the table schema.

### DIFF
--- a/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/LocationKeyExtractor.java
+++ b/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/LocationKeyExtractor.java
@@ -33,7 +33,10 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import static org.apache.hadoop.hive.metastore.Warehouse.getDnsPath;
 

--- a/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/LocationKeyExtractor.java
+++ b/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/LocationKeyExtractor.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.hive;
 
+import org.apache.paimon.utils.StringUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -31,8 +33,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import static org.apache.hadoop.hive.metastore.Warehouse.getDnsPath;
 
@@ -59,6 +60,7 @@ public class LocationKeyExtractor {
         // read what metastore tells us
         location = properties.getProperty(hive_metastoreConstants.META_TABLE_LOCATION);
         if (location != null) {
+            location = tableLocation(location, properties);
             if (conf != null) {
                 try {
                     return getDnsPath(new Path(location), conf).toString();
@@ -149,5 +151,18 @@ public class LocationKeyExtractor {
         }
 
         return null;
+    }
+
+    /** Get table location through partition location. */
+    private static String tableLocation(String location, Properties properties) {
+        String partitionProperty =
+                properties.getProperty(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS);
+        if (StringUtils.isEmpty(partitionProperty)) {
+            return location;
+        }
+
+        List<String> partitionKeys =
+                Arrays.asList(partitionProperty.split(org.apache.paimon.fs.Path.SEPARATOR));
+        return location.split(org.apache.paimon.fs.Path.SEPARATOR + partitionKeys.get(0) + "=")[0];
     }
 }


### PR DESCRIPTION
… 

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1865 

When using Hive Cli to read the hive external partition table created by Flink, the location obtained by the PaimonSerDe class is the partition location, so the schema of the external table cannot be found.

<img width="1439" alt="iShot_2023-09-02_09 54 32" src="https://github.com/apache/incubator-paimon/assets/37063904/ae2bf3b0-d37a-403c-b09b-b5533e72995b">


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
HiveCatalogITCaseBase#testFlinkWriteAndHiveReadToCompare

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
