### PR TITLE
[flink] Remove cross-partition-upsert.bootstrap-min-partition

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -85,13 +85,9 @@ existing keys in the table when starting stream write job. Different merge engin
 Performance: For tables with a large amount of data, there will be a significant loss in performance. Moreover,
 initialization takes a long time.
 
-If your upsert does not rely on too old data, you can consider configuring index TTL and bootstrap-min-partition to
-reduce Index and initialization time:
-- `'cross-partition-upsert.index-ttl'`: The TTL in rocksdb index, this can avoid maintaining too many indexes and lead
-  to worse and worse performance.
-- `'cross-partition-upsert.bootstrap-min-partition'`: The min partition bootstrap of rocksdb index, bootstrap will only
-  read the partitions above it, and the smaller partitions will not be read into the index. This can reduce job startup
-  time and excessive initialization of index.
+If your upsert does not rely on too old data, you can consider configuring index TTL to reduce Index and initialization time:
+- `'cross-partition-upsert.index-ttl'`: The TTL in rocksdb index and initialization, this can avoid maintaining too many
+  indexes and lead to worse and worse performance.
 
 But please note that this may also cause data duplication.
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -117,12 +117,6 @@ under the License.
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
-            <td><h5>cross-partition-upsert.bootstrap-min-partition</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The min partition bootstrap of rocksdb index for cross partition upsert (primary keys not contain all partition fields), bootstrap will only read the partitions above it, and the smaller partitions will not be read into the index. This can reduce job startup time and excessive initialization of index, but please note that this may also cause data duplication.</td>
-        </tr>
-        <tr>
             <td><h5>cross-partition-upsert.index-ttl</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -880,16 +880,6 @@ public class CoreOptions implements Serializable {
                                     + "this can avoid maintaining too many indexes and lead to worse and worse performance, "
                                     + "but please note that this may also cause data duplication.");
 
-    public static final ConfigOption<String> CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION =
-            key("cross-partition-upsert.bootstrap-min-partition")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The min partition bootstrap of rocksdb index for cross partition upsert (primary keys not contain all partition fields), "
-                                    + "bootstrap will only read the partitions above it, and the smaller partitions will not be read into the index. "
-                                    + "This can reduce job startup time and excessive initialization of index, "
-                                    + "but please note that this may also cause data duplication.");
-
     public static final ConfigOption<Integer> ZORDER_VAR_LENGTH_CONTRIBUTION =
             key("zorder.var-length-contribution")
                     .intType()
@@ -1335,10 +1325,6 @@ public class CoreOptions implements Serializable {
 
     public Duration crossPartitionUpsertIndexTtl() {
         return options.get(CROSS_PARTITION_UPSERT_INDEX_TTL);
-    }
-
-    public String crossPartitionUpsertBootstrapMinPartition() {
-        return options.get(CROSS_PARTITION_UPSERT_BOOTSTRAP_MIN_PARTITION);
     }
 
     public int varTypeSize() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- `cross-partition-upsert.bootstrap-min-partition` is hard to be configured, actually we need a TTL instead of startup partition, a long running job should not rely on a static startup partition.
- now, use `cross-partition-upsert.index-ttl` to filter scan splits, this can just replace old `bootstrap-min-partition` feature.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
