### PR TITLE
[core] Partial-update streaming read supports input changelog-producer

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -120,7 +120,8 @@ For example, suppose Paimon receives three records:
 Assuming that the first column is the primary key, the final result would be `<1, 25.2, 10, 'This is a book'>`.
 
 {{< hint info >}}
-For streaming queries, `partial-update` merge engine must be used together with `lookup` or `full-compaction` [changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}).
+For streaming queries, `partial-update` merge engine must be used together with `lookup` or `full-compaction`
+[changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}). ('input' changelog producer is also supported, but only returns input records.)
 {{< /hint >}}
 
 {{< hint info >}}
@@ -257,7 +258,8 @@ If you allow some functions to ignore retraction messages, you can configure:
 `'fields.${field_name}.ignore-retract'='true'`.
 
 {{< hint info >}}
-For streaming queries, `aggregation` merge engine must be used together with `lookup` or `full-compaction` [changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}).
+For streaming queries, `aggregation` merge engine must be used together with `lookup` or `full-compaction`
+[changelog producer]({{< ref "concepts/primary-key-table#changelog-producers" >}}). ('input' changelog producer is also supported, but only returns input records.)
 {{< /hint >}}
 
 ### First Row

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
@@ -39,14 +39,12 @@ public class TableScanUtils {
                     }
                 };
         if (table.primaryKeys().size() > 0 && mergeEngineDesc.containsKey(mergeEngine)) {
-            switch (options.changelogProducer()) {
-                case NONE:
-                case INPUT:
-                    throw new RuntimeException(
-                            mergeEngineDesc.get(mergeEngine)
-                                    + " streaming reading is not supported. You can use "
-                                    + "'lookup' or 'full-compaction' changelog producer to support streaming reading.");
-                default:
+            if (options.changelogProducer() == CoreOptions.ChangelogProducer.NONE) {
+                throw new RuntimeException(
+                        mergeEngineDesc.get(mergeEngine)
+                                + " streaming reading is not supported. You can use "
+                                + "'lookup' or 'full-compaction' changelog producer to support streaming reading. "
+                                + "('input' changelog producer is also supported, but only returns input records.)");
             }
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -469,7 +469,8 @@ public class LookupJoinITCase extends CatalogITCaseBase {
                 .hasRootCauseMessage(
                         "Partial update streaming"
                                 + " reading is not supported. "
-                                + "You can use 'lookup' or 'full-compaction' changelog producer to support streaming reading.");
+                                + "You can use 'lookup' or 'full-compaction' changelog producer to support streaming reading. "
+                                + "('input' changelog producer is also supported, but only returns input records.)");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We can support input changelog-producer for Partial-update streaming reading, but only returns input records.
This is also a requirement for scenarios where the downstream only wants to read incremental data.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
