### PR TITLE
[core] Enable zorder compact configering how many bytes should be devoted for type VARCHAR/CHAR/BINARY/VARBINARY

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -474,6 +474,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The time zone to parse the long watermark value to TIMESTAMP value. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-08:00'.</td>
         </tr>
         <tr>
+            <td><h5>snapshot.expire.execution-mode</h5></td>
+            <td style="word-wrap: break-word;">sync</td>
+            <td><p>Enum</p></td>
+            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>snapshot.expire.limit</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The maximum number of snapshots allowed to expire at a time.</td>
+        </tr>
+        <tr>
             <td><h5>snapshot.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
@@ -490,19 +502,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
             <td>The maximum time of completed snapshots to retain.</td>
-        </tr>
-        <tr>
-            <td><h5>snapshot.expire.execution-mode</h5></td>
-            <td style="word-wrap: break-word;">sync</td>
-            <td>Enum</td>
-            <td>Specifies the execution mode of expire.<br /><br />Possible values:<ul><li>"sync": Execute expire synchronously. If there are too many files, it may take a long time and block stream processing.</li><li>"async": Execute expire asynchronously. If the generation of snapshots is greater than the deletion, there will be a backlog of files.</li></ul></td>
-        </tr>
-        </tr>
-        <tr>
-            <td><h5>snapshot.expire.limit</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>The maximum number of snapshots allowed to expire at a time.</td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>
@@ -611,6 +610,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
+        </tr>
+        <tr>
+            <td><h5>zorder.vartype.size</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
+            <td>The bytes of types (CHAR, VARCHAR, BINARY, VARBINARY) devote to the zorder sort.</td>
         </tr>
     </tbody>
 </table>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -897,6 +897,13 @@ public class CoreOptions implements Serializable {
                                     + "This can reduce job startup time and excessive initialization of index, "
                                     + "but please note that this may also cause data duplication.");
 
+    public static final ConfigOption<Integer> ZORDER_VARTYPE_SIZE =
+            key("zorder.vartype.size")
+                    .intType()
+                    .defaultValue(8)
+                    .withDescription(
+                            "The bytes of types (CHAR, VARCHAR, BINARY, VARBINARY) devote to the zorder sort.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1333,6 +1340,10 @@ public class CoreOptions implements Serializable {
 
     public String crossPartitionUpsertBootstrapMinPartition() {
         return options.get(CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION);
+    }
+
+    public int varTypeSize() {
+        return options.get(ZORDER_VARTYPE_SIZE);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/ZorderSorter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/ZorderSorter.java
@@ -70,7 +70,8 @@ public class ZorderSorter extends TableSorter {
      */
     private DataStream<RowData> sortStreamByZOrder(
             DataStream<RowData> inputStream, FileStoreTable table) {
-        final ZIndexer zIndexer = new ZIndexer(table.rowType(), orderColNames);
+        final ZIndexer zIndexer =
+                new ZIndexer(table.rowType(), orderColNames, table.coreOptions().varTypeSize());
         return SortUtils.sortStreamByKey(
                 inputStream,
                 table,


### PR DESCRIPTION
Currently the bytes in zorder sort is fixed 8 byte.

The pull request enable configuring how many bytes should be devoted when the type is `VARCHAR/CHAR/BINARY/VARBINARY`

Added a table-conf zorder.vartype.size  referring to the parameter.

Usage example:
flink run ./paimon-flink-action-0.6-SNAPSHOT.jar compact \
--warehouse \
/Users/paimontest/GlobalBatchReadWrite \
--database \
my_db \
--table \
Orders1 \
--order-strategy zorder \
--partition "f0=0" \
--order-by f3,f4,f1 \
--table-conf zorder.vartype.size=10 \
--table-conf sink.parallelism=1