### PR TITLE
[core] Lazy load all table paths for system database

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -246,7 +246,7 @@ public abstract class AbstractCatalog implements Catalog {
             String tableName = identifier.getObjectName();
             Table table =
                     SystemTableLoader.loadGlobal(
-                            tableName, fileIO, allTablePaths(), catalogOptions);
+                            tableName, fileIO, this::allTablePaths, catalogOptions);
             if (table == null) {
                 throw new TableNotExistException(identifier);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -26,6 +26,7 @@ import org.apache.paimon.table.Table;
 import javax.annotation.Nullable;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
 import static org.apache.paimon.table.system.AuditLogTable.AUDIT_LOG;
@@ -73,11 +74,11 @@ public class SystemTableLoader {
     public static Table loadGlobal(
             String tableName,
             FileIO fileIO,
-            Map<String, Map<String, Path>> allTablePaths,
+            Supplier<Map<String, Map<String, Path>>> allTablePaths,
             Map<String, String> catalogOptions) {
         switch (tableName.toLowerCase()) {
             case ALL_TABLE_OPTIONS:
-                return new AllTableOptionsTable(fileIO, allTablePaths);
+                return new AllTableOptionsTable(fileIO, allTablePaths.get());
             case CATALOG_OPTIONS:
                 return new CatalogOptionsTable(catalogOptions);
             default:


### PR DESCRIPTION
### Purpose

Linked issue: close #2195 

This PR aims to load all table paths lazily for system database

### Tests

This issue is covered by existing test `CatalogTableITCase`

### API and Format

no

### Documentation

no
