### PR TITLE
[core] Introduce index-ttl and bootstrap-min-partition for cross-partition-upsert

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -64,13 +64,13 @@ Performance:
    entries in a partition takes up **1 GB** more memory, partitions that are no longer active do not take up memory.
 2. For tables with low update rates, this mode is recommended to significantly improve performance.
 
-#### Cross Partitions Update Dynamic Bucket Mode
+#### Cross Partitions Upsert Dynamic Bucket Mode
 
 {{< hint info >}}
 This is an experimental feature.
 {{< /hint >}}
 
-When you need cross partition updates (primary keys not contain all partition fields), Dynamic Bucket mode directly
+When you need cross partition upsert (primary keys not contain all partition fields), Dynamic Bucket mode directly
 maintains the mapping of keys to partition and bucket, uses local disks, and initializes indexes by reading all 
 existing keys in the table when starting stream write job. Different merge engines have different behaviors:
 
@@ -80,6 +80,16 @@ existing keys in the table when starting stream write job. Different merge engin
 
 Performance: For tables with a large amount of data, there will be a significant loss in performance. Moreover,
 initialization takes a long time.
+
+If your upsert does not rely on too old data, you can consider configuring index TTL and bootstrap-min-partition to
+reduce Index and initialization time:
+- `'cross-partition-upsert.index-ttl'`: The TTL in rocksdb index, this can avoid maintaining too many indexes and lead
+  to worse and worse performance.
+- `'cross-partition-upsert.bootstrap-min-partition'`: The min partition bootstrap of rocksdb index, bootstrap will only
+  read the partitions above it, and the smaller partitions will not be read into the index. This can reduce job startup
+  time and excessive initialization of index.
+
+But please note that this may also cause data duplication.
 
 ## Merge Engines
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -117,6 +117,18 @@ under the License.
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
+            <td><h5>cross-partition-upsert.bootstrap-min-partition</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The min partition bootstrap of rocksdb index for cross partition upsert (primary keys not contain all partition fields), bootstrap will only read the partitions above it, and the smaller partitions will not be read into the index. This can reduce job startup time and excessive initialization of index, but please note that this may also cause data duplication.</td>
+        </tr>
+        <tr>
+            <td><h5>cross-partition-upsert.index-ttl</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.assigner-parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -849,6 +849,25 @@ public class CoreOptions implements Serializable {
                                     + "Mainly to resolve data skew on primary keys. "
                                     + "We recommend starting with 64 mb when trying out this feature.");
 
+    public static final ConfigOption<Duration> CROSS_PARTITION_UPSERT_INDEX_TTL =
+            key("cross-partition-upsert.index-ttl")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), "
+                                    + "this can avoid maintaining too many indexes and lead to worse and worse performance, "
+                                    + "but please note that this may also cause data duplication.");
+
+    public static final ConfigOption<String> CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION =
+            key("cross-partition-upsert.bootstrap-min-partition")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The min partition bootstrap of rocksdb index for cross partition upsert (primary keys not contain all partition fields), "
+                                    + "bootstrap will only read the partitions above it, and the smaller partitions will not be read into the index. "
+                                    + "This can reduce job startup time and excessive initialization of index, "
+                                    + "but please note that this may also cause data duplication.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1261,6 +1280,14 @@ public class CoreOptions implements Serializable {
 
     public long localMergeBufferSize() {
         return options.get(LOCAL_MERGE_BUFFER_SIZE).getBytes();
+    }
+
+    public Duration crossPartitionUpsertIndexTtl() {
+        return options.get(CROSS_PARTITION_UPSERT_INDEX_TTL);
+    }
+
+    public String crossPartitionUpsertBootstrapMinPartition() {
+        return options.get(CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -124,7 +124,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private void open() throws Exception {
         Options options = Options.fromMap(table.options());
         this.refreshInterval = options.get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL);
-        this.stateFactory = new RocksDBStateFactory(path.toString(), options);
+        this.stateFactory = new RocksDBStateFactory(path.toString(), options, null);
 
         List<String> fieldNames = table.rowType().getFieldNames();
         int[] projection = projectFields.stream().mapToInt(fieldNames::indexOf).toArray();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalIndexAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalIndexAssigner.java
@@ -106,7 +106,10 @@ public class GlobalIndexAssigner<T> implements Serializable {
         // state
         Options options = coreOptions.toConfiguration();
         this.path = new File(tmpDir, "lookup-" + UUID.randomUUID());
-        this.stateFactory = new RocksDBStateFactory(path.toString(), options);
+
+        this.stateFactory =
+                new RocksDBStateFactory(
+                        path.toString(), options, coreOptions.crossPartitionUpsertIndexTtl());
         RowType keyType = table.schema().logicalTrimmedPrimaryKeysType();
         this.keyIndex =
                 stateFactory.valueState(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -50,7 +50,7 @@ public class LookupTableTest {
 
     @BeforeEach
     public void before() throws IOException {
-        this.stateFactory = new RocksDBStateFactory(tempDir.toString(), new Options());
+        this.stateFactory = new RocksDBStateFactory(tempDir.toString(), new Options(), null);
         this.rowType = RowType.of(new IntType(), new IntType(), new IntType());
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
@@ -47,7 +47,8 @@ public class RocksDBListStateTest {
 
     @Test
     void test() throws Exception {
-        RocksDBStateFactory factory = new RocksDBStateFactory(tempDir.toString(), new Options());
+        RocksDBStateFactory factory =
+                new RocksDBStateFactory(tempDir.toString(), new Options(), null);
 
         RowType keyType = RowType.of(DataTypes.STRING());
         RowType valueType = RowType.of(DataTypes.STRING());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/IndexBootstrapTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/IndexBootstrapTest.java
@@ -26,29 +26,34 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.DynamicBucketRow;
 import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.apache.paimon.CoreOptions.CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link IndexBootstrap}. */
 public class IndexBootstrapTest extends TableTestBase {
 
     @Test
-    public void test() throws Exception {
+    public void testBoostrap() throws Exception {
         Identifier identifier = identifier("T");
         Options options = new Options();
-        options.set(CoreOptions.BUCKET, 5);
+        options.set(CoreOptions.BUCKET, -1);
         Schema schema =
                 Schema.newBuilder()
+                        .column("pt", DataTypes.INT())
                         .column("col", DataTypes.INT())
                         .column("pk", DataTypes.INT())
                         .primaryKey("pk")
+                        .partitionKeys("pt")
                         .options(options.toMap())
                         .build();
         catalog.createTable(identifier, schema, true);
@@ -56,33 +61,57 @@ public class IndexBootstrapTest extends TableTestBase {
 
         write(
                 table,
-                GenericRow.of(1, 1),
-                GenericRow.of(2, 2),
-                GenericRow.of(3, 3),
-                GenericRow.of(4, 4),
-                GenericRow.of(5, 5),
-                GenericRow.of(6, 6),
-                GenericRow.of(7, 7));
+                row(1, 1, 1, 2),
+                row(1, 2, 2, 3),
+                row(1, 3, 3, 4),
+                row(2, 4, 4, 5),
+                row(2, 5, 5, 6),
+                row(3, 6, 6, 7),
+                row(3, 7, 7, 8));
 
         IndexBootstrap indexBootstrap = new IndexBootstrap(table);
         List<GenericRow> result = new ArrayList<>();
         Consumer<InternalRow> consumer =
-                row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1)));
+                row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2)));
 
         // output key and bucket
 
         indexBootstrap.bootstrap(2, 0, consumer);
-        assertThat(result).containsExactlyInAnyOrder(GenericRow.of(2, 4), GenericRow.of(3, 0));
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(7, 3, 8),
+                        GenericRow.of(5, 2, 6),
+                        GenericRow.of(1, 1, 2),
+                        GenericRow.of(3, 1, 4));
         result.clear();
 
         indexBootstrap.bootstrap(2, 1, consumer);
         assertThat(result)
                 .containsExactlyInAnyOrder(
-                        GenericRow.of(1, 3),
-                        GenericRow.of(4, 1),
-                        GenericRow.of(5, 1),
-                        GenericRow.of(6, 3),
-                        GenericRow.of(7, 1));
+                        GenericRow.of(2, 1, 3), GenericRow.of(4, 2, 5), GenericRow.of(6, 3, 7));
         result.clear();
+
+        // test bootstrap min partition
+        indexBootstrap =
+                new IndexBootstrap(
+                        table.copy(
+                                Collections.singletonMap(
+                                        CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION.key(),
+                                        "2")));
+
+        indexBootstrap.bootstrap(2, 0, consumer);
+        assertThat(result)
+                .containsExactlyInAnyOrder(GenericRow.of(7, 3, 8), GenericRow.of(5, 2, 6));
+        result.clear();
+
+        indexBootstrap.bootstrap(2, 1, consumer);
+        assertThat(result)
+                .containsExactlyInAnyOrder(GenericRow.of(4, 2, 5), GenericRow.of(6, 3, 7));
+        result.clear();
+    }
+
+    private DynamicBucketRow row(int pt, int col, int pk, int bucket) {
+        GenericRow row = GenericRow.of(pt, col, pk);
+        return new DynamicBucketRow(row, bucket);
     }
 }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Cross-partition-upsert Performance: For tables with a large amount of data, there will be a significant loss in performance. Moreover,
initialization takes a long time.

If your upsert does not rely on too old data, you can consider configuring index TTL and bootstrap-min-partition to
reduce Index and initialization time:
- `'cross-partition-upsert.index-ttl'`: The TTL in rocksdb index, this can avoid maintaining too many indexes and lead
  to worse and worse performance.
- `'cross-partition-upsert.bootstrap-min-partition'`: The min partition bootstrap of rocksdb index, bootstrap will only
  read the partitions above it, and the smaller partitions will not be read into the index. This can reduce job startup
  time and excessive initialization of index.

But please note that this may also cause data duplication.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
