### PR TITLE
[flink] add dynamic table option for CompactAction and SortCompactAction.

### DIFF
--- a/docs/content/concepts/append-only-table.md
+++ b/docs/content/concepts/append-only-table.md
@@ -241,6 +241,7 @@ You can trigger action by shell script:
     --warehouse hdfs:///path/to/warehouse \
     --database test_db \
     --table <tableName> \
+    --table-conf <key>=<value> \
     --order-strategy <orderType> \
     --order-by <col1,col2,...>
 ```

--- a/docs/content/concepts/append-only-table.md
+++ b/docs/content/concepts/append-only-table.md
@@ -248,6 +248,7 @@ You can trigger action by shell script:
 
 {{< generated/sort-compact >}}
 
+The sort parallelism is the same as the sink parallelism, you can dynamically specify it by add conf --table-conf sink.parallelism=<value>.
 Other config is the same as [Compact Table]({{< ref "concepts/file-operations#compact-table" >}})
 
 ### Streaming Source

--- a/docs/content/concepts/file-operations.md
+++ b/docs/content/concepts/file-operations.md
@@ -253,6 +253,7 @@ Let's trigger the full-compaction now, and run a dedicated compaction job throug
     --table <table-name> \
     [--partition <partition-name>] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
+    [--table-conf <paimon-table-dynamic-conf> [--table-conf <paimon-table-dynamic-conf>] ...]
 ```
 
 an example would be (suppose you're already in Flink home)

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -474,18 +474,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The time zone to parse the long watermark value to TIMESTAMP value. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-08:00'.</td>
         </tr>
         <tr>
-            <td><h5>snapshot.expire.execution-mode</h5></td>
-            <td style="word-wrap: break-word;">sync</td>
-            <td><p>Enum</p></td>
-            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>snapshot.expire.limit</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>The maximum number of snapshots allowed to expire at a time.</td>
-        </tr>
-        <tr>
             <td><h5>snapshot.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
@@ -502,6 +490,19 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
             <td>The maximum time of completed snapshots to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>snapshot.expire.execution-mode</h5></td>
+            <td style="word-wrap: break-word;">sync</td>
+            <td>Enum</td>
+            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
+        </tr>
+        </tr>
+        <tr>
+            <td><h5>snapshot.expire.limit</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The maximum number of snapshots allowed to expire at a time.</td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -474,6 +474,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The time zone to parse the long watermark value to TIMESTAMP value. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-08:00'.</td>
         </tr>
         <tr>
+            <td><h5>snapshot.expire.execution-mode</h5></td>
+            <td style="word-wrap: break-word;">sync</td>
+            <td><p>Enum</p></td>
+            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>snapshot.expire.limit</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The maximum number of snapshots allowed to expire at a time.</td>
+        </tr>
+        <tr>
             <td><h5>snapshot.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
@@ -490,19 +502,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
             <td>The maximum time of completed snapshots to retain.</td>
-        </tr>
-        <tr>
-            <td><h5>snapshot.expire.execution-mode</h5></td>
-            <td style="word-wrap: break-word;">sync</td>
-            <td>Enum</td>
-            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
-        </tr>
-        </tr>
-        <tr>
-            <td><h5>snapshot.expire.limit</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>The maximum number of snapshots allowed to expire at a time.</td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,14 +44,15 @@ public class CompactAction extends TableActionBase {
     private List<Map<String, String>> partitions;
 
     public CompactAction(String warehouse, String database, String tableName) {
-        this(warehouse, database, tableName, Collections.emptyMap());
+        this(warehouse, database, tableName, Collections.emptyMap(), Collections.emptyMap());
     }
 
     public CompactAction(
             String warehouse,
             String database,
             String tableName,
-            Map<String, String> catalogConfig) {
+            Map<String, String> catalogConfig,
+            Map<String, String> tableConf) {
         super(warehouse, database, tableName, catalogConfig);
         if (!(table instanceof FileStoreTable)) {
             throw new UnsupportedOperationException(
@@ -58,7 +60,9 @@ public class CompactAction extends TableActionBase {
                             "Only FileStoreTable supports compact action. The table type is '%s'.",
                             table.getClass().getName()));
         }
-        table = table.copy(Collections.singletonMap(CoreOptions.WRITE_ONLY.key(), "false"));
+        HashMap<String, String> dynamicOptions = new HashMap<>(tableConf);
+        dynamicOptions.put(CoreOptions.WRITE_ONLY.key(), "false");
+        table = table.copy(dynamicOptions);
     }
 
     // ------------------------------------------------------------------------
@@ -67,6 +71,11 @@ public class CompactAction extends TableActionBase {
 
     public CompactAction withPartitions(List<Map<String, String>> partitions) {
         this.partitions = partitions;
+        return this;
+    }
+
+    public CompactAction withTableConfig(Map<String, String> tableConfig) {
+        table = table.copy(tableConfig);
         return this;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -74,11 +74,6 @@ public class CompactAction extends TableActionBase {
         return this;
     }
 
-    public CompactAction withTableConfig(Map<String, String> tableConfig) {
-        table = table.copy(tableConfig);
-        return this;
-    }
-
     @Override
     public void build(StreamExecutionEnvironment env) {
         ReadableConfig conf = StreamExecutionEnvironmentUtils.getConfiguration(env);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -113,6 +113,7 @@ public class CompactActionFactory implements ActionFactory {
                         + "--table test_table "
                         + "--order-strategy zorder "
                         + "--order-by a,b,c "
+                        + "--table-conf sink.parallelism=9 "
                         + "--catalog-conf s3.endpoint=https://****.com "
                         + "--catalog-conf s3.access-key=***** "
                         + "--catalog-conf s3.secret-key=***** ");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -44,11 +44,22 @@ public class CompactActionFactory implements ActionFactory {
         CompactAction action;
         if (params.has("order-strategy")) {
             action =
-                    new SortCompactAction(tablePath.f0, tablePath.f1, tablePath.f2, catalogConfig)
+                    new SortCompactAction(
+                                    tablePath.f0,
+                                    tablePath.f1,
+                                    tablePath.f2,
+                                    catalogConfig,
+                                    optionalConfigMap(params, "table-conf"))
                             .withOrderStrategy(params.get("order-strategy"))
                             .withOrderColumns(getRequiredValue(params, "order-by").split(","));
         } else {
-            action = new CompactAction(tablePath.f0, tablePath.f1, tablePath.f2, catalogConfig);
+            action =
+                    new CompactAction(
+                            tablePath.f0,
+                            tablePath.f1,
+                            tablePath.f2,
+                            catalogConfig,
+                            optionalConfigMap(params, "table-conf"));
         }
 
         if (params.has("partition")) {
@@ -70,6 +81,7 @@ public class CompactActionFactory implements ActionFactory {
                 "  compact --warehouse <warehouse-path> --database <database-name> "
                         + "--table <table-name> [--partition <partition-name>]"
                         + "[--order-strategy <order-strategy>]"
+                        + "[--table-conf <key>=<value>]"
                         + "[--order-by <order-columns>]");
         System.out.println(
                 "  compact --warehouse s3://path/to/warehouse --database <database-name> "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
@@ -59,8 +59,9 @@ public class SortCompactAction extends CompactAction {
             String warehouse,
             String database,
             String tableName,
-            Map<String, String> catalogConfig) {
-        super(warehouse, database, tableName, catalogConfig);
+            Map<String, String> catalogConfig,
+            Map<String, String> tableConf) {
+        super(warehouse, database, tableName, catalogConfig, tableConf);
 
         checkArgument(
                 table instanceof AppendOnlyFileStoreTable,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -79,7 +79,7 @@ public class CompactProcedure extends ProcedureBase {
         String warehouse = ((AbstractCatalog) catalog).warehouse();
         Map<String, String> catalogOptions = ((AbstractCatalog) catalog).options();
         Map<String, String> tableConf =
-                StringUtils.isEmpty(tableConfString)
+                StringUtils.isBlank(tableConfString)
                         ? Collections.emptyMap()
                         : ActionFactory.parseCommaSeparatedKeyValues(tableConfString);
         Identifier identifier = Identifier.fromString(tableId);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.action.ActionFactory;
 import org.apache.paimon.flink.action.CompactAction;
 import org.apache.paimon.flink.action.SortCompactAction;
 import org.apache.paimon.utils.StringUtils;
@@ -80,7 +81,7 @@ public class CompactProcedure extends ProcedureBase {
         Map<String, String> tableConf =
                 StringUtils.isEmpty(tableConfString)
                         ? Collections.emptyMap()
-                        : parseCommaSeparatedKeyValues(tableConfString);
+                        : ActionFactory.parseCommaSeparatedKeyValues(tableConfString);
         Identifier identifier = Identifier.fromString(tableId);
         CompactAction action;
         String jobName;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -26,6 +26,7 @@ import org.apache.paimon.flink.action.SortCompactAction;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -83,7 +84,8 @@ public class CompactProcedure extends ProcedureBase {
                             warehouse,
                             identifier.getDatabaseName(),
                             identifier.getObjectName(),
-                            catalogOptions);
+                            catalogOptions,
+                            Collections.emptyMap());
             jobName = "Compact Job";
         } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {
             action =
@@ -91,7 +93,8 @@ public class CompactProcedure extends ProcedureBase {
                                     warehouse,
                                     identifier.getDatabaseName(),
                                     identifier.getObjectName(),
-                                    catalogOptions)
+                                    catalogOptions,
+                                    Collections.emptyMap())
                             .withOrderStrategy(orderStrategy)
                             .withOrderColumns(orderByColumns.split(","));
             jobName = "Sort Compact Job";

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -23,9 +23,11 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.CompactAction;
 import org.apache.paimon.flink.action.SortCompactAction;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -75,7 +77,10 @@ public class CompactProcedure extends ProcedureBase {
             throws Exception {
         String warehouse = ((AbstractCatalog) catalog).warehouse();
         Map<String, String> catalogOptions = ((AbstractCatalog) catalog).options();
-        Map<String, String> tableConf = parseCommaSeparatedKeyValues(tableConfString);
+        Map<String, String> tableConf =
+                StringUtils.isEmpty(tableConfString)
+                        ? Collections.emptyMap()
+                        : parseCommaSeparatedKeyValues(tableConfString);
         Identifier identifier = Identifier.fromString(tableId);
         CompactAction action;
         String jobName;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -26,7 +26,6 @@ import org.apache.paimon.flink.action.SortCompactAction;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -63,7 +62,7 @@ public class CompactProcedure extends ProcedureBase {
             String orderStrategy,
             String orderByColumns)
             throws Exception {
-        return call(procedureContext, tableId, orderStrategy, orderByColumns, new String[0]);
+        return call(procedureContext, tableId, orderStrategy, orderByColumns, "", new String[0]);
     }
 
     public String[] call(
@@ -71,10 +70,12 @@ public class CompactProcedure extends ProcedureBase {
             String tableId,
             String orderStrategy,
             String orderByColumns,
+            String tableConfString,
             String... partitionStrings)
             throws Exception {
         String warehouse = ((AbstractCatalog) catalog).warehouse();
         Map<String, String> catalogOptions = ((AbstractCatalog) catalog).options();
+        Map<String, String> tableConf = parseCommaSeparatedKeyValues(tableConfString);
         Identifier identifier = Identifier.fromString(tableId);
         CompactAction action;
         String jobName;
@@ -85,7 +86,7 @@ public class CompactProcedure extends ProcedureBase {
                             identifier.getDatabaseName(),
                             identifier.getObjectName(),
                             catalogOptions,
-                            Collections.emptyMap());
+                            tableConf);
             jobName = "Compact Job";
         } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {
             action =
@@ -94,7 +95,7 @@ public class CompactProcedure extends ProcedureBase {
                                     identifier.getDatabaseName(),
                                     identifier.getObjectName(),
                                     catalogOptions,
-                                    Collections.emptyMap())
+                                    tableConf)
                             .withOrderStrategy(orderStrategy)
                             .withOrderColumns(orderByColumns.split(","));
             jobName = "Sort Compact Job";

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -301,7 +301,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
     private void callProcedure(boolean isStreaming) {
         callProcedure(
                 String.format(
-                        "CALL compact('%s.%s', '', '', '%s', '%s')",
+                        "CALL compact('%s.%s', '', '', '', '%s', '%s')",
                         database, tableName, "dt=20221208,hh=15", "dt=20221209,hh=15"),
                 isStreaming,
                 !isStreaming);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.action;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.source.DataSplit;
@@ -241,6 +242,25 @@ public class CompactActionITCase extends CompactActionITCaseBase {
 
         // first compaction, snapshot will be 3.
         checkFileAndRowSize(table, 3L, 0L, 1, 6);
+    }
+
+    @Test
+    public void testTableConf() throws Exception {
+        prepareTable(
+                Arrays.asList("dt", "hh"), Arrays.asList("dt", "hh", "k"), Collections.emptyMap());
+
+        CompactAction compactAction =
+                new CompactAction(
+                                warehouse,
+                                database,
+                                tableName,
+                                Collections.emptyMap(),
+                                Collections.singletonMap(
+                                        FlinkConnectorOptions.SCAN_PARALLELISM.key(), "6"))
+                        .withPartitions(getSpecifiedPartitions());
+
+        assertThat(compactAction.table.options().get(FlinkConnectorOptions.SCAN_PARALLELISM.key()))
+                .isEqualTo("6");
     }
 
     private FileStoreTable prepareTable(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionITCase.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -206,9 +207,36 @@ public class SortCompactActionITCase extends ActionITCaseBase {
                 .isLessThan(filesFilterOrder.size() / (double) filesOrder.size());
     }
 
+    @Test
+    public void testTableConf() throws Exception {
+        createTable();
+        SortCompactAction sortCompactAction =
+                new SortCompactAction(
+                                warehouse,
+                                database,
+                                tableName,
+                                Collections.emptyMap(),
+                                Collections.singletonMap(
+                                        FlinkConnectorOptions.SINK_PARALLELISM.key(), "20"))
+                        .withOrderStrategy("zorder")
+                        .withOrderColumns(Collections.singletonList("f0"));
+
+        Assertions.assertThat(
+                        sortCompactAction
+                                .table
+                                .options()
+                                .get(FlinkConnectorOptions.SINK_PARALLELISM.key()))
+                .isEqualTo("20");
+    }
+
     private void zorder(List<String> columns) throws Exception {
         if (random.nextBoolean()) {
-            new SortCompactAction(warehouse, database, tableName, Collections.emptyMap())
+            new SortCompactAction(
+                            warehouse,
+                            database,
+                            tableName,
+                            Collections.emptyMap(),
+                            Collections.emptyMap())
                     .withOrderStrategy("zorder")
                     .withOrderColumns(columns)
                     .run();
@@ -219,7 +247,12 @@ public class SortCompactActionITCase extends ActionITCaseBase {
 
     private void order(List<String> columns) throws Exception {
         if (random.nextBoolean()) {
-            new SortCompactAction(warehouse, database, tableName, Collections.emptyMap())
+            new SortCompactAction(
+                            warehouse,
+                            database,
+                            tableName,
+                            Collections.emptyMap(),
+                            Collections.emptyMap())
                     .withOrderStrategy("order")
                     .withOrderColumns(columns)
                     .run();


### PR DESCRIPTION
### Purpose

Add dynamic option to specify the dynamic table conf when execute CompactAction or SortCompactAction.
For example, we can add --table-conf sink.parallelism=xxx to specify the compaction sink parallelism without change the meta data of the table.

flink run  ./action.jar 
    --table-conf sink.parallelism=9
    --table-conf xxx=xxx


### Tests

Add Tests for CompactAction and SortCompactAction about dynamic table conf

### API and Format

No influence to other user behavior.

### Documentation

Added documentations.
