### PR TITLE
[test] Fix typo in the SortMergeReaderTestBase unit test

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -112,7 +112,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
     }
 
     /** Tests for {@link SortMergeReader} with {@link ValueCountMergeFunction}. */
-    public static class WithValueRecordMergeFunctionTest extends SortMergeReaderTestBase {
+    public static class WithValueCountMergeFunctionTest extends SortMergeReaderTestBase {
 
         @Override
         protected boolean addOnly() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix typo in the SortMergeReaderTestBase unit test:
WithValueRecordMergeFunctionTest -> WithValueCountMergeFunctionTest
