### PR TITLE
Support set execute mode for compact action

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -74,10 +74,9 @@ public class CompactActionFactory implements ActionFactory {
         }
 
         if (params.has(ExecutionOptions.RUNTIME_MODE.key())) {
-            Boolean isStreaming =
-                    params.get(ExecutionOptions.RUNTIME_MODE.key())
-                            .equalsIgnoreCase(RuntimeExecutionMode.STREAMING.name());
-            action.withRuntimeMode(isStreaming);
+            RuntimeExecutionMode runtimeExecutionMode =
+                    RuntimeExecutionMode.valueOf(params.get(ExecutionOptions.RUNTIME_MODE.key()));
+            action.withRuntimeMode(runtimeExecutionMode);
         }
 
         return Optional.of(action);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -18,8 +18,10 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.configuration.ExecutionOptions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -69,6 +71,13 @@ public class CompactActionFactory implements ActionFactory {
         if (params.has("partition")) {
             List<Map<String, String>> partitions = getPartitions(params);
             action.withPartitions(partitions);
+        }
+
+        if (params.has(ExecutionOptions.RUNTIME_MODE.key())) {
+            Boolean isStreaming =
+                    params.get(ExecutionOptions.RUNTIME_MODE.key())
+                            .equalsIgnoreCase(RuntimeExecutionMode.STREAMING.name());
+            action.withRuntimeMode(isStreaming);
         }
 
         return Optional.of(action);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support set execute mode for compact action.


We can set execute mode by main args  ,  this  default value of  `execution.runtime-mode`  is streaming.

For example , 
When we submit a  compcat flink job by  rest service , we can set main args :
compact --path hdfs://ns1007/user/mart_sch/tmp.db/paimon_test_table26 --catalog-conf metastore=hive --execution.runtime-mode batch
