### PR TITLE
[core] Introduce bucket level value filter (filter push down) in primary key table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -43,6 +43,7 @@ import org.apache.paimon.utils.SnapshotManager;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -275,6 +276,20 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                 files.add(file);
             }
         }
+
+        // We group files by bucket here, and filter them by the whole bucket filter.
+        // Why do this: because in primary key table, we can't just filter the value
+        // by the stat in files (see `ChangelogWithKeyFileStoreTable.nonPartitionFilterConsumer`),
+        // but we can do this by filter the whole bucket files
+        files =
+                files.stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::bucket))
+                        .values()
+                        .stream()
+                        .filter(this::filterByStats)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
+
         return Pair.of(snapshot, files);
     }
 
@@ -338,6 +353,9 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     /** Note: Keep this thread-safe. */
     protected abstract boolean filterByStats(ManifestEntry entry);
+
+    /** Note: Keep this thread-safe. */
+    protected abstract boolean filterByStats(List<ManifestEntry> entries);
 
     /** Note: Keep this thread-safe. */
     private List<ManifestEntry> readManifestFileMeta(ManifestFileMeta manifest) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -82,7 +82,7 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     }
 
     @Override
-    protected boolean filterByStats(List<ManifestEntry> entries) {
+    protected boolean filterWholeBucketByStats(List<ManifestEntry> entries) {
         // We don't need to filter per-bucket entries here
         return true;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -28,6 +28,8 @@ import org.apache.paimon.stats.FieldStatsConverters;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.SnapshotManager;
 
+import java.util.List;
+
 /** {@link FileStoreScan} for {@link AppendOnlyFileStore}. */
 public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
 
@@ -77,5 +79,11 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                                 .fields(
                                         fieldStatsConverters.getOrCreate(entry.file().schemaId()),
                                         entry.file().rowCount()));
+    }
+
+    @Override
+    protected boolean filterByStats(List<ManifestEntry> entries) {
+        // We don't need to filter per-bucket entries here
+        return true;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -97,7 +97,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
 
     /** Note: Keep this thread-safe. */
     @Override
-    protected boolean filterByStats(List<ManifestEntry> entries) {
+    protected boolean filterWholeBucketByStats(List<ManifestEntry> entries) {
         // entries come from the same bucket, if any of it doesn't meet the request, we could filter
         // the bucket.
         if (valueFilter != null) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -29,12 +29,16 @@ import org.apache.paimon.stats.FieldStatsConverters;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.SnapshotManager;
 
+import java.util.List;
+
 /** {@link FileStoreScan} for {@link KeyValueFileStore}. */
 public class KeyValueFileStoreScan extends AbstractFileStoreScan {
 
-    private final FieldStatsConverters fieldStatsConverters;
+    private final FieldStatsConverters fieldKeyStatsConverters;
+    private final FieldStatsConverters fieldValueStatsConverters;
 
     private Predicate keyFilter;
+    private Predicate valueFilter;
 
     public KeyValueFileStoreScan(
             RowType partitionType,
@@ -58,14 +62,22 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                 numOfBuckets,
                 checkNumOfBuckets,
                 scanManifestParallelism);
-        this.fieldStatsConverters =
+        this.fieldKeyStatsConverters =
                 new FieldStatsConverters(
                         sid -> keyValueFieldsExtractor.keyFields(scanTableSchema(sid)), schemaId);
+        this.fieldValueStatsConverters =
+                new FieldStatsConverters(
+                        sid -> keyValueFieldsExtractor.valueFields(scanTableSchema(sid)), schemaId);
     }
 
     public KeyValueFileStoreScan withKeyFilter(Predicate predicate) {
         this.keyFilter = predicate;
         this.bucketKeyFilter.pushdown(predicate);
+        return this;
+    }
+
+    public KeyValueFileStoreScan withValueFilter(Predicate predicate) {
+        this.valueFilter = predicate;
         return this;
     }
 
@@ -78,7 +90,30 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                         entry.file()
                                 .keyStats()
                                 .fields(
-                                        fieldStatsConverters.getOrCreate(entry.file().schemaId()),
+                                        fieldKeyStatsConverters.getOrCreate(
+                                                entry.file().schemaId()),
                                         entry.file().rowCount()));
+    }
+
+    /** Note: Keep this thread-safe. */
+    @Override
+    protected boolean filterByStats(List<ManifestEntry> entries) {
+        // entries come from the same bucket, if any of it doesn't meet the request, we could filter
+        // the bucket.
+        if (valueFilter != null) {
+            for (ManifestEntry entry : entries) {
+                if (valueFilter.test(
+                        entry.file().rowCount(),
+                        entry.file()
+                                .valueStats()
+                                .fields(
+                                        fieldValueStatsConverters.getOrCreate(
+                                                entry.file().schemaId()),
+                                        entry.file().rowCount()))) {
+                    return true;
+                }
+            }
+        }
+        return valueFilter == null;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTable.java
@@ -136,7 +136,6 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
             // if we perform filter push down on values, data file 1 will be chosen, but data
             // file 2 will be ignored, and the final result will be key = a, value = 1 while the
             // correct result is an empty set
-            // TODO support value filter
             List<Predicate> keyFilters =
                     pickTransformFieldMapping(
                             splitAnd(predicate),
@@ -145,6 +144,9 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
             if (keyFilters.size() > 0) {
                 ((KeyValueFileStoreScan) scan).withKeyFilter(and(keyFilters));
             }
+
+            // support value filter in bucket level
+            ((KeyValueFileStoreScan) scan).withValueFilter(predicate);
         };
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
@@ -214,6 +214,28 @@ public class TestKeyValueGenerator {
                         rowSerializer.toBinaryRow(convertToRow(order)).copy());
     }
 
+    public KeyValue nextInsert(
+            String dt,
+            int hr,
+            @Nullable Long itemId,
+            @Nullable int[] priceMount,
+            @Nullable String comment) {
+        Order order = new Order();
+        order.dt = dt;
+        order.hr = hr;
+        order.itemId = itemId;
+        order.priceAmount = priceMount;
+        order.comment = comment;
+        return new KeyValue()
+                .replace(
+                        KEY_SERIALIZER
+                                .toBinaryRow(GenericRow.of(order.shopId, order.orderId))
+                                .copy(),
+                        sequenceNumber++,
+                        RowKind.INSERT,
+                        rowSerializer.toBinaryRow(convertToRow(order)).copy());
+    }
+
     // used for FileStoreExpireDeleteDirTest to generate data in specified partition
     public KeyValue nextPartitionedData(RowKind kind, Object... partitionSpec) {
         Order order = new Order();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -23,6 +23,8 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.TestFileStore;
 import org.apache.paimon.TestKeyValueGenerator;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -173,6 +175,34 @@ public class KeyValueFileStoreScanTest {
     }
 
     @Test
+    public void testWithValuePartitionFilter() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        List<KeyValue> data = generateData(100, Math.abs(random.nextInt(1000)));
+        writeData(data, "0", 0);
+        data = generateData(100, Math.abs(random.nextInt(1000)) + 1000);
+        writeData(data, "1", 0);
+        data = generateData(100, Math.abs(random.nextInt(1000)) + 2000);
+        writeData(data, "2", 0);
+        generateData(100, Math.abs(random.nextInt(1000)) + 3000);
+        Snapshot snapshot = writeData(data, "3", 0);
+
+        KeyValueFileStoreScan scan = store.newScan();
+        scan.withSnapshot(snapshot.id());
+        List<ManifestEntry> files = scan.plan().files();
+
+        scan = store.newScan();
+        scan.withSnapshot(snapshot.id());
+        scan.withValueFilter(
+                new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE)
+                        .between(1, 1000, 2000));
+
+        List<ManifestEntry> filesFiltered = scan.plan().files();
+
+        assertThat(files.size()).isEqualTo(4);
+        assertThat(filesFiltered.size()).isEqualTo(1);
+    }
+
+    @Test
     public void testWithBucket() throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         List<KeyValue> data = generateData(random.nextInt(1000) + 1);
@@ -291,6 +321,16 @@ public class KeyValueFileStoreScanTest {
 
     private Snapshot writeData(List<KeyValue> kvs, int bucket) throws Exception {
         List<Snapshot> snapshots = store.commitData(kvs, gen::getPartition, b -> bucket);
+        return snapshots.get(snapshots.size() - 1);
+    }
+
+    private Snapshot writeData(List<KeyValue> kvs, String partition, int bucket) throws Exception {
+        BinaryRow binaryRow = new BinaryRow(2);
+        BinaryRowWriter binaryRowWriter = new BinaryRowWriter(binaryRow);
+        binaryRowWriter.writeString(0, BinaryString.fromString(partition));
+        binaryRowWriter.writeInt(1, 0);
+        binaryRowWriter.complete();
+        List<Snapshot> snapshots = store.commitData(kvs, p -> binaryRow, b -> bucket);
         return snapshots.get(snapshots.size() - 1);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyColumnTypeFileDataTest.java
@@ -49,10 +49,6 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    /**
-                     * Changelog with key table doesn't support filter in value, it will scan all
-                     * data. TODO support filter value in future.
-                     */
                     Predicate predicate =
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
@@ -66,17 +62,12 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                     assertThat(getResult(table.newRead(), splits, fieldGetterList))
                             .containsExactlyInAnyOrder(
                                     "2|200|201|202.00|203|204|205|206.0|207.0|208|1970-07-29T00:00|210",
-                                    "2|300|301|302.00|303|304|305|306.0|307.0|308|1970-11-06T00:00|310",
-                                    "1|100|101|102.00|103|104|105|106.0|107.0|108|1970-04-20T00:00|110");
+                                    "2|300|301|302.00|303|304|305|306.0|307.0|308|1970-11-06T00:00|310");
                     return null;
                 },
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
 
-                    /**
-                     * Changelog with key table doesn't support filter in value, it will scan all
-                     * data. TODO support filter value in future.
-                     */
                     List<Split> splits =
                             toSplits(
                                     table.newSnapshotReader()
@@ -91,10 +82,7 @@ public class ChangelogWithKeyColumnTypeFileDataTest extends ColumnTypeFileDataTe
                             .containsExactlyInAnyOrder(
                                     "2|200|201|202.0|203|204.00|205.0|206.0|207.00|208|209|210",
                                     "2|300|301|302.0|303|304.00|305.0|306.0|307.00|308|309|310",
-                                    "2|400|401|402.0|403|404.00|405.0|406.0|407.00|408|409|410",
-                                    "1|100|101|102.0|103|104.00|105.0|106.0|107.00|108|109|110",
-                                    "1|500|501|502.0|503|504.00|505.0|506.0|507.00|508|509|510",
-                                    "1|600|601|602.0|603|604.00|605.0|606.0|607.00|608|609|610");
+                                    "2|400|401|402.0|403|404.00|405.0|406.0|407.00|408|409|410");
                 },
                 getPrimaryKeyNames(),
                 tableConfig,

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileDataTableTest.java
@@ -72,7 +72,6 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                                             "1|22|122|1122|S012|S22"));
 
                     // filter with "a" = 1122 in scan and read
-                    /// TODO: changelog with key only supports to filter key
                     splits =
                             toSplits(
                                     table.newSnapshotReader()
@@ -83,9 +82,6 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
                     assertThat(getResult(read2, splits, SCHEMA_1_ROW_TO_STRING))
                             .hasSameElementsAs(
                                     Arrays.asList(
-                                            "2|12|112|null|null|null",
-                                            "2|15|115|null|null|null",
-                                            "2|16|116|null|null|null",
                                             "1|11|111|null|null|null",
                                             "1|13|113|null|null|null",
                                             "1|14|114|null|null|null",

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -129,16 +129,15 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
                             new PredicateBuilder(table.schema().logicalRowType());
                     // results of field "a" in (1120, -] in SCHEMA_1_FIELDS, "a" is not existed in
                     // SCHEMA_0_FIELDS
-                    Predicate predicate = builder.greaterThan(3, 1120);
+                    Predicate predicate = builder.greaterOrEqual(3, 1120);
                     List<DataSplit> splits =
                             table.newSnapshotReader().withFilter(predicate).read().dataSplits();
                     checkFilterRowCount(toDataFileMetas(splits), 12L);
 
-                    /**
-                     * TODO ChangelogWithKeyFileStoreTable doesn't support value predicate and can't
-                     * get value stats. The test for filtering the primary key and partition already
-                     * exists.
-                     */
+                    predicate = builder.greaterThan(3, 1120);
+                    splits = table.newSnapshotReader().withFilter(predicate).read().dataSplits();
+                    // filtered the whole bucket
+                    checkFilterRowCount(toDataFileMetas(splits), 7L);
                 },
                 getPrimaryKeyNames(),
                 tableConfig,

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyTableColumnTypeFileMetaTest.java
@@ -83,16 +83,13 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
         writeAndCheckFileResultForColumnType(
                 schemas -> {
                     FileStoreTable table = createFileStoreTable(schemas);
-                    /**
-                     * Changelog with key table doesn't support filter in value, it will scan all
-                     * data. TODO support filter value in future.
-                     */
                     Predicate predicate =
                             new PredicateBuilder(table.schema().logicalRowType())
                                     .between(6, 200L, 500L);
                     List<DataSplit> splits =
                             table.newSnapshotReader().withFilter(predicate).read().dataSplits();
-                    checkFilterRowCount(toDataFileMetas(splits), 3L);
+                    // filter value by whole bucket
+                    checkFilterRowCount(toDataFileMetas(splits), 2L);
                     return splits.stream()
                             .flatMap(s -> s.dataFiles().stream())
                             .collect(Collectors.toList());
@@ -100,10 +97,6 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                 (files, schemas) -> {
                     FileStoreTable table = createFileStoreTable(schemas);
 
-                    /**
-                     * Changelog with key table doesn't support filter in value, it will scan all
-                     * data. TODO support filter value in future.
-                     */
                     List<DataSplit> splits =
                             table.newSnapshotReader()
                                     .withFilter(
@@ -111,7 +104,8 @@ public class ChangelogWithKeyTableColumnTypeFileMetaTest extends ColumnTypeFileM
                                                     .between(6, 200F, 500F))
                                     .read()
                                     .dataSplits();
-                    checkFilterRowCount(toDataFileMetas(splits), 6L);
+                    // filtered and only 3 rows left
+                    checkFilterRowCount(toDataFileMetas(splits), 3L);
                 },
                 getPrimaryKeyNames(),
                 tableConfig,

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
@@ -130,7 +130,7 @@ public abstract class SchemaEvolutionTableTestBase {
         fileIO = FileIOFinder.find(tablePath);
         commitUser = UUID.randomUUID().toString();
         tableConfig.set(CoreOptions.PATH, tablePath.toString());
-        tableConfig.set(CoreOptions.BUCKET, 2);
+        tableConfig.set(CoreOptions.BUCKET, 1);
     }
 
     @AfterEach


### PR DESCRIPTION

### Purpose
Introduce bucket level value filter in primary key.

Current:  primary key does not support value filter.

Improve: if the bucket range min/max doesn't contains the filter target, we don't need to search the bucket any more.



### Tests

Add test.

### API and Format

The may speed up select in some conditions. No other influence to user.

### Documentation


