### PR TITLE
[flink] Introduce fine-grained options to increase Committer heap memory only

### DIFF
--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -226,7 +226,7 @@ In the initialization of write, the writer of the bucket needs to read all histo
 here (For example, writing a large number of partitions simultaneously), you can use `write-manifest-cache` to cache
 the read manifest data to accelerate initialization.
 
-## Memory
+## Write Memory
 
 There are three main places in Paimon writer that takes up memory:
 
@@ -242,3 +242,14 @@ If your Flink job does not rely on state, please avoid using managed memory, whi
 ```shell
 taskmanager.memory.managed.size=1m
 ```
+
+## Commit Memory
+
+Committer node may use a large memory if the amount of data written to the table is particularly large, OOM may occur
+if the memory is too small. In this case, you need to increase the Committer heap memory, but you may not want to
+increase the memory of Flink's TaskManager uniformly, which may lead to a waste of memory.
+
+You can use fine-grained-resource-management of Flink to increase committer heap memory only:
+1. Configure Flink Configuration `cluster.fine-grained-resource-management.enabled: true`. (This is default after Flink 1.18)
+2. Configure Paimon Table Options: `sink.committer-cpu` (for example 1.0) and `sink.committer-memory` (for example 300 MB,
+   depends on your `TaskManager`).

--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -251,5 +251,5 @@ increase the memory of Flink's TaskManager uniformly, which may lead to a waste 
 
 You can use fine-grained-resource-management of Flink to increase committer heap memory only:
 1. Configure Flink Configuration `cluster.fine-grained-resource-management.enabled: true`. (This is default after Flink 1.18)
-2. Configure Paimon Table Options: `sink.committer-cpu` (for example 1.0) and `sink.committer-memory` (for example 300 MB,
-   depends on your `TaskManager`).
+2. Configure Paimon Table Options: `sink.committer-memory`, for example 300 MB, depends on your `TaskManager`.
+   (`sink.committer-cpu` is also supported)

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -129,6 +129,18 @@ under the License.
             <td>If no records flow in a partition of a stream for that amount of time, then that partition is considered "idle" and will not hold back the progress of watermarks in downstream operators.</td>
         </tr>
         <tr>
+            <td><h5>sink.committer-cpu</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Double</td>
+            <td>Sink committer cpu to control cpu cores of global committer.</td>
+        </tr>
+        <tr>
+            <td><h5>sink.committer-memory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Sink committer memory to control heap memory of global committer.</td>
+        </tr>
+        <tr>
             <td><h5>sink.managed.writer-buffer-memory</h5></td>
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -130,7 +130,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>sink.committer-cpu</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">1.0</td>
             <td>Double</td>
             <td>Sink committer cpu to control cpu cores of global committer.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/spark_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/spark_connector_configuration.html
@@ -27,6 +27,36 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>read.stream.maxBytesPerTrigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>The maximum number of bytes returned in a single batch.</td>
+        </tr>
+        <tr>
+            <td><h5>read.stream.maxFilesPerTrigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The maximum number of files returned in a single batch.</td>
+        </tr>
+        <tr>
+            <td><h5>read.stream.maxRowsPerTrigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>The maximum number of rows returned in a single batch.</td>
+        </tr>
+        <tr>
+            <td><h5>read.stream.maxTriggerDelayMs</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>The maximum delay between two adjacent batches, which used to create MinRowsReadLimit with read.stream.minRowsPerTrigger together.</td>
+        </tr>
+        <tr>
+            <td><h5>read.stream.minRowsPerTrigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>The minimum number of rows returned in a single batch, which used to create MinRowsReadLimit with read.stream.maxTriggerDelayMs together.</td>
+        </tr>
+        <tr>
             <td><h5>write.merge-schema</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -37,36 +67,6 @@ under the License.
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If true, allow to merge data types if the two types meet the rules for explicit casting.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxFilesPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The maximum number of files returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxBytesPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum number of bytes returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxRowsPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum number of rows returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.minRowsPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The minimum number of rows returned in a single batch, which used to create MinRowsReadLimit with read.stream.maxTriggerDelayMs together.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxTriggerDelayMs</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum delay between two adjacent batches, which used to create MinRowsReadLimit with read.stream.minRowsPerTrigger together.</td>
         </tr>
     </tbody>
 </table>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.action.cdc.mysql;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionBase;
 import org.apache.paimon.flink.action.MultiTablesSinkMode;
@@ -283,23 +282,15 @@ public class MySqlSyncDatabaseAction extends ActionBase {
 
         String database = this.database;
         MultiTablesSinkMode mode = this.mode;
-        FlinkCdcSyncDatabaseSinkBuilder<String> sinkBuilder =
-                new FlinkCdcSyncDatabaseSinkBuilder<String>()
-                        .withInput(
-                                env.fromSource(
-                                        source, WatermarkStrategy.noWatermarks(), "MySQL Source"))
-                        .withParserFactory(parserFactory)
-                        .withDatabase(database)
-                        .withCatalogLoader(catalogLoader())
-                        .withTables(fileStoreTables)
-                        .withMode(mode);
-
-        String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
-        if (sinkParallelism != null) {
-            sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));
-        }
-
-        sinkBuilder.build();
+        new FlinkCdcSyncDatabaseSinkBuilder<String>()
+                .withInput(env.fromSource(source, WatermarkStrategy.noWatermarks(), "MySQL Source"))
+                .withParserFactory(parserFactory)
+                .withDatabase(database)
+                .withCatalogLoader(catalogLoader())
+                .withTables(fileStoreTables)
+                .withMode(mode)
+                .withTableOptions(tableConfig)
+                .build();
     }
 
     private void validateCaseInsensitive() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -269,7 +269,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Double> SINK_COMMITTER_CPU =
             ConfigOptions.key("sink.committer-cpu")
                     .doubleType()
-                    .noDefaultValue()
+                    .defaultValue(1.0)
                     .withDescription(
                             "Sink committer cpu to control cpu cores of global committer.");
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -266,6 +266,20 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "If true, a tag will be automatically created for the snapshot created by flink savepoint.");
 
+    public static final ConfigOption<Double> SINK_COMMITTER_CPU =
+            ConfigOptions.key("sink.committer-cpu")
+                    .doubleType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Sink committer cpu to control cpu cores of global committer.");
+
+    public static final ConfigOption<MemorySize> SINK_COMMITTER_MEMORY =
+            ConfigOptions.key("sink.committer-memory")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Sink committer memory to control heap memory of global committer.");
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -215,13 +215,13 @@ public abstract class FlinkSink<T> implements Serializable {
 
     public static void configureGlobalCommitter(
             SingleOutputStreamOperator<?> committed,
-            @Nullable Double cpuCores,
+            double cpuCores,
             @Nullable MemorySize heapMemory) {
         committed.setParallelism(1).setMaxParallelism(1);
         if (heapMemory != null) {
             SlotSharingGroup slotSharingGroup =
                     SlotSharingGroup.newBuilder(committed.getName())
-                            .setCpuCores(1)
+                            .setCpuCores(cpuCores)
                             .setTaskHeapMemory(
                                     new org.apache.flink.configuration.MemorySize(
                                             heapMemory.getBytes()))

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -33,6 +33,7 @@ import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.sink.WrappedManifestCommittableSerializer;
 import org.apache.paimon.manifest.WrappedManifestCommittable;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -42,10 +43,13 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.UUID;
 
 import static org.apache.paimon.flink.sink.FlinkSink.assertStreamingConfiguration;
+import static org.apache.paimon.flink.sink.FlinkSink.configureGlobalCommitter;
 
 /**
  * A {@link FlinkSink} which accepts {@link CdcRecord} and waits for a schema change if necessary.
@@ -58,9 +62,16 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     private final boolean isOverwrite = false;
     private final Catalog.Loader catalogLoader;
+    @Nullable private final Double commitCpuCores;
+    @Nullable private final MemorySize commitHeapMemory;
 
-    public FlinkCdcMultiTableSink(Catalog.Loader catalogLoader) {
+    public FlinkCdcMultiTableSink(
+            Catalog.Loader catalogLoader,
+            @Nullable Double commitCpuCores,
+            @Nullable MemorySize commitHeapMemory) {
         this.catalogLoader = catalogLoader;
+        this.commitCpuCores = commitCpuCores;
+        this.commitHeapMemory = commitHeapMemory;
     }
 
     private StoreSinkWrite.WithWriteBufferProvider createWriteProvider() {
@@ -103,15 +114,14 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
         SingleOutputStreamOperator<?> committed =
                 written.transform(
-                                GLOBAL_COMMITTER_NAME,
-                                typeInfo,
-                                new CommitterOperator<>(
-                                        true,
-                                        commitUser,
-                                        createCommitterFactory(),
-                                        createCommittableStateManager()))
-                        .setParallelism(1)
-                        .setMaxParallelism(1);
+                        GLOBAL_COMMITTER_NAME,
+                        typeInfo,
+                        new CommitterOperator<>(
+                                true,
+                                commitUser,
+                                createCommitterFactory(),
+                                createCommittableStateManager()));
+        configureGlobalCommitter(committed, commitCpuCores, commitHeapMemory);
         return committed.addSink(new DiscardingSink<>()).name("end").setParallelism(1);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -62,12 +62,12 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     private final boolean isOverwrite = false;
     private final Catalog.Loader catalogLoader;
-    @Nullable private final Double commitCpuCores;
+    private final double commitCpuCores;
     @Nullable private final MemorySize commitHeapMemory;
 
     public FlinkCdcMultiTableSink(
             Catalog.Loader catalogLoader,
-            @Nullable Double commitCpuCores,
+            double commitCpuCores,
             @Nullable MemorySize commitHeapMemory) {
         this.catalogLoader = catalogLoader;
         this.commitCpuCores = commitCpuCores;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -64,7 +64,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     private List<FileStoreTable> tables = new ArrayList<>();
 
     @Nullable private Integer parallelism;
-    @Nullable private Double committerCpu;
+    private double committerCpu;
     @Nullable private MemorySize committerMemory;
 
     // Paimon catalog used to check and create tables. There will be two

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -57,6 +57,8 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
+import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_PARALLELISM;
+
 /** IT cases for {@link FlinkCdcSyncDatabaseSinkBuilder}. */
 public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
 
@@ -160,7 +162,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
                 .withTables(fileStoreTables)
                 // because we have at most 3 tables and 8 slots in AbstractTestBase
                 // each table can only get 2 slots
-                .withParallelism(2)
+                .withTableOptions(Collections.singletonMap(SINK_PARALLELISM.key(), "2"))
                 .withDatabase(DATABASE_NAME)
                 .withCatalogLoader(catalogLoader)
                 .build();


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Committer node may use a large memory if the amount of data written to the table is particularly large, OOM may occur
if the memory is too small. In this case, you need to increase the Committer heap memory, but you may not want to
increase the memory of Flink's TaskManager uniformly, which may lead to a waste of memory.

You can use fine-grained-resource-management of Flink to increase committer heap memory only:
1. Configure Flink Configuration `cluster.fine-grained-resource-management.enabled: true`. (This is default after Flink 1.18)
2. Configure Paimon Table Options: `sink.committer-cpu` (for example 1.0) and `sink.committer-memory` (for example 300 MB, depends on your `TaskManager`).


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
