### PR TITLE
[flink] Support default.id.generation parameter

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -478,13 +478,17 @@ To use this feature through `flink run`, run the following shell command.
 
 Here are a few points to take note of:
 
-1. The "mongodb-conf" introduces the "schema.start.mode" parameter on top of the MongoDB CDC source configuration."schema.start.mode" provides two modes: "dynamic" (default) and "specified".
-In "dynamic" mode, MongoDB schema information is parsed at one level, which forms the basis for schema change evolution.
-In "specified" mode, synchronization takes place according to specified criteria.
-This can be done by configuring "field.name" to specify the synchronization fields and "parser.path" to specify the JSON parsing path for those fields.
-The difference between the two is that the "specify" mode requires the user to explicitly identify the fields to be used and create a mapping table based on those fields.
+1. The `mongodb-conf` introduces the `schema.start.mode` parameter on top of the MongoDB CDC source configuration.`schema.start.mode` provides two modes: `dynamic` (default) and `specified`.
+In `dynamic` mode, MongoDB schema information is parsed at one level, which forms the basis for schema change evolution.
+In `specified` mode, synchronization takes place according to specified criteria.
+This can be done by configuring `field.name` to specify the synchronization fields and `parser.path` to specify the JSON parsing path for those fields.
+The difference between the two is that the `specify` mode requires the user to explicitly identify the fields to be used and create a mapping table based on those fields.
 Dynamic mode, on the other hand, ensures that Paimon and MongoDB always keep the top-level fields consistent, eliminating the need to focus on specific fields.
 Further processing of the data table is required when using values from nested fields.
+2. The `mongodb-conf` introduces the `default.id.generation` parameter as an enhancement to the MongoDB CDC source configuration. The `default.id.generation` setting offers two distinct behaviors: when set to true and when set to false.
+When `default.id.generation` is set to true, the MongoDB CDC source adheres to the default `_id` generation strategy, which involves stripping the outer $oid nesting to provide a more straightforward identifier. This mode simplifies the `_id` representation, making it more direct and user-friendly.
+On the contrary, when `default.id.generation` is set to false, the MongoDB CDC source retains the original `_id` structure, without any additional processing. This mode offers users the flexibility to work with the raw `_id` format as provided by MongoDB, preserving any nested elements like `$oid`.
+The choice between the two hinges on the user's preference: the former for a cleaner, simplified `_id` and the latter for a direct representation of MongoDB's `_id` structure.
 
 {{< generated/mongodb_operator >}}
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
@@ -178,5 +178,31 @@ public class JsonSerdeUtil {
                 });
     }
 
+    /**
+     * Parses the provided JSON string and casts it to the specified type of {@link JsonNode}.
+     *
+     * <p>This method is useful when the exact subtype of {@link JsonNode} is known beforehand and
+     * needs to be enforced.
+     *
+     * @param <T> The type of the JsonNode to return. Must be a subtype of {@link JsonNode}.
+     * @param json The JSON string to parse.
+     * @param clazz The expected class type of the parsed JSON.
+     * @return The parsed JSON as an instance of the specified type.
+     * @throws JsonProcessingException If there's an error during JSON parsing.
+     * @throws IllegalArgumentException If the parsed JSON is not of the expected type.
+     */
+    public static <T extends JsonNode> T asSpecificNodeType(String json, Class<T> clazz)
+            throws JsonProcessingException {
+        JsonNode resultNode = OBJECT_MAPPER_INSTANCE.readTree(json);
+        if (!clazz.isInstance(resultNode)) {
+            throw new IllegalArgumentException(
+                    "Expected node of type "
+                            + clazz.getName()
+                            + " but was "
+                            + resultNode.getClass().getName());
+        }
+        return clazz.cast(resultNode);
+    }
+
     private JsonSerdeUtil() {}
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionUtils.java
@@ -91,6 +91,13 @@ public class MongoDBActionUtils {
                     .defaultValue("dynamic")
                     .withDescription("Mode selection: `dynamic` or `specified`.");
 
+    public static final ConfigOption<Boolean> DEFAULT_ID_GENERATION =
+            ConfigOptions.key("default.id.generation")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Determines whether to use the default MongoDB _id generation strategy. If set to true, the default _id generation will remove the outer $oid nesting. If set to false, no additional processing will be done on the _id field.");
+
     static MongoDBSource<String> buildMongodbSource(Configuration mongodbConfig, String tableList) {
         validateMongodbConfig(mongodbConfig);
         MongoDBSourceBuilder<String> sourceBuilder = MongoDBSource.builder();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableActionITCase.java
@@ -254,4 +254,40 @@ public class MongoDBSyncTableActionITCase extends MongoDBActionITCaseBase {
                         "+I[100000000000000000000102, new car battery, New 12V car battery, 9]");
         waitForResult(expectedDelete, table, rowType, primaryKeys);
     }
+
+    @Test
+    @Timeout(60)
+    public void testDefaultId() throws Exception {
+        writeRecordsToMongoDB("defaultId-1", database, "table/defaultid");
+
+        Map<String, String> mongodbConfig = getBasicMongoDBConfig();
+        mongodbConfig.put("database", database);
+        mongodbConfig.put("collection", "defaultId");
+        mongodbConfig.put("default.id.generation", "false");
+
+        MongoDBSyncTableAction action =
+                syncTableActionBuilder(mongodbConfig)
+                        .withTableConfig(getBasicTableConfig())
+                        .build();
+        runActionWithDefaultEnv(action);
+
+        FileStoreTable table = getFileStoreTable(tableName);
+        List<String> primaryKeys = Collections.singletonList("_id");
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.STRING().notNull(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING()
+                        },
+                        new String[] {"_id", "name", "description", "weight"});
+
+        List<String> expectedInsert =
+                Arrays.asList(
+                        "+I[100000000000000000000101, scooter, Small 2-wheel scooter, 3.14]",
+                        "+I[100000000000000000000102, car battery, 12V car battery, 8.1]",
+                        "+I[100000000000000000000103, 12-pack drill bits, 12-pack of drill bits with sizes ranging from #40 to #3, 0.8]");
+        waitForResult(expectedInsert, table, rowType, primaryKeys);
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mongodb/table/defaultid/defaultId-1.js
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mongodb/table/defaultid/defaultId-1.js
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+//  -- this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+db.getCollection('defaultId').insertMany([
+    {
+        "_id": "100000000000000000000101",
+        "name": "scooter",
+        "description": "Small 2-wheel scooter",
+        "weight": 3.14
+    },
+    {
+        "_id": "100000000000000000000102",
+        "name": "car battery",
+        "description": "12V car battery",
+        "weight": 8.1
+    },
+    {
+        "_id": "100000000000000000000103",
+        "name": "12-pack drill bits",
+        "description": "12-pack of drill bits with sizes ranging from #40 to #3",
+        "weight": 0.8
+    }
+]);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The `mongodb-conf` introduces the `default.id.generation` parameter as an enhancement to the MongoDB CDC source configuration. The `default.id.generation` setting offers two distinct behaviors: when set to true and when set to false.
When `default.id.generation` is set to true, the MongoDB CDC source adheres to the default `_id` generation strategy, which involves stripping the outer $oid nesting to provide a more straightforward identifier. This mode simplifies the `_id` representation, making it more direct and user-friendly.
On the contrary, when `default.id.generation` is set to false, the MongoDB CDC source retains the original `_id` structure, without any additional processing. This mode offers users the flexibility to work with the raw `_id` format as provided by MongoDB, preserving any nested elements like `$oid`.
The choice between the two hinges on the user's preference: the former for a cleaner, simplified `_id` and the latter for a direct representation of MongoDB's `_id` structure.


<!-- What is the purpose of the change -->

### Tests

MongoDBSyncTableActionITCase#testDefaultId()

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

docs/content/how-to/cdc-ingestion.md
