### PR TITLE
[lineage] Use lineage meta factory in CatalogEnvironment

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/lineage/LineageMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lineage/LineageMeta.java
@@ -22,11 +22,10 @@ import org.apache.paimon.predicate.Predicate;
 
 import javax.annotation.Nullable;
 
-import java.io.Serializable;
 import java.util.Iterator;
 
 /** Metadata store will manage table lineage and data lineage information for the catalog. */
-public interface LineageMeta extends Serializable {
+public interface LineageMeta extends AutoCloseable {
     /**
      * Save the source table and job lineage.
      *

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.table;
 
-import org.apache.paimon.lineage.LineageMeta;
+import org.apache.paimon.lineage.LineageMetaFactory;
 import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.Lock;
 
@@ -36,15 +36,15 @@ public class CatalogEnvironment implements Serializable {
 
     private final Lock.Factory lockFactory;
     @Nullable private final MetastoreClient.Factory metastoreClientFactory;
-    @Nullable private final LineageMeta lineageMeta;
+    @Nullable private final LineageMetaFactory lineageMetaFactory;
 
     public CatalogEnvironment(
             Lock.Factory lockFactory,
             @Nullable MetastoreClient.Factory metastoreClientFactory,
-            @Nullable LineageMeta lineageMeta) {
+            @Nullable LineageMetaFactory lineageMetaFactory) {
         this.lockFactory = lockFactory;
         this.metastoreClientFactory = metastoreClientFactory;
-        this.lineageMeta = lineageMeta;
+        this.lineageMetaFactory = lineageMetaFactory;
     }
 
     public Lock.Factory lockFactory() {
@@ -57,7 +57,7 @@ public class CatalogEnvironment implements Serializable {
     }
 
     @Nullable
-    public LineageMeta lineageMeta() {
-        return lineageMeta;
+    public LineageMetaFactory lineageMetaFactory() {
+        return lineageMetaFactory;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkLineageITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkLineageITCase.java
@@ -68,12 +68,12 @@ public class FlinkLineageITCase extends CatalogITCaseBase {
         tEnv.getConfig().getConfiguration().set(PipelineOptions.NAME, "insert_t_job");
         assertThatThrownBy(
                         () -> tEnv.executeSql("INSERT INTO T VALUES (1, 2, 3),(4, 5, 6);").await())
-                .hasCauseExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
                 .hasRootCauseMessage("Method saveSinkTableLineage is not supported");
 
         tEnv.getConfig().getConfiguration().set(PipelineOptions.NAME, "select_t_job");
         assertThatThrownBy(() -> tEnv.executeSql("SELECT * FROM T").collect().close())
-                .hasCauseExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
                 .hasRootCauseMessage("Method saveSourceTableLineage is not supported");
     }
 
@@ -151,5 +151,8 @@ public class FlinkLineageITCase extends CatalogITCaseBase {
         public Iterator<DataLineageEntity> sinkDataLineages(@Nullable Predicate predicate) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public void close() throws Exception {}
     }
 }


### PR DESCRIPTION
### Purpose

Linked issue: close #2189 

Use `LineageMetaFactory` in `CatalogEnvironment` instead of `LineageMeta` because `LineageMeta` may has some non-serialized fields such as connection for jdbc lineage meta.

### Tests

This change can be covered by `FlinkLineageITCase`

### API and Format

no

### Documentation

no
