### PR TITLE
[flink] Bridge Flink's metrics system with Paimon's metrics

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -22,7 +22,6 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.flink.VersionedSerializerWrapper;
 import org.apache.paimon.flink.sink.CommittableStateManager;
 import org.apache.paimon.flink.sink.Committer;
-import org.apache.paimon.flink.sink.CommitterMetrics;
 import org.apache.paimon.flink.sink.CommitterOperator;
 import org.apache.paimon.flink.sink.FlinkSink;
 import org.apache.paimon.flink.sink.FlinkStreamPartitioner;
@@ -158,8 +157,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
         // commit new files list even if they're empty.
         // Otherwise we can't tell if the commit is successful after
         // a restart.
-        return (user, metricGroup) ->
-                new StoreMultiCommitter(catalogLoader, user, new CommitterMetrics(metricGroup));
+        return (user, metricGroup) -> new StoreMultiCommitter(catalogLoader, user, metricGroup);
     }
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkCounter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkCounter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.metrics;
+
+import org.apache.paimon.metrics.Counter;
+
+/** {@link Counter} which wraps a Flink's {@link org.apache.flink.metrics.Counter}. */
+public class FlinkCounter implements Counter {
+
+    private final org.apache.flink.metrics.Counter wrapped;
+
+    public FlinkCounter(org.apache.flink.metrics.Counter wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void inc() {
+        wrapped.inc();
+    }
+
+    @Override
+    public void inc(long n) {
+        wrapped.inc(n);
+    }
+
+    @Override
+    public void dec() {
+        wrapped.dec();
+    }
+
+    @Override
+    public void dec(long n) {
+        wrapped.dec(n);
+    }
+
+    @Override
+    public long getCount() {
+        return wrapped.getCount();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkGauge.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkGauge.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.metrics;
+
+import org.apache.paimon.metrics.Gauge;
+
+/** {@link Gauge} which wraps a Flink's {@link org.apache.flink.metrics.Gauge}. */
+public class FlinkGauge<T> implements Gauge<T> {
+
+    private final org.apache.flink.metrics.Gauge<T> wrapped;
+
+    public FlinkGauge(org.apache.flink.metrics.Gauge<T> wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public T getValue() {
+        return wrapped.getValue();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkHistogram.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkHistogram.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.metrics;
+
+import org.apache.paimon.metrics.Histogram;
+import org.apache.paimon.metrics.HistogramStatistics;
+
+/** {@link Histogram} which wraps a Flink's {@link org.apache.flink.metrics.Histogram}. */
+public class FlinkHistogram implements Histogram {
+
+    private final org.apache.flink.metrics.Histogram wrapped;
+
+    public FlinkHistogram(org.apache.flink.metrics.Histogram wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void update(long value) {
+        wrapped.update(value);
+    }
+
+    @Override
+    public long getCount() {
+        return wrapped.getCount();
+    }
+
+    @Override
+    public HistogramStatistics getStatistics() {
+        org.apache.flink.metrics.HistogramStatistics stats = wrapped.getStatistics();
+
+        return new HistogramStatistics() {
+
+            @Override
+            public double getQuantile(double quantile) {
+                return stats.getQuantile(quantile);
+            }
+
+            @Override
+            public long[] getValues() {
+                return stats.getValues();
+            }
+
+            @Override
+            public int size() {
+                return stats.size();
+            }
+
+            @Override
+            public double getMean() {
+                return stats.getMean();
+            }
+
+            @Override
+            public double getStdDev() {
+                return stats.getStdDev();
+            }
+
+            @Override
+            public long getMax() {
+                return stats.getMax();
+            }
+
+            @Override
+            public long getMin() {
+                return stats.getMin();
+            }
+        };
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.metrics;
+
+import org.apache.paimon.metrics.Counter;
+import org.apache.paimon.metrics.Gauge;
+import org.apache.paimon.metrics.Histogram;
+import org.apache.paimon.metrics.Metric;
+import org.apache.paimon.metrics.MetricGroup;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * {@link MetricGroup} which wraps a Flink's {@link org.apache.flink.metrics.MetricGroup} and
+ * register all metrics into Flink's metric system.
+ */
+public class FlinkMetricGroup implements MetricGroup {
+
+    private static final String PAIMON_GROUP_NAME = "paimon";
+
+    private final org.apache.flink.metrics.MetricGroup wrapped;
+    private final String groupName;
+    private final Map<String, String> variables;
+
+    public FlinkMetricGroup(
+            org.apache.flink.metrics.MetricGroup wrapped,
+            String groupName,
+            Map<String, String> variables) {
+        wrapped = wrapped.addGroup(PAIMON_GROUP_NAME);
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            wrapped = wrapped.addGroup(entry.getKey(), entry.getValue());
+        }
+        wrapped = wrapped.addGroup(groupName);
+
+        this.wrapped = wrapped;
+        this.groupName = groupName;
+        this.variables = variables;
+    }
+
+    @Override
+    public Counter counter(String name) {
+        return new FlinkCounter(wrapped.counter(name));
+    }
+
+    @Override
+    public <T> Gauge<T> gauge(String name, Gauge<T> gauge) {
+        return new FlinkGauge<>(wrapped.gauge(name, gauge::getValue));
+    }
+
+    @Override
+    public Histogram histogram(String name, int windowSize) {
+        return new FlinkHistogram(
+                wrapped.histogram(
+                        name,
+                        new org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram(
+                                windowSize)));
+    }
+
+    @Override
+    public Map<String, String> getAllVariables() {
+        return Collections.unmodifiableMap(variables);
+    }
+
+    @Override
+    public String getGroupName() {
+        return groupName;
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        throw new UnsupportedOperationException(
+                "FlinkMetricGroup does not support fetching all metrics. "
+                        + "Please read the metrics through Flink's metric system.");
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.metrics;
+
+import org.apache.paimon.metrics.AbstractMetricRegistry;
+import org.apache.paimon.metrics.MetricGroup;
+
+import java.util.Map;
+
+/** {@link AbstractMetricRegistry} to create {@link FlinkMetricGroup}. */
+public class FlinkMetricRegistry extends AbstractMetricRegistry {
+
+    private final org.apache.flink.metrics.MetricGroup group;
+
+    public FlinkMetricRegistry(org.apache.flink.metrics.MetricGroup group) {
+        this.group = group;
+    }
+
+    @Override
+    protected MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {
+        return new FlinkMetricGroup(group, groupName, variables);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
@@ -18,13 +18,13 @@
 
 package org.apache.paimon.flink.metrics;
 
-import org.apache.paimon.metrics.AbstractMetricRegistry;
 import org.apache.paimon.metrics.MetricGroup;
+import org.apache.paimon.metrics.MetricRegistry;
 
 import java.util.Map;
 
-/** {@link AbstractMetricRegistry} to create {@link FlinkMetricGroup}. */
-public class FlinkMetricRegistry extends AbstractMetricRegistry {
+/** {@link MetricRegistry} to create {@link FlinkMetricGroup}. */
+public class FlinkMetricRegistry extends MetricRegistry {
 
     private final org.apache.flink.metrics.MetricGroup group;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -19,7 +19,7 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -54,6 +54,6 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
     interface Factory<CommitT, GlobalCommitT> extends Serializable {
 
         Committer<CommitT, GlobalCommitT> create(
-                String commitUser, OperatorIOMetricGroup metricGroup);
+                String commitUser, OperatorMetricGroup metricGroup);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -105,7 +105,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
         // parallelism of commit operator is always 1, so commitUser will never be null
-        committer = committerFactory.create(commitUser, getMetricGroup().getIOMetricGroup());
+        committer = committerFactory.create(commitUser, getMetricGroup());
 
         committableStateManager.initializeState(context, committer);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -42,8 +42,7 @@ public class CompactorSink extends FlinkSink<RowData> {
     @Override
     protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
             boolean streamingCheckpointEnabled) {
-        return (user, metricGroup) ->
-                new StoreCommitter(table.newCommit(user), new CommitterMetrics(metricGroup));
+        return (user, metricGroup) -> new StoreCommitter(table.newCommit(user), metricGroup);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -51,7 +51,7 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
                         table.newCommit(user)
                                 .withOverwrite(overwritePartition)
                                 .ignoreEmptyCommit(!streamingCheckpointEnabled),
-                        new CommitterMetrics(metricGroup));
+                        metricGroup);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
@@ -179,8 +179,7 @@ public class MultiTablesCompactorSink implements Serializable {
     protected Committer.Factory<MultiTableCommittable, WrappedManifestCommittable>
             createCommitterFactory() {
         return (user, metricGroup) ->
-                new StoreMultiCommitter(
-                        catalogLoader, user, new CommitterMetrics(metricGroup), true);
+                new StoreMultiCommitter(catalogLoader, user, metricGroup, true);
     }
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -50,8 +50,7 @@ public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionT
     @Override
     protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
             boolean streamingCheckpointEnabled) {
-        return (s, metricGroup) ->
-                new StoreCommitter(table.newCommit(s), new CommitterMetrics(metricGroup));
+        return (s, metricGroup) -> new StoreCommitter(table.newCommit(s), metricGroup);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.VersionedSerializerWrapper;
+import org.apache.paimon.flink.utils.MetricUtils;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestCommittableSerializer;
@@ -37,6 +39,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -215,7 +218,6 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
 
     @Test
     public void testRestoreCommitUser() throws Exception {
-
         FileStoreTable table = createFileStoreTable();
         String commitUser = UUID.randomUUID().toString();
 
@@ -324,9 +326,15 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
         testHarness.snapshot(cpId, timestamp++);
         testHarness.notifyOfCompletedCheckpoint(cpId);
+
         testHarness.close();
+        write.close();
         assertThat(table.snapshotManager().latestSnapshot().watermark()).isEqualTo(1024L);
     }
+
+    // ------------------------------------------------------------------------
+    //  Metrics tests
+    // ------------------------------------------------------------------------
 
     @Test
     public void testCalcDataBytesSend() throws Exception {
@@ -351,6 +359,73 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         assertThat(metrics.getNumBytesOutCounter().getCount()).isEqualTo(275);
         assertThat(metrics.getNumRecordsOutCounter().getCount()).isEqualTo(2);
         committer.close();
+    }
+
+    @Test
+    public void testCommitMetrics() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
+                createRecoverableTestHarness(table);
+        testHarness.open();
+        long timestamp = 0;
+        StreamTableWrite write =
+                table.newStreamWriteBuilder().withCommitUser(initialCommitUser).newWrite();
+
+        long cpId = 1;
+        write.write(GenericRow.of(1, 100L));
+        testHarness.processElement(
+                new Committable(
+                        cpId, Committable.Kind.FILE, write.prepareCommit(false, cpId).get(0)),
+                timestamp++);
+        testHarness.snapshot(cpId, timestamp++);
+        testHarness.notifyOfCompletedCheckpoint(cpId);
+
+        OperatorMetricGroup operatorMetricGroup =
+                testHarness.getOperator().getRuntimeContext().getMetricGroup();
+        MetricGroup commitMetricGroup =
+                operatorMetricGroup
+                        .addGroup("paimon")
+                        .addGroup("table", table.name())
+                        .addGroup("commit");
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesAdded").getValue())
+                .isEqualTo(1L);
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesDeleted").getValue())
+                .isEqualTo(0L);
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesAppended").getValue())
+                .isEqualTo(1L);
+        assertThat(
+                        MetricUtils.getGauge(commitMetricGroup, "lastTableFilesCommitCompacted")
+                                .getValue())
+                .isEqualTo(0L);
+
+        cpId = 2;
+        write.write(GenericRow.of(1, 101L));
+        // just flush the writer
+        write.compact(BinaryRow.EMPTY_ROW, 0, false);
+        write.write(GenericRow.of(2, 200L));
+        // real compaction
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        testHarness.processElement(
+                new Committable(
+                        cpId, Committable.Kind.FILE, write.prepareCommit(true, cpId).get(0)),
+                timestamp++);
+        testHarness.snapshot(cpId, timestamp++);
+        testHarness.notifyOfCompletedCheckpoint(cpId);
+
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesAdded").getValue())
+                .isEqualTo(3L);
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesDeleted").getValue())
+                .isEqualTo(3L);
+        assertThat(MetricUtils.getGauge(commitMetricGroup, "lastTableFilesAppended").getValue())
+                .isEqualTo(2L);
+        assertThat(
+                        MetricUtils.getGauge(commitMetricGroup, "lastTableFilesCommitCompacted")
+                                .getValue())
+                .isEqualTo(4L);
+
+        testHarness.close();
+        write.close();
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -468,9 +468,7 @@ class StoreMultiCommitterTest {
                         initialCommitUser,
                         (user, metricGroup) ->
                                 new StoreMultiCommitter(
-                                        catalogLoader,
-                                        initialCommitUser,
-                                        new CommitterMetrics(metricGroup)),
+                                        catalogLoader, initialCommitUser, metricGroup),
                         new RestoreAndFailCommittableStateManager<>(
                                 () ->
                                         new VersionedSerializerWrapper<>(
@@ -486,9 +484,7 @@ class StoreMultiCommitterTest {
                         initialCommitUser,
                         (user, metricGroup) ->
                                 new StoreMultiCommitter(
-                                        catalogLoader,
-                                        initialCommitUser,
-                                        new CommitterMetrics(metricGroup)),
+                                        catalogLoader, initialCommitUser, metricGroup),
                         new CommittableStateManager<WrappedManifestCommittable>() {
                             @Override
                             public void initializeState(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/utils/MetricUtils.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/utils/MetricUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/** Test utils for Flink's {@link Metric}s. */
+public class MetricUtils {
+
+    public static Gauge<?> getGauge(MetricGroup group, String metricName) {
+        return (Gauge<?>) getMetric(group, metricName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Metric getMetric(MetricGroup group, String metricName) {
+        try {
+            Field field = AbstractMetricGroup.class.getDeclaredField("metrics");
+            field.setAccessible(true);
+            return ((Map<String, Metric>) field.get(group)).get(metricName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR connects Paimon's metric system with Flink's metric system. The life cycle of Paimon's metrics is now handled by Flink's metric group in Flink connector.

### Tests

* `CommitterOperatorTest#testCommitMetrics`
* `StoreMultiCommitterTest#testCommitMetrics`

### API and Format

No.

### Documentation

No.
