### PR TITLE
[flink] create tags for the previous savepoint after a successful checkpoint.

### DIFF
--- a/docs/content/maintenance/manage-tags.md
+++ b/docs/content/maintenance/manage-tags.md
@@ -258,6 +258,15 @@ Paimon's snapshot is similar to flink's checkpoint, and both will automatically 
 allows snapshots to be retained for a long time. Therefore, we can combine the two features of paimon's tag and flink's 
 savepoint to achieve incremental recovery of job from the specified savepoint.
 
+{{< hint warning >}}
+Starting from Flink 1.15 intermediate savepoints (savepoints other than created with 
+[stop-with-savepoint](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/savepoints/#stopping-a-job-with-savepoint)) 
+are not used for recovery and do not commit any side effects. 
+
+For savepoint created with [stop-with-savepoint](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/savepoints/#stopping-a-job-with-savepoint), 
+tags will be created automatically. For other savepoints, tags will be created after the next checkpoint succeeds.
+{{< /hint >}}
+
 **Step 1: Enable automatically create tags for savepoint.**
 
 You can set `sink.savepoint.auto-tag` to `true` to enable the feature of automatically creating tags for savepoint.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -200,7 +200,8 @@ public abstract class FlinkSink<T> implements Serializable {
                     new AutoTagForSavepointCommitterOperator<>(
                             (CommitterOperator<Committable, ManifestCommittable>) committerOperator,
                             table::snapshotManager,
-                            table::tagManager);
+                            table::tagManager,
+                            () -> table.store().newTagDeletion());
         }
         SingleOutputStreamOperator<?> committed =
                 written.transform(


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2057 

<!-- What is the purpose of the change -->
Currently flink will not send a complete message to the task after the savepoint is successful (unless use `stop-with-savepoint`).  Therefore, we need to create tags for the previous savepoint after the next checkpoint is successful.

### Tests

<!-- List UT and IT cases to verify this change -->

- `org.apache.paimon.flink.sink.AutoTagForSavepointCommitterOperatorTest#testAbortSavepointAndCleanTag` to verify that the tag can be cleaned after the savepoint abort.
- `org.apache.paimon.flink.sink.AutoTagForSavepointCommitterOperatorTest#testAutoTagForSavepoint` to verify that the tag can be automatically created for the savepoint after the checkpoint is successful.

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No