### PR TITLE
[core] clean up files generated by compactManager when AppendOnlyWriter is closed.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -162,6 +162,13 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow> {
         compactManager.cancelCompaction();
         sync();
 
+        compactManager.close();
+        for (DataFileMeta file : compactAfter) {
+            // appendOnlyCompactManager will rewrite the file and no file upgrade will occur, so we
+            // can directly delete the file in compactAfter.
+            fileIO.deleteQuietly(pathFactory.toPath(file.fileName()));
+        }
+
         if (writer != null) {
             writer.abort();
             writer = null;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1947 

<!-- What is the purpose of the change -->
[core] clean up files generated by `compactManager` when `AppendOnlyWriter` is closed.

### Tests

<!-- List UT and IT cases to verify this change -->
Added unit test `org.apache.paimon.append.AppendOnlyWriterTest#testCloseUnexpectedly` to verify that files are properly cleaned.

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No