### PR TITLE
Remove unnecessary error when the one option and doc are inconsistent

### DIFF
--- a/paimon-docs/src/test/java/org/apache/paimon/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/paimon-docs/src/test/java/org/apache/paimon/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -156,6 +156,23 @@ public class ConfigOptionsDocsCompletenessITCase {
                                             + " in "
                                             + supposedState.containingClass
                                             + " is not documented.");
+                        } else if (documentedState.size() == 1) {
+                            DocumentedOption candidate = documentedState.get(0);
+                            boolean matchFound = false;
+                            if (supposedState.defaultValue.equals(candidate.defaultValue)
+                                    && supposedState.description.equals(candidate.description)) {
+                                matchFound = true;
+                            }
+                            if (!matchFound) {
+                                problems.add(
+                                        String.format(
+                                                "Documentation of %s in %s is outdated. Expected: default=(%s) description=(%s).",
+                                                supposedState.key,
+                                                supposedState.containingClass.getSimpleName(),
+                                                supposedState.defaultValue,
+                                                supposedState.description));
+                            }
+                            documentedOptions.remove(key);
                         } else {
                             final Iterator<DocumentedOption> candidates =
                                     documentedState.iterator();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose



```java
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.319 s <<< FAILURE! - in org.apache.paimon.docs.configuration.ConfigOptionsDocsCompletenessITCase
Error:  org.apache.paimon.docs.configuration.ConfigOptionsDocsCompletenessITCase.testCompleteness  Time elapsed: 0.298 s  <<< FAILURE!
java.lang.AssertionError: 
Documentation is outdated, please regenerate it according to the instructions in paimon-docs/README.md.
	Problems:
		Documentation of hadoop-conf-dir in HiveCatalogOptions is outdated. Expected: default=((none)) description=(File directory of the core-site.xml、hdfs-site.xml、yarn-site.xml、mapred-site.xml. Currently, only local file system paths are supported.
If not configured, try to load from 'HADOOP_CONF_DIR' or 'HADOOP_HOME' system environment.
Configure Priority: 1.from 'hadoop-conf-dir' 2.from HADOOP_CONF_DIR  3.from HADOOP_HOME/conf 4.HADOOP_HOME/etc/hadoop.).
		Documentation of hive-conf-dir in HiveCatalogOptions is outdated. Expected: default=((none)) description=(File directory of the hive-site.xml , used to create HiveMetastoreClient and security authentication, such as Kerberos, LDAP, Ranger and so on.
If not configured, try to load from 'HIVE_CONF_DIR' env.).
		Documented option hadoop-conf-dir does not exist.
		Documented option hive-conf-dir does not exist.
```



The error has ambiguity, when  both document  and ConfigOption exist, but the description or default value are not same.

	Documented option hadoop-conf-dir does not exist.
        Documented option hive-conf-dir does not exist.


Is it feasible to add the following code?


We can remove the invalid error.
![image](https://github.com/apache/incubator-paimon/assets/18002496/bb5e9066-4676-4496-9523-b3ad875c2ba8)
