### PR TITLE
[flink] Correct the partitioning for multi-table CDC between write to commit

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecordChannelComputer.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecordChannelComputer.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-/** {@link ChannelComputer} for {@link CdcRecord}. */
+/** {@link ChannelComputer} for {@link CdcMultiplexRecord}. */
 public class CdcMultiplexRecordChannelComputer implements ChannelComputer<CdcMultiplexRecord> {
 
     private static final Logger LOG =
@@ -90,6 +90,6 @@ public class CdcMultiplexRecordChannelComputer implements ChannelComputer<CdcMul
 
     @Override
     public String toString() {
-        return "shuffle by table";
+        return "shuffle by bucket";
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableCommittableChannelComputer.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableCommittableChannelComputer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.flink.sink.ChannelComputer;
+import org.apache.paimon.flink.sink.MultiTableCommittable;
+
+import java.util.Objects;
+
+/** {@link ChannelComputer} for {@link MultiTableCommittable}. */
+public class MultiTableCommittableChannelComputer
+        implements ChannelComputer<MultiTableCommittable> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient int numChannels;
+
+    @Override
+    public void setup(int numChannels) {
+        this.numChannels = numChannels;
+    }
+
+    @Override
+    public int channel(MultiTableCommittable multiTableCommittable) {
+        return Math.floorMod(
+                Objects.hash(multiTableCommittable.getDatabase(), multiTableCommittable.getTable()),
+                numChannels);
+    }
+
+    @Override
+    public String toString() {
+        return "shuffle by table";
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.options.Options;
+
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link FlinkCdcMultiTableSink}. */
+public class FlinkCdcMultiTableSinkTest {
+
+    @Test
+    public void testTransformationParallelism() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(8);
+        int inputParallelism = ThreadLocalRandom.current().nextInt(8) + 1;
+        DataStreamSource<CdcMultiplexRecord> input =
+                env.addSource(
+                                new ParallelSourceFunction<CdcMultiplexRecord>() {
+                                    @Override
+                                    public void run(SourceContext<CdcMultiplexRecord> ctx) {}
+
+                                    @Override
+                                    public void cancel() {}
+                                })
+                        .setParallelism(inputParallelism);
+
+        FlinkCdcMultiTableSink sink =
+                new FlinkCdcMultiTableSink(
+                        () -> FlinkCatalogFactory.createPaimonCatalog(new Options()),
+                        FlinkConnectorOptions.SINK_COMMITTER_CPU.defaultValue(),
+                        null);
+        DataStreamSink<?> dataStreamSink = sink.sinkFrom(input, Collections.emptyMap());
+
+        // check the transformation graph
+        LegacySinkTransformation<?> end =
+                (LegacySinkTransformation<?>) dataStreamSink.getTransformation();
+        assertThat(end.getName()).isEqualTo("end");
+
+        OneInputTransformation<?, ?> committer =
+                (OneInputTransformation<?, ?>) end.getInputs().get(0);
+        assertThat(committer.getName()).isEqualTo("Multiplex Global Committer");
+        assertThat(committer.getParallelism()).isEqualTo(inputParallelism);
+
+        PartitionTransformation<?> partitioner =
+                (PartitionTransformation<?>) committer.getInputs().get(0);
+        assertThat(partitioner.getParallelism()).isEqualTo(inputParallelism);
+
+        OneInputTransformation<?, ?> writer =
+                (OneInputTransformation<?, ?>) partitioner.getInputs().get(0);
+        assertThat(writer.getName()).isEqualTo("CDC MultiplexWriter");
+        assertThat(writer.getParallelism()).isEqualTo(inputParallelism);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -206,9 +206,11 @@ public abstract class FlinkSink<T> implements Serializable {
         }
         SingleOutputStreamOperator<?> committed =
                 written.transform(
-                        GLOBAL_COMMITTER_NAME + " : " + table.name(),
-                        new CommittableTypeInfo(),
-                        committerOperator);
+                                GLOBAL_COMMITTER_NAME + " : " + table.name(),
+                                new CommittableTypeInfo(),
+                                committerOperator)
+                        .setParallelism(1)
+                        .setMaxParallelism(1);
         Options options = Options.fromMap(table.options());
         configureGlobalCommitter(
                 committed,
@@ -223,7 +225,6 @@ public abstract class FlinkSink<T> implements Serializable {
             double cpuCores,
             @Nullable MemorySize heapMemory,
             ReadableConfig conf) {
-        committed.setParallelism(1).setMaxParallelism(1);
         if (heapMemory == null) {
             return;
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently， the parallelism is set to 1 but actually the cdc records can be shuffled by table name. This PR fix it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
