### PR TITLE
[flink] optimize code style and remove useless code

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
@@ -116,16 +116,11 @@ public class SortCompactAction extends CompactAction {
         DataStream<RowData> source = sourceBuilder.withEnv(env).withContinuousMode(false).build();
         TableSorter sorter =
                 TableSorter.getSorter(env, source, fileStoreTable, sortStrategy, orderColumns);
-        DataStream<RowData> sorted = sorter.sort();
 
-        FlinkSinkBuilder flinkSinkBuilder = new FlinkSinkBuilder(fileStoreTable);
-        flinkSinkBuilder.withInput(sorted).withOverwritePartition(new HashMap<>());
-        String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
-        if (sinkParallelism != null) {
-            flinkSinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));
-        }
-
-        flinkSinkBuilder.build();
+        new FlinkSinkBuilder(fileStoreTable)
+                .withInput(sorter.sort())
+                .withOverwritePartition(new HashMap<>())
+                .build();
     }
 
     public SortCompactAction withOrderStrategy(String sortStrategy) {


### PR DESCRIPTION
Just remove useless code, the sink builder will use the sorter parallelism, so we don't need to set parallelism.

No other influence.