### PR TITLE
[core] close commits in UTs

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionITTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionITTest.java
@@ -33,6 +33,7 @@ import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -145,8 +146,10 @@ public class AppendOnlyTableCompactionITTest {
         return schemaBuilder.build();
     }
 
-    private void commit(List<CommitMessage> messages) {
-        appendOnlyFileStoreTable.newCommit(commitUser).commit(messages);
+    private void commit(List<CommitMessage> messages) throws Exception {
+        TableCommitImpl commit = appendOnlyFileStoreTable.newCommit(commitUser);
+        commit.commit(messages);
+        commit.close();
     }
 
     private List<CommitMessage> writeCommit(int number) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.StreamTableCommit;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,11 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
     public void beforeEach() throws Exception {
         fileHandler = table.store().newIndexFileHandler();
         commit = table.newStreamWriteBuilder().withCommitUser(commitUser).newCommit();
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        commit.close();
     }
 
     private HashBucketAssigner createAssigner(int numAssigners, int assignId) {

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashIndexMaintainerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashIndexMaintainerTest.java
@@ -122,6 +122,7 @@ public class HashIndexMaintainerTest extends PrimaryKeyTableTestBase {
                 .containsExactlyInAnyOrder(-771300025, 1340390384, 1465514398);
 
         write.close();
+        commit.close();
     }
 
     @Test
@@ -137,5 +138,6 @@ public class HashIndexMaintainerTest extends PrimaryKeyTableTestBase {
         assertThat(readIndex(commitMessages)).isEmpty();
 
         write.close();
+        commit.close();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
@@ -65,8 +65,8 @@ public class MetricGroupTest {
     public void testAddAndRemoveMetricGroups() {
         AbstractMetricGroup metricGroup =
                 GenericMetricGroup.createGenericMetricGroup("myTable", "commit");
-        assertThat(Metrics.getInstance().getMetricGroups()).containsExactly(metricGroup);
+        assertThat(Metrics.getInstance().getMetricGroups()).contains(metricGroup);
         metricGroup.close();
-        assertThat(Metrics.getInstance().getMetricGroups()).isEmpty();
+        assertThat(Metrics.getInstance().getMetricGroups()).doesNotContain(metricGroup);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/groups/BucketMetricGroupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/groups/BucketMetricGroupTest.java
@@ -39,5 +39,6 @@ public class BucketMetricGroupTest {
         assertThat(group.getAllTags().get("partition")).isEqualTo("dt=1");
         assertThat(group.getMetricIdentifier("myMetric", ".")).isEqualTo("commit.myMetric");
         assertThat(group.getGroupName()).isEqualTo("commit");
+        group.close();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -133,6 +133,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(3, 33, 303L));
         commit.commit(2, write.prepareCommit(true, 2));
         write.close();
+        commit.close();
 
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         int[] partitions =
@@ -162,6 +163,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
+        commit.close();
 
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         int[] partitions =
@@ -204,6 +206,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(scan.plan().splits().size()).isEqualTo(3);
 
         write.close();
+        commit.close();
     }
 
     @Test
@@ -279,6 +282,8 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
             dataPerBucket.clear();
         }
         commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        commit.close();
 
         int partition = random.nextInt(numOfPartition);
         List<Integer> availableBucket = new ArrayList<>(dataset.get(partition).keySet());
@@ -319,6 +324,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 expected.add(i);
             }
             write.close();
+            commit.close();
 
             ReadBuilder readBuilder = table.newReadBuilder();
             List<Split> splits = readBuilder.newScan().plan().splits();
@@ -341,6 +347,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 expected.add(i);
             }
             write.close();
+            commit.close();
 
             ReadBuilder readBuilder = table.newReadBuilder();
             List<Split> splits = readBuilder.newScan().plan().splits();
@@ -374,6 +381,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
+        commit.close();
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChangelogWithKeyFileStoreTableTest.java
@@ -188,6 +188,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(1, 11, 55L));
         commit.commit(1, write.prepareCommit(true, 1));
         write.close();
+        commit.close();
 
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
@@ -364,6 +365,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowDataWithKind(RowKind.UPDATE_AFTER, 1, 10, 102L));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         List<Split> splits =
                 toSplits(
@@ -462,6 +464,9 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.compact(binaryRow(1), 0, true);
         write.compact(binaryRow(2), 0, true);
         commit.commit(4, write.prepareCommit(true, 4));
+
+        write.close();
+        commit.close();
 
         splits =
                 toSplits(
@@ -567,6 +572,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowDataWithKind(RowKind.DELETE, 2, 10, 301L));
         commit.commit(2, write.prepareCommit(true, 2));
         write.close();
+        commit.close();
 
         assertNextSnapshot.apply(2);
 
@@ -597,6 +603,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
+        commit.close();
     }
 
     @Override
@@ -661,6 +668,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(3, write.prepareCommit(true, 3));
 
         write.close();
+        commit.close();
 
         // cannot push down value filter b = 600L
         splits = toSplits(table.newSnapshotReader().read().dataSplits());
@@ -694,6 +702,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowDataWithKind(RowKind.DELETE, 1, 20, 400L));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
@@ -724,6 +733,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(2, committables2);
 
         write.close();
+        commit.close();
 
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
         TableRead read = table.newRead();
@@ -765,6 +775,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(splits1.get(0).dataFiles()).hasSize(1);
         assertThat(splits1.get(0).dataFiles().get(0).fileName())
                 .isNotEqualTo(splits0.get(0).dataFiles().get(0).fileName());
+        write.close();
+        commit.close();
     }
 
     @Test
@@ -937,6 +949,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowToString);
         assertThat(result).containsExactlyInAnyOrder("+I[1, 1, 2, 3]");
+        write.close();
+        commit.close();
     }
 
     @Test
@@ -999,6 +1013,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         commit.commit(3, write.prepareCommit(true, 3));
 
         write.close();
+        commit.close();
 
         assertThat(
                         getResult(

--- a/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
@@ -221,6 +221,9 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
         // commit bucket 2 only
         write.write(createRow(2, 2, 5, 5));
         commit.commit(5, write.prepareCommit(true, 5));
+
+        write.close();
+        commit.close();
     }
 
     private void checkIndexFiles(long snapshotId) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTableTestBase.java
@@ -181,6 +181,7 @@ public abstract class SchemaEvolutionTableTestBase {
         write.write(rowData("S006", 2, 16, "S16", 116L, "S116"));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
         R result = firstChecker.apply(tableSchemas);
 
         /**
@@ -219,6 +220,7 @@ public abstract class SchemaEvolutionTableTestBase {
         write.write(rowData(1, 22, 122L, 1122, "S012", "S22"));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         secondChecker.accept(result, tableSchemas);
     }
@@ -306,6 +308,8 @@ public abstract class SchemaEvolutionTableTestBase {
                         toBytes("310")));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
+
         R result = firstChecker.apply(tableSchemas);
 
         /**
@@ -400,6 +404,7 @@ public abstract class SchemaEvolutionTableTestBase {
                         toBytes("610")));
         commit.commit(1, write.prepareCommit(true, 1));
         write.close();
+        commit.close();
 
         secondChecker.accept(result, tableSchemas);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -33,6 +33,7 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
@@ -216,8 +217,10 @@ public class SchemaEvolutionTest {
         StreamTableWrite write = table.newWrite(commitUser);
         write.write(GenericRow.of(1, 1L));
         write.write(GenericRow.of(2, 2L));
-        table.newCommit(commitUser).commit(0, write.prepareCommit(true, 0));
+        TableCommitImpl commit = table.newCommit(commitUser);
+        commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         schemaManager.commitChanges(
                 Collections.singletonList(SchemaChange.addColumn("f3", DataTypes.BIGINT())));
@@ -226,8 +229,10 @@ public class SchemaEvolutionTest {
         write = table.newWrite(commitUser);
         write.write(GenericRow.of(3, 3L, 3L));
         write.write(GenericRow.of(4, 4L, 4L));
-        table.newCommit(commitUser).commit(1, write.prepareCommit(true, 1));
+        commit = table.newCommit(commitUser);
+        commit.commit(1, write.prepareCommit(true, 1));
         write.close();
+        commit.close();
 
         // read all
         List<String> rows = readRecords(table, null);

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -153,7 +153,9 @@ public abstract class TableTestBase {
     }
 
     protected void commitDefault(List<CommitMessage> messages) throws Exception {
-        getTableDefault().newBatchWriteBuilder().newCommit().commit(messages);
+        BatchTableCommit commit = getTableDefault().newBatchWriteBuilder().newCommit();
+        commit.commit(messages);
+        commit.close();
     }
 
     protected List<CommitMessage> writeDataDefault(int size, int times) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
@@ -75,6 +75,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         }
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         // read
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StreamTableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StreamTableScanTest.java
@@ -254,6 +254,9 @@ public class StreamTableScanTest extends ScannerTestBase {
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
         TableScan.Plan plan = scan.plan();
         assertThat(plan.splits()).isEmpty();
+
+        write.close();
+        commit.close();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanListPartitionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanListPartitionsTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.source.snapshot.ScannerTestBase;
 
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,8 @@ public class TableScanListPartitionsTest extends ScannerTestBase {
             write.write(row);
         }
         List<CommitMessage> result = write.prepareCommit();
-        table.newCommit(commitUser).commit(result);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        commit.commit(result);
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -58,5 +60,6 @@ public class TableScanListPartitionsTest extends ScannerTestBase {
         for (BinaryRow row : rows) {
             assertThat(row.getInt(0)).isEqualTo(ai.getAndIncrement());
         }
+        commit.close();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/BoundedWatermarkCheckerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/BoundedWatermarkCheckerTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BoundedWatermarkCheckerTest extends ScannerTestBase {
 
     @Test
-    public void testBounded() {
+    public void testBounded() throws Exception {
         SnapshotManager snapshotManager = table.snapshotManager();
         TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
         BoundedChecker checker = BoundedChecker.watermark(2000L);
@@ -47,5 +47,6 @@ public class BoundedWatermarkCheckerTest extends ScannerTestBase {
         commit.commit(new ManifestCommittable(0, 2001L));
         snapshot = snapshotManager.latestSnapshot();
         assertThat(checker.shouldEndInput(snapshot)).isTrue();
+        commit.close();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DefaultValueScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DefaultValueScannerTest.java
@@ -75,6 +75,8 @@ public class DefaultValueScannerTest extends ScannerTestBase {
             List<String> result = getResult(read, plan.splits());
             assertThat(result).hasSameElementsAs(Arrays.asList("+I 2|11|200", "+I 2|12|100"));
         }
+        write.close();
+        commit.close();
     }
 
     protected FileStoreTable createFileStoreTable() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
 
     @Test
-    public void testTag() {
+    public void testTag() throws Exception {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
@@ -81,6 +81,8 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         Options expireSetting = new Options();
         expireSetting.set(SNAPSHOT_NUM_RETAINED_MIN, 1);
         expireSetting.set(SNAPSHOT_NUM_RETAINED_MAX, 1);
+        commit.close();
+
         commit = table.copy(expireSetting.toMap()).newCommit(commitUser).ignoreEmptyCommit(false);
 
         // trigger snapshot expiration
@@ -91,10 +93,11 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         commit.commit(new ManifestCommittable(9, utcMills("2023-07-18T16:00:00")));
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-18 13", "2023-07-18 14", "2023-07-18 15");
+        commit.close();
     }
 
     @Test
-    public void testTagDelay() {
+    public void testTagDelay() throws Exception {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
@@ -114,10 +117,11 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         // test create
         commit.commit(new ManifestCommittable(0, utcMills("2023-07-18T13:00:10")));
         assertThat(tagManager.tags().values()).containsOnly("2023-07-18 11", "2023-07-18 12");
+        commit.close();
     }
 
     @Test
-    public void testTagSinkWatermark() {
+    public void testTagSinkWatermark() throws Exception {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
@@ -133,10 +137,11 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         // test second create
         commit.commit(new ManifestCommittable(0, localZoneMills("2023-07-18T13:00:10")));
         assertThat(tagManager.tags().values()).containsOnly("2023-07-18 11", "2023-07-18 12");
+        commit.close();
     }
 
     @Test
-    public void testTagTwoHour() {
+    public void testTagTwoHour() throws Exception {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.TWO_HOURS);
@@ -155,6 +160,7 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         // test second create
         commit.commit(new ManifestCommittable(0, utcMills("2023-07-18T14:00:09")));
         assertThat(tagManager.tags().values()).containsOnly("2023-07-18 10", "2023-07-18 12");
+        commit.close();
     }
 
     @Test
@@ -180,6 +186,7 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
         commit.commit(new ManifestCommittable(0, utcMills("2023-07-20T12:00:01")));
         assertThat(tagManager.tags().values())
                 .containsOnly("2023-07-17", "2023-07-18", "2023-07-19");
+        commit.close();
     }
 
     private long utcMills(String timestamp) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
@@ -125,6 +125,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
                 assertThat(snapshot.id()).isEqualTo(2);
                 assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+                write.close();
+                commit.close();
             }
         }
 
@@ -198,6 +200,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 StreamTableScan scan = table.newReadBuilder().newStreamScan();
                 TableScan.Plan plan = scan.plan();
                 assertThat(plan.splits()).isEmpty();
+                write.close();
+                commit.close();
             }
         }
 
@@ -275,6 +279,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                     Duration.ofSeconds(100),
                     String.format(
                             "Cannot validate snapshot expiration in %s milliseconds.", 60_000));
+            write.close();
+            commit.close();
         }
 
         // In combined mode, check whether newly created table can be detected
@@ -310,6 +316,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                             snapshotManager.snapshot(snapshotManager.latestSnapshotId());
                     assertThat(snapshot.id()).isEqualTo(1);
                     assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+                    write.close();
+                    commit.close();
                 }
             }
 
@@ -364,6 +372,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                         Duration.ofSeconds(100),
                         String.format(
                                 "Cannot validate snapshot expiration in %s milliseconds.", 60_000));
+                write.close();
+                commit.close();
             }
         }
     }
@@ -457,6 +467,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
                 assertThat(snapshot.id()).isEqualTo(2);
                 assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+                write.close();
+                commit.close();
             }
         }
 
@@ -566,6 +578,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
             Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
             assertThat(snapshot.id()).isEqualTo(2);
             assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+            write.close();
+            commit.close();
         }
 
         if (ThreadLocalRandom.current().nextBoolean()) {
@@ -592,6 +606,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
 
             // second compaction, snapshot will be 5
             checkFileAndRowSize(table, 5L, 30_000L, 1, 9);
+            write.close();
+            commit.close();
         }
     }
 
@@ -633,6 +649,8 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
             Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
             assertThat(snapshot.id()).isEqualTo(2);
             assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+            write.close();
+            commit.close();
         }
 
         if (ThreadLocalRandom.current().nextBoolean()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
@@ -30,6 +30,7 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.ChangelogWithKeyFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -227,7 +228,9 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
     }
 
     private void commit(List<CommitMessage> messages) throws Exception {
-        getTable().newBatchWriteBuilder().newCommit().commit(messages);
+        BatchTableCommit commit = getTable().newBatchWriteBuilder().newCommit();
+        commit.commit(messages);
+        commit.close();
     }
 
     private void createTable() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -31,6 +31,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -280,7 +281,9 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
     }
 
     private void commit(List<CommitMessage> messages) throws Exception {
-        getTable().newBatchWriteBuilder().newCommit().commit(messages);
+        BatchTableCommit commit = getTable().newBatchWriteBuilder().newCommit();
+        commit.commit(messages);
+        commit.close();
     }
 
     // schema with all the basic types.

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -32,6 +32,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -136,8 +137,10 @@ public class FileStoreLookupFunctionTest {
         fileStoreLookupFunction.lookup(new FlinkRowData(GenericRow.of(1, 1, 10L)));
     }
 
-    private void commit(List<CommitMessage> messages) {
-        fileStoreTable.newCommit(commitUser).commit(messages);
+    private void commit(List<CommitMessage> messages) throws Exception {
+        TableCommitImpl commit = fileStoreTable.newCommit(commitUser);
+        commit.commit(messages);
+        commit.close();
     }
 
     private List<CommitMessage> writeCommit(int number) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
@@ -81,6 +81,7 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
 
         // notify checkpoint success and tag for savepoint-2
         testHarness.notifyOfCompletedCheckpoint(checkpointId);
+        testHarness.close();
         assertThat(table.snapshotManager().snapshotCount()).isEqualTo(3);
         assertThat(table.tagManager().tagCount()).isEqualTo(1);
 
@@ -116,6 +117,7 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
                         .getJobManagerOwnedState();
         assertThat(table.snapshotManager().latestSnapshot()).isNull();
         assertThat(table.tagManager().tagCount()).isEqualTo(0);
+        testHarness.close();
 
         testHarness = createRecoverableTestHarness(table);
         try {
@@ -131,6 +133,8 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
                                     + "By restarting the job we hope that "
                                     + "writers can start writing based on these new commits.");
         }
+        testHarness.close();
+
         Snapshot snapshot = table.snapshotManager().latestSnapshot();
         assertThat(snapshot).isNotNull();
         assertThat(snapshot.id()).isEqualTo(checkpointId);
@@ -170,6 +174,8 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
 
         // abort savepoint 1
         testHarness.getOneInputOperator().notifyCheckpointAborted(1);
+        testHarness.close();
+
         assertThat(table.snapshotManager().snapshotCount()).isEqualTo(2);
         assertThat(table.tagManager().tagCount()).isEqualTo(0);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -91,6 +91,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         // checkpoint is completed but not notified, so no snapshot is committed
         OperatorSubtaskState snapshot = testHarness.snapshot(0, timestamp++);
         assertThat(table.snapshotManager().latestSnapshotId()).isNull();
+        testHarness.close();
 
         testHarness = createRecoverableTestHarness(table);
         try {
@@ -107,12 +108,14 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                                     + "writers can start writing based on these new commits.");
         }
         assertResults(table, "1, 10", "2, 20");
+        testHarness.close();
 
         // snapshot is successfully committed, no failure is needed
         testHarness = createRecoverableTestHarness(table);
         testHarness.initializeState(snapshot);
         testHarness.open();
         assertResults(table, "1, 10", "2, 20");
+        testHarness.close();
     }
 
     @Test
@@ -145,6 +148,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
 
         // should create 10 snapshots
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(cpId);
+        testHarness.close();
     }
 
     // ------------------------------------------------------------------------
@@ -227,6 +231,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
             OperatorSubtaskState snapshot =
                     writeAndSnapshot(table, commitUser, timestamp, ++checkpoint, testHarness);
             operatorSubtaskStates.add(snapshot);
+            testHarness.close();
         }
 
         // 2. Clearing redundant union list state
@@ -239,6 +244,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         testHarness.initializeState(operatorSubtaskState);
         OperatorSubtaskState snapshot =
                 writeAndSnapshot(table, initialCommitUser, timestamp, ++checkpoint, testHarness);
+        testHarness.close();
 
         // 3. Check whether success
         List<String> actual = new ArrayList<>();
@@ -260,6 +266,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         OneInputStreamOperatorTestHarness<Committable, Committable> testHarness1 =
                 createTestHarness(operator);
         testHarness1.initializeState(snapshot);
+        testHarness1.close();
 
         Assertions.assertThat(actual.size()).isEqualTo(1);
 
@@ -316,6 +323,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
         testHarness.snapshot(cpId, timestamp++);
         testHarness.notifyOfCompletedCheckpoint(cpId);
+        testHarness.close();
         assertThat(table.snapshotManager().latestSnapshot().watermark()).isEqualTo(1024L);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -159,6 +159,7 @@ class StoreMultiCommitterTest {
         // checkpoint is completed but not notified, so no snapshot is committed
         OperatorSubtaskState snapshot = testHarness.snapshot(0, timestamp++);
         assertThat(table.snapshotManager().latestSnapshotId()).isNull();
+        testHarness.close();
 
         testHarness = createRecoverableTestHarness();
         try {
@@ -175,6 +176,7 @@ class StoreMultiCommitterTest {
                                     + "writers can start writing based on these new commits.");
         }
         assertResultsForFirstTable(table, "1, 10", "2, 20");
+        testHarness.close();
 
         // snapshot is successfully committed, no failure is needed
         testHarness = createRecoverableTestHarness();
@@ -200,6 +202,7 @@ class StoreMultiCommitterTest {
         // checkpoint is completed but not notified, so no snapshot is committed
         snapshot = testHarness.snapshot(1, timestamp++);
         assertThat(table.snapshotManager().latestSnapshotId()).isNull();
+        testHarness.close();
 
         testHarness = createRecoverableTestHarness();
         try {
@@ -216,12 +219,14 @@ class StoreMultiCommitterTest {
                                     + "writers can start writing based on these new commits.");
         }
         assertResultsForSecondTable(table, "3, 30.0, s3", "4, 40.0, s4");
+        testHarness.close();
 
         // snapshot is successfully committed, no failure is needed
         testHarness = createRecoverableTestHarness();
         testHarness.initializeState(snapshot);
         testHarness.open();
         assertResultsForSecondTable(table, "3, 30.0, s3", "4, 40.0, s4");
+        testHarness.close();
     }
 
     @Test
@@ -300,6 +305,7 @@ class StoreMultiCommitterTest {
         assertThat(snapshotManager1.latestSnapshotId()).isEqualTo(20);
         // should create 10 snapshots for second table
         assertThat(snapshotManager2.latestSnapshotId()).isEqualTo(10);
+        testHarness.close();
     }
 
     // ------------------------------------------------------------------------
@@ -445,6 +451,7 @@ class StoreMultiCommitterTest {
         testHarness.processWatermark(new Watermark(2048));
         testHarness.snapshot(cpId, timestamp++);
         testHarness.notifyOfCompletedCheckpoint(cpId);
+        testHarness.close();
         assertThat(table1.snapshotManager().latestSnapshot().watermark()).isEqualTo(2048L);
         assertThat(table1.snapshotManager().latestSnapshot().watermark()).isEqualTo(2048L);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
@@ -301,6 +301,8 @@ public class MultiTablesCompactorSourceBuilderITCase extends AbstractTestBase
                     rowData(2, 1520, 15, BinaryString.fromString("20221209")),
                     rowData(1, 1510, 16, BinaryString.fromString("20221208")),
                     rowData(1, 1511, 15, BinaryString.fromString("20221209")));
+            write.close();
+            commit.close();
         }
         actual.clear();
         for (int i = 0; i < 8; i++) {
@@ -340,6 +342,8 @@ public class MultiTablesCompactorSourceBuilderITCase extends AbstractTestBase
                         0,
                         rowData(2, 1520, 15, BinaryString.fromString("20221209")),
                         rowData(1, 1510, 16, BinaryString.fromString("20221208")));
+                write.close();
+                commit.close();
             }
         }
         actual.clear();
@@ -466,6 +470,8 @@ public class MultiTablesCompactorSourceBuilderITCase extends AbstractTestBase
                         0,
                         rowData(2, 1520, 15, BinaryString.fromString("20221209")),
                         rowData(1, 1510, 16, BinaryString.fromString("20221208")));
+                write.close();
+                commit.close();
             }
         }
         actual.clear();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.source.Split;
@@ -92,8 +93,10 @@ public class OperatorSourceTest {
         BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
         BatchTableWrite write = writeBuilder.newWrite();
         write.write(GenericRow.of(a, b, c));
-        writeBuilder.newCommit().commit(write.prepareCommit());
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
         write.close();
+        commit.close();
     }
 
     private List<List<Integer>> readSplit(Split split) throws IOException {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
@@ -151,6 +151,7 @@ public abstract class FileStoreTableStatisticsTestBase {
         commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
+        commit.close();
 
         return table;
     }

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
@@ -170,6 +170,7 @@ public class HiveWriteITCase {
                                 "CREATE EXTERNAL TABLE " + tableName + " ",
                                 "STORED BY '" + PaimonStorageHandler.class.getName() + "'",
                                 "LOCATION '" + path + "'")));
+        commit.close();
         return tableName;
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
@@ -180,6 +180,7 @@ public class HiveWriteITCase {
         commit.commit(commitIdentifier, write.prepareCommit(true, commitIdentifier));
         commitIdentifier++;
         write.close();
+        commit.close();
 
         String tableName = "test_table_" + (UUID.randomUUID().toString().substring(0, 4));
         hiveShell.execute(
@@ -642,6 +643,7 @@ public class HiveWriteITCase {
         }
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         hiveShell.execute(
                 String.join(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -544,6 +544,7 @@ public class PaimonStorageHandlerITCase {
         commit.commit(commitIdentifier, write.prepareCommit(true, commitIdentifier));
         commitIdentifier++;
         write.close();
+        commit.close();
     }
 
     @Test
@@ -578,6 +579,7 @@ public class PaimonStorageHandlerITCase {
         }
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         createExternalTable();
         List<Object[]> actual =
@@ -686,7 +688,7 @@ public class PaimonStorageHandlerITCase {
         write.write(GenericRow.of(6));
         commit.commit(3, write.prepareCommit(true, 3));
         write.close();
-
+        commit.close();
         hiveShell.execute(
                 String.join(
                         "\n",
@@ -773,6 +775,7 @@ public class PaimonStorageHandlerITCase {
                                 LocalDateTime.of(2022, 6, 18, 8, 30, 0, 100_000_000))));
         commit.commit(2, write.prepareCommit(true, 2));
         write.close();
+        commit.close();
 
         createExternalTable();
         assertThat(
@@ -827,6 +830,7 @@ public class PaimonStorageHandlerITCase {
         commit.commit(4, write.prepareCommit(true, 3));
 
         write.close();
+        commit.close();
 
         createExternalTable();
 
@@ -917,6 +921,7 @@ public class PaimonStorageHandlerITCase {
                         new GenericMap(varcharMap)));
         commit.commit(0, write.prepareCommit(true, 0));
         write.close();
+        commit.close();
 
         createExternalTable();
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -81,6 +81,9 @@ public class PaimonRecordReaderTest {
         write.write(GenericRow.ofKind(RowKind.DELETE, 2L, BinaryString.fromString("Hello")));
         commit.commit(0, write.prepareCommit(true, 0));
 
+        write.close();
+        commit.close();
+
         PaimonRecordReader reader = read(table, BinaryRow.EMPTY_ROW, 0);
         RowDataContainer container = reader.createValue();
         Set<String> actual = new HashSet<>();
@@ -119,6 +122,9 @@ public class PaimonRecordReaderTest {
         write.write(GenericRow.of(2, 20L, BinaryString.fromString("Hello")));
         write.write(GenericRow.of(1, 10L, BinaryString.fromString("Hi")));
         commit.commit(0, write.prepareCommit(true, 0));
+
+        write.close();
+        commit.close();
 
         PaimonRecordReader reader = read(table, BinaryRow.EMPTY_ROW, 0, Arrays.asList("c", "a"));
         RowDataContainer container = reader.createValue();

--- a/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SimpleTableTestHelper.java
+++ b/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SimpleTableTestHelper.java
@@ -75,4 +75,9 @@ public class SimpleTableTestHelper {
         commit.commit(commitIdentifier, writer.prepareCommit(true, commitIdentifier));
         commitIdentifier++;
     }
+
+    public void close() throws Exception {
+        writer.close();
+        commit.close();
+    }
 }

--- a/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-2/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -70,6 +70,7 @@ public class SparkReadITCase {
         testHelper1.write(GenericRow.of(5, 6L, BinaryString.fromString("3")));
         testHelper1.write(GenericRow.ofKind(RowKind.DELETE, 3, 4L, BinaryString.fromString("2")));
         testHelper1.commit();
+        testHelper1.close();
 
         tablePath2 = new Path(warehousePath, "default.db/t2");
         SimpleTableTestHelper testHelper2 = createTestHelper(tablePath2);
@@ -79,6 +80,7 @@ public class SparkReadITCase {
         testHelper2.write(GenericRow.of(5, 6L, BinaryString.fromString("3")));
         testHelper2.write(GenericRow.of(7, 8L, BinaryString.fromString("4")));
         testHelper2.commit();
+        testHelper2.close();
     }
 
     private static SimpleTableTestHelper createTestHelper(Path tablePath) throws Exception {

--- a/paimon-spark/paimon-spark-3.1/src/test/java/org/apache/paimon/spark/SparkGenericCatalogTest.java
+++ b/paimon-spark/paimon-spark-3.1/src/test/java/org/apache/paimon/spark/SparkGenericCatalogTest.java
@@ -114,5 +114,6 @@ public class SparkGenericCatalogTest {
         }
         commit.commit(writer.prepareCommit());
         writer.close();
+        commit.close();
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -140,15 +140,17 @@ case class WriteIntoPaimonTable(
       .collect()
       .map(deserializeCommitMessage(serializer, _))
 
+    val tableCommit = if (overwritePartition == null) {
+      writeBuilder.newCommit()
+    } else {
+      writeBuilder.withOverwrite(overwritePartition.asJava).newCommit()
+    }
     try {
-      val tableCommit = if (overwritePartition == null) {
-        writeBuilder.newCommit()
-      } else {
-        writeBuilder.withOverwrite(overwritePartition.asJava).newCommit()
-      }
       tableCommit.commit(commitMessages.toList.asJava)
     } catch {
       case e: Throwable => throw new RuntimeException(e);
+    } finally {
+      tableCommit.close();
     }
 
     Seq.empty

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
@@ -184,6 +184,8 @@ public abstract class SparkReadTestBase {
         }
         long commitIdentifier = COMMIT_IDENTIFIER.getAndIncrement();
         commit.commit(commitIdentifier, writer.prepareCommit(true, commitIdentifier));
+        writer.close();
+        commit.close();
     }
 
     protected static void writeTable(String tableName, String... values) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: subtask of #1638 

There are non-standard table commit creation in paimon UTs, we need to close the table commits after use in case of commit resources leak.