### PR TITLE
Add validation that append table of unware bucket mode do not support…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.CoreOptions.CHANGELOG_PRODUCER;
+import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN;
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP;
 import static org.apache.paimon.CoreOptions.SCAN_MODE;
@@ -122,6 +123,13 @@ public class SchemaValidation {
         if (options.bucket() == -1 && options.toMap().get(BUCKET_KEY.key()) != null) {
             throw new RuntimeException(
                     "Cannot define 'bucket-key' in unaware or dynamic bucket mode.");
+        }
+
+        if (options.bucket() == -1
+                && schema.primaryKeys().isEmpty()
+                && options.toMap().get(FULL_COMPACTION_DELTA_COMMITS.key()) != null) {
+            throw new RuntimeException(
+                    "AppendOnlyTable of unware or dynamic bucket does not support 'full-compaction.delta-commits'");
         }
 
         if (schema.primaryKeys().isEmpty() && options.streamingReadOverwrite()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -50,6 +50,18 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testCreateUnawareBucketTableWithFullCompaction() {
+        assertThatThrownBy(
+                        () ->
+                                batchSql(
+                                        "CREATE TABLE pk_table (id INT, data STRING) "
+                                                + "WITH ('bucket' = '-1','full-compaction.delta-commits'='10')"))
+                .hasRootCauseInstanceOf(RuntimeException.class)
+                .hasRootCauseMessage(
+                        "AppendOnlyTable of unware or dynamic bucket does not support 'full-compaction.delta-commits'");
+    }
+
+    @Test
     public void testReadEmpty() {
         assertThat(batchSql("SELECT * FROM append_table")).isEmpty();
     }


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently , append table of unware bucket mode do not support compaction 'full-compaction.delta-commits'.add a validation when creating table

### Tests
AppendOnlyTableITCase#testCreateUnawareBucketTableWithFullCompaction

