### PR TITLE
[flink] exclude dependency of protobuf

### DIFF
--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -262,6 +262,10 @@ under the License.
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION

### Purpose

To run test in idea, we need to exclude the low version of protobuf. Otherwise, idea will will the low version protobuf (it can't recognize shade)