### PR TITLE
[cdc] Compute column function should be case-insensitive

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
@@ -51,7 +51,7 @@ public interface Expression extends Serializable {
 
     static Expression create(
             String exprName, String fieldReference, DataType fieldType, String... literals) {
-        switch (exprName) {
+        switch (exprName.toLowerCase()) {
             case "year":
                 return year(fieldReference);
             case "month":

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -716,7 +716,7 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         "_date_format_timestamp=date_format(_timestamp,yyyyMMdd)",
                         "_substring_date1=substring(_date,2)",
                         "_substring_date2=substring(_timestamp,5,10)",
-                        "_truncate_date=truncate(pk,2)");
+                        "_truncate_date=trUNcate(pk,2)"); // test case-insensitive too
 
         MySqlSyncTableAction action =
                 syncTableActionBuilder(mySqlConfig)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
