### PR TITLE
[common] Fix class java doc errors in serializer tests

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/ByteSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/ByteSerializerTest.java
@@ -20,7 +20,7 @@ package org.apache.paimon.data.serializer;
 
 import java.util.Random;
 
-/** Test for {@link ShortSerializer}. */
+/** Test for {@link ByteSerializer}. */
 public class ByteSerializerTest extends SerializerTestBase<Byte> {
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/LongSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/LongSerializerTest.java
@@ -20,7 +20,7 @@ package org.apache.paimon.data.serializer;
 
 import java.util.Random;
 
-/** Test for {@link IntSerializer}. */
+/** Test for {@link LongSerializer}. */
 public class LongSerializerTest extends SerializerTestBase<Long> {
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/NullableSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/NullableSerializerTest.java
@@ -25,7 +25,7 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link IntSerializer}. */
+/** Test for {@link NullableSerializer}. */
 public class NullableSerializerTest extends SerializerTestBase<Integer> {
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

This pr is aims to modify some wrong comments in java doc of serializer tests module.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
