### PR TITLE
[core] Fix iterator bug after reset for InMemoryBuffer

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
@@ -44,6 +44,8 @@ public class InMemoryBuffer implements RowBuffer {
     private int numBytesInLastBuffer;
     private int numRecords = 0;
 
+    private boolean isInitialized;
+
     InMemoryBuffer(MemorySegmentPool pool, AbstractRowDataSerializer<InternalRow> serializer) {
         // serializer has states, so we must duplicate
         this.serializer = (AbstractRowDataSerializer<InternalRow>) serializer.duplicate();
@@ -52,14 +54,26 @@ public class InMemoryBuffer implements RowBuffer {
         this.recordBufferSegments = new ArrayList<>();
         this.recordCollector =
                 new SimpleCollectingOutputView(this.recordBufferSegments, pool, segmentSize);
+        this.isInitialized = true;
+    }
+
+    /** Try to initialize the buffer if all contained data is discarded. */
+    private void tryInitialize() {
+        if (!isInitialized) {
+            this.recordCollector.reset();
+            this.isInitialized = true;
+        }
     }
 
     @Override
     public void reset() {
-        this.currentDataBufferOffset = 0;
-        this.numRecords = 0;
-        returnToSegmentPool();
-        this.recordCollector.reset();
+        if (this.isInitialized) {
+            this.currentDataBufferOffset = 0;
+            this.numBytesInLastBuffer = 0;
+            this.numRecords = 0;
+            returnToSegmentPool();
+            this.isInitialized = false;
+        }
     }
 
     private void returnToSegmentPool() {
@@ -70,6 +84,7 @@ public class InMemoryBuffer implements RowBuffer {
     @Override
     public boolean put(InternalRow row) throws IOException {
         try {
+            tryInitialize();
             this.serializer.serializeToPages(row, this.recordCollector);
             currentDataBufferOffset = this.recordCollector.getCurrentOffset();
             numBytesInLastBuffer = this.recordCollector.getCurrentPositionInSegment();
@@ -95,6 +110,7 @@ public class InMemoryBuffer implements RowBuffer {
 
     @Override
     public InMemoryBufferIterator newIterator() {
+        tryInitialize();
         RandomAccessInputView recordBuffer =
                 new RandomAccessInputView(
                         this.recordBufferSegments, segmentSize, numBytesInLastBuffer);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Lack `this.numBytesInLastBuffer = 0;` in reset.
After reset for InMemoryBuffer, iterator may produce strange records or exception:
```
Caused by: java.io.IOException: Read unexpected bytes in source of positionInSegment[4] and limitInSegment[12344]
  at org.apache.paimon.data.serializer.BinaryRowSerializer.pointTo(BinaryRowSerializer.java:200)
  at org.apache.paimon.data.serializer.BinaryRowSerializer.mapFromPages(BinaryRowSerializer.java:165)
  at org.apache.paimon.data.serializer.InternalRowSerializer.mapFromPages(InternalRowSerializer.java:188)
  at org.apache.paimon.data.serializer.InternalRowSerializer.mapFromPages(InternalRowSerializer.java:39)
  at org.apache.paimon.disk.InMemoryBuffer$InMemoryBufferIterator.next(InMemoryBuffer.java:163)
  at org.apache.paimon.disk.InMemoryBuffer$InMemoryBufferIterator.advanceNext(InMemoryBuffer.java:148)
  ... 30 more
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
