### PR TITLE
[doc] Fixed an error with the Hadoop configuration in presto and trino

### DIFF
--- a/docs/content/engines/presto.md
+++ b/docs/content/engines/presto.md
@@ -97,7 +97,7 @@ If you are using HDFS, choose one of the following ways to configure your HDFS:
 
 - set environment variable HADOOP_HOME.
 - set environment variable HADOOP_CONF_DIR.
-- configure fs.hdfs.hadoopconf in the properties.
+- configure `hadoop-conf-dir` in the properties.
 
 ## Kerberos
 

--- a/docs/content/engines/trino.md
+++ b/docs/content/engines/trino.md
@@ -122,7 +122,7 @@ If you are using HDFS, choose one of the following ways to configure your HDFS:
 
 - set environment variable HADOOP_HOME.
 - set environment variable HADOOP_CONF_DIR.
-- configure fs.hdfs.hadoopconf in the properties.
+- configure `hadoop-conf-dir` in the properties.
 
 ## Kerberos
 


### PR DESCRIPTION
Fixed an error with the Hadoop configuration in presto and trino
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
