### PR TITLE
[core] reduce unnecessary traversals to optimize the assign logic of PartitionIndex.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
@@ -157,6 +157,7 @@ public class HashBucketAssigner {
                 indexFileHandler,
                 partition,
                 targetBucketRowNumber,
-                (hash) -> computeAssignId(hash) == assignId);
+                (hash) -> computeAssignId(hash) == assignId,
+                (bucket) -> computeAssignId(bucket) == assignId);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -245,7 +245,8 @@ object WriteIntoPaimonTable {
               indexFileHandler,
               partition,
               targetBucketRowNumber,
-              (_) => true))
+              (_) => true,
+              buckFilter))
           val bucket = index.assign(hash, buckFilter)
           val sparkInternalRow = toRow(row)
           sparkInternalRow.setInt(bucketColIndex, bucket)


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2075 

<!-- What is the purpose of the change -->
 [core] reduce unnecessary traversals to optimize the assign logic of PartitionIndex.

I made a simple benchmark and continuously used random keys to call the `assign` of `PartitionIndex`. The results showed that removing unnecessary traversals can improve performance by 50% to 200%.

|   | benchmark 1s |  benchmark 5s |  benchmark 10s |  benchmark 30s |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| before | 4247.443 ops/ms  | 2342.67 ops/ms  | 1766.141 ops/ms  | 1287.669 ops/ms  |
| after | 6324.565 ops/ms  | 5738.319 ops/ms  | 5200.766 ops/ms  | 4563.41 ops/ms  |

### Tests

The existing `org.apache.paimon.index.HashBucketAssignerTest` can verify this change.


### API and Format

No

### Documentation

No
