### PR TITLE
[core] fix the issue that partitionExpire will fail when logOffsets is not empty.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -393,7 +393,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 Collections.emptyList(),
                 commitIdentifier,
                 null,
-                Collections.emptyMap());
+                new HashMap<>());
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -609,7 +609,8 @@ public class FileStoreCommitTest {
         store.commitData(
                 data.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
                 gen::getPartition,
-                kv -> 0);
+                kv -> 0,
+                Collections.singletonMap(0, 1L));
 
         // generate partitions to be dropped
         ThreadLocalRandom random = ThreadLocalRandom.current();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1976 

<!-- What is the purpose of the change -->
[core] fix the issue that partitionExpire will fail when logOffsets is not empty.

### Tests

<!-- List UT and IT cases to verify this change -->
Enhanced `org.apache.paimon.operation. FileStoreCommitTest#testDropPartitions` to verify the correctness when `logOffsets` is not empty.

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No