### PR TITLE
[core] Fix outputlevel is still 0 in extreme scenarios

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
@@ -171,6 +171,10 @@ public class UniversalCompaction implements CompactStrategy {
             }
         }
 
+        if (outputLevel == 0) {
+            outputLevel = maxLevel;
+        }
+
         return CompactUnit.fromLevelRuns(outputLevel, runs.subList(0, runCount));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
@@ -171,7 +171,7 @@ public class UniversalCompaction implements CompactStrategy {
             }
         }
 
-        if (outputLevel == 0) {
+        if (runCount == runs.size()) {
             outputLevel = maxLevel;
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ForceUpLevel0CompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ForceUpLevel0CompactionTest.java
@@ -45,7 +45,7 @@ public class ForceUpLevel0CompactionTest {
 
         result = compaction.pick(3, Arrays.asList(run(0, 1), run(1, 10)));
         assertThat(result).isPresent();
-        assertThat(result.get().outputLevel()).isEqualTo(1);
+        assertThat(result.get().outputLevel()).isEqualTo(2);
 
         result = compaction.pick(3, Arrays.asList(run(0, 1), run(0, 5), run(2, 10)));
         assertThat(result).isPresent();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -95,6 +95,26 @@ public class UniversalCompactionTest {
     }
 
     @Test
+    public void testExtremeCaseNoOutputLevel0() {
+        UniversalCompaction compaction = new UniversalCompaction(200, 1, 5);
+
+        Optional<CompactUnit> pick =
+                compaction.pick(
+                        6,
+                        Arrays.asList(
+                                level(0, 1),
+                                level(0, 1),
+                                level(0, 1),
+                                level(0, 1024),
+                                level(0, 1024 * 1024)));
+
+        assertThat(pick.isPresent()).isTrue();
+        long[] results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
+        assertThat(results).isEqualTo(new long[] {1, 1, 1, 1024, 1024 * 1024});
+        assertThat(pick.get().outputLevel()).isEqualTo(5);
+    }
+
+    @Test
     public void testSizeAmplification() {
         UniversalCompaction compaction = new UniversalCompaction(25, 0, 1);
         long[] sizes = new long[] {1};


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix outputlevel is still 0 in extreme scenarios.

This may not be a common case, but it is indeed possible.

For a newly created paimon pk table, with default parameters for num-levels and
others, without adjusting the max-size-amp, size-ratio, and other
configurations, assuming all configurations are using default values.

For a specific bucket:
file1 (1kb) is written,
file2 (1kb) is written,
file3 (1kb) is written,
file4 (1mb) is written,
file5 (10mb) is written

The srS of level0 will be sorted according to
https://github.com/apache/incubator-paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java#L58 
In this situation, these five level0 files may not go through the pickForSizeAmp
function, outputlevel is 0. This may cause a larger file to appear in level0. I
think setting the outputlevel to 5 would be more ideal.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests
Add UT org.apache.paimon.mergetree.compact.UniversalCompactionTest#testExtremeCaseNoOutputLevel0

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
