### PR TITLE
[flink] support the feature of ContinuousFileStoreSource using consumer-id.

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -332,6 +332,17 @@ NOTE: The consumer will prevent expiration of the snapshot. You can specify 'con
 lifetime of consumers.
 {{< /hint >}}
 
+You can set `consumer.use-legacy-mode` to `false` to use the consumer function implemented based on 
+[flip-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface), which can provide 
+more capabilities, such as watermark alignment.
+
+{{< hint warning >}}
+1. When there is no watermark definition, the consumer in non-legacy mode cannot provide the ability to pass the 
+watermark in the snapshot to the downstream. 
+2. Since the implementation of legacy mode and non-legacy mode are completely different, the state of flink is 
+incompatible and cannot be restored from the state when switching modes.
+{{< /hint >}}
+
 You can reset a consumer with a given consumer ID and next snapshot ID and delete a consumer with a given consumer ID.
 
 {{< hint info >}}

--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -332,15 +332,16 @@ NOTE: The consumer will prevent expiration of the snapshot. You can specify 'con
 lifetime of consumers.
 {{< /hint >}}
 
-You can set `consumer.use-legacy-mode` to `false` to use the consumer function implemented based on 
-[flip-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface), which can provide 
-more capabilities, such as watermark alignment.
+By default, the consumer uses `exactly-once` mode to record consumption progress, which strictly ensures that what is 
+recorded in the consumer is the snapshot-id + 1 that all readers have exactly consumed. You can set `consumer.mode` to 
+`at-least-once` to allow readers consume snapshots at different rates and record the slowest snapshot-id among all 
+readers into the consumer. This mode can provide more capabilities, such as watermark alignment.
 
 {{< hint warning >}}
-1. When there is no watermark definition, the consumer in non-legacy mode cannot provide the ability to pass the 
+1. When there is no watermark definition, the consumer in `at-least-once` mode cannot provide the ability to pass the 
 watermark in the snapshot to the downstream. 
-2. Since the implementation of legacy mode and non-legacy mode are completely different, the state of flink is 
-incompatible and cannot be restored from the state when switching modes.
+2. Since the implementation of `exactly-once` mode and `at-least-once` mode are completely different, the state of 
+flink is incompatible and cannot be restored from the state when switching modes.
 {{< /hint >}}
 
 You can reset a consumer with a given consumer ID and next snapshot ID and delete a consumer with a given consumer ID.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -111,6 +111,12 @@ under the License.
             <td>The expiration interval of consumer files. A consumer file will be expired if it's lifetime after last modification is over this value.</td>
         </tr>
         <tr>
+            <td><h5>consumer.use-legacy-mode</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to use legacy mode when setting consumer-id. Legacy mode is implemented through the flink legacy source interface and will not have flip-27 related features. To maintain compatibility with the previous state, the default value is set to true.</td>
+        </tr>
+        <tr>
             <td><h5>continuous.discovery-interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -111,10 +111,10 @@ under the License.
             <td>The expiration interval of consumer files. A consumer file will be expired if it's lifetime after last modification is over this value.</td>
         </tr>
         <tr>
-            <td><h5>consumer.use-legacy-mode</h5></td>
-            <td style="word-wrap: break-word;">true</td>
+            <td><h5>consumer.mode</h5></td>
+            <td style="word-wrap: break-word;">exactly-once</td>
             <td>Boolean</td>
-            <td>Whether to use legacy mode when setting consumer-id. Legacy mode is implemented through the flink legacy source interface and will not have flip-27 related features. To maintain compatibility with the previous state, the default value is set to true.</td>
+            <td>Specify the consumer consistency mode for table.<br /><br />Possible values:<ul><li>"exactly-once": Readers consume data at snapshot granularity, and strictly ensure that the snapshot-id recorded in the consumer is the snapshot-id + 1 that all readers have exactly consumed.</li><li>"at-least-once": Each reader consumes snapshots at a different rate, and the snapshot with the slowest consumption progress among all readers will be recorded in the consumer.</li></ul></td>
         </tr>
         <tr>
             <td><h5>continuous.discovery-interval</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -709,6 +709,13 @@ public class CoreOptions implements Serializable {
                             "The expiration interval of consumer files. A consumer file will be expired if "
                                     + "it's lifetime after last modification is over this value.");
 
+    public static final ConfigOption<Boolean> CONSUMER_WITH_LEGACY_MODE =
+            key("consumer.use-legacy-mode")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to use legacy mode when setting consumer-id. Legacy mode is implemented through the flink legacy source interface and will not have flip-27 related features. To maintain compatibility with the previous state, the default value is set to true.");
+
     public static final ConfigOption<Long> DYNAMIC_BUCKET_TARGET_ROW_NUM =
             key("dynamic-bucket.target-row-num")
                     .longType()
@@ -1305,6 +1312,10 @@ public class CoreOptions implements Serializable {
 
     public Duration consumerExpireTime() {
         return options.get(CONSUMER_EXPIRATION_TIME);
+    }
+
+    public boolean consumerWithLegacyMode() {
+        return options.get(CONSUMER_WITH_LEGACY_MODE);
     }
 
     public boolean partitionedTableInMetastore() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -709,12 +709,11 @@ public class CoreOptions implements Serializable {
                             "The expiration interval of consumer files. A consumer file will be expired if "
                                     + "it's lifetime after last modification is over this value.");
 
-    public static final ConfigOption<Boolean> CONSUMER_WITH_LEGACY_MODE =
-            key("consumer.use-legacy-mode")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether to use legacy mode when setting consumer-id. Legacy mode is implemented through the flink legacy source interface and will not have flip-27 related features. To maintain compatibility with the previous state, the default value is set to true.");
+    public static final ConfigOption<ConsumerMode> CONSUMER_CONSISTENCY_MODE =
+            key("consumer.mode")
+                    .enumType(ConsumerMode.class)
+                    .defaultValue(ConsumerMode.EXACTLY_ONCE)
+                    .withDescription("Specify the consumer consistency mode for table.");
 
     public static final ConfigOption<Long> DYNAMIC_BUCKET_TARGET_ROW_NUM =
             key("dynamic-bucket.target-row-num")
@@ -1314,8 +1313,8 @@ public class CoreOptions implements Serializable {
         return options.get(CONSUMER_EXPIRATION_TIME);
     }
 
-    public boolean consumerWithLegacyMode() {
-        return options.get(CONSUMER_WITH_LEGACY_MODE);
+    public ConsumerMode consumerWithLegacyMode() {
+        return options.get(CONSUMER_CONSISTENCY_MODE);
     }
 
     public boolean partitionedTableInMetastore() {
@@ -1948,6 +1947,35 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         ExpireExecutionMode(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Specifies the log consistency mode for table. */
+    public enum ConsumerMode implements DescribedEnum {
+        EXACTLY_ONCE(
+                "exactly-once",
+                "Readers consume data at snapshot granularity, and strictly ensure that the snapshot-id recorded in the consumer is the snapshot-id + 1 that all readers have exactly consumed."),
+
+        AT_LEAST_ONCE(
+                "at-least-once",
+                "Each reader consumes snapshots at a different rate, and the snapshot with the slowest consumption progress among all readers will be recorded in the consumer.");
+
+        private final String value;
+        private final String description;
+
+        ConsumerMode(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ConsumerProgressCalculator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ConsumerProgressCalculator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.flink.utils.TableScanUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+/** Calculator for calculating consumer consumption progress. */
+public class ConsumerProgressCalculator {
+    private final TreeMap<Long, Long> minNextSnapshotPerCheckpoint;
+
+    private final Map<Integer, Long> assignedSnapshotPerReader;
+
+    private final Map<Integer, Long> consumingSnapshotPerReader;
+
+    public ConsumerProgressCalculator(int parallelism) {
+        this.minNextSnapshotPerCheckpoint = new TreeMap<>();
+        this.assignedSnapshotPerReader = new HashMap<>(parallelism);
+        this.consumingSnapshotPerReader = new HashMap<>(parallelism);
+    }
+
+    public void updateConsumeProgress(int subtaskId, ReaderConsumeProgressEvent event) {
+        consumingSnapshotPerReader.put(subtaskId, event.lastConsumeSnapshotId());
+    }
+
+    public void updateAssignInformation(int subtaskId, FileStoreSourceSplit split) {
+        TableScanUtils.getSnapshotId(split)
+                .ifPresent(snapshotId -> assignedSnapshotPerReader.put(subtaskId, snapshotId));
+    }
+
+    public void notifySnapshotState(
+            long checkpointId,
+            Set<Integer> readersAwaitingSplit,
+            Function<Integer, Long> unassignedCalculationFunction,
+            int parallelism) {
+        computeMinNextSnapshotId(readersAwaitingSplit, unassignedCalculationFunction, parallelism)
+                .ifPresent(
+                        minNextSnapshotId ->
+                                minNextSnapshotPerCheckpoint.put(checkpointId, minNextSnapshotId));
+    }
+
+    public OptionalLong notifyCheckpointComplete(long checkpointId) {
+        NavigableMap<Long, Long> nextSnapshots =
+                minNextSnapshotPerCheckpoint.headMap(checkpointId, true);
+        OptionalLong max = nextSnapshots.values().stream().mapToLong(Long::longValue).max();
+        nextSnapshots.clear();
+        return max;
+    }
+
+    /** Calculate the minimum snapshot currently being consumed by all readers. */
+    private Optional<Long> computeMinNextSnapshotId(
+            Set<Integer> readersAwaitingSplit,
+            Function<Integer, Long> unassignedCalculationFunction,
+            int parallelism) {
+        long globalMinSnapshotId = Long.MAX_VALUE;
+        for (int subtask = 0; subtask < parallelism; subtask++) {
+            // 1. if the reader is in the waiting list, it means that all allocated splits have
+            // been
+            // consumed, and the next snapshotId is calculated from splitAssigner.
+            //
+            // 2. if the reader is not in the waiting list, the larger value between the
+            // consumption
+            // progress reported by the reader and the most recently assigned snapshot id is
+            // used.
+            Long snapshotIdForSubtask;
+            if (readersAwaitingSplit.contains(subtask)) {
+                snapshotIdForSubtask = unassignedCalculationFunction.apply(subtask);
+            } else {
+                Long consumingSnapshotId = consumingSnapshotPerReader.get(subtask);
+                Long assignedSnapshotId = assignedSnapshotPerReader.get(subtask);
+                if (consumingSnapshotId != null && assignedSnapshotId != null) {
+                    snapshotIdForSubtask = Math.max(consumingSnapshotId, assignedSnapshotId);
+                } else {
+                    snapshotIdForSubtask =
+                            consumingSnapshotId != null ? consumingSnapshotId : assignedSnapshotId;
+                }
+            }
+
+            if (snapshotIdForSubtask != null) {
+                globalMinSnapshotId = Math.min(globalMinSnapshotId, snapshotIdForSubtask);
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(globalMinSnapshotId);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -71,7 +71,7 @@ public class ContinuousFileSplitEnumerator
 
     protected final SplitAssigner splitAssigner;
 
-    private final ConsumerProgressCalculator consumerProgressCalculator;
+    protected final ConsumerProgressCalculator consumerProgressCalculator;
 
     @Nullable protected Long nextSnapshotId;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -236,7 +236,8 @@ public class FlinkSourceBuilder {
                 if (conf.get(FlinkConnectorOptions.SOURCE_CHECKPOINT_ALIGN_ENABLED)) {
                     return buildAlignedContinuousFileSource();
                 } else if (conf.contains(CoreOptions.CONSUMER_ID)
-                        && conf.get(CoreOptions.CONSUMER_WITH_LEGACY_MODE)) {
+                        && conf.get(CoreOptions.CONSUMER_CONSISTENCY_MODE)
+                                == CoreOptions.ConsumerMode.EXACTLY_ONCE) {
                     return buildContinuousStreamOperator();
                 } else {
                     return buildContinuousFileSource();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -235,7 +235,8 @@ public class FlinkSourceBuilder {
             } else {
                 if (conf.get(FlinkConnectorOptions.SOURCE_CHECKPOINT_ALIGN_ENABLED)) {
                     return buildAlignedContinuousFileSource();
-                } else if (conf.contains(CoreOptions.CONSUMER_ID)) {
+                } else if (conf.contains(CoreOptions.CONSUMER_ID)
+                        && conf.get(CoreOptions.CONSUMER_WITH_LEGACY_MODE)) {
                     return buildContinuousStreamOperator();
                 } else {
                     return buildContinuousFileSource();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ReaderConsumeProgressEvent.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ReaderConsumeProgressEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+/**
+ * Event sent from {@link FileStoreSourceReader} to {@link ContinuousFileSplitEnumerator} to
+ * describe the current consumption progress.
+ */
+public class ReaderConsumeProgressEvent implements SourceEvent {
+
+    private static final long serialVersionUID = -1L;
+
+    private final long lastConsumeSnapshotId;
+
+    public ReaderConsumeProgressEvent(long lastConsumeSnapshotId) {
+        this.lastConsumeSnapshotId = lastConsumeSnapshotId;
+    }
+
+    public long lastConsumeSnapshotId() {
+        return lastConsumeSnapshotId;
+    }
+
+    @Override
+    public String toString() {
+        return "ReaderConsumeProgressEvent{"
+                + "lastConsumeSnapshotId="
+                + lastConsumeSnapshotId
+                + '}';
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -164,7 +164,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
             assignSplits();
         }
         Preconditions.checkArgument(alignedAssigner.isAligned());
-        lastConsumedSnapshotId = alignedAssigner.minRemainingSnapshotId();
+        lastConsumedSnapshotId = alignedAssigner.getNextSnapshotId(0).orElse(null);
         alignedAssigner.removeFirst();
         currentCheckpointId = checkpointId;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Splits are allocated at the granularity of snapshots. When the splits of the current snapshot are
@@ -98,6 +99,12 @@ public class AlignedSplitAssigner implements SplitAssigner {
         return remainingSplits;
     }
 
+    @Override
+    public Optional<Long> getNextSnapshotId(int subtask) {
+        PendingSnapshot head = pendingSplitAssignment.peek();
+        return Optional.ofNullable(head != null ? head.snapshotId : null);
+    }
+
     public boolean isAligned() {
         PendingSnapshot head = pendingSplitAssignment.peek();
         return head != null && head.empty();
@@ -112,11 +119,6 @@ public class AlignedSplitAssigner implements SplitAssigner {
         Preconditions.checkArgument(
                 head != null && head.empty(),
                 "The head pending splits is not empty. This is a bug, please file an issue.");
-    }
-
-    public Long minRemainingSnapshotId() {
-        PendingSnapshot head = pendingSplitAssignment.peek();
-        return head != null ? head.snapshotId : null;
     }
 
     private static class PendingSnapshot {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssigner.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Assigner to perform dynamic partition pruning by given {@link DynamicFilteringData}. */
@@ -101,6 +102,11 @@ public class DynamicPartitionPruningAssigner implements SplitAssigner {
                 ? new DynamicPartitionPruningAssigner(
                         oriAssigner, partitionRowProjection, dynamicFilteringData)
                 : oriAssigner;
+    }
+
+    @Override
+    public Optional<Long> getNextSnapshotId(int subtask) {
+        return innerAssigner.getNextSnapshotId(subtask);
     }
 
     private boolean filter(FileStoreSourceSplit sourceSplit) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/FIFOSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/FIFOSplitAssigner.java
@@ -28,6 +28,9 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
+
+import static org.apache.paimon.flink.utils.TableScanUtils.getSnapshotId;
 
 /**
  * Splits are assigned preemptively in the order requested by the task. Only one split is assigned
@@ -64,5 +67,12 @@ public class FIFOSplitAssigner implements SplitAssigner {
     @Override
     public Collection<FileStoreSourceSplit> remainingSplits() {
         return new ArrayList<>(pendingSplitAssignment);
+    }
+
+    @Override
+    public Optional<Long> getNextSnapshotId(int subtask) {
+        return pendingSplitAssignment.isEmpty()
+                ? Optional.empty()
+                : getSnapshotId(pendingSplitAssignment.peekFirst());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
@@ -32,7 +32,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
+
+import static org.apache.paimon.flink.utils.TableScanUtils.getSnapshotId;
 
 /**
  * Pre-calculate which splits each task should process according to the weight, and then distribute
@@ -103,5 +106,13 @@ public class PreAssignSplitAssigner implements SplitAssigner {
             assignment.put(i, new LinkedList<>(assignmentList.get(i)));
         }
         return assignment;
+    }
+
+    @Override
+    public Optional<Long> getNextSnapshotId(int subtask) {
+        LinkedList<FileStoreSourceSplit> pendingSplits = pendingSplitAssignment.get(subtask);
+        return (pendingSplits == null || pendingSplits.isEmpty())
+                ? Optional.empty()
+                : getSnapshotId(pendingSplits.peekFirst());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/SplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/SplitAssigner.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The {@code SplitAssigner} is responsible for deciding what splits should be processed next by
@@ -50,4 +51,7 @@ public interface SplitAssigner {
 
     /** Gets the remaining splits that this assigner has pending. */
     Collection<FileStoreSourceSplit> remainingSplits();
+
+    /** Gets the snapshot id of the next split. */
+    Optional<Long> getNextSnapshotId(int subtask);
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
@@ -19,10 +19,13 @@
 package org.apache.paimon.flink.utils;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.TableScan;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 /** Utility methods for {@link TableScan}, such as validating. */
 public class TableScanUtils {
@@ -47,5 +50,13 @@ public class TableScanUtils {
                                 + "('input' changelog producer is also supported, but only returns input records.)");
             }
         }
+    }
+
+    /** Get snapshot id from {@link FileStoreSourceSplit}. */
+    public static Optional<Long> getSnapshotId(FileStoreSourceSplit split) {
+        if (split.split() instanceof DataSplit) {
+            return Optional.of(((DataSplit) split.split()).snapshotId());
+        }
+        return Optional.empty();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.table.data.RowData;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -58,6 +59,12 @@ public class AlignedSourceReaderTest extends FileStoreSourceReaderTest {
         reader.handleSourceEvents(new CheckpointEvent(1L));
         assertThat(reader.shouldTriggerCheckpoint()).isEqualTo(Optional.of(1L));
         assertThat(context.getNumSplitRequests()).isEqualTo(2);
+    }
+
+    @Override
+    @Ignore
+    public void testReaderOnSplitFinished() throws Exception {
+        // ignore
     }
 
     @Override


### PR DESCRIPTION


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2157 

<!-- What is the purpose of the change -->
[flink] support the feature of ContinuousFileStoreSource using consumer-id.

`Enumerator` will assign split to the `reader` in the order of snapshots, and the `reader` will also consume in the order of snapshots. Therefore, the consumption progress of a single reader is:

1. If the reader is in the `enumerator's` waiting list, then the consumption progress of the `reader` is equal to the snapshot assigned by `splitAssigner` next time. If there is no split in `splitAssigner`, it is equal to the snapshot of the next scan by enumerator.
2. If the reader is not in the `enumerator's` waiting list, the `reader's` consumption progress is equal to the greater of the snapshot consumed by the consumer and the snapshot recently assigned to it by `splitAssigner`.

The minimum value of the consumption progress of all readers is the current position of the `consumer`.

### Tests

<!-- List UT and IT cases to verify this change -->

1. `org.apache.paimon.flink.source.ContinuousFileSplitEnumeratorTest#testEnumeratorWithConsumer`
2. `org.apache.paimon.flink.source.FileStoreSourceReaderTest#testReaderOnSplitFinished`

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No