### PR TITLE
[flink] Use InternalRow instead of RowData in sink sub topo

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
@@ -18,16 +18,18 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.DynamicBucketRow;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.table.data.RowData;
 
-/** A {@link PrepareCommitOperator} to write {@link RowData} with bucket. Record schema is fixed. */
-public class DynamicBucketRowWriteOperator extends TableWriteOperator<Tuple2<RowData, Integer>> {
+/**
+ * A {@link PrepareCommitOperator} to write {@link InternalRow} with bucket. Record schema is fixed.
+ */
+public class DynamicBucketRowWriteOperator
+        extends TableWriteOperator<Tuple2<InternalRow, Integer>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -44,9 +46,9 @@ public class DynamicBucketRowWriteOperator extends TableWriteOperator<Tuple2<Row
     }
 
     @Override
-    public void processElement(StreamRecord<Tuple2<RowData, Integer>> element) throws Exception {
-        FlinkRowWrapper internalRow = new FlinkRowWrapper(element.getValue().f0);
-        DynamicBucketRow row = new DynamicBucketRow(internalRow, element.getValue().f1);
+    public void processElement(StreamRecord<Tuple2<InternalRow, Integer>> element)
+            throws Exception {
+        DynamicBucketRow row = new DynamicBucketRow(element.getValue().f0, element.getValue().f1);
         write.write(row);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FileStoreSink.java
@@ -18,17 +18,17 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;
 
 import java.util.Map;
 
 /** {@link FlinkSink} for writing records into paimon. */
-public class FileStoreSink extends FlinkWriteSink<RowData> {
+public class FileStoreSink extends FlinkWriteSink<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
@@ -43,7 +43,7 @@ public class FileStoreSink extends FlinkWriteSink<RowData> {
     }
 
     @Override
-    protected OneInputStreamOperator<RowData, Committable> createWriteOperator(
+    protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MapToInternalRow.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MapToInternalRow.java
@@ -32,6 +32,7 @@ public class MapToInternalRow {
 
     public static DataStream<InternalRow> map(DataStream<RowData> input, RowType rowType) {
         return input.map((MapFunction<RowData, InternalRow>) FlinkRowWrapper::new)
+                .setParallelism(input.getParallelism())
                 .returns(InternalTypeInfo.fromRowType(rowType));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataChannelComputer.java
@@ -19,13 +19,13 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.FixedBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.KeyAndBucketExtractor;
 
-import org.apache.flink.table.data.RowData;
-
-/** {@link ChannelComputer} for {@link RowData}. */
-public class RowDataChannelComputer implements ChannelComputer<RowData> {
+/** {@link ChannelComputer} for {@link InternalRow}. */
+public class RowDataChannelComputer implements ChannelComputer<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
@@ -33,7 +33,7 @@ public class RowDataChannelComputer implements ChannelComputer<RowData> {
     private final boolean hasLogSink;
 
     private transient int numChannels;
-    private transient KeyAndBucketExtractor<RowData> extractor;
+    private transient KeyAndBucketExtractor<InternalRow> extractor;
 
     public RowDataChannelComputer(TableSchema schema, boolean hasLogSink) {
         this.schema = schema;
@@ -43,11 +43,11 @@ public class RowDataChannelComputer implements ChannelComputer<RowData> {
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
-        this.extractor = new RowDataKeyAndBucketExtractor(schema);
+        this.extractor = new FixedBucketRowKeyExtractor(schema);
     }
 
     @Override
-    public int channel(RowData record) {
+    public int channel(InternalRow record) {
         extractor.setRecord(record);
         return channel(extractor.partition(), extractor.bucket());
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.log.LogWriteCallback;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
@@ -37,7 +37,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
-import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;
 
@@ -45,8 +44,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-/** A {@link PrepareCommitOperator} to write {@link RowData}. Record schema is fixed. */
-public class RowDataStoreWriteOperator extends TableWriteOperator<RowData> {
+/** A {@link PrepareCommitOperator} to write {@link InternalRow}. Record schema is fixed. */
+public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
 
     private static final long serialVersionUID = 3L;
 
@@ -115,12 +114,12 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<RowData> {
     }
 
     @Override
-    public void processElement(StreamRecord<RowData> element) throws Exception {
+    public void processElement(StreamRecord<InternalRow> element) throws Exception {
         sinkContext.timestamp = element.hasTimestamp() ? element.getTimestamp() : null;
 
         SinkRecord record;
         try {
-            record = write.write(new FlinkRowWrapper(element.getValue()));
+            record = write.write(element.getValue());
         } catch (Exception e) {
             throw new IOException(e);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -18,21 +18,22 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;
 
 import java.util.Map;
 
 /** Sink for dynamic bucket table. */
-public class RowDynamicBucketSink extends DynamicBucketSink<RowData> {
+public class RowDynamicBucketSink extends DynamicBucketSink<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
@@ -42,23 +43,23 @@ public class RowDynamicBucketSink extends DynamicBucketSink<RowData> {
     }
 
     @Override
-    protected ChannelComputer<RowData> channelComputer1() {
+    protected ChannelComputer<InternalRow> channelComputer1() {
         return new RowHashKeyChannelComputer(table.schema());
     }
 
     @Override
-    protected ChannelComputer<Tuple2<RowData, Integer>> channelComputer2() {
+    protected ChannelComputer<Tuple2<InternalRow, Integer>> channelComputer2() {
         return new RowWithBucketChannelComputer(table.schema());
     }
 
     @Override
-    protected SerializableFunction<TableSchema, PartitionKeyExtractor<RowData>>
+    protected SerializableFunction<TableSchema, PartitionKeyExtractor<InternalRow>>
             extractorFunction() {
-        return RowDataPartitionKeyExtractor::new;
+        return RowPartitionKeyExtractor::new;
     }
 
     @Override
-    protected OneInputStreamOperator<Tuple2<RowData, Integer>, Committable> createWriteOperator(
+    protected OneInputStreamOperator<Tuple2<InternalRow, Integer>, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new DynamicBucketRowWriteOperator(table, writeProvider, commitUser);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowHashKeyChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowHashKeyChannelComputer.java
@@ -18,19 +18,21 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 
 import org.apache.flink.table.data.RowData;
 
 /** Hash key of a {@link RowData}. */
-public class RowHashKeyChannelComputer implements ChannelComputer<RowData> {
+public class RowHashKeyChannelComputer implements ChannelComputer<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
     private final TableSchema schema;
 
     private transient int numChannels;
-    private transient RowDataPartitionKeyExtractor extractor;
+    private transient RowPartitionKeyExtractor extractor;
 
     public RowHashKeyChannelComputer(TableSchema schema) {
         this.schema = schema;
@@ -39,11 +41,11 @@ public class RowHashKeyChannelComputer implements ChannelComputer<RowData> {
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
-        this.extractor = new RowDataPartitionKeyExtractor(schema);
+        this.extractor = new RowPartitionKeyExtractor(schema);
     }
 
     @Override
-    public int channel(RowData record) {
+    public int channel(InternalRow record) {
         int hash = extractor.trimmedPrimaryKey(record).hashCode();
         return Math.abs(hash % numChannels);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowWithBucketChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowWithBucketChannelComputer.java
@@ -18,20 +18,22 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.data.RowData;
 
 /** Hash key of a {@link RowData} with bucket. */
-public class RowWithBucketChannelComputer implements ChannelComputer<Tuple2<RowData, Integer>> {
+public class RowWithBucketChannelComputer implements ChannelComputer<Tuple2<InternalRow, Integer>> {
 
     private static final long serialVersionUID = 1L;
 
     private final TableSchema schema;
 
     private transient int numChannels;
-    private transient RowDataPartitionKeyExtractor extractor;
+    private transient RowPartitionKeyExtractor extractor;
 
     public RowWithBucketChannelComputer(TableSchema schema) {
         this.schema = schema;
@@ -40,11 +42,11 @@ public class RowWithBucketChannelComputer implements ChannelComputer<Tuple2<RowD
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
-        this.extractor = new RowDataPartitionKeyExtractor(schema);
+        this.extractor = new RowPartitionKeyExtractor(schema);
     }
 
     @Override
-    public int channel(Tuple2<RowData, Integer> record) {
+    public int channel(Tuple2<InternalRow, Integer> record) {
         return ChannelComputer.select(extractor.partition(record.f0), record.f1, numChannels);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketWriteSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.compact.UnawareBucketCompactionTopoBuilder;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.table.data.RowData;
 
 import java.util.Map;
 
@@ -53,7 +53,7 @@ public class UnawareBucketWriteSink extends FileStoreSink {
     }
 
     @Override
-    public DataStreamSink<?> sinkFrom(DataStream<RowData> input, String initialCommitUser) {
+    public DataStreamSink<?> sinkFrom(DataStream<InternalRow> input, String initialCommitUser) {
         // do the actually writing action, no snapshot generated in this stage
         DataStream<Committable> written = doWrite(input, initialCommitUser, parallelism);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
@@ -18,12 +18,13 @@
 
 package org.apache.paimon.flink.sink.index;
 
-import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.DynamicBucketRowWriteOperator;
 import org.apache.paimon.flink.sink.FlinkWriteSink;
 import org.apache.paimon.flink.sink.RowWithBucketChannelComputer;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.flink.utils.InternalRowTypeSerializer;
 import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
@@ -35,8 +36,6 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 
 import javax.annotation.Nullable;
 
@@ -44,12 +43,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
 import static org.apache.paimon.flink.sink.index.IndexBootstrap.bootstrapType;
 
 /** Sink for global dynamic bucket table. */
-public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<RowData, Integer>> {
+public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<InternalRow, Integer>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -59,34 +57,34 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<RowData, Inte
     }
 
     @Override
-    protected OneInputStreamOperator<Tuple2<RowData, Integer>, Committable> createWriteOperator(
+    protected OneInputStreamOperator<Tuple2<InternalRow, Integer>, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new DynamicBucketRowWriteOperator(table, writeProvider, commitUser);
     }
 
-    public DataStreamSink<?> build(DataStream<RowData> input, @Nullable Integer parallelism) {
+    public DataStreamSink<?> build(DataStream<InternalRow> input, @Nullable Integer parallelism) {
         String initialCommitUser = UUID.randomUUID().toString();
 
         TableSchema schema = table.schema();
         RowType rowType = schema.logicalRowType();
         List<String> primaryKeys = schema.primaryKeys();
-        RowDataSerializer rowSerializer = new RowDataSerializer(toLogicalType(rowType));
+        InternalRowTypeSerializer rowSerializer = new InternalRowTypeSerializer(rowType);
 
         RowType bootstrapType = bootstrapType(schema);
-        RowDataSerializer bootstrapSerializer = new RowDataSerializer(toLogicalType(bootstrapType));
+        InternalRowTypeSerializer bootstrapSerializer =
+                new InternalRowTypeSerializer(bootstrapType);
 
         // Topology:
         // input -- bootstrap -- shuffle by key hash --> bucket-assigner -- shuffle by bucket -->
         // writer --> committer
 
-        DataStream<Tuple2<KeyPartOrRow, RowData>> bootstraped =
+        DataStream<Tuple2<KeyPartOrRow, InternalRow>> bootstraped =
                 input.transform(
                                 "INDEX_BOOTSTRAP",
                                 new InternalTypeInfo<>(
                                         new KeyWithRowSerializer<>(
                                                 bootstrapSerializer, rowSerializer)),
-                                new IndexBootstrapOperator<>(
-                                        new IndexBootstrap(table), FlinkRowData::new))
+                                new IndexBootstrapOperator<>(new IndexBootstrap(table), r -> r))
                         .setParallelism(input.getParallelism());
 
         // 1. shuffle by key hash
@@ -97,13 +95,13 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<RowData, Inte
 
         KeyPartRowChannelComputer channelComputer =
                 new KeyPartRowChannelComputer(rowType, bootstrapType, primaryKeys);
-        DataStream<Tuple2<KeyPartOrRow, RowData>> partitionByKeyHash =
+        DataStream<Tuple2<KeyPartOrRow, InternalRow>> partitionByKeyHash =
                 partition(bootstraped, channelComputer, assignerParallelism);
 
         // 2. bucket-assigner
-        TupleTypeInfo<Tuple2<RowData, Integer>> rowWithBucketType =
+        TupleTypeInfo<Tuple2<InternalRow, Integer>> rowWithBucketType =
                 new TupleTypeInfo<>(input.getType(), BasicTypeInfo.INT_TYPE_INFO);
-        DataStream<Tuple2<RowData, Integer>> bucketAssigned =
+        DataStream<Tuple2<InternalRow, Integer>> bucketAssigned =
                 partitionByKeyHash
                         .transform(
                                 "dynamic-bucket-assigner",
@@ -113,7 +111,7 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<RowData, Inte
 
         // 3. shuffle by bucket
 
-        DataStream<Tuple2<RowData, Integer>> partitionByBucket =
+        DataStream<Tuple2<InternalRow, Integer>> partitionByBucket =
                 partition(bucketAssigned, new RowWithBucketChannelComputer(schema), parallelism);
 
         // 4. writer and committer

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/KeyPartPartitionKeyExtractor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/KeyPartPartitionKeyExtractor.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.sink.index;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.Projection;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
 import org.apache.paimon.types.RowType;
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** A {@link PartitionKeyExtractor} to {@link RowData} with only key and partiton fields. */
-public class KeyPartPartitionKeyExtractor implements PartitionKeyExtractor<RowData> {
+public class KeyPartPartitionKeyExtractor implements PartitionKeyExtractor<InternalRow> {
 
     private final Projection partitionProjection;
     private final Projection keyProjection;
@@ -50,12 +50,12 @@ public class KeyPartPartitionKeyExtractor implements PartitionKeyExtractor<RowDa
     }
 
     @Override
-    public BinaryRow partition(RowData record) {
-        return partitionProjection.apply(new FlinkRowWrapper(record));
+    public BinaryRow partition(InternalRow record) {
+        return partitionProjection.apply(record);
     }
 
     @Override
-    public BinaryRow trimmedPrimaryKey(RowData record) {
-        return keyProjection.apply(new FlinkRowWrapper(record));
+    public BinaryRow trimmedPrimaryKey(InternalRow record) {
+        return keyProjection.apply(record);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/KeyPartRowChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/KeyPartRowChannelComputer.java
@@ -21,17 +21,17 @@ package org.apache.paimon.flink.sink.index;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.Projection;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.sink.ChannelComputer;
 import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.table.data.RowData;
 
 import java.util.List;
 
 /** A {@link ChannelComputer} for KeyPartOrRow and row. */
-public class KeyPartRowChannelComputer implements ChannelComputer<Tuple2<KeyPartOrRow, RowData>> {
+public class KeyPartRowChannelComputer
+        implements ChannelComputer<Tuple2<KeyPartOrRow, InternalRow>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -58,10 +58,9 @@ public class KeyPartRowChannelComputer implements ChannelComputer<Tuple2<KeyPart
     }
 
     @Override
-    public int channel(Tuple2<KeyPartOrRow, RowData> record) {
+    public int channel(Tuple2<KeyPartOrRow, InternalRow> record) {
         BinaryRow key =
-                (record.f0 == KeyPartOrRow.KEY_PART ? keyPartProject : rowProject)
-                        .apply(new FlinkRowWrapper(record.f1));
+                (record.f0 == KeyPartOrRow.KEY_PART ? keyPartProject : rowProject).apply(record.f1);
         return Math.abs(key.hashCode() % numChannels);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/OrderSorter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/OrderSorter.java
@@ -21,10 +21,8 @@ package org.apache.paimon.flink.sorter;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkRowWrapper;
-import org.apache.paimon.flink.utils.InternalRowTypeSerializer;
 import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.KeyComparatorSupplier;
 import org.apache.paimon.utils.Projection;
@@ -59,9 +57,7 @@ public class OrderSorter extends TableSorter {
                 origin,
                 table,
                 keyRowType,
-                new InternalTypeInfo<>(
-                        new InternalRowTypeSerializer(
-                                keyRowType.getFieldTypes().toArray(new DataType[0]))),
+                InternalTypeInfo.fromRowType(keyRowType),
                 new KeyComparatorSupplier(keyRowType),
                 new SortUtils.KeyAbstract<InternalRow>() {
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -25,11 +25,9 @@ import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowWrapper;
 import org.apache.paimon.flink.shuffle.RangeShuffle;
-import org.apache.paimon.flink.utils.InternalRowTypeSerializer;
 import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.KeyProjectedRow;
 import org.apache.paimon.utils.SerializableSupplier;
@@ -114,9 +112,7 @@ public class SortUtils {
         fields.addAll(dataFields);
         final RowType longRowType = new RowType(fields);
         final InternalTypeInfo<InternalRow> internalRowType =
-                new InternalTypeInfo<>(
-                        new InternalRowTypeSerializer(
-                                longRowType.getFieldTypes().toArray(new DataType[0])));
+                InternalTypeInfo.fromRowType(longRowType);
 
         // generate the KEY as the key of Pair.
         DataStream<Tuple2<KEY, RowData>> inputWithKey =
@@ -177,9 +173,7 @@ public class SortUtils {
                                 return keyProjectedRow.replaceRow(value);
                             }
                         },
-                        new InternalTypeInfo<>(
-                                new InternalRowTypeSerializer(
-                                        valueRowType.getFieldTypes().toArray(new DataType[0]))))
+                        InternalTypeInfo.fromRowType(valueRowType))
                 .setParallelism(sinkParallelism)
                 .map(FlinkRowData::new, inputStream.getType())
                 .setParallelism(sinkParallelism);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/InternalRowTypeSerializer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/InternalRowTypeSerializer.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -35,6 +36,10 @@ import java.util.Objects;
 public class InternalRowTypeSerializer extends InternalTypeSerializer<InternalRow> {
 
     private final InternalRowSerializer internalRowSerializer;
+
+    public InternalRowTypeSerializer(RowType rowType) {
+        this(rowType.getFieldTypes().toArray(new DataType[0]));
+    }
 
     public InternalRowTypeSerializer(DataType... types) {
         internalRowSerializer = new InternalRowSerializer(types);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/InternalTypeInfo.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/InternalTypeInfo.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.flink.utils;
 
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.RowType;
+
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -33,6 +36,10 @@ public class InternalTypeInfo<T> extends TypeInformation<T> {
 
     public InternalTypeInfo(InternalTypeSerializer<T> serializer) {
         this.serializer = serializer;
+    }
+
+    public static InternalTypeInfo<InternalRow> fromRowType(RowType rowType) {
+        return new InternalTypeInfo<>(new InternalRowTypeSerializer(rowType));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
@@ -45,8 +45,6 @@ public class GlobalDynamicBucketTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testWriteRead() {
-        setParallelism(1);
-
         sql("INSERT INTO T VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
         assertThat(sql("SELECT * FROM T"))
                 .containsExactlyInAnyOrder(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
@@ -45,6 +45,8 @@ public class GlobalDynamicBucketTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testWriteRead() {
+        setParallelism(1);
+
         sql("INSERT INTO T VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
         assertThat(sql("SELECT * FROM T"))
                 .containsExactlyInAnyOrder(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -20,7 +20,7 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.GenericRow;
-import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.operation.KeyValueFileStoreWrite;
@@ -48,7 +48,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorStateStore;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
-import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -82,10 +81,10 @@ public class FlinkSinkTest {
     private boolean testSpillable(
             StreamExecutionEnvironment streamExecutionEnvironment, FileStoreTable fileStoreTable)
             throws Exception {
-        DataStreamSource<RowData> source =
+        DataStreamSource<InternalRow> source =
                 streamExecutionEnvironment.fromCollection(
-                        Collections.singletonList(new FlinkRowData(GenericRow.of(1, 1))));
-        FlinkSink<RowData> flinkSink = new FileStoreSink(fileStoreTable, null, null);
+                        Collections.singletonList(GenericRow.of(1, 1)));
+        FlinkSink<InternalRow> flinkSink = new FileStoreSink(fileStoreTable, null, null);
         SingleOutputStreamOperator<Committable> written = flinkSink.doWrite(source, "123", 1);
         RowDataStoreWriteOperator operator =
                 ((RowDataStoreWriteOperator)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerTest.java
@@ -21,15 +21,15 @@ package org.apache.paimon.flink.sink.index;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -44,12 +44,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link GlobalIndexAssigner}. */
 public class GlobalIndexAssignerTest extends TableTestBase {
 
-    private GlobalIndexAssigner<RowData> createAssigner(MergeEngine mergeEngine) throws Exception {
+    private GlobalIndexAssigner<InternalRow> createAssigner(MergeEngine mergeEngine)
+            throws Exception {
         return createAssigner(mergeEngine, false);
     }
 
-    private GlobalIndexAssigner<RowData> createAssigner(MergeEngine mergeEngine, boolean enableTtl)
-            throws Exception {
+    private GlobalIndexAssigner<InternalRow> createAssigner(
+            MergeEngine mergeEngine, boolean enableTtl) throws Exception {
         Identifier identifier = identifier("T");
         Options options = new Options();
         options.set(CoreOptions.MERGE_ENGINE, mergeEngine);
@@ -85,31 +86,32 @@ public class GlobalIndexAssignerTest extends TableTestBase {
     }
 
     private void innerTestBucketAssign(boolean enableTtl) throws Exception {
-        GlobalIndexAssigner<RowData> assigner = createAssigner(MergeEngine.DEDUPLICATE, enableTtl);
+        GlobalIndexAssigner<InternalRow> assigner =
+                createAssigner(MergeEngine.DEDUPLICATE, enableTtl);
         List<Integer> output = new ArrayList<>();
         assigner.open(new File(warehouse.getPath()), 2, 0, (row, bucket) -> output.add(bucket));
 
         // assign
-        assigner.process(GenericRowData.of(1, 1, 1));
-        assigner.process(GenericRowData.of(1, 2, 2));
-        assigner.process(GenericRowData.of(1, 3, 3));
+        assigner.process(GenericRow.of(1, 1, 1));
+        assigner.process(GenericRow.of(1, 2, 2));
+        assigner.process(GenericRow.of(1, 3, 3));
         assertThat(output).containsExactly(0, 0, 0);
         output.clear();
 
         // full
-        assigner.process(GenericRowData.of(1, 4, 4));
+        assigner.process(GenericRow.of(1, 4, 4));
         assertThat(output).containsExactly(2);
         output.clear();
 
         // another partition
-        assigner.process(GenericRowData.of(2, 5, 5));
+        assigner.process(GenericRow.of(2, 5, 5));
         assertThat(output).containsExactly(0);
         output.clear();
 
         // read assigned
-        assigner.process(GenericRowData.of(1, 4, 4));
-        assigner.process(GenericRowData.of(1, 2, 2));
-        assigner.process(GenericRowData.of(1, 3, 3));
+        assigner.process(GenericRow.of(1, 4, 4));
+        assigner.process(GenericRow.of(1, 2, 2));
+        assigner.process(GenericRow.of(1, 3, 3));
         assertThat(output).containsExactly(2, 0, 0);
         output.clear();
 
@@ -118,8 +120,8 @@ public class GlobalIndexAssignerTest extends TableTestBase {
 
     @Test
     public void testUpsert() throws Exception {
-        GlobalIndexAssigner<RowData> assigner = createAssigner(MergeEngine.DEDUPLICATE);
-        List<Tuple2<RowData, Integer>> output = new ArrayList<>();
+        GlobalIndexAssigner<InternalRow> assigner = createAssigner(MergeEngine.DEDUPLICATE);
+        List<Tuple2<InternalRow, Integer>> output = new ArrayList<>();
         assigner.open(
                 new File(warehouse.getPath()),
                 2,
@@ -127,32 +129,32 @@ public class GlobalIndexAssignerTest extends TableTestBase {
                 (row, bucket) -> output.add(new Tuple2<>(row, bucket)));
 
         // change partition
-        assigner.process(GenericRowData.of(1, 1, 1));
-        assigner.process(GenericRowData.of(2, 1, 2));
+        assigner.process(GenericRow.of(1, 1, 1));
+        assigner.process(GenericRow.of(2, 1, 2));
         assertThat(output)
                 .containsExactly(
-                        new Tuple2<>(GenericRowData.of(1, 1, 1), 0),
-                        new Tuple2<>(GenericRowData.ofKind(RowKind.DELETE, 1, 1, 2), 0),
-                        new Tuple2<>(GenericRowData.of(2, 1, 2), 0));
+                        new Tuple2<>(GenericRow.of(1, 1, 1), 0),
+                        new Tuple2<>(GenericRow.ofKind(RowKind.DELETE, 1, 1, 2), 0),
+                        new Tuple2<>(GenericRow.of(2, 1, 2), 0));
         output.clear();
 
         // test partition 1 deleted
-        assigner.process(GenericRowData.of(1, 2, 2));
-        assigner.process(GenericRowData.of(1, 3, 3));
-        assigner.process(GenericRowData.of(1, 4, 4));
+        assigner.process(GenericRow.of(1, 2, 2));
+        assigner.process(GenericRow.of(1, 3, 3));
+        assigner.process(GenericRow.of(1, 4, 4));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0, 0, 0);
         output.clear();
 
         // move from full bucket
-        assigner.process(GenericRowData.of(2, 4, 4));
+        assigner.process(GenericRow.of(2, 4, 4));
         assertThat(output)
                 .containsExactly(
-                        new Tuple2<>(GenericRowData.ofKind(RowKind.DELETE, 1, 4, 4), 0),
-                        new Tuple2<>(GenericRowData.of(2, 4, 4), 0));
+                        new Tuple2<>(GenericRow.ofKind(RowKind.DELETE, 1, 4, 4), 0),
+                        new Tuple2<>(GenericRow.of(2, 4, 4), 0));
         output.clear();
 
         // test partition 1 deleted
-        assigner.process(GenericRowData.of(1, 5, 5));
+        assigner.process(GenericRow.of(1, 5, 5));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0);
         output.clear();
 
@@ -165,8 +167,8 @@ public class GlobalIndexAssignerTest extends TableTestBase {
                 ThreadLocalRandom.current().nextBoolean()
                         ? MergeEngine.PARTIAL_UPDATE
                         : MergeEngine.AGGREGATE;
-        GlobalIndexAssigner<RowData> assigner = createAssigner(mergeEngine);
-        List<Tuple2<RowData, Integer>> output = new ArrayList<>();
+        GlobalIndexAssigner<InternalRow> assigner = createAssigner(mergeEngine);
+        List<Tuple2<InternalRow, Integer>> output = new ArrayList<>();
         assigner.open(
                 new File(warehouse.getPath()),
                 2,
@@ -174,18 +176,18 @@ public class GlobalIndexAssignerTest extends TableTestBase {
                 (row, bucket) -> output.add(new Tuple2<>(row, bucket)));
 
         // change partition
-        assigner.process(GenericRowData.of(1, 1, 1));
-        assigner.process(GenericRowData.of(2, 1, 2));
+        assigner.process(GenericRow.of(1, 1, 1));
+        assigner.process(GenericRow.of(2, 1, 2));
         assertThat(output)
                 .containsExactly(
-                        new Tuple2<>(GenericRowData.of(1, 1, 1), 0),
-                        new Tuple2<>(GenericRowData.of(1, 1, 2), 0));
+                        new Tuple2<>(GenericRow.of(1, 1, 1), 0),
+                        new Tuple2<>(GenericRow.of(1, 1, 2), 0));
         output.clear();
 
         // test partition 2 no effect
-        assigner.process(GenericRowData.of(2, 2, 2));
-        assigner.process(GenericRowData.of(2, 3, 3));
-        assigner.process(GenericRowData.of(2, 4, 4));
+        assigner.process(GenericRow.of(2, 2, 2));
+        assigner.process(GenericRow.of(2, 3, 3));
+        assigner.process(GenericRow.of(2, 4, 4));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0, 0, 0);
         output.clear();
         assigner.close();
@@ -193,8 +195,8 @@ public class GlobalIndexAssignerTest extends TableTestBase {
 
     @Test
     public void testFirstRow() throws Exception {
-        GlobalIndexAssigner<RowData> assigner = createAssigner(MergeEngine.FIRST_ROW);
-        List<Tuple2<RowData, Integer>> output = new ArrayList<>();
+        GlobalIndexAssigner<InternalRow> assigner = createAssigner(MergeEngine.FIRST_ROW);
+        List<Tuple2<InternalRow, Integer>> output = new ArrayList<>();
         assigner.open(
                 new File(warehouse.getPath()),
                 2,
@@ -202,15 +204,15 @@ public class GlobalIndexAssignerTest extends TableTestBase {
                 (row, bucket) -> output.add(new Tuple2<>(row, bucket)));
 
         // change partition
-        assigner.process(GenericRowData.of(1, 1, 1));
-        assigner.process(GenericRowData.of(2, 1, 2));
-        assertThat(output).containsExactly(new Tuple2<>(GenericRowData.of(1, 1, 1), 0));
+        assigner.process(GenericRow.of(1, 1, 1));
+        assigner.process(GenericRow.of(2, 1, 2));
+        assertThat(output).containsExactly(new Tuple2<>(GenericRow.of(1, 1, 1), 0));
         output.clear();
 
         // test partition 2 no effect
-        assigner.process(GenericRowData.of(2, 2, 2));
-        assigner.process(GenericRowData.of(2, 3, 3));
-        assigner.process(GenericRowData.of(2, 4, 4));
+        assigner.process(GenericRow.of(2, 2, 2));
+        assigner.process(GenericRow.of(2, 3, 3));
+        assigner.process(GenericRow.of(2, 4, 4));
         assertThat(output.stream().map(t -> t.f1)).containsExactly(0, 0, 0);
         output.clear();
         assigner.close();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This can avoid many conversion cost between InternalRow and RowData.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
