### PR TITLE
[core] Move common code from FileSystemCatalog and HiveCatalog into AbstractCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -320,8 +320,12 @@ public abstract class AbstractCatalog implements Catalog {
         return identifier.getObjectName().contains(SYSTEM_TABLE_SPLITTER);
     }
 
+    protected boolean isSystemTable(Identifier identifier) {
+        return isSystemDatabase(identifier.getDatabaseName()) || isSpecifiedSystemTable(identifier);
+    }
+
     private void checkNotSystemTable(Identifier identifier, String method) {
-        if (isSystemDatabase(identifier.getDatabaseName()) || isSpecifiedSystemTable(identifier)) {
+        if (isSystemTable(identifier)) {
             throw new IllegalArgumentException(
                     String.format(
                             "Cannot '%s' for system table '%s', please use data table.",

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -92,6 +92,10 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public boolean tableExists(Identifier identifier) {
+        if (isSystemTable(identifier)) {
+            return super.tableExists(identifier);
+        }
+
         return tableExists(getDataTableLocation(identifier));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -65,58 +65,22 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     @Override
-    public boolean databaseExists(String databaseName) {
-        if (isSystemDatabase(databaseName)) {
-            return true;
-        }
+    protected boolean databaseExistsImpl(String databaseName) {
         return uncheck(() -> fileIO.exists(databasePath(databaseName)));
     }
 
     @Override
-    public void createDatabase(String name, boolean ignoreIfExists)
-            throws DatabaseAlreadyExistException {
-        if (isSystemDatabase(name)) {
-            throw new ProcessSystemDatabaseException();
-        }
-        if (databaseExists(name)) {
-            if (ignoreIfExists) {
-                return;
-            }
-            throw new DatabaseAlreadyExistException(name);
-        }
+    protected void createDatabaseImpl(String name) {
         uncheck(() -> fileIO.mkdirs(databasePath(name)));
     }
 
     @Override
-    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
-            throws DatabaseNotExistException, DatabaseNotEmptyException {
-        if (isSystemDatabase(name)) {
-            throw new ProcessSystemDatabaseException();
-        }
-        if (!databaseExists(name)) {
-            if (ignoreIfNotExists) {
-                return;
-            }
-
-            throw new DatabaseNotExistException(name);
-        }
-
-        if (!cascade && listTables(name).size() > 0) {
-            throw new DatabaseNotEmptyException(name);
-        }
-
+    protected void dropDatabaseImpl(String name) {
         uncheck(() -> fileIO.delete(databasePath(name), true));
     }
 
     @Override
-    public List<String> listTables(String databaseName) throws DatabaseNotExistException {
-        if (isSystemDatabase(databaseName)) {
-            return GLOBAL_TABLES;
-        }
-        if (!databaseExists(databaseName)) {
-            throw new DatabaseNotExistException(databaseName);
-        }
-
+    protected List<String> listTablesImpl(String databaseName) {
         List<String> tables = new ArrayList<>();
         for (FileStatus status : uncheck(() -> fileIO.listStatus(databasePath(databaseName)))) {
             if (status.isDir() && tableExists(status.getPath())) {
@@ -127,11 +91,8 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     @Override
-    public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
-        Path path = getDataTableLocation(identifier);
-        return new SchemaManager(fileIO, path)
-                .latest()
-                .orElseThrow(() -> new TableNotExistException(identifier));
+    public boolean tableExists(Identifier identifier) {
+        return tableExists(getDataTableLocation(identifier));
     }
 
     private boolean tableExists(Path tablePath) {
@@ -139,74 +100,35 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
-            throws TableNotExistException {
-        checkNotSystemTable(identifier, "dropTable");
+    public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
         Path path = getDataTableLocation(identifier);
-        if (!tableExists(path)) {
-            if (ignoreIfNotExists) {
-                return;
-            }
+        return new SchemaManager(fileIO, path)
+                .latest()
+                .orElseThrow(() -> new TableNotExistException(identifier));
+    }
 
-            throw new TableNotExistException(identifier);
-        }
-
+    @Override
+    protected void dropTableImpl(Identifier identifier) {
+        Path path = getDataTableLocation(identifier);
         uncheck(() -> fileIO.delete(path, true));
     }
 
     @Override
-    public void createTable(Identifier identifier, Schema schema, boolean ignoreIfExists)
-            throws TableAlreadyExistException, DatabaseNotExistException {
-        checkNotSystemTable(identifier, "createTable");
-        if (!databaseExists(identifier.getDatabaseName())) {
-            throw new DatabaseNotExistException(identifier.getDatabaseName());
-        }
-
+    public void createTableImpl(Identifier identifier, Schema schema) {
         Path path = getDataTableLocation(identifier);
-        if (tableExists(path)) {
-            if (ignoreIfExists) {
-                return;
-            }
-
-            throw new TableAlreadyExistException(identifier);
-        }
-
-        copyTableDefaultOptions(schema.options());
-
         uncheck(() -> new SchemaManager(fileIO, path).createTable(schema));
     }
 
     @Override
-    public void renameTable(Identifier fromTable, Identifier toTable, boolean ignoreIfNotExists)
-            throws TableNotExistException, TableAlreadyExistException {
-        checkNotSystemTable(fromTable, "renameTable");
-        checkNotSystemTable(toTable, "renameTable");
+    public void renameTableImpl(Identifier fromTable, Identifier toTable) {
         Path fromPath = getDataTableLocation(fromTable);
-        if (!tableExists(fromPath)) {
-            if (ignoreIfNotExists) {
-                return;
-            }
-
-            throw new TableNotExistException(fromTable);
-        }
-
         Path toPath = getDataTableLocation(toTable);
-        if (tableExists(toPath)) {
-            throw new TableAlreadyExistException(toTable);
-        }
-
         uncheck(() -> fileIO.rename(fromPath, toPath));
     }
 
     @Override
-    public void alterTable(
-            Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
+    protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
-        checkNotSystemTable(identifier, "alterTable");
-        if (!tableExists(getDataTableLocation(identifier))) {
-            throw new TableNotExistException(identifier);
-        }
-
         new SchemaManager(fileIO, getDataTableLocation(identifier)).commitChanges(changes);
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -220,6 +220,10 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     public boolean tableExists(Identifier identifier) {
+        if (isSystemTable(identifier)) {
+            return super.tableExists(identifier);
+        }
+
         Table table;
         try {
             table = client.getTable(identifier.getDatabaseName(), identifier.getObjectName());

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -42,14 +42,12 @@ import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
-import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -171,10 +169,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public boolean databaseExists(String databaseName) {
-        if (isSystemDatabase(databaseName)) {
-            return true;
-        }
+    protected boolean databaseExistsImpl(String databaseName) {
         try {
             client.getDatabase(databaseName);
             return true;
@@ -187,93 +182,77 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void createDatabase(String name, boolean ignoreIfExists)
-            throws DatabaseAlreadyExistException {
-        if (isSystemDatabase(name)) {
-            throw new ProcessSystemDatabaseException();
-        }
+    protected void createDatabaseImpl(String name) {
         try {
             client.createDatabase(convertToDatabase(name));
-
             locationHelper.createPathIfRequired(databasePath(name), fileIO);
-        } catch (AlreadyExistsException e) {
-            if (!ignoreIfExists) {
-                throw new DatabaseAlreadyExistException(name, e);
-            }
         } catch (TException | IOException e) {
             throw new RuntimeException("Failed to create database " + name, e);
         }
     }
 
     @Override
-    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
-            throws DatabaseNotExistException, DatabaseNotEmptyException {
-        if (isSystemDatabase(name)) {
-            throw new ProcessSystemDatabaseException();
-        }
+    protected void dropDatabaseImpl(String name) {
         try {
-            if (!cascade && client.getAllTables(name).size() > 0) {
-                throw new DatabaseNotEmptyException(name);
-            }
-
             locationHelper.dropPathIfRequired(databasePath(name), fileIO);
             client.dropDatabase(name, true, false, true);
-        } catch (NoSuchObjectException | UnknownDBException e) {
-            if (!ignoreIfNotExists) {
-                throw new DatabaseNotExistException(name, e);
-            }
         } catch (TException | IOException e) {
             throw new RuntimeException("Failed to drop database " + name, e);
         }
     }
 
     @Override
-    public List<String> listTables(String databaseName) throws DatabaseNotExistException {
-        if (isSystemDatabase(databaseName)) {
-            return GLOBAL_TABLES;
-        }
+    protected List<String> listTablesImpl(String databaseName) {
         try {
             return client.getAllTables(databaseName).stream()
                     .filter(
                             tableName -> {
                                 Identifier identifier = new Identifier(databaseName, tableName);
                                 // the environment here may not be able to access non-paimon
-                                // tables.
-                                // so we just check the schema file first
-                                return schemaFileExists(identifier)
-                                        && paimonTableExists(identifier);
+                                // tables, so we just check the schema file first
+                                return schemaFileExists(identifier) && tableExists(identifier);
                             })
                     .collect(Collectors.toList());
-        } catch (UnknownDBException e) {
-            throw new DatabaseNotExistException(databaseName, e);
         } catch (TException e) {
             throw new RuntimeException("Failed to list all tables in database " + databaseName, e);
         }
     }
 
     @Override
+    public boolean tableExists(Identifier identifier) {
+        Table table;
+        try {
+            table = client.getTable(identifier.getDatabaseName(), identifier.getObjectName());
+        } catch (NoSuchObjectException e) {
+            return false;
+        } catch (TException e) {
+            throw new RuntimeException(
+                    "Cannot determine if table " + identifier.getFullName() + " is a paimon table.",
+                    e);
+        }
+
+        return isPaimonTable(table) || LegacyHiveClasses.isPaimonTable(table);
+    }
+
+    private static boolean isPaimonTable(Table table) {
+        return INPUT_FORMAT_CLASS_NAME.equals(table.getSd().getInputFormat())
+                && OUTPUT_FORMAT_CLASS_NAME.equals(table.getSd().getOutputFormat());
+    }
+
+    @Override
     public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
-        if (!paimonTableExists(identifier)) {
+        if (!tableExists(identifier)) {
             throw new TableNotExistException(identifier);
         }
         Path tableLocation = getDataTableLocation(identifier);
         return new SchemaManager(fileIO, tableLocation)
                 .latest()
-                .orElseThrow(() -> new RuntimeException("There is no paimond in " + tableLocation));
+                .orElseThrow(
+                        () -> new RuntimeException("There is no paimon table in " + tableLocation));
     }
 
     @Override
-    public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
-            throws TableNotExistException {
-        checkNotSystemTable(identifier, "dropTable");
-        if (!paimonTableExists(identifier)) {
-            if (ignoreIfNotExists) {
-                return;
-            } else {
-                throw new TableNotExistException(identifier);
-            }
-        }
-
+    protected void dropTableImpl(Identifier identifier) {
         try {
             client.dropTable(
                     identifier.getDatabaseName(), identifier.getObjectName(), true, false, true);
@@ -294,27 +273,11 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void createTable(Identifier identifier, Schema schema, boolean ignoreIfExists)
-            throws TableAlreadyExistException, DatabaseNotExistException {
-        checkNotSystemTable(identifier, "createTable");
-        String databaseName = identifier.getDatabaseName();
-        if (!databaseExists(databaseName)) {
-            throw new DatabaseNotExistException(databaseName);
-        }
-        if (paimonTableExists(identifier)) {
-            if (ignoreIfExists) {
-                return;
-            } else {
-                throw new TableAlreadyExistException(identifier);
-            }
-        }
-
+    protected void createTableImpl(Identifier identifier, Schema schema) {
         checkFieldNamesUpperCase(schema.rowType().getFieldNames());
+
         // first commit changes to underlying files
         // if changes on Hive fails there is no harm to perform the same changes to files again
-
-        copyTableDefaultOptions(schema.options());
-
         TableSchema tableSchema;
         try {
             tableSchema = schemaManager(identifier).createTable(schema);
@@ -325,6 +288,7 @@ public class HiveCatalog extends AbstractCatalog {
                             + " to underlying files.",
                     e);
         }
+
         Table table =
                 newHmsTable(
                         identifier,
@@ -351,22 +315,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void renameTable(Identifier fromTable, Identifier toTable, boolean ignoreIfNotExists)
-            throws TableNotExistException, TableAlreadyExistException {
-        checkNotSystemTable(fromTable, "renameTable");
-        checkNotSystemTable(toTable, "renameTable");
-        if (!paimonTableExists(fromTable)) {
-            if (ignoreIfNotExists) {
-                return;
-            } else {
-                throw new TableNotExistException(fromTable);
-            }
-        }
-
-        if (paimonTableExists(toTable)) {
-            throw new TableAlreadyExistException(toTable);
-        }
-
+    protected void renameTableImpl(Identifier fromTable, Identifier toTable) {
         try {
             checkIdentifierUpperCase(toTable);
             String fromDB = fromTable.getDatabaseName();
@@ -401,18 +350,8 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void alterTable(
-            Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
+    protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
-        checkNotSystemTable(identifier, "alterTable");
-        if (!paimonTableExists(identifier)) {
-            if (ignoreIfNotExists) {
-                return;
-            } else {
-                throw new TableNotExistException(identifier);
-            }
-        }
-
         checkFieldNamesUpperCaseInSchemaChange(changes);
 
         final SchemaManager schemaManager = schemaManager(identifier);
@@ -577,26 +516,6 @@ public class HiveCatalog extends AbstractCatalog {
 
     private boolean schemaFileExists(Identifier identifier) {
         return new SchemaManager(fileIO, getDataTableLocation(identifier)).latest().isPresent();
-    }
-
-    private boolean paimonTableExists(Identifier identifier) {
-        Table table;
-        try {
-            table = client.getTable(identifier.getDatabaseName(), identifier.getObjectName());
-        } catch (NoSuchObjectException e) {
-            return false;
-        } catch (TException e) {
-            throw new RuntimeException(
-                    "Cannot determine if table " + identifier.getFullName() + " is a paimon table.",
-                    e);
-        }
-
-        return isPaimonTable(table) || LegacyHiveClasses.isPaimonTable(table);
-    }
-
-    private static boolean isPaimonTable(Table table) {
-        return INPUT_FORMAT_CLASS_NAME.equals(table.getSd().getInputFormat())
-                && OUTPUT_FORMAT_CLASS_NAME.equals(table.getSd().getOutputFormat());
     }
 
     private SchemaManager schemaManager(Identifier identifier) {


### PR DESCRIPTION
### Purpose

Currently, `FileSystemCatalog` and `HiveCatalog` contains a lot of common code. For example, both catalog needs to check if the table to be deleted is a system table, and if that table exists.

This PR extracts common code into `AbstractCatalog`, which makes introducing new catalog easier.

### Tests

Existing tests should cover this change.

### API and Format

No.

### Documentation

No.
