### PR TITLE
[flink] Support setting upper limit for inferring scan parallelism for source

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -344,7 +344,7 @@ commits of `OVERWRITE`, you can configure `streaming-read-overwrite`.
 {{< tab "Flink" >}}
 
 By default, the parallelism of batch reads is the same as the number of splits, while the parallelism of stream 
-reads is the same as the number of buckets.
+reads is the same as the number of buckets, but not greater than `scan.infer-parallelism.max`.
 
 Disable `scan.infer-parallelism`, global parallelism will be used for reads.
 
@@ -365,6 +365,12 @@ You can also manually specify the parallelism from `scan.parallelism`.
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>If it is false, parallelism of source are set by global parallelism. Otherwise, source parallelism is inferred from splits number (batch mode) or bucket number(streaming mode).</td>
+        </tr>
+         <tr>
+            <td><h5>scan.infer-parallelism.max</h5></td>
+            <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
+            <td>If scan.infer-parallelism is true, limit the parallelism of source through this option.</td>
         </tr>
         <tr>
             <td><h5>scan.parallelism</h5></td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -69,6 +69,12 @@ under the License.
             <td>If it is false, parallelism of source are set by global parallelism. Otherwise, source parallelism is inferred from splits number (batch mode) or bucket number(streaming mode).</td>
         </tr>
         <tr>
+            <td><h5>scan.infer-parallelism.max</h5></td>
+            <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
+            <td>If scan.infer-parallelism is true, limit the parallelism of source through this option.</td>
+        </tr>
+        <tr>
             <td><h5>scan.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -120,6 +120,13 @@ public class FlinkConnectorOptions {
                             "If it is false, parallelism of source are set by global parallelism."
                                     + " Otherwise, source parallelism is inferred from splits number (batch mode) or bucket number(streaming mode).");
 
+    public static final ConfigOption<Integer> INFER_SCAN_MAX_PARALLELISM =
+            ConfigOptions.key("scan.infer-parallelism.max")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            "If scan.infer-parallelism is true, limit the parallelism of source through this option.");
+
     @Deprecated
     @ExcludeFromDocumentation("Deprecated")
     public static final ConfigOption<Duration> CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -123,7 +123,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Integer> INFER_SCAN_MAX_PARALLELISM =
             ConfigOptions.key("scan.infer-parallelism.max")
                     .intType()
-                    .defaultValue(Integer.MAX_VALUE)
+                    .defaultValue(1024)
                     .withDescription(
                             "If scan.infer-parallelism is true, limit the parallelism of source through this option.");
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -243,6 +243,10 @@ public class DataTableSource extends FlinkTableSource {
 
                 parallelism = Math.max(1, parallelism);
             }
+            parallelism =
+                    Math.min(
+                            parallelism,
+                            options.get(FlinkConnectorOptions.INFER_SCAN_MAX_PARALLELISM));
         }
 
         return sourceBuilder.withParallelism(parallelism).withEnv(env).build();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ReadWriteTableITCase.java
@@ -78,6 +78,7 @@ import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
 import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST;
 import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_TARGET_SIZE;
 import static org.apache.paimon.flink.AbstractFlinkTableFactory.buildPaimonTable;
+import static org.apache.paimon.flink.FlinkConnectorOptions.INFER_SCAN_MAX_PARALLELISM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.INFER_SCAN_PARALLELISM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_PARALLELISM;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_PARALLELISM;
@@ -1136,6 +1137,22 @@ public class ReadWriteTableITCase extends AbstractTestBase {
                                             }
                                         })))
                 .isEqualTo(3);
+
+        // when scan.infer-parallelism.max less than infer parallelism, the parallelism is
+        // scan.infer-parallelism.max
+        assertThat(
+                        sourceParallelism(
+                                buildQueryWithTableOptions(
+                                        table,
+                                        "*",
+                                        "",
+                                        new HashMap<String, String>() {
+                                            {
+                                                put(INFER_SCAN_PARALLELISM.key(), "true");
+                                                put(INFER_SCAN_MAX_PARALLELISM.key(), "1");
+                                            }
+                                        })))
+                .isEqualTo(1);
 
         // for streaming mode
         assertThat(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2205

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
