### PR TITLE
[hotfix] Fix antlr4-runtime dependency of paimon-spark-common

### DIFF
--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -31,10 +31,6 @@ under the License.
     <artifactId>paimon-common</artifactId>
     <name>Paimon : Common</name>
 
-    <properties>
-        <antlr4.version>4.7</antlr4.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.paimon</groupId>

--- a/paimon-common/src/main/resources/META-INF/NOTICE
+++ b/paimon-common/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the BSD 3-clause license.
 You find them under licenses/LICENSE.antlr-runtime and licenses/LICENSE.janino.
 
-- org.antlr:antlr4-runtime:4.7
+- org.antlr:antlr4-runtime:4.8
 - org.codehaus.janino:janino:3.0.11
 - org.codehaus.janino:commons-compiler:3.0.11
 - it.unimi.dsi:fastutil:8.5.12

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -168,6 +168,11 @@ under the License.
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${antlr4.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>3.1.0</version>
@@ -280,7 +285,7 @@ under the License.
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>${antlr4-maven-plugin.version}</version>
+                <version>${antlr4.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@ under the License.
         <paimon.shade.jackson.version>2.14.2</paimon.shade.jackson.version>
         <paimon.shade.guava.version>30.1.1-jre</paimon.shade.guava.version>
         <paimon.shade.caffeine.version>2.9.3</paimon.shade.caffeine.version>
+        <antlr4.version>4.8</antlr4.version>
         <hadoop.version>2.8.5</hadoop.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -126,7 +127,6 @@ under the License.
         <avro.version>1.11.1</avro.version>
         <kafka.version>3.2.3</kafka.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
-        <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
         <jsoup.version>1.15.3</jsoup.version>
     </properties>
 


### PR DESCRIPTION
### Purpose

Linked issue: close #2045 

`paimon-spark-common` module should add antlr4-runtime dependency, otherwise the exception which message is like `ANTLR Runtime version used for parser compilation does not match the current version 4.8` for call procedure.

### Tests

None.

### API and Format

None.

### Documentation

None.