### PR TITLE
[core] Fix that time travel to tag with expired snapshot throws FileNotFoundException

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
@@ -32,12 +32,6 @@ public class StaticFromTagStartingScanner extends AbstractStartingScanner {
     public StaticFromTagStartingScanner(SnapshotManager snapshotManager, String tagName) {
         super(snapshotManager);
         this.tagName = tagName;
-        TagManager tagManager =
-                new TagManager(snapshotManager.fileIO(), snapshotManager.tablePath());
-        Snapshot snapshot = tagManager.taggedSnapshot(this.tagName);
-        if (snapshot != null) {
-            this.startingSnapshotId = snapshot.id();
-        }
     }
 
     @Override
@@ -47,10 +41,10 @@ public class StaticFromTagStartingScanner extends AbstractStartingScanner {
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        if (startingSnapshotId == null) {
-            return new NoSnapshot();
-        }
+        TagManager tagManager =
+                new TagManager(snapshotManager.fileIO(), snapshotManager.tablePath());
+        Snapshot snapshot = tagManager.taggedSnapshot(tagName);
         return StartingScanner.fromPlan(
-                snapshotReader.withMode(ScanMode.ALL).withSnapshot(startingSnapshotId).read());
+                snapshotReader.withMode(ScanMode.ALL).withSnapshot(snapshot).read());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScannerTest.java
@@ -69,7 +69,10 @@ public class StaticFromTagStartingScannerTest extends ScannerTestBase {
     @Test
     public void testNonExistingTag() {
         SnapshotManager snapshotManager = table.snapshotManager();
-        assertThatThrownBy(() -> new StaticFromTagStartingScanner(snapshotManager, "non-existing"))
+        assertThatThrownBy(
+                        () ->
+                                new StaticFromTagStartingScanner(snapshotManager, "non-existing")
+                                        .scan(snapshotReader))
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
                                 IllegalArgumentException.class,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
`StaticFromTagStartingScanner` should read a tag instead of a snapshot id.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
