### PR TITLE
[core] ConsumerManager should use atomic overwrite for HDFS

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/Path.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/Path.java
@@ -28,6 +28,7 @@ import org.apache.paimon.utils.StringUtils;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -316,6 +317,11 @@ public class Path implements Comparable<Path>, Serializable {
         String path = uri.getPath();
         int slash = path.lastIndexOf(SEPARATOR);
         return path.substring(slash + 1);
+    }
+
+    /** Create a temporary path (to be used as a copy) for this path. */
+    public Path createTempPath() {
+        return new Path(getParent(), String.format(".%s.%s.tmp", getName(), UUID.randomUUID()));
     }
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
@@ -47,4 +47,21 @@ public class ReflectionUtils {
             throws InvocationTargetException, IllegalAccessException {
         return (T) method.invoke(null, args);
     }
+
+    public static Method getMethod(Class<?> clz, String methodName, int argSize)
+            throws NoSuchMethodException {
+        Method method = null;
+        Method[] methods = clz.getMethods();
+        for (Method m : methods) {
+            if (methodName.equals(m.getName()) && m.getParameterTypes().length == argSize) {
+                method = m;
+                break;
+            }
+        }
+
+        if (method == null) {
+            throw new NoSuchMethodException(methodName);
+        }
+        return method;
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOBehaviorTestBase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOBehaviorTestBase.java
@@ -227,7 +227,7 @@ public abstract class FileIOBehaviorTestBase {
     //  Utilities
     // ------------------------------------------------------------------------
 
-    private static String randomName() {
+    protected static String randomName() {
         return StringUtils.getRandomString(RND, 16, 16, 'a', 'z');
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fs/HdfsBehaviorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/HdfsBehaviorTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -100,48 +99,7 @@ class HdfsBehaviorTest extends FileIOBehaviorTestBase {
     }
 
     @Test
-    public void testAtomicWriteMultipleThreads() throws InterruptedException, IOException {
-        Path file = new Path(getBasePath(), randomName());
-        AtomicReference<Exception> exception = new AtomicReference<>();
-        final int max = 10;
-        fs.tryAtomicOverwriteViaRename(file, "0");
-
-        Thread writeThread =
-                new Thread(
-                        () -> {
-                            for (int i = 1; i <= max; i++) {
-                                try {
-                                    fs.tryAtomicOverwriteViaRename(file, "" + i);
-                                    Thread.sleep(100);
-                                } catch (Exception e) {
-                                    exception.set(e);
-                                    return;
-                                }
-                            }
-                        });
-
-        Thread readThread =
-                new Thread(
-                        () -> {
-                            while (true) {
-                                try {
-                                    int value = Integer.parseInt(fs.readFileUtf8(file));
-                                    if (value == max) {
-                                        return;
-                                    }
-                                } catch (Exception e) {
-                                    exception.set(e);
-                                    return;
-                                }
-                            }
-                        });
-
-        writeThread.start();
-        readThread.start();
-
-        writeThread.join();
-        readThread.join();
-
-        assertThat(exception.get()).isNull();
+    public void testAtomicWriteMultipleThreads() throws InterruptedException {
+        FileIOTest.testOverwriteFileUtf8(new Path(getBasePath(), randomName()), fs);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/consumer/ConsumerManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/consumer/ConsumerManager.java
@@ -21,6 +21,7 @@ package org.apache.paimon.consumer;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.hadoop.HadoopFileIO;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import java.io.IOException;
@@ -59,6 +60,22 @@ public class ConsumerManager implements Serializable {
     }
 
     public void resetConsumer(String consumerId, Consumer consumer) {
+        Path path = consumerPath(consumerId);
+        if (fileIO instanceof HadoopFileIO) {
+            // For HDFS, try to use rename with overwrite
+            try {
+                boolean success =
+                        ((HadoopFileIO) fileIO)
+                                .tryAtomicOverwriteViaRename(path, consumer.toJson());
+                if (success) {
+                    return;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // For Non-HDFS, just use write overwrite
         try (PositionOutputStream out = fileIO.newOutputStream(consumerPath(consumerId), true)) {
             OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
             writer.write(consumer.toJson());

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -180,6 +180,13 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-hive-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This fixes #2144
The `fileIO.newOutputStream(path, overwrite))` is not atomic for HDFS, it may results to empty file.

We should use rename with overwrite for HDFS.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
