### PR TITLE
[doc] fix the hyperlink in the description of cdc module "--computed-column" cannot be jumped

### DIFF
--- a/docs/layouts/shortcodes/generated/kafka_sync_table.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_table.html
@@ -51,7 +51,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--computed-column</h5></td>
-        <td>The definitions of computed columns. The argument field is from Kafka topic's table field name. See <a href="#computed-functions">here</a> for a complete list of configurations. </td>
+        <td>The definitions of computed columns. The argument field is from Kafka topic's table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>
     <tr>
         <td><h5>--kafka-conf</h5></td>

--- a/docs/layouts/shortcodes/generated/mongodb_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mongodb_sync_table.html
@@ -43,7 +43,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--computed-column</h5></td>
-        <td>The definitions of computed columns. The argument field is from MongoDB collection field name. See <a href="#computed-functions">here</a> for a complete list of configurations. </td>
+        <td>The definitions of computed columns. The argument field is from MongoDB collection field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>
     <tr>
         <td><h5>--mongodb-conf</h5></td>

--- a/docs/layouts/shortcodes/generated/mysql_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_table.html
@@ -61,7 +61,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--computed-column</h5></td>
-        <td>The definitions of computed columns. The argument field is from MySQL table field name. See <a href="#computed-functions">here</a> for a complete list of configurations. </td>
+        <td>The definitions of computed columns. The argument field is from MySQL table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>
     <tr>
         <td><h5>--metadata-column</h5></td>


### PR DESCRIPTION

 fix the hyperlink in the description of cdc module "--computed-column" cannot be jumped
<!-- Linking this pull request to the issue -->
Linked issue: open #2191 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation


<!-- Does this change introduce a new feature -->
