### PR TITLE
[hive]When creating a hive external table pointing to the existing paimon table, the field name is capitalized, and hive show table does not display the field.

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -164,9 +164,12 @@ public class HiveSchema {
             // doesn't contain precision and thus may cause casting problems
             Map<String, DataField> paimonFields =
                     tableSchema.get().fields().stream()
-                            .collect(Collectors.toMap(DataField::name, Function.identity()));
+                            .collect(
+                                    Collectors.toMap(
+                                            dataField -> dataField.name().toLowerCase(),
+                                            Function.identity()));
             for (int i = 0; i < columnNames.size(); i++) {
-                String columnName = columnNames.get(i);
+                String columnName = columnNames.get(i).toLowerCase();
                 dataTypes.set(i, paimonFields.get(columnName).type());
                 comments.set(i, paimonFields.get(columnName).description());
             }
@@ -239,7 +242,7 @@ public class HiveSchema {
 
         List<String> mismatched = new ArrayList<>();
         for (int i = 0; i < hiveFieldNames.size(); i++) {
-            if (!Objects.equals(hiveFieldNames.get(i), schemaFieldNames.get(i))
+            if (!hiveFieldNames.get(i).equalsIgnoreCase(schemaFieldNames.get(i))
                     || !Objects.equals(hiveFieldTypeInfos.get(i), schemaFieldTypeInfos.get(i))) {
                 String ddlField =
                         hiveFieldNames.get(i) + " " + hiveFieldTypeInfos.get(i).getTypeName();
@@ -295,7 +298,7 @@ public class HiveSchema {
 
         List<String> mismatched = new ArrayList<>();
         for (int i = 0; i < hivePartitionKeys.size(); i++) {
-            if (!Objects.equals(hivePartitionKeys.get(i), schemaPartitionKeys.get(i))
+            if (!hivePartitionKeys.get(i).equalsIgnoreCase(schemaPartitionKeys.get(i))
                     || !Objects.equals(
                             hivePartitionTypeInfos.get(i), schemaPartitionTypeInfos.get(i))) {
                 String ddlField =

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/CreateTableITCase.java
@@ -87,8 +87,8 @@ public class CreateTableITCase extends HiveTestBase {
                 new Schema(
                         Lists.newArrayList(
                                 new DataField(0, "col1", DataTypes.INT(), "first comment"),
-                                new DataField(1, "col2", DataTypes.STRING(), "second comment"),
-                                new DataField(2, "col3", DataTypes.DECIMAL(5, 3), "last comment")),
+                                new DataField(1, "Col2", DataTypes.STRING(), "second comment"),
+                                new DataField(2, "COL3", DataTypes.DECIMAL(5, 3), "last comment")),
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Maps.newHashMap(),
@@ -106,6 +106,18 @@ public class CreateTableITCase extends HiveTestBase {
                                 "STORED BY '" + PaimonStorageHandler.class.getName() + "'",
                                 "LOCATION '" + tablePath.toUri().toString() + "'"));
         assertThatCode(() -> hiveShell.execute(hiveSql)).doesNotThrowAnyException();
+
+        List<String> result = hiveShell.executeQuery("SHOW CREATE TABLE " + tableName);
+        assertThat(result)
+                .containsAnyOf(
+                        "CREATE EXTERNAL TABLE `with_paimon_table`(",
+                        "  `col1` int COMMENT 'first comment', ",
+                        "  `col2` string COMMENT 'second comment', ",
+                        "  `col3` decimal(5,3) COMMENT 'last comment')",
+                        "ROW FORMAT SERDE ",
+                        "  'org.apache.paimon.hive.PaimonSerDe' ",
+                        "STORED BY ",
+                        "  'org.apache.paimon.hive.PaimonStorageHandler' ");
     }
 
     @Test


### PR DESCRIPTION
…

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When creating a hive external table pointing to the existing paimon table, the field name is capitalized, and hive show table does not display the field.



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
