### PR TITLE
[spark] Enhance spark DELETE

### DIFF
--- a/docs/content/how-to/writing-tables.md
+++ b/docs/content/how-to/writing-tables.md
@@ -430,8 +430,18 @@ DELETE FROM MyTable WHERE currency = 'UNKNOWN';
 {{< /tab >}}
 
 {{< tab "Spark" >}}
+{{< hint info >}}
+Important table properties setting:
+1. Only primary key tables support this feature.
+2. If the table has primary keys, [MergeEngine]({{< ref "concepts/primary-key-table#merge-engines" >}}) needs to be [deduplicate]({{< ref "concepts/primary-key-table#deduplicate" >}}) to support this feature.
+   {{< /hint >}}
 
-Spark `DELETE` currently supports only a single point execution, for deleting small amounts of data.
+To enable delete needs these configs below:
+
+```text
+--conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog
+--conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
+```
 
 ```sql
 DELETE FROM MyTable WHERE currency = 'UNKNOWN';

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -54,10 +54,16 @@ public class SparkRow implements InternalRow, Serializable {
 
     private final RowType type;
     private final Row row;
+    private final RowKind rowKind;
 
     public SparkRow(RowType type, Row row) {
+        this(type, row, RowKind.INSERT);
+    }
+
+    public SparkRow(RowType type, Row row, RowKind rowkind) {
         this.type = type;
         this.row = row;
+        this.rowKind = rowkind;
     }
 
     @Override
@@ -67,16 +73,13 @@ public class SparkRow implements InternalRow, Serializable {
 
     @Override
     public RowKind getRowKind() {
-        return RowKind.INSERT;
+        return rowKind;
     }
 
     @Override
     public void setRowKind(RowKind rowKind) {
-        if (rowKind == RowKind.INSERT) {
-            return;
-        }
-
-        throw new UnsupportedOperationException("Can not set row kind for this row except INSERT.");
+        throw new UnsupportedOperationException(
+                "Spark row does not support modifying rowkind field");
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -29,8 +29,6 @@ import java.io.IOException
 /** Helper trait for all paimon commands. */
 trait PaimonCommand extends WithFileStoreTable {
 
-  val BUCKET_COL = "_bucket_"
-
   lazy val bucketMode: BucketMode = table match {
     case fileStoreTable: FileStoreTable =>
       fileStoreTable.bucketMode

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -19,6 +19,7 @@ package org.apache.paimon.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.analysis.{CoerceArguments, PaimonAnalysis, ResolveProcedures}
+import org.apache.spark.sql.catalyst.optimizer.RewriteRowLeverCommands
 import org.apache.spark.sql.catalyst.parser.extensions.PaimonSparkSqlExtensionsParser
 import org.apache.spark.sql.catalyst.plans.logical.PaimonTableValuedFunctions
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
@@ -31,10 +32,13 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectParser { case (_, parser) => new PaimonSparkSqlExtensionsParser(parser) }
 
     // analyzer extensions
-    // resolution rule extensions
     extensions.injectResolutionRule(sparkSession => new PaimonAnalysis(sparkSession))
     extensions.injectResolutionRule(spark => ResolveProcedures(spark))
     extensions.injectResolutionRule(_ => CoerceArguments)
+
+    // optimizer extensions
+    extensions.injectOptimizerRule(_ => RewriteRowLeverCommands)
+
     // table function extensions
     PaimonTableValuedFunctions.supportedFnNames.foreach {
       fnName =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/SparkSystemColumns.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/SparkSystemColumns.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.schema
+
+import org.apache.spark.sql.types.StructType
+
+/** System columns for paimon spark. */
+object SparkSystemColumns {
+
+  // for assigning bucket when writing
+  val BUCKET_COL = "_bucket_"
+
+  // for row lever operation
+  val ROW_KIND_COL = "_row_kind_"
+
+  val SPARK_SYSTEM_COLUMNS_NAME: Seq[String] = Seq(BUCKET_COL, ROW_KIND_COL)
+
+  def filterSparkSystemColumns(schema: StructType): StructType = {
+    StructType(schema.fields.filterNot(field => SPARK_SYSTEM_COLUMNS_NAME.contains(field.name)))
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkRowUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkRowUtils.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.util
+
+import org.apache.paimon.types.RowKind
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+object SparkRowUtils {
+
+  def getRowKind(row: Row, rowkindColIdx: Int): RowKind = {
+    if (rowkindColIdx != -1) {
+      RowKind.fromByteValue(row.getByte(rowkindColIdx))
+    } else {
+      RowKind.INSERT
+    }
+  }
+
+  def getFieldIndex(schema: StructType, colName: String): Int = {
+    try {
+      schema.fieldIndex(colName)
+    } catch {
+      case _: IllegalArgumentException =>
+        -1
+    }
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteRowLeverCommands.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteRowLeverCommands.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.paimon.CoreOptions.{MERGE_ENGINE, MergeEngine}
+import org.apache.paimon.options.Options
+import org.apache.paimon.spark.SparkTable
+import org.apache.paimon.table.Table
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Expression, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromPaimonTableCommand, DeleteFromTable, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.SupportsDelete
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+object RewriteRowLeverCommands extends Rule[LogicalPlan] with PredicateHelper {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case d @ DeleteFromTable(r: DataSourceV2Relation, condition) =>
+      validateDeletable(r.table.asInstanceOf[SparkTable].getTable)
+      if (canDeleteWhere(r, condition)) {
+        d
+      } else {
+        DeleteFromPaimonTableCommand(r, condition)
+      }
+  }
+
+  private def validateDeletable(table: Table): Boolean = {
+    val options = Options.fromMap(table.options)
+    if (table.primaryKeys().isEmpty) {
+      throw new UnsupportedOperationException(
+        String.format(
+          "table '%s' can not support delete, because there is no primary key.",
+          table.getClass.getName))
+    }
+    if (!options.get(MERGE_ENGINE).equals(MergeEngine.DEDUPLICATE)) {
+      throw new UnsupportedOperationException(
+        String.format(
+          "merge engine '%s' can not support delete, currently only %s can support delete.",
+          options.get(MERGE_ENGINE),
+          MergeEngine.DEDUPLICATE))
+    }
+    true
+  }
+
+  private def canDeleteWhere(relation: DataSourceV2Relation, condition: Expression): Boolean = {
+    relation.table match {
+      case t: SupportsDelete if !SubqueryExpression.hasSubquery(condition) =>
+        // fail if any filter cannot be converted.
+        // correctness depends on removing all matching data.
+        val filters = DataSourceStrategy
+          .normalizeExprs(Seq(condition), relation.output)
+          .flatMap(splitConjunctivePredicates(_).map {
+            f =>
+              DataSourceStrategy
+                .translateFilter(f, supportNestedPredicatePushdown = true)
+                .getOrElse(throw new AnalysisException(s"Exec update failed:" +
+                  s" cannot translate expression to source filter: $f"))
+          })
+          .toArray
+        t.canDeleteWhere(filters)
+      case _ => false
+    }
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeleteFromPaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeleteFromPaimonTableCommand.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.paimon.options.Options
+import org.apache.paimon.spark.{InsertInto, SparkTable}
+import org.apache.paimon.spark.commands.WriteIntoPaimonTable
+import org.apache.paimon.spark.schema.SparkSystemColumns.ROW_KIND_COL
+import org.apache.paimon.table.FileStoreTable
+import org.apache.paimon.types.RowKind
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.functions.lit
+
+case class DeleteFromPaimonTableCommand(relation: DataSourceV2Relation, condition: Expression)
+  extends LeafRunnableCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val filteredPlan = if (condition != null) {
+      Filter(condition, relation)
+    } else {
+      relation
+    }
+    val df = Dataset
+      .ofRows(sparkSession, filteredPlan)
+      .withColumn(ROW_KIND_COL, lit(RowKind.DELETE.toByteValue))
+
+    WriteIntoPaimonTable(
+      relation.table.asInstanceOf[SparkTable].getTable.asInstanceOf[FileStoreTable],
+      InsertInto,
+      df,
+      Options.fromMap(relation.options)).run(sparkSession)
+
+    Seq.empty[Row]
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions;
 
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -43,7 +44,13 @@ public class SparkWriteITCase {
     @BeforeAll
     public void startMetastoreAndSpark(@TempDir java.nio.file.Path tempDir) {
         Path warehousePath = new Path("file:///" + tempDir.toString());
-        spark = SparkSession.builder().master("local[2]").getOrCreate();
+        spark =
+                SparkSession.builder()
+                        .master("local[2]")
+                        .config(
+                                "spark.sql.extensions",
+                                PaimonSparkSessionExtensions.class.getName())
+                        .getOrCreate();
         spark.conf().set("spark.sql.catalog.paimon", SparkCatalog.class.getName());
         spark.conf().set("spark.sql.catalog.paimon.warehouse", warehousePath.toString());
         spark.sql("CREATE DATABASE paimon.db");

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteWithKyroITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteWithKyroITCase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions;
 
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +35,9 @@ public class SparkWriteWithKyroITCase extends SparkWriteITCase {
         spark =
                 SparkSession.builder()
                         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+                        .config(
+                                "spark.sql.extensions",
+                                PaimonSparkSessionExtensions.class.getName())
                         .master("local[2]")
                         .getOrCreate();
         spark.conf().set("spark.sql.catalog.paimon", SparkCatalog.class.getName());

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
+
+class DeleteFromTableTest extends PaimonSparkTestBase {
+
+  test(s"test delete from append only table") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22')")
+
+    assertThatThrownBy(() => spark.sql("DELETE FROM T WHERE name = 'a'"))
+      .isInstanceOf(classOf[UnsupportedOperationException]);
+  }
+
+  CoreOptions.MergeEngine.values().foreach {
+    mergeEngine =>
+      {
+        test(s"test delete with merge engine $mergeEngine") {
+          val supportUpdateEngines = Seq("deduplicate")
+          val options = if ("first-row".equals(mergeEngine.toString)) {
+            s"'primary-key' = 'id', 'merge-engine' = '$mergeEngine', 'changelog-producer' = 'lookup'"
+          } else {
+            s"'primary-key' = 'id', 'merge-engine' = '$mergeEngine'"
+          }
+          spark.sql(s"""
+                       |CREATE TABLE T (id INT, name STRING, dt STRING)
+                       |TBLPROPERTIES ($options)
+                       |""".stripMargin)
+
+          spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22')")
+
+          if (supportUpdateEngines.contains(mergeEngine.toString)) {
+            spark.sql("DELETE FROM T WHERE name = 'a'")
+          } else
+            assertThatThrownBy(() => spark.sql("DELETE FROM T WHERE name = 'a'"))
+              .isInstanceOf(classOf[UnsupportedOperationException])
+        }
+      }
+  }
+
+  test(s"test delete with primary key") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33')")
+
+    spark.sql("DELETE FROM T WHERE id = 1")
+
+    val rows1 = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows1.toString).isEqualTo("[[2,b,22], [3,c,33]]")
+
+    spark.sql("DELETE FROM T WHERE id < 3")
+
+    val rows2 = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows2.toString).isEqualTo("[[3,c,33]]")
+  }
+
+  test(s"test delete with non-primary key") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33'), (4, 'a', '44')")
+
+    spark.sql("DELETE FROM T WHERE name = 'a'")
+
+    val rows1 = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows1.toString).isEqualTo("[[2,b,22], [3,c,33]]")
+
+    spark.sql("DELETE FROM T WHERE name < 'c'")
+
+    val rows2 = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows2.toString).isEqualTo("[[3,c,33]]")
+  }
+
+  test(s"test delete with no where") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33')")
+
+    spark.sql("DELETE FROM T")
+
+    val rows = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows.toString).isEqualTo("[]")
+  }
+
+  test(s"test delete with in condition") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33')")
+
+    spark.sql("DELETE FROM T WHERE id IN (1, 2)")
+
+    val rows = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows.toString).isEqualTo("[[3,c,33]]")
+  }
+
+  test(s"test delete with in subquery") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33')")
+
+    import testImplicits._
+    val df = Seq(1, 2).toDF("id")
+    df.createOrReplaceTempView("deleted_ids")
+    spark.sql("DELETE FROM T WHERE id IN (SELECT * FROM deleted_ids)")
+
+    val rows = spark.sql("SELECT * FROM T").collectAsList()
+    assertThat(rows.toString).isEqualTo("[[3,c,33]]")
+  }
+
+  test(s"test delete is drop partition") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING, hh STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id, dt, hh', 'merge-engine' = 'deduplicate')
+                 |PARTITIONED BY (dt, hh)
+                 |""".stripMargin)
+
+    spark.sql(
+      "INSERT INTO T VALUES " +
+        "(1, 'a', '2023-10-01', '12')," +
+        "(2, 'b', '2023-10-01', '12')," +
+        "(3, 'c', '2023-10-02', '12')," +
+        "(4, 'd', '2023-10-02', '13')," +
+        "(5, 'e', '2023-10-02', '14')," +
+        "(6, 'f', '2023-10-02', '15')")
+
+    // delete isn't drop partition
+    spark.sql("DELETE FROM T WHERE name = 'a' and hh = '12'")
+    val rows1 = spark.sql("SELECT * FROM T ORDER BY id").collectAsList()
+    assertThat(rows1.toString).isEqualTo(
+      "[[2,b,2023-10-01,12], [3,c,2023-10-02,12], [4,d,2023-10-02,13], [5,e,2023-10-02,14], [6,f,2023-10-02,15]]")
+
+    // delete is drop partition
+    spark.sql("DELETE FROM T WHERE hh = '12'")
+    val rows2 = spark.sql("SELECT * FROM T ORDER BY id").collectAsList()
+    assertThat(rows2.toString).isEqualTo(
+      "[[4,d,2023-10-02,13], [5,e,2023-10-02,14], [6,f,2023-10-02,15]]")
+
+    spark.sql("DELETE FROM T WHERE dt = '2023-10-02' and hh = '13'")
+    val rows3 = spark.sql("SELECT * FROM T ORDER BY id").collectAsList()
+    assertThat(rows3.toString).isEqualTo("[[5,e,2023-10-02,14], [6,f,2023-10-02,15]]")
+
+    spark.sql("DELETE FROM T WHERE dt = '2023-10-02'")
+    val rows4 = spark.sql("SELECT * FROM T ORDER BY id").collectAsList()
+    assertThat(rows4.toString).isEqualTo("[]")
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

1. add delete check: pk table && 'merge-engine' = 'deduplicate'
2. support distributed delete by spark
3. optimization for delete is drop partition
4. optimization for truncate table (using commit.purgeTable)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
