### PR TITLE
[core]Show the latest modification time of a specified partition.

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1338,15 +1338,15 @@ public abstract class FileStoreTableTestBase {
         ReadBuilder readBuilder = fileMonitorTable.newReadBuilder();
         TableScan tableScan = readBuilder.newScan();
         TableRead read = readBuilder.newRead();
-        List<FileMonitorTable.FileChange> results = new ArrayList<>();
+        List<FileMonitorTable.ParitionChange> results = new ArrayList<>();
 
         read.createReader(tableScan.plan())
                 .forEachRemaining(
                         row -> {
                             try {
-                                FileMonitorTable.FileChange fileChange =
-                                        FileMonitorTable.toFileChange(row);
-                                results.add(fileChange);
+                                FileMonitorTable.ParitionChange paritionChange =
+                                        FileMonitorTable.toPartitionChange(row);
+                                results.add(paritionChange);
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }


### PR DESCRIPTION
Show the latest modification time of a specified partition.

for example:
A table has 3 partitions: dt, hour, and eventid, but the modify time of only one specified parition dt should be show


2023-10-30/22/click, modifyTime:100
2023-10-30/23/show,modifyTime:101    
2023-10-31/00/show,modifyTime:102

tranfer to

2023-10-30,modifyTime:101 
2023-10-31,modifyTime:102


### Tests
FileStoreTableTestBase#testMultiParitionModifyTime


