### PR TITLE
[core] Add validation to forbid setting stream-read-overwrite with 'full-compaction' or 'lookup' changelog producer

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -561,7 +561,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>streaming-read-overwrite</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to read the changes from overwrite in streaming mode.</td>
+            <td>Whether to read the changes from overwrite in streaming mode. Cannot be set to true when changelog producer is full-compaction or lookup because it will read duplicated changes.</td>
         </tr>
         <tr>
             <td><h5>tag.automatic-creation</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -514,7 +514,8 @@ public class CoreOptions implements Serializable {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to read the changes from overwrite in streaming mode.");
+                            "Whether to read the changes from overwrite in streaming mode. Cannot be set to true when "
+                                    + "changelog producer is full-compaction or lookup because it will read duplicated changes.");
 
     public static final ConfigOption<Boolean> DYNAMIC_PARTITION_OVERWRITE =
             key("dynamic-partition-overwrite")

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -53,6 +53,7 @@ import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
 import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MIN;
+import static org.apache.paimon.CoreOptions.STREAMING_READ_OVERWRITE;
 import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 import static org.apache.paimon.schema.SystemColumns.SYSTEM_FIELD_NAMES;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -86,6 +87,16 @@ public class SchemaValidation {
                     String.format(
                             "Can not set %s on table without primary keys, please define primary keys.",
                             CHANGELOG_PRODUCER.key()));
+        }
+        if (options.streamingReadOverwrite()
+                && (changelogProducer == ChangelogProducer.FULL_COMPACTION
+                        || changelogProducer == ChangelogProducer.LOOKUP)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Cannot set %s to true when changelog producer is %s or %s.",
+                            STREAMING_READ_OVERWRITE.key(),
+                            ChangelogProducer.FULL_COMPACTION,
+                            ChangelogProducer.LOOKUP));
         }
 
         checkArgument(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -93,7 +93,7 @@ public class SchemaValidation {
                         || changelogProducer == ChangelogProducer.LOOKUP)) {
             throw new UnsupportedOperationException(
                     String.format(
-                            "Cannot set %s to true when changelog producer is %s or %s.",
+                            "Cannot set %s to true when changelog producer is %s or %s because it will read duplicated changes.",
                             STREAMING_READ_OVERWRITE.key(),
                             ChangelogProducer.FULL_COMPACTION,
                             ChangelogProducer.LOOKUP));


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This is because `full-compaction` and `lookup` changelog producers will output the changes in later compact snapshot. If we read the changes of the overwrite snapshot, the output is duplicated.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
