### PR TITLE
[hive] Introduce metastore.tag-to-partition for Hive metastore

### DIFF
--- a/docs/content/migration/_index.md
+++ b/docs/content/migration/_index.md
@@ -1,10 +1,9 @@
 ---
-title: Project
-icon: <i class="fa fa-sitemap title maindish" aria-hidden="true"></i>
+title: Migration
+icon: <i class="fa fa-briefcase title maindish" aria-hidden="true"></i>
 bold: true
 bookCollapseSection: true
-sectionBreak: true
-weight: 9
+weight: 8
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/migration/upsert-to-partitioned.md
+++ b/docs/content/migration/upsert-to-partitioned.md
@@ -1,0 +1,99 @@
+---
+title: "Upsert To Partitioned"
+weight: 1
+type: docs
+aliases:
+- /migration/upsert-to-partitioned.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Upsert To Partitioned
+
+The [Tag Management]({{< ref "maintenance/manage-tags" >}}) will maintain the manifests and data files of the snapshot.
+A typical usage is creating tags daily, then you can maintain the historical data of each day for batch reading.
+
+When using primary key tables, a non-partitioned approach is often used to maintain updates, in order to mirror and
+synchronize tables from upstream database tables. This allows users to query the latest data. The tradition of Hive
+data warehouses is not like this. Offline data warehouses require an immutable view every day to ensure the idempotence
+of calculations. So we created a Tag mechanism to output these views.
+
+However, the traditional use of Hive data warehouses is more accustomed to using partitions to specify the query's Tag,
+and is more accustomed to using Hive computing engines.
+
+So, we introduce `'metastore.tag-to-partition'` to mapping a non-partitioned primary key table to the partition table
+in Hive metastore, and mapping the partition field to the name of the Tag to be fully compatible with Hive.
+
+## Example
+
+**Step 1: Create table and tag in Flink SQL**
+
+{{< tabs "Create table and tag in Flink SQL" >}}
+{{< tab "Flink" >}}
+```sql
+CREATE CATALOG my_hive WITH (
+    'type' = 'paimon',
+    'metastore' = 'hive',
+    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+    -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
+    -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
+    'warehouse' = 'hdfs:///path/to/warehouse'
+);
+
+USE CATALOG my_hive;
+
+CREATE TABLE mydb.T (
+    pk INT,
+    col1 STRING,
+    col2 STRING
+) WITH (
+    'bucket' = '-1',
+    'metastore.tag-to-partition' = 'dt'
+);
+
+INSERT INTO t VALUES (1, '10', '100'), (2, '20', '200');
+
+-- create tag '2023-10-16' for snapshot 1
+CALL my_hive.system.create_tag('mydb.T', '2023-10-16', 1);
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+**Step 2: Query table in Hive with Partition Pruning**
+
+{{< tabs "Query table in Hive with Partition Pruning" >}}
+{{< tab "Hive" >}}
+```sql
+SHOW PARTITIONS T;
+/*
+OK
+dt=2023-10-16
+*/
+
+SELECT * FROM T WHERE dt='2023-10-16';
+/*
+OK
+1 10 100 2023-10-16
+2 20 200 2023-10-16
+*/
+```
+
+{{< /tab >}}
+{{< /tabs >}}

--- a/docs/content/migration/upsert-to-partitioned.md
+++ b/docs/content/migration/upsert-to-partitioned.md
@@ -37,14 +37,15 @@ of calculations. So we created a Tag mechanism to output these views.
 However, the traditional use of Hive data warehouses is more accustomed to using partitions to specify the query's Tag,
 and is more accustomed to using Hive computing engines.
 
-So, we introduce `'metastore.tag-to-partition'` to mapping a non-partitioned primary key table to the partition table
-in Hive metastore, and mapping the partition field to the name of the Tag to be fully compatible with Hive.
+So, we introduce `'metastore.tag-to-partition'` and `'metastore.tag-to-partition-preview'` to mapping a non-partitioned
+primary key table to the partition table in Hive metastore, and mapping the partition field to the name of the Tag to be
+fully compatible with Hive.
 
-## Example
+## Example for Tag to Partition
 
 **Step 1: Create table and tag in Flink SQL**
 
-{{< tabs "Create table and tag in Flink SQL" >}}
+{{< tabs "Create table and tag in Flink SQL 1" >}}
 {{< tab "Flink" >}}
 ```sql
 CREATE CATALOG my_hive WITH (
@@ -70,7 +71,7 @@ CREATE TABLE mydb.T (
 INSERT INTO t VALUES (1, '10', '100'), (2, '20', '200');
 
 -- create tag '2023-10-16' for snapshot 1
-CALL my_hive.system.create_tag('mydb.T', '2023-10-16', 1);
+CALL sys.create_tag('mydb.T', '2023-10-16', 1);
 ```
 
 {{< /tab >}}
@@ -78,7 +79,7 @@ CALL my_hive.system.create_tag('mydb.T', '2023-10-16', 1);
 
 **Step 2: Query table in Hive with Partition Pruning**
 
-{{< tabs "Query table in Hive with Partition Pruning" >}}
+{{< tabs "Query table in Hive with Partition Pruning 1" >}}
 {{< tab "Hive" >}}
 ```sql
 SHOW PARTITIONS T;
@@ -92,6 +93,80 @@ SELECT * FROM T WHERE dt='2023-10-16';
 OK
 1 10 100 2023-10-16
 2 20 200 2023-10-16
+*/
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+## Example for Tag Preview
+
+The above example can only query tags that have already been created, but Paimon is a real-time data lake, and you also
+need to query the latest data. Therefore, Paimon provides a preview feature:
+
+**Step 1: Create table and tag in Flink SQL**
+
+{{< tabs "Create table and tag in Flink SQL 2" >}}
+{{< tab "Flink" >}}
+```sql
+CREATE CATALOG my_hive WITH (
+    'type' = 'paimon',
+    'metastore' = 'hive',
+    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+    -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
+    -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
+    'warehouse' = 'hdfs:///path/to/warehouse'
+);
+
+USE CATALOG my_hive;
+
+CREATE TABLE mydb.T (
+    pk INT,
+    col1 STRING,
+    col2 STRING
+) WITH (
+    'bucket' = '-1',
+    'metastore.tag-to-partition' = 'dt',
+    -- preview tag creation mode process-time
+    -- paimon will create partitions early based on process-time
+    'metastore.tag-to-partition-preview' = 'process-time'
+);
+
+INSERT INTO t VALUES (1, '10', '100'), (2, '20', '200');
+
+-- create tag '2023-10-16' for snapshot 1
+CALL sys.create_tag('mydb.T', '2023-10-16', 1);
+
+-- new data in '2023-10-17'
+INSERT INTO t VALUES (3, '30', '300'), (4, '40', '400');
+
+-- haven't finished writing the data for '2023-10-17' yet, so there's no need to create a tag for now
+-- but the data is already visible for Hive
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+**Step 2: Query table in Hive with Partition Pruning**
+
+{{< tabs "Query table in Hive with Partition Pruning 2" >}}
+{{< tab "Hive" >}}
+```sql
+SHOW PARTITIONS T;
+/*
+OK
+dt=2023-10-16
+dt=2023-10-17
+*/
+
+SELECT * FROM T WHERE dt='2023-10-17';
+-- preview tag '2023-10-17'
+/*
+OK
+1 10 100 2023-10-17
+2 20 200 2023-10-17
+3 30 300 2023-10-17
+4 40 400 2023-10-17
 */
 ```
 

--- a/docs/content/migration/upsert-to-partitioned.md
+++ b/docs/content/migration/upsert-to-partitioned.md
@@ -37,7 +37,7 @@ of calculations. So we created a Tag mechanism to output these views.
 However, the traditional use of Hive data warehouses is more accustomed to using partitions to specify the query's Tag,
 and is more accustomed to using Hive computing engines.
 
-So, we introduce `'metastore.tag-to-partition'` and `'metastore.tag-to-partition-preview'` to mapping a non-partitioned
+So, we introduce `'metastore.tag-to-partition'` and `'metastore.tag-to-partition.preview'` to mapping a non-partitioned
 primary key table to the partition table in Hive metastore, and mapping the partition field to the name of the Tag to be
 fully compatible with Hive.
 
@@ -129,7 +129,7 @@ CREATE TABLE mydb.T (
     'metastore.tag-to-partition' = 'dt',
     -- preview tag creation mode process-time
     -- paimon will create partitions early based on process-time
-    'metastore.tag-to-partition-preview' = 'process-time'
+    'metastore.tag-to-partition.preview' = 'process-time'
 );
 
 INSERT INTO t VALUES (1, '10', '100'), (2, '20', '200');

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -312,7 +312,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Whether to create this table as a partitioned table for mapping non-partitioned table tags in metastore. This allows the Hive engine to view this table in a partitioned table view and use partitioning field to read specific partitions (specific tags).</td>
         </tr>
         <tr>
-            <td><h5>metastore.tag-to-partition-preview</h5></td>
+            <td><h5>metastore.tag-to-partition.preview</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
             <td>Whether to preview tag of generated snapshots in metastore. This allows the Hive engine to query specific tag before creation.<br /><br />Possible values:<ul><li>"none": No automatically created tags.</li><li>"process-time": Based on the time of the machine, create TAG once the processing time passes period time plus delay.</li><li>"watermark": Based on the watermark of the input, create TAG once the watermark passes period time plus delay.</li></ul></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -306,6 +306,12 @@ For example, if you want to list all partitions of a Paimon table in Hive, you n
 This config option does not affect the default filesystem metastore.</td>
         </tr>
         <tr>
+            <td><h5>metastore.tag-to-partition</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Whether to create this table as a partitioned table for mapping non-partitioned table tags in metastore. This allows the Hive engine to view this table in a partitioned table view and use partitioning field to read specific partitions (specific tags).</td>
+        </tr>
+        <tr>
             <td><h5>num-levels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -556,6 +562,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
             <td>Whether to create tag automatically. And how to generate tags.<br /><br />Possible values:<ul><li>"none": No automatically created tags.</li><li>"process-time": Based on the time of the machine, create TAG once the processing time passes period time plus delay.</li><li>"watermark": Based on the watermark of the input, create TAG once the watermark passes period time plus delay.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>tag.callback.#.param</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Parameter string for the constructor of class #. Callback class should parse the parameter by itself.</td>
+        </tr>
+        <tr>
+            <td><h5>tag.callbacks</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A list of commit callback classes to be called after a successful tag. Class names are connected with comma (example: com.test.CallbackA,com.sample.CallbackB).</td>
         </tr>
         <tr>
             <td><h5>tag.creation-delay</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -312,6 +312,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Whether to create this table as a partitioned table for mapping non-partitioned table tags in metastore. This allows the Hive engine to view this table in a partitioned table view and use partitioning field to read specific partitions (specific tags).</td>
         </tr>
         <tr>
+            <td><h5>metastore.tag-to-partition-preview</h5></td>
+            <td style="word-wrap: break-word;">none</td>
+            <td><p>Enum</p></td>
+            <td>Whether to preview tag of generated snapshots in metastore. This allows the Hive engine to query specific tag before creation.<br /><br />Possible values:<ul><li>"none": No automatically created tags.</li><li>"process-time": Based on the time of the machine, create TAG once the processing time passes period time plus delay.</li><li>"watermark": Based on the watermark of the input, create TAG once the watermark passes period time plus delay.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>num-levels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/spark_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/spark_connector_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>read.changelog</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to read row in the form of changelog (add rowkind column in row to represent its change type).</td>
+        </tr>
+        <tr>
             <td><h5>read.stream.maxBytesPerTrigger</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>
@@ -55,12 +61,6 @@ under the License.
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>
             <td>The minimum number of rows returned in a single batch, which used to create MinRowsReadLimit with read.stream.maxTriggerDelayMs together.</td>
-        </tr>
-        <tr>
-            <td><h5>read.changelog</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to read row in the form of changelog (add rowkind column in row to represent its change type).</td>
         </tr>
         <tr>
             <td><h5>write.merge-schema</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -836,7 +836,7 @@ public class CoreOptions implements Serializable {
                                     + "use partitioning field to read specific partitions (specific tags).");
 
     public static final ConfigOption<TagCreationMode> METASTORE_TAG_TO_PARTITION_PREVIEW =
-            key("metastore.tag-to-partition-preview")
+            key("metastore.tag-to-partition.preview")
                     .enumType(TagCreationMode.class)
                     .defaultValue(TagCreationMode.NONE)
                     .withDescription(

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -835,6 +835,14 @@ public class CoreOptions implements Serializable {
                                     + "This allows the Hive engine to view this table in a partitioned table view and "
                                     + "use partitioning field to read specific partitions (specific tags).");
 
+    public static final ConfigOption<TagCreationMode> METASTORE_TAG_TO_PARTITION_PREVIEW =
+            key("metastore.tag-to-partition-preview")
+                    .enumType(TagCreationMode.class)
+                    .defaultValue(TagCreationMode.NONE)
+                    .withDescription(
+                            "Whether to preview tag of generated snapshots in metastore. "
+                                    + "This allows the Hive engine to query specific tag before creation.");
+
     public static final ConfigOption<TagCreationMode> TAG_AUTOMATIC_CREATION =
             key("tag.automatic-creation")
                     .enumType(TagCreationMode.class)
@@ -1315,6 +1323,10 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String tagToPartitionField() {
         return options.get(METASTORE_TAG_TO_PARTITION);
+    }
+
+    public TagCreationMode tagToPartitionPreview() {
+        return options.get(METASTORE_TAG_TO_PARTITION_PREVIEW);
     }
 
     public TagCreationMode tagCreationMode() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -33,6 +33,8 @@ import org.apache.paimon.options.description.InlineElement;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.StringUtils;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -797,6 +799,23 @@ public class CoreOptions implements Serializable {
                             "Parameter string for the constructor of class #. "
                                     + "Callback class should parse the parameter by itself.");
 
+    public static final ConfigOption<String> TAG_CALLBACKS =
+            key("tag.callbacks")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "A list of commit callback classes to be called after a successful tag. "
+                                    + "Class names are connected with comma "
+                                    + "(example: com.test.CallbackA,com.sample.CallbackB).");
+
+    public static final ConfigOption<String> TAG_CALLBACK_PARAM =
+            key("tag.callback.#.param")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Parameter string for the constructor of class #. "
+                                    + "Callback class should parse the parameter by itself.");
+
     public static final ConfigOption<Boolean> METASTORE_PARTITIONED_TABLE =
             key("metastore.partitioned-table")
                     .booleanType()
@@ -806,6 +825,15 @@ public class CoreOptions implements Serializable {
                                     + "For example, if you want to list all partitions of a Paimon table in Hive, "
                                     + "you need to create this table as a partitioned table in Hive metastore.\n"
                                     + "This config option does not affect the default filesystem metastore.");
+
+    public static final ConfigOption<String> METASTORE_TAG_TO_PARTITION =
+            key("metastore.tag-to-partition")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Whether to create this table as a partitioned table for mapping non-partitioned table tags in metastore. "
+                                    + "This allows the Hive engine to view this table in a partitioned table view and "
+                                    + "use partitioning field to read specific partitions (specific tags).");
 
     public static final ConfigOption<TagCreationMode> TAG_AUTOMATIC_CREATION =
             key("tag.automatic-creation")
@@ -1284,6 +1312,11 @@ public class CoreOptions implements Serializable {
         return options.get(METASTORE_PARTITIONED_TABLE);
     }
 
+    @Nullable
+    public String tagToPartitionField() {
+        return options.get(METASTORE_TAG_TO_PARTITION);
+    }
+
     public TagCreationMode tagCreationMode() {
         return options.get(TAG_AUTOMATIC_CREATION);
     }
@@ -1319,14 +1352,23 @@ public class CoreOptions implements Serializable {
     }
 
     public Map<String, String> commitCallbacks() {
+        return callbacks(COMMIT_CALLBACKS, COMMIT_CALLBACK_PARAM);
+    }
+
+    public Map<String, String> tagCallbacks() {
+        return callbacks(TAG_CALLBACKS, TAG_CALLBACK_PARAM);
+    }
+
+    private Map<String, String> callbacks(
+            ConfigOption<String> callbacks, ConfigOption<String> callbackParam) {
         Map<String, String> result = new HashMap<>();
-        for (String className : options.get(COMMIT_CALLBACKS).split(",")) {
+        for (String className : options.get(callbacks).split(",")) {
             className = className.trim();
             if (className.length() == 0) {
                 continue;
             }
 
-            String param = options.get(COMMIT_CALLBACK_PARAM.key().replace("#", className));
+            String param = options.get(callbackParam.key().replace("#", className));
             result.put(className, param);
         }
         return result;

--- a/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
@@ -87,6 +87,14 @@ public class JoinedRow implements InternalRow {
         return this;
     }
 
+    public InternalRow row1() {
+        return row1;
+    }
+
+    public InternalRow row2() {
+        return row2;
+    }
+
     // ---------------------------------------------------------------------------------------------
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.tag.TagPreview;
+
+import java.util.List;
+import java.util.Optional;
+
+/** A {@link CommitCallback} to add partitions to metastore for tag preview. */
+public class TagPreviewCommitCallback implements CommitCallback {
+
+    private final AddPartitionTagCallback tagCallback;
+    private final TagPreview tagPreview;
+
+    public TagPreviewCommitCallback(AddPartitionTagCallback tagCallback, TagPreview tagPreview) {
+        this.tagCallback = tagCallback;
+        this.tagPreview = tagPreview;
+    }
+
+    @Override
+    public void call(List<ManifestCommittable> committables) {
+        long currentMillis = System.currentTimeMillis();
+        for (ManifestCommittable c : committables) {
+            Optional<String> tagOptional = tagPreview.extractTag(currentMillis, c.watermark());
+            tagOptional.ifPresent(tagCallback::notifyCreation);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        tagCallback.close();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -26,6 +26,8 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.metastore.AddPartitionCommitCallback;
+import org.apache.paimon.metastore.AddPartitionTagCallback;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.DefaultValueAssigner;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
@@ -39,6 +41,7 @@ import org.apache.paimon.table.sink.DynamicBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.FixedBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.table.sink.UnawareBucketRowKeyExtractor;
 import org.apache.paimon.table.source.InnerStreamTableScan;
 import org.apache.paimon.table.source.InnerStreamTableScanImpl;
@@ -51,6 +54,7 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.SnapshotReaderImpl;
 import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanner;
+import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -58,6 +62,7 @@ import org.apache.paimon.utils.TagManager;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -276,10 +281,30 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
         return callbacks;
     }
 
-    private List<CommitCallback> loadCommitCallbacks() {
-        List<CommitCallback> result = new ArrayList<>();
+    private List<TagCallback> createTagCallbacks() {
+        List<TagCallback> callbacks = new ArrayList<>(loadTagCallbacks());
+        String partitionField = coreOptions().tagToPartitionField();
+        MetastoreClient.Factory metastoreClientFactory =
+                catalogEnvironment.metastoreClientFactory();
+        if (partitionField != null && metastoreClientFactory != null) {
+            callbacks.add(
+                    new AddPartitionTagCallback(metastoreClientFactory.create(), partitionField));
+        }
+        return callbacks;
+    }
 
-        Map<String, String> clazzParamMaps = coreOptions().commitCallbacks();
+    private List<TagCallback> loadTagCallbacks() {
+        return loadCallbacks(coreOptions().tagCallbacks(), TagCallback.class);
+    }
+
+    private List<CommitCallback> loadCommitCallbacks() {
+        return loadCallbacks(coreOptions().commitCallbacks(), CommitCallback.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> List<T> loadCallbacks(Map<String, String> clazzParamMaps, Class<T> expectClass) {
+        List<T> result = new ArrayList<>();
+
         for (Map.Entry<String, String> classParamEntry : clazzParamMaps.entrySet()) {
             String className = classParamEntry.getKey();
             String param = classParamEntry.getValue();
@@ -292,15 +317,14 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
             }
 
             Preconditions.checkArgument(
-                    CommitCallback.class.isAssignableFrom(clazz),
-                    "Class " + clazz + " must implement " + CommitCallback.class);
+                    expectClass.isAssignableFrom(clazz),
+                    "Class " + clazz + " must implement " + expectClass);
 
             try {
                 if (param == null) {
-                    result.add((CommitCallback) clazz.newInstance());
+                    result.add((T) clazz.newInstance());
                 } else {
-                    result.add(
-                            (CommitCallback) clazz.getConstructor(String.class).newInstance(param));
+                    result.add((T) clazz.getConstructor(String.class).newInstance(param));
                 }
             } catch (Exception e) {
                 throw new RuntimeException(
@@ -413,6 +437,16 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
         Snapshot snapshot = snapshotManager.snapshot(fromSnapshotId);
         tagManager().createTag(snapshot, tagName);
+
+        List<TagCallback> callbacks = Collections.emptyList();
+        try {
+            callbacks = createTagCallbacks();
+            callbacks.forEach(callback -> callback.notifyCreation(tagName));
+        } finally {
+            for (TagCallback tagCallback : callbacks) {
+                IOUtils.closeQuietly(tagCallback);
+            }
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TagCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TagCallback.java
@@ -16,26 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.metastore;
-
-import org.apache.paimon.data.BinaryRow;
-
-import java.io.Serializable;
-import java.util.LinkedHashMap;
+package org.apache.paimon.table.sink;
 
 /**
- * A metastore client related to a table. All methods of this interface operate on the same specific
- * table.
+ * This callback will be called after tag operations.
+ *
+ * <p>NOTE: No guarantee that this callback must be called.
  */
-public interface MetastoreClient extends AutoCloseable {
+public interface TagCallback extends AutoCloseable {
 
-    void addPartition(BinaryRow partition) throws Exception;
-
-    void addPartition(LinkedHashMap<String, String> partitionSpec) throws Exception;
-
-    /** Factory to create {@link MetastoreClient}. */
-    interface Factory extends Serializable {
-
-        MetastoreClient create();
-    }
+    void notifyCreation(String tagName);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -20,7 +20,6 @@ package org.apache.paimon.tag;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -28,54 +27,20 @@ import org.apache.paimon.utils.TagManager;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.ResolverStyle;
-import java.time.format.SignStyle;
 import java.util.Optional;
 import java.util.SortedMap;
 
-import static java.time.temporal.ChronoField.DAY_OF_MONTH;
-import static java.time.temporal.ChronoField.HOUR_OF_DAY;
-import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
-import static java.time.temporal.ChronoField.YEAR;
 import static org.apache.paimon.Snapshot.FIRST_SNAPSHOT_ID;
 import static org.apache.paimon.shade.guava30.com.google.common.base.MoreObjects.firstNonNull;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** A manager to create tags automatically. */
 public class TagAutoCreation {
 
-    private static final DateTimeFormatter HOUR_FORMATTER =
-            new DateTimeFormatterBuilder()
-                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
-                    .appendLiteral(" ")
-                    .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NORMAL)
-                    .toFormatter()
-                    .withResolverStyle(ResolverStyle.LENIENT);
-
-    private static final DateTimeFormatter DAY_FORMATTER =
-            new DateTimeFormatterBuilder()
-                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
-                    .toFormatter()
-                    .withResolverStyle(ResolverStyle.LENIENT);
-
     private final SnapshotManager snapshotManager;
     private final TagManager tagManager;
     private final TagDeletion tagDeletion;
-    private final TimeExtractor timeExtractor;
+    private final TagTimeExtractor timeExtractor;
     private final TagPeriodHandler periodHandler;
     private final Duration delay;
     private final Integer numRetainedMax;
@@ -87,7 +52,7 @@ public class TagAutoCreation {
             SnapshotManager snapshotManager,
             TagManager tagManager,
             TagDeletion tagDeletion,
-            TimeExtractor timeExtractor,
+            TagTimeExtractor timeExtractor,
             TagPeriodHandler periodHandler,
             Duration delay,
             Integer numRetainedMax) {
@@ -133,7 +98,8 @@ public class TagAutoCreation {
     }
 
     private void tryToTag(Snapshot snapshot) {
-        Optional<LocalDateTime> timeOptional = timeExtractor.extract(snapshot);
+        Optional<LocalDateTime> timeOptional =
+                timeExtractor.extract(snapshot.timeMillis(), snapshot.watermark());
         if (!timeOptional.isPresent()) {
             return;
         }
@@ -141,7 +107,7 @@ public class TagAutoCreation {
         LocalDateTime time = timeOptional.get();
         if (nextTag == null
                 || isAfterOrEqual(time.minus(delay), periodHandler.nextTagTime(nextTag))) {
-            LocalDateTime thisTag = periodHandler.normalizeToTagTime(time);
+            LocalDateTime thisTag = periodHandler.normalizeToPreviousTag(time);
             String tagName = periodHandler.timeToTag(thisTag);
             tagManager.createTag(snapshot, tagName);
             nextTag = periodHandler.nextTagTime(thisTag);
@@ -167,184 +133,22 @@ public class TagAutoCreation {
         return t1.isAfter(t2) || t1.isEqual(t2);
     }
 
-    private interface TimeExtractor {
-
-        Optional<LocalDateTime> extract(Snapshot snapshot);
-    }
-
-    private static class ProcessTimeExtractor implements TimeExtractor {
-
-        @Override
-        public Optional<LocalDateTime> extract(Snapshot snapshot) {
-            return Optional.of(
-                    Instant.ofEpochMilli(snapshot.timeMillis())
-                            .atZone(ZoneId.systemDefault())
-                            .toLocalDateTime());
-        }
-    }
-
-    private static class WatermarkExtractor implements TimeExtractor {
-
-        private final ZoneId watermarkZoneId;
-
-        private WatermarkExtractor(ZoneId watermarkZoneId) {
-            this.watermarkZoneId = watermarkZoneId;
-        }
-
-        @Override
-        public Optional<LocalDateTime> extract(Snapshot snapshot) {
-            Long watermark = snapshot.watermark();
-            if (watermark == null) {
-                return Optional.empty();
-            }
-
-            return Optional.of(
-                    Instant.ofEpochMilli(watermark).atZone(watermarkZoneId).toLocalDateTime());
-        }
-    }
-
-    private interface TagPeriodHandler {
-
-        void validateDelay(Duration delay);
-
-        LocalDateTime tagToTime(String tag);
-
-        LocalDateTime normalizeToTagTime(LocalDateTime time);
-
-        String timeToTag(LocalDateTime time);
-
-        LocalDateTime nextTagTime(LocalDateTime time);
-    }
-
-    private abstract static class BaseTagPeriodHandler implements TagPeriodHandler {
-
-        protected abstract Duration onePeriod();
-
-        protected abstract DateTimeFormatter formatter();
-
-        @Override
-        public void validateDelay(Duration delay) {
-            checkArgument(onePeriod().compareTo(delay) > 0);
-        }
-
-        @Override
-        public LocalDateTime tagToTime(String tag) {
-            return LocalDateTime.parse(tag, formatter());
-        }
-
-        @Override
-        public LocalDateTime normalizeToTagTime(LocalDateTime time) {
-            long mills = Timestamp.fromLocalDateTime(time).getMillisecond();
-            long periodMills = onePeriod().toMillis();
-            LocalDateTime normalized =
-                    Timestamp.fromEpochMillis((mills / periodMills) * periodMills)
-                            .toLocalDateTime();
-            return normalized.minus(onePeriod());
-        }
-
-        @Override
-        public String timeToTag(LocalDateTime time) {
-            return time.format(formatter());
-        }
-
-        @Override
-        public LocalDateTime nextTagTime(LocalDateTime time) {
-            return time.plus(onePeriod());
-        }
-    }
-
-    private static class HourlyTagPeriodHandler extends BaseTagPeriodHandler {
-
-        private static final Duration ONE_PERIOD = Duration.ofHours(1);
-
-        @Override
-        protected Duration onePeriod() {
-            return ONE_PERIOD;
-        }
-
-        @Override
-        protected DateTimeFormatter formatter() {
-            return HOUR_FORMATTER;
-        }
-    }
-
-    private static class DailyTagPeriodHandler extends BaseTagPeriodHandler {
-
-        private static final Duration ONE_PERIOD = Duration.ofDays(1);
-
-        @Override
-        protected Duration onePeriod() {
-            return ONE_PERIOD;
-        }
-
-        @Override
-        protected DateTimeFormatter formatter() {
-            return DAY_FORMATTER;
-        }
-
-        @Override
-        public LocalDateTime tagToTime(String tag) {
-            return LocalDate.parse(tag, formatter()).atStartOfDay();
-        }
-    }
-
-    private static class TwoHoursTagPeriodHandler extends BaseTagPeriodHandler {
-
-        private static final Duration ONE_PERIOD = Duration.ofHours(2);
-
-        @Override
-        protected Duration onePeriod() {
-            return ONE_PERIOD;
-        }
-
-        @Override
-        protected DateTimeFormatter formatter() {
-            return HOUR_FORMATTER;
-        }
-    }
-
     @Nullable
     public static TagAutoCreation create(
             CoreOptions options,
             SnapshotManager snapshotManager,
             TagManager tagManager,
             TagDeletion tagDeletion) {
-        TimeExtractor timeExtractor;
-        switch (options.tagCreationMode()) {
-            case NONE:
-                return null;
-            case PROCESS_TIME:
-                timeExtractor = new ProcessTimeExtractor();
-                break;
-            case WATERMARK:
-                timeExtractor = new WatermarkExtractor(ZoneId.of(options.sinkWatermarkTimeZone()));
-                break;
-            default:
-                throw new UnsupportedOperationException("Unsupported " + options.tagCreationMode());
+        TagTimeExtractor extractor = TagTimeExtractor.createForAutoTag(options);
+        if (extractor == null) {
+            return null;
         }
-
-        TagPeriodHandler periodHandler;
-        switch (options.tagCreationPeriod()) {
-            case DAILY:
-                periodHandler = new DailyTagPeriodHandler();
-                break;
-            case HOURLY:
-                periodHandler = new HourlyTagPeriodHandler();
-                break;
-            case TWO_HOURS:
-                periodHandler = new TwoHoursTagPeriodHandler();
-                break;
-            default:
-                throw new UnsupportedOperationException(
-                        "Unsupported " + options.tagCreationPeriod());
-        }
-
         return new TagAutoCreation(
                 snapshotManager,
                 tagManager,
                 tagDeletion,
-                timeExtractor,
-                periodHandler,
+                extractor,
+                TagPeriodHandler.create(options),
                 options.tagCreationDelay(),
                 options.tagNumRetainedMax());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.Timestamp;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Handle time for tag. */
+public interface TagPeriodHandler {
+
+    DateTimeFormatter HOUR_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
+                    .appendLiteral(" ")
+                    .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NORMAL)
+                    .toFormatter()
+                    .withResolverStyle(ResolverStyle.LENIENT);
+
+    DateTimeFormatter DAY_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
+                    .toFormatter()
+                    .withResolverStyle(ResolverStyle.LENIENT);
+
+    void validateDelay(Duration delay);
+
+    LocalDateTime tagToTime(String tag);
+
+    LocalDateTime normalizeToPreviousTag(LocalDateTime time);
+
+    String timeToTag(LocalDateTime time);
+
+    LocalDateTime nextTagTime(LocalDateTime time);
+
+    /** Base implementation of {@link TagPeriodHandler}. */
+    abstract class BaseTagPeriodHandler implements TagPeriodHandler {
+
+        protected abstract Duration onePeriod();
+
+        protected abstract DateTimeFormatter formatter();
+
+        @Override
+        public void validateDelay(Duration delay) {
+            checkArgument(onePeriod().compareTo(delay) > 0);
+        }
+
+        @Override
+        public LocalDateTime tagToTime(String tag) {
+            return LocalDateTime.parse(tag, formatter());
+        }
+
+        @Override
+        public LocalDateTime normalizeToPreviousTag(LocalDateTime time) {
+            long mills = Timestamp.fromLocalDateTime(time).getMillisecond();
+            long periodMills = onePeriod().toMillis();
+            LocalDateTime normalized =
+                    Timestamp.fromEpochMillis((mills / periodMills) * periodMills)
+                            .toLocalDateTime();
+            return normalized.minus(onePeriod());
+        }
+
+        @Override
+        public String timeToTag(LocalDateTime time) {
+            return time.format(formatter());
+        }
+
+        @Override
+        public LocalDateTime nextTagTime(LocalDateTime time) {
+            return time.plus(onePeriod());
+        }
+    }
+
+    /** Hourly {@link TagPeriodHandler}. */
+    class HourlyTagPeriodHandler extends BaseTagPeriodHandler {
+
+        final Duration ONE_PERIOD = Duration.ofHours(1);
+
+        @Override
+        protected Duration onePeriod() {
+            return ONE_PERIOD;
+        }
+
+        @Override
+        protected DateTimeFormatter formatter() {
+            return HOUR_FORMATTER;
+        }
+    }
+
+    /** Daily {@link TagPeriodHandler}. */
+    class DailyTagPeriodHandler extends BaseTagPeriodHandler {
+
+        final Duration ONE_PERIOD = Duration.ofDays(1);
+
+        @Override
+        protected Duration onePeriod() {
+            return ONE_PERIOD;
+        }
+
+        @Override
+        protected DateTimeFormatter formatter() {
+            return DAY_FORMATTER;
+        }
+
+        @Override
+        public LocalDateTime tagToTime(String tag) {
+            return LocalDate.parse(tag, formatter()).atStartOfDay();
+        }
+    }
+
+    /** Two Hours {@link TagPeriodHandler}. */
+    class TwoHoursTagPeriodHandler extends BaseTagPeriodHandler {
+
+        final Duration ONE_PERIOD = Duration.ofHours(2);
+
+        @Override
+        protected Duration onePeriod() {
+            return ONE_PERIOD;
+        }
+
+        @Override
+        protected DateTimeFormatter formatter() {
+            return HOUR_FORMATTER;
+        }
+    }
+
+    static TagPeriodHandler create(CoreOptions options) {
+        switch (options.tagCreationPeriod()) {
+            case DAILY:
+                return new DailyTagPeriodHandler();
+            case HOURLY:
+                return new HourlyTagPeriodHandler();
+            case TWO_HOURS:
+                return new TwoHoursTagPeriodHandler();
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported " + options.tagCreationPeriod());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -111,7 +111,7 @@ public interface TagPeriodHandler {
     /** Hourly {@link TagPeriodHandler}. */
     class HourlyTagPeriodHandler extends BaseTagPeriodHandler {
 
-        final Duration ONE_PERIOD = Duration.ofHours(1);
+        static final Duration ONE_PERIOD = Duration.ofHours(1);
 
         @Override
         protected Duration onePeriod() {
@@ -127,7 +127,7 @@ public interface TagPeriodHandler {
     /** Daily {@link TagPeriodHandler}. */
     class DailyTagPeriodHandler extends BaseTagPeriodHandler {
 
-        final Duration ONE_PERIOD = Duration.ofDays(1);
+        static final Duration ONE_PERIOD = Duration.ofDays(1);
 
         @Override
         protected Duration onePeriod() {
@@ -148,7 +148,7 @@ public interface TagPeriodHandler {
     /** Two Hours {@link TagPeriodHandler}. */
     class TwoHoursTagPeriodHandler extends BaseTagPeriodHandler {
 
-        final Duration ONE_PERIOD = Duration.ofHours(2);
+        static final Duration ONE_PERIOD = Duration.ofHours(2);
 
         @Override
         protected Duration onePeriod() {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPreview.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPreview.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import javax.annotation.Nullable;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonMap;
+import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
+import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
+
+/** A class of tag preview to find suitable snapshots. */
+public class TagPreview {
+
+    private final TagTimeExtractor timeExtractor;
+    private final TagPeriodHandler periodHandler;
+
+    private TagPreview(CoreOptions options) {
+        this.timeExtractor = TagTimeExtractor.createForTagPreview(options);
+        this.periodHandler = TagPeriodHandler.create(options);
+    }
+
+    public static TagPreview create(CoreOptions options) {
+        if (options.tagToPartitionPreview() != CoreOptions.TagCreationMode.NONE) {
+            return new TagPreview(options);
+        }
+        return null;
+    }
+
+    public Optional<String> extractTag(long timeMilli, @Nullable Long watermark) {
+        Optional<LocalDateTime> timeOptional = timeExtractor.extract(timeMilli, watermark);
+        if (!timeOptional.isPresent()) {
+            return Optional.empty();
+        }
+        LocalDateTime currentTag =
+                periodHandler.nextTagTime(periodHandler.normalizeToPreviousTag(timeOptional.get()));
+        String tag = periodHandler.timeToTag(currentTag);
+        return Optional.of(tag);
+    }
+
+    public Map<String, String> timeTravel(FileStoreTable table, String tag) {
+        TagManager tagManager = table.tagManager();
+        if (tagManager.tagExists(tag)) {
+            return singletonMap(SCAN_TAG_NAME.key(), tag);
+        }
+
+        SnapshotManager snapshotManager = table.snapshotManager();
+        Snapshot snapshot =
+                snapshotManager.traversalSnapshotsFromLatestSafely(
+                        s ->
+                                extractTag(s.timeMillis(), s.watermark())
+                                        .map(t -> t.compareTo(tag) <= 0)
+                                        .orElse(false));
+        if (snapshot != null) {
+            return singletonMap(SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshot.id()));
+        }
+
+        Optional<String> findTag =
+                tagManager.tags().values().stream()
+                        .filter(t -> t.compareTo(tag) <= 0)
+                        .max(Comparator.naturalOrder());
+        if (findTag.isPresent()) {
+            return singletonMap(SCAN_TAG_NAME.key(), findTag.get());
+        }
+
+        throw new RuntimeException("Cannot find snapshot or tag for tag name: " + tag);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+
+import javax.annotation.Nullable;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+/** Extractor to extract tag time from {@link Snapshot}. */
+public interface TagTimeExtractor {
+
+    Optional<LocalDateTime> extract(long timeMilli, @Nullable Long watermark);
+
+    /** Extract time from snapshot time millis. */
+    class ProcessTimeExtractor implements TagTimeExtractor {
+
+        @Override
+        public Optional<LocalDateTime> extract(long timeMilli, @Nullable Long watermark) {
+            return Optional.of(
+                    Instant.ofEpochMilli(timeMilli)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime());
+        }
+    }
+
+    /** Extract time from snapshot watermark. */
+    class WatermarkExtractor implements TagTimeExtractor {
+
+        private final ZoneId watermarkZoneId;
+
+        private WatermarkExtractor(ZoneId watermarkZoneId) {
+            this.watermarkZoneId = watermarkZoneId;
+        }
+
+        @Override
+        public Optional<LocalDateTime> extract(long timeMilli, @Nullable Long watermark) {
+            if (watermark == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(
+                    Instant.ofEpochMilli(watermark).atZone(watermarkZoneId).toLocalDateTime());
+        }
+    }
+
+    @Nullable
+    static TagTimeExtractor createForAutoTag(CoreOptions options) {
+        return create(options.tagCreationMode(), options);
+    }
+
+    @Nullable
+    static TagTimeExtractor createForTagPreview(CoreOptions options) {
+        return create(options.tagToPartitionPreview(), options);
+    }
+
+    @Nullable
+    static TagTimeExtractor create(CoreOptions.TagCreationMode mode, CoreOptions options) {
+        switch (mode) {
+            case NONE:
+                return null;
+            case PROCESS_TIME:
+                return new ProcessTimeExtractor();
+            case WATERMARK:
+                return new WatermarkExtractor(ZoneId.of(options.sinkWatermarkTimeZone()));
+            default:
+                throw new UnsupportedOperationException("Unsupported " + options.tagCreationMode());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPathUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPathUtils.java
@@ -25,9 +25,13 @@ import java.util.BitSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Utils for file system. */
 public class PartitionPathUtils {
+
+    private static final Pattern PARTITION_NAME_PATTERN = Pattern.compile("([^/]+)=([^/]+)");
 
     private static final BitSet CHAR_TO_ESCAPE = new BitSet(128);
 
@@ -150,5 +154,57 @@ public class PartitionPathUtils {
             sb.append('0');
         }
         sb.append(Integer.toHexString(c).toUpperCase());
+    }
+
+    public static String unescapePathName(String path) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '%' && i + 2 < path.length()) {
+                int code = -1;
+                try {
+                    code = Integer.parseInt(path.substring(i + 1, i + 3), 16);
+                } catch (Exception ignored) {
+                }
+                if (code >= 0) {
+                    sb.append((char) code);
+                    i += 2;
+                    continue;
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Make partition spec from path.
+     *
+     * @param currPath partition file path.
+     * @return Sequential partition specs.
+     */
+    public static LinkedHashMap<String, String> extractPartitionSpecFromPath(Path currPath) {
+        LinkedHashMap<String, String> fullPartSpec = new LinkedHashMap<>();
+        List<String[]> kvs = new ArrayList<>();
+        do {
+            String component = currPath.getName();
+            Matcher m = PARTITION_NAME_PATTERN.matcher(component);
+            if (m.matches()) {
+                String k = unescapePathName(m.group(1));
+                String v = unescapePathName(m.group(2));
+                String[] kv = new String[2];
+                kv[0] = k;
+                kv[1] = v;
+                kvs.add(kv);
+            }
+            currPath = currPath.getParent();
+        } while (currPath != null && !currPath.getName().isEmpty());
+
+        // reverse the list since we checked the part from leaf dir to table's base dir
+        for (int i = kvs.size(); i > 0; i--) {
+            fullPartSpec.put(kvs.get(i - 1)[0], kvs.get(i - 1)[1]);
+        }
+
+        return fullPartSpec;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/PrimaryKeyTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/PrimaryKeyTableTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -75,5 +77,9 @@ public abstract class PrimaryKeyTableTestBase {
 
     protected Options tableOptions() {
         return new Options();
+    }
+
+    protected static long utcMills(String timestamp) {
+        return Timestamp.fromLocalDateTime(LocalDateTime.parse(timestamp)).getMillisecond();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
@@ -21,7 +21,6 @@ package org.apache.paimon.tag;
 import org.apache.paimon.CoreOptions.TagCreationMode;
 import org.apache.paimon.CoreOptions.TagCreationPeriod;
 import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
-import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
@@ -180,10 +179,6 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         commit.commit(new ManifestCommittable(0, utcMills("2023-07-20T12:00:01")));
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-17", "2023-07-18", "2023-07-19");
-    }
-
-    private long utcMills(String timestamp) {
-        return Timestamp.fromLocalDateTime(LocalDateTime.parse(timestamp)).getMillisecond();
     }
 
     private long localZoneMills(String timestamp) {

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagPreviewTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagPreviewTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.CoreOptions.TagCreationMode;
+import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.sink.TableCommitImpl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonMap;
+import static org.apache.paimon.CoreOptions.METASTORE_TAG_TO_PARTITION_PREVIEW;
+import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
+import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
+import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
+import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link TagPreview}. */
+public class TagPreviewTest extends PrimaryKeyTableTestBase {
+
+    @Test
+    public void testExtractTag() {
+        TagPreview preview = create();
+        Optional<String> tag = preview.extractTag(-1, utcMills("2023-07-18T12:12:00"));
+        assertThat(tag).hasValue("2023-07-18");
+    }
+
+    @Test
+    public void testTimeTravel() {
+        TagPreview preview = create();
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(SNAPSHOT_NUM_RETAINED_MIN.key(), "3");
+        dynamicOptions.put(SNAPSHOT_NUM_RETAINED_MAX.key(), "3");
+        TableCommitImpl commit =
+                table.copy(dynamicOptions).newCommit(commitUser).ignoreEmptyCommit(false);
+
+        commit.commit(new ManifestCommittable(0, utcMills("2023-07-18T12:12:00")));
+        assertThat(preview.timeTravel(table, "2023-07-18"))
+                .containsAllEntriesOf(singletonMap(SCAN_SNAPSHOT_ID.key(), "1"));
+
+        commit.commit(new ManifestCommittable(0, utcMills("2023-07-18T13:12:00")));
+        assertThat(preview.timeTravel(table, "2023-07-18"))
+                .containsAllEntriesOf(singletonMap(SCAN_SNAPSHOT_ID.key(), "2"));
+
+        commit.commit(new ManifestCommittable(0, utcMills("2023-07-19T12:12:00")));
+        assertThat(preview.timeTravel(table, "2023-07-18"))
+                .containsAllEntriesOf(singletonMap(SCAN_SNAPSHOT_ID.key(), "2"));
+        assertThat(preview.timeTravel(table, "2023-07-19"))
+                .containsAllEntriesOf(singletonMap(SCAN_SNAPSHOT_ID.key(), "3"));
+        assertThat(preview.timeTravel(table, "2023-07-20"))
+                .containsAllEntriesOf(singletonMap(SCAN_SNAPSHOT_ID.key(), "3"));
+
+        table.createTag("2023-07-17", 1);
+        table.createTag("2023-07-18", 2);
+        assertThat(preview.timeTravel(table, "2023-07-18"))
+                .containsAllEntriesOf(singletonMap(SCAN_TAG_NAME.key(), "2023-07-18"));
+
+        // expire 2023-07-19
+        for (int i = 0; i < 5; i++) {
+            commit.commit(new ManifestCommittable(0, utcMills("2023-07-21T12:12:00")));
+        }
+        table.createTag("2023-07-20", 7);
+        assertThat(preview.timeTravel(table, "2023-07-20"))
+                .containsAllEntriesOf(singletonMap(SCAN_TAG_NAME.key(), "2023-07-20"));
+
+        assertThat(preview.timeTravel(table, "2023-07-19"))
+                .containsAllEntriesOf(singletonMap(SCAN_TAG_NAME.key(), "2023-07-18"));
+    }
+
+    private TagPreview create() {
+        Options options = new Options();
+        options.set(METASTORE_TAG_TO_PARTITION_PREVIEW, TagCreationMode.WATERMARK);
+        TagPreview preview = TagPreview.create(new CoreOptions(options));
+        assertThat(preview).isNotNull();
+        return preview;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -136,7 +135,7 @@ public class SnapshotManagerTest {
                 });
 
         // test safely
-        Function<Snapshot, Boolean> func =
+        Filter<Snapshot> func =
                 snapshot -> {
                     try {
                         Thread.sleep(100);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
@@ -60,10 +60,12 @@ public class HiveMetastoreClient implements MetastoreClient {
 
     @Override
     public void addPartition(BinaryRow partition) throws Exception {
-        LinkedHashMap<String, String> partitionMap =
-                partitionComputer.generatePartValues(partition);
-        List<String> partitionValues = new ArrayList<>(partitionMap.values());
+        addPartition(partitionComputer.generatePartValues(partition));
+    }
 
+    @Override
+    public void addPartition(LinkedHashMap<String, String> partitionSpec) throws Exception {
+        List<String> partitionValues = new ArrayList<>(partitionSpec.values());
         try {
             client.getPartition(
                     identifier.getDatabaseName(), identifier.getObjectName(), partitionValues);
@@ -74,7 +76,7 @@ public class HiveMetastoreClient implements MetastoreClient {
             newSd.setLocation(
                     sd.getLocation()
                             + "/"
-                            + PartitionPathUtils.generatePartitionPath(partitionMap));
+                            + PartitionPathUtils.generatePartitionPath(partitionSpec));
 
             Partition hivePartition = new Partition();
             hivePartition.setDbName(identifier.getDatabaseName());

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.hive.mapred;
 
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.hive.RowDataContainer;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -26,6 +27,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.PartitionPathUtils;
 
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.io.IOConstants;
@@ -38,6 +40,8 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,6 +51,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.util.Collections.singletonMap;
+import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
 import static org.apache.paimon.hive.utils.HiveUtils.createFileStoreTable;
 import static org.apache.paimon.hive.utils.HiveUtils.createPredicate;
 
@@ -70,19 +76,36 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
         // the location of Hive.
         String locations = jobConf.get(FileInputFormat.INPUT_DIR);
 
+        @Nullable String tagToPartField = table.coreOptions().tagToPartitionField();
+
         List<PaimonInputSplit> splits = new ArrayList<>();
         // locations may contain multiple partitions
         for (String location : locations.split(",")) {
-            List<Predicate> predicatePerPartition = new ArrayList<>(predicates);
-            createPartitionPredicate(
-                            table.schema().logicalRowType(),
-                            table.schema().partitionKeys(),
-                            location)
-                    .ifPresent(predicatePerPartition::add);
+            InnerTableScan scan;
+            if (tagToPartField != null) {
+                // the location should be pruned by partition predicate
+                // we can extract tag name from location, and use time travel to scan
+                scan =
+                        table.copy(
+                                        singletonMap(
+                                                SCAN_TAG_NAME.key(),
+                                                extractTagName(location, tagToPartField)))
+                                .newScan();
+                if (predicates.size() > 0) {
+                    scan.withFilter(PredicateBuilder.and(predicates));
+                }
+            } else {
+                List<Predicate> predicatePerPartition = new ArrayList<>(predicates);
+                createPartitionPredicate(
+                                table.schema().logicalRowType(),
+                                table.schema().partitionKeys(),
+                                location)
+                        .ifPresent(predicatePerPartition::add);
 
-            InnerTableScan scan = table.newScan();
-            if (predicatePerPartition.size() > 0) {
-                scan.withFilter(PredicateBuilder.and(predicatePerPartition));
+                scan = table.newScan();
+                if (predicatePerPartition.size() > 0) {
+                    scan.withFilter(PredicateBuilder.and(predicatePerPartition));
+                }
             }
             scan.plan()
                     .splits()
@@ -129,7 +152,8 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
                 split,
                 paimonColumns,
                 getHiveColumns(jobConf).orElse(paimonColumns),
-                Arrays.asList(getSelectedColumns(jobConf)));
+                Arrays.asList(getSelectedColumns(jobConf)),
+                table.coreOptions().tagToPartitionField());
     }
 
     private Optional<List<String>> getHiveColumns(JobConf jobConf) {
@@ -155,5 +179,12 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
         return Arrays.stream(ColumnProjectionUtils.getReadColumnNames(jobConf))
                 .distinct()
                 .toArray(String[]::new);
+    }
+
+    /** Extract tag name from location, partition field should be tag name. */
+    public static String extractTagName(String location, String tagToPartField) {
+        LinkedHashMap<String, String> partSpec =
+                PartitionPathUtils.extractPartitionSpecFromPath(new Path(location));
+        return partSpec.get(tagToPartField);
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -972,7 +972,7 @@ public abstract class HiveCatalogITCaseBase {
                         ") WITH (",
                         "    'bucket' = '2',",
                         "    'metastore.tag-to-partition' = 'dt',",
-                        "    'metastore.tag-to-partition-preview' = 'process-time'",
+                        "    'metastore.tag-to-partition.preview' = 'process-time'",
                         ")"));
 
         tEnv.executeSql("INSERT INTO t VALUES (1, 10), (2, 20)").await();

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -193,7 +193,8 @@ public class PaimonRecordReaderTest {
                         new PaimonInputSplit(tempDir.toString(), dataSplit),
                         originalColumns,
                         originalColumns,
-                        selectedColumns);
+                        selectedColumns,
+                        null);
             }
         }
         throw new IllegalArgumentException(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2125

<!-- What is the purpose of the change -->

The Tag will maintain the manifests and data files of the snapshot.
A typical usage is creating tags daily, then you can maintain the historical data of each day for batch reading.

When using primary key tables, a non-partitioned approach is often used to maintain updates, in order to mirror and
synchronize tables from upstream database tables. This allows users to query the latest data. The tradition of Hive
data warehouses is not like this. Offline data warehouses require an immutable view every day to ensure the idempotence
of calculations. So we created a Tag mechanism to output these views.

However, the traditional use of Hive data warehouses is more accustomed to using partitions to specify the query's Tag,
and is more accustomed to using Hive computing engines.

So, we introduce `'metastore.tag-to-partition'` to mapping a non-partitioned primary key table to the partition table
in Hive metastore, and mapping the partition field to the name of the Tag to be fully compatible with Hive.

## Example

**Step 1: Create table and tag in Flink SQL**

```sql
CREATE CATALOG my_hive WITH (
    'type' = 'paimon',
    'metastore' = 'hive',
    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
    -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
    -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
    'warehouse' = 'hdfs:///path/to/warehouse'
);

USE CATALOG my_hive;

CREATE TABLE mydb.T (
    pk INT,
    col1 STRING,
    col2 STRING
) WITH (
    'bucket' = '-1',
    'metastore.tag-to-partition' = 'dt'
);

INSERT INTO t VALUES (1, '10', '100'), (2, '20', '200');

-- create tag '2023-10-16' for snapshot 1
CALL my_hive.system.create_tag('mydb.T', '2023-10-16', 1);
```

**Step 2: Query table in Hive with Partition Pruning**

```sql
SHOW PARTITIONS T;
/*
OK
dt=2023-10-16
*/

SELECT * FROM T WHERE dt='2023-10-16';
/*
OK
1 10 100 2023-10-16
2 20 200 2023-10-16
*/
```
