### PR TITLE
[core] Introduce PartitionPredicate to improve performance for multiple partitions

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -103,8 +103,10 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     @Override
     public FileStoreScan withPartitionFilter(Predicate predicate) {
-        if (partitionType.getFieldCount() > 0) {
+        if (partitionType.getFieldCount() > 0 && predicate != null) {
             this.partitionFilter = PartitionPredicate.fromPredicate(partitionType, predicate);
+        } else {
+            this.partitionFilter = null;
         }
         return this;
     }
@@ -113,6 +115,8 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     public FileStoreScan withPartitionFilter(List<BinaryRow> partitions) {
         if (partitionType.getFieldCount() > 0 && !partitions.isEmpty()) {
             this.partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
+        } else {
+            this.partitionFilter = null;
         }
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -103,13 +103,15 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     @Override
     public FileStoreScan withPartitionFilter(Predicate predicate) {
-        this.partitionFilter = PartitionPredicate.fromPredicate(partitionType, predicate);
+        if (partitionType.getFieldCount() > 0) {
+            this.partitionFilter = PartitionPredicate.fromPredicate(partitionType, predicate);
+        }
         return this;
     }
 
     @Override
     public FileStoreScan withPartitionFilter(List<BinaryRow> partitions) {
-        if (!partitions.isEmpty()) {
+        if (partitionType.getFieldCount() > 0 && !partitions.isEmpty()) {
             this.partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
         }
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -109,12 +109,10 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     @Override
     public FileStoreScan withPartitionFilter(List<BinaryRow> partitions) {
-        if (partitions.isEmpty()) {
-            return this;
-        } else {
+        if (!partitions.isEmpty()) {
             this.partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
-            return this;
         }
+        return this;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -112,7 +112,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         if (partitions.isEmpty()) {
             return this;
         } else {
-            this.partitionFilter = PartitionPredicate.fromPartitions(partitionType, partitions);
+            this.partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
             return this;
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -112,7 +112,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         if (partitions.isEmpty()) {
             return this;
         } else {
-            this.partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
+            this.partitionFilter = PartitionPredicate.fromPartitions(partitionType, partitions);
             return this;
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.format.FieldStats;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.statistics.FullFieldStatsCollector;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** A special predicate to filter partition only, just like {@link Predicate}. */
+public interface PartitionPredicate {
+
+    boolean test(BinaryRow part);
+
+    boolean test(long rowCount, FieldStats[] fieldStats);
+
+    static PartitionPredicate fromPredicate(RowType partitionType, Predicate predicate) {
+        return new DefaultPartitionPredicate(
+                new RowDataToObjectArrayConverter(partitionType), predicate);
+    }
+
+    static PartitionPredicate fromMultiple(RowType partitionType, List<BinaryRow> partitions) {
+        return new MultiplePartitionPredicate(
+                new RowDataToObjectArrayConverter(partitionType), new HashSet<>(partitions));
+    }
+
+    class DefaultPartitionPredicate implements PartitionPredicate {
+
+        private final RowDataToObjectArrayConverter converter;
+        private final Predicate predicate;
+
+        private DefaultPartitionPredicate(
+                RowDataToObjectArrayConverter converter, Predicate predicate) {
+            this.converter = converter;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean test(BinaryRow part) {
+            return predicate.test(converter.convert(part));
+        }
+
+        @Override
+        public boolean test(long rowCount, FieldStats[] fieldStats) {
+            return predicate.test(rowCount, fieldStats);
+        }
+    }
+
+    class MultiplePartitionPredicate implements PartitionPredicate {
+
+        private final Set<BinaryRow> partitions;
+
+        private final Predicate[] min;
+        private final Predicate[] max;
+
+        private MultiplePartitionPredicate(
+                RowDataToObjectArrayConverter converter, Set<BinaryRow> partitions) {
+            this.partitions = partitions;
+            RowType partitionType = converter.rowType();
+            int fieldNum = partitionType.getFieldCount();
+            @SuppressWarnings("unchecked")
+            Serializer<Object>[] serializers = new Serializer[fieldNum];
+            FullFieldStatsCollector[] collectors = new FullFieldStatsCollector[fieldNum];
+            min = new Predicate[fieldNum];
+            max = new Predicate[fieldNum];
+            for (int i = 0; i < fieldNum; i++) {
+                serializers[i] = InternalSerializers.create(partitionType.getTypeAt(i));
+                collectors[i] = new FullFieldStatsCollector();
+            }
+            for (BinaryRow part : partitions) {
+                Object[] fields = converter.convert(part);
+                for (int i = 0; i < fields.length; i++) {
+                    collectors[i].collect(fields[i], serializers[i]);
+                }
+            }
+            PredicateBuilder builder = new PredicateBuilder(partitionType);
+            for (int i = 0; i < collectors.length; i++) {
+                FieldStats stats = collectors[i].result();
+                min[i] = builder.greaterOrEqual(i, stats.minValue());
+                max[i] = builder.lessOrEqual(i, stats.maxValue());
+            }
+        }
+
+        @Override
+        public boolean test(BinaryRow part) {
+            return partitions.contains(part);
+        }
+
+        @Override
+        public boolean test(long rowCount, FieldStats[] fieldStats) {
+            for (int i = 0; i < fieldStats.length; i++) {
+                if (min[i].test(rowCount, fieldStats) && max[i].test(rowCount, fieldStats)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
@@ -118,6 +118,10 @@ public interface PartitionPredicate {
 
         @Override
         public boolean test(long rowCount, FieldStats[] fieldStats) {
+            if (fieldStats.length == 0) {
+                return true;
+            }
+
             for (int i = 0; i < fieldStats.length; i++) {
                 if (min[i].test(rowCount, fieldStats) && max[i].test(rowCount, fieldStats)) {
                     return true;

--- a/paimon-core/src/test/java/org/apache/paimon/partition/PartitionPredicateTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/partition/PartitionPredicateTest.java
@@ -29,7 +29,9 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
+import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.predicate.PredicateBuilder.and;
 import static org.apache.paimon.predicate.PredicateBuilder.or;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +40,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PartitionPredicateTest {
 
     @Test
-    public void test() {
+    public void testNoPartition() {
+        PartitionPredicate predicate =
+                PartitionPredicate.fromMultiple(RowType.of(), Collections.singletonList(EMPTY_ROW));
+
+        assertThat(predicate.test(EMPTY_ROW)).isTrue();
+        assertThat(predicate.test(1, new FieldStats[] {})).isTrue();
+    }
+
+    @Test
+    public void testPartition() {
         RowType type = DataTypes.ROW(DataTypes.INT(), DataTypes.INT());
         PredicateBuilder builder = new PredicateBuilder(type);
         Predicate predicate =

--- a/paimon-core/src/test/java/org/apache/paimon/partition/PartitionPredicateTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/partition/PartitionPredicateTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.format.FieldStats;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.predicate.PredicateBuilder.and;
+import static org.apache.paimon.predicate.PredicateBuilder.or;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link PartitionPredicate}. */
+public class PartitionPredicateTest {
+
+    @Test
+    public void test() {
+        RowType type = DataTypes.ROW(DataTypes.INT(), DataTypes.INT());
+        PredicateBuilder builder = new PredicateBuilder(type);
+        Predicate predicate =
+                or(
+                        and(builder.equal(0, 3), builder.equal(1, 5)),
+                        and(builder.equal(0, 4), builder.equal(1, 6)));
+
+        PartitionPredicate p1 = PartitionPredicate.fromPredicate(type, predicate);
+        PartitionPredicate p2 =
+                PartitionPredicate.fromMultiple(
+                        type, Arrays.asList(createPart(3, 5), createPart(4, 6)));
+
+        assertThat(vailidate(p1, p2, createPart(3, 4))).isFalse();
+        assertThat(vailidate(p1, p2, createPart(3, 5))).isTrue();
+        assertThat(vailidate(p1, p2, createPart(4, 6))).isTrue();
+        assertThat(vailidate(p1, p2, createPart(4, 5))).isFalse();
+
+        assertThat(
+                        vailidate(
+                                p1,
+                                new FieldStats[] {
+                                    new FieldStats(4, 8, 0L), new FieldStats(10, 12, 0L)
+                                }))
+                .isFalse();
+        assertThat(
+                        vailidate(
+                                p2,
+                                new FieldStats[] {
+                                    new FieldStats(4, 8, 0L), new FieldStats(10, 12, 0L)
+                                }))
+                .isTrue();
+        assertThat(
+                        vailidate(
+                                p2,
+                                new FieldStats[] {
+                                    new FieldStats(6, 8, 0L), new FieldStats(10, 12, 0L)
+                                }))
+                .isFalse();
+
+        assertThat(
+                        vailidate(
+                                p1,
+                                new FieldStats[] {
+                                    new FieldStats(4, 8, 0L), new FieldStats(5, 12, 0L)
+                                }))
+                .isTrue();
+        assertThat(
+                        vailidate(
+                                p2,
+                                new FieldStats[] {
+                                    new FieldStats(4, 8, 0L), new FieldStats(5, 12, 0L)
+                                }))
+                .isTrue();
+
+        assertThat(
+                        vailidate(
+                                p1,
+                                new FieldStats[] {
+                                    new FieldStats(1, 2, 0L), new FieldStats(2, 3, 0L)
+                                }))
+                .isFalse();
+        assertThat(
+                        vailidate(
+                                p2,
+                                new FieldStats[] {
+                                    new FieldStats(1, 2, 0L), new FieldStats(2, 3, 0L)
+                                }))
+                .isFalse();
+    }
+
+    private boolean vailidate(
+            PartitionPredicate predicate1, PartitionPredicate predicate2, BinaryRow part) {
+        boolean ret = predicate1.test(part);
+        assertThat(predicate2.test(part)).isEqualTo(ret);
+        return ret;
+    }
+
+    private boolean vailidate(PartitionPredicate predicate, FieldStats[] fieldStats) {
+        return predicate.test(3, fieldStats);
+    }
+
+    private static BinaryRow createPart(int i, int j) {
+        BinaryRow row = new BinaryRow(2);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        writer.writeInt(0, i);
+        writer.writeInt(1, j);
+        writer.complete();
+        return row;
+    }
+}


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

When considering tens of thousands of partitions, in Committer node:
- `FileStoreCommitImpl.readAllEntriesFromChangedPartitions` will read all partitions, the predicate will be tens of thousands of `OR`, this will be very low performance.
- We can optimize this by using specific `PartitionPredicate`.

<!-- What is the purpose of the change -->

### Tests

- `PartitionPredicateTest`.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
