### PR TITLE
[core] FileDeletionBase should cancel reading manifest files when any file is failed to read

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/operation/CleanedFileStoreExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/CleanedFileStoreExpireTest.java
@@ -88,7 +88,7 @@ public class CleanedFileStoreExpireTest extends FileStoreExpireTestBase {
         ManifestEntry delete = new ManifestEntry(FileKind.DELETE, partition, 0, 1, dataFile);
 
         // expire
-        expire.snapshotDeletion().doCleanUnusedDataFile(Arrays.asList(add, delete), f -> false);
+        expire.snapshotDeletion().cleanUnusedDataFile(Arrays.asList(add, delete));
 
         // check
         assertThat(fileIO.exists(myDataFile)).isFalse();


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example, if a data file is upgraded, it has an ADD entry and a DELETE entry. If it only reads the DELETE entry successfull, the upgraded data file will be deleted.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
