### PR TITLE
[core] fix ArrayIndexOutOfBoundsException when sequenceGroup repeat d…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -214,7 +214,10 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                                                             "Field %s is defined repeatedly by multiple groups: %s",
                                                             fieldNames.get(field), k));
                                         }
-                                        fieldSequences.put(field, sequenceGen);
+
+                                        if (field >= 0) {
+                                            fieldSequences.put(field, sequenceGen);
+                                        }
                                     });
 
                     // add self

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -205,7 +205,17 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                     SequenceGenerator sequenceGen =
                             new SequenceGenerator(sequenceFieldName, rowType);
                     Arrays.stream(v.split(","))
-                            .map(fieldNames::indexOf)
+                            .map(
+                                    fieldName -> {
+                                        int field = fieldNames.indexOf(fieldName);
+                                        if (field == -1) {
+                                            throw new IllegalArgumentException(
+                                                    String.format(
+                                                            "Field %s can not be found in table schema",
+                                                            fieldName));
+                                        }
+                                        return field;
+                                    })
                             .forEach(
                                     field -> {
                                         if (fieldSequences.containsKey(field)) {
@@ -214,10 +224,7 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                                                             "Field %s is defined repeatedly by multiple groups: %s",
                                                             fieldNames.get(field), k));
                                         }
-
-                                        if (field >= 0) {
-                                            fieldSequences.put(field, sequenceGen);
-                                        }
+                                        fieldSequences.put(field, sequenceGen);
                                     });
 
                     // add self

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -91,6 +91,24 @@ public class PartialUpdateMergeFunctionTest {
     }
 
     @Test
+    public void testSequenceGroupDefinedNoField() {
+        Options options = new Options();
+        options.set("fields.f3.sequence-group", "f1,f2,f7");
+        options.set("fields.f6.sequence-group", "f4,f5");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        assertThatThrownBy(() -> PartialUpdateMergeFunction.factory(options, rowType))
+                .hasMessageContaining("can not be found in table schema");
+    }
+
+    @Test
     public void testSequenceGroupRepeatDefine() {
         Options options = new Options();
         options.set("fields.f3.sequence-group", "f1,f2");
@@ -104,33 +122,6 @@ public class PartialUpdateMergeFunctionTest {
                         DataTypes.INT());
         assertThatThrownBy(() -> PartialUpdateMergeFunction.factory(options, rowType))
                 .hasMessageContaining("is defined repeatedly by multiple groups");
-    }
-
-    @Test
-    public void testSequenceGroupRepeatDefineNoField() {
-        Options options = new Options();
-        options.set("fields.f3.sequence-group", "f1,f2,f6");
-        options.set("fields.f5.sequence-group", "f4,f6");
-        RowType rowType =
-                RowType.of(
-                        DataTypes.INT(),
-                        DataTypes.INT(),
-                        DataTypes.INT(),
-                        DataTypes.INT(),
-                        DataTypes.INT(),
-                        DataTypes.INT());
-        MergeFunction<KeyValue> func =
-                PartialUpdateMergeFunction.factory(options, rowType).create();
-        func.reset();
-        add(func, 1, 1, 1, 1, 1, 1);
-        add(func, 1, 2, 2, 2, 2, null);
-        validate(func, 1, 2, 2, 2, 1, 1);
-        add(func, 1, 3, 3, 1, 3, 3);
-        validate(func, 1, 2, 2, 2, 3, 3);
-
-        // delete
-        add(func, RowKind.DELETE, 1, 1, 1, 3, 1, null);
-        validate(func, 1, null, null, 3, 3, 3);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -107,6 +107,33 @@ public class PartialUpdateMergeFunctionTest {
     }
 
     @Test
+    public void testSequenceGroupRepeatDefineNoField() {
+        Options options = new Options();
+        options.set("fields.f3.sequence-group", "f1,f2,f6");
+        options.set("fields.f5.sequence-group", "f4,f6");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        MergeFunction<KeyValue> func =
+                PartialUpdateMergeFunction.factory(options, rowType).create();
+        func.reset();
+        add(func, 1, 1, 1, 1, 1, 1);
+        add(func, 1, 2, 2, 2, 2, null);
+        validate(func, 1, 2, 2, 2, 1, 1);
+        add(func, 1, 3, 3, 1, 3, 3);
+        validate(func, 1, 2, 2, 2, 3, 3);
+
+        // delete
+        add(func, RowKind.DELETE, 1, 1, 1, 3, 1, null);
+        validate(func, 1, null, null, 3, 3, 3);
+    }
+
+    @Test
     public void testAdjustProjectionRepeatProject() {
         Options options = new Options();
         options.set("fields.f4.sequence-group", "f1,f3");


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
when sequenceGroup is repeat defined with no field in table，it cause 

`java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.ArrayList.elementData(ArrayList.java:424)
	at java.util.ArrayList.get(ArrayList.java:437)
	at org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction$Factory.lambda$new$0(PartialUpdateMergeFunction.java:215)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction$Factory.<init>(PartialUpdateMergeFunction.java:209)
	at org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction$Factory.<init>(PartialUpdateMergeFunction.java:183)
	at org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.factory(PartialUpdateMergeFunction.java:180)`

This message is not friendly.
### Tests

PartialUpdateMergeFunctionTest.testSequenceGroupRepeatDefineNoField
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
