### PR TITLE
[core] Introduce Index BulkLoading for cross partition update

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
@@ -244,7 +244,9 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable implements S
 
     @Override
     public final MutableObjectIterator<BinaryRow> sortedIterator() {
-        new QuickSort().sort(this);
+        if (numRecords > 0) {
+            new QuickSort().sort(this);
+        }
         return iterator();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -71,7 +71,7 @@ public abstract class TableTestBase {
     protected Path warehouse;
     protected Catalog catalog;
     protected String database;
-    @TempDir java.nio.file.Path tempPath;
+    @TempDir public java.nio.file.Path tempPath;
 
     @BeforeEach
     public void beforeEach() throws Catalog.DatabaseAlreadyExistException {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBState.java
@@ -77,7 +77,11 @@ public abstract class RocksDBState<K, V, CacheV> {
                         .build();
     }
 
-    protected byte[] serializeKey(K key) throws IOException {
+    public ColumnFamilyHandle columnFamily() {
+        return columnFamily;
+    }
+
+    public byte[] serializeKey(K key) throws IOException {
         keyOutView.clear();
         keySerializer.serialize(key, keyOutView);
         return keyOutView.getCopyOfBuffer();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBValueState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/RocksDBValueState.java
@@ -88,12 +88,12 @@ public class RocksDBValueState<K, V> extends RocksDBState<K, V, RocksDBState.Ref
         }
     }
 
-    private V deserializeValue(byte[] valueBytes) throws IOException {
+    public V deserializeValue(byte[] valueBytes) throws IOException {
         valueInputView.setBuffer(valueBytes);
         return valueSerializer.deserialize(valueInputView);
     }
 
-    private byte[] serializeValue(V value) throws IOException {
+    public byte[] serializeValue(V value) throws IOException {
         valueOutputView.clear();
         valueSerializer.serialize(value, valueOutputView);
         return valueOutputView.getCopyOfBuffer();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
@@ -90,6 +90,7 @@ public class GlobalDynamicBucketTableITCase extends CatalogITCaseBase {
         sql(
                 "create table large_t (pt int, k int, v int, primary key (k) not enforced) partitioned by (pt) with ("
                         + "'bucket'='-1', "
+                        + "'rocksdb.compaction.level.target-file-size-base'='2 kb', "
                         + "'dynamic-bucket.target-row-num'='10000')");
         sql(
                 "create temporary table src (pt int, k int, v int) with ("


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
RocksDB put is too slow, we can use RocksDB bulkload.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
