### PR TITLE
[doc] Fix the documentation about partition keys

### DIFF
--- a/docs/content/concepts/basic-concepts.md
+++ b/docs/content/concepts/basic-concepts.md
@@ -40,7 +40,7 @@ By partitioning, users can efficiently operate on a slice of records in the tabl
 
 {{< hint info >}}
 
-Partition keys must be a subset of primary keys if primary keys are defined.
+Partition keys must be a subset of primary keys if primary keys are defined. If you need cross partition upsert (primary keys not contain all partition fields), you should use [Dynamic Bucket]({{< ref "concepts/primary-key-table#dynamic-bucket">}}) mode.
 
 {{< /hint >}}
 

--- a/docs/content/how-to/creating-tables.md
+++ b/docs/content/how-to/creating-tables.md
@@ -224,7 +224,7 @@ By configuring [partition.expiration-time]({{< ref "maintenance/manage-partition
 #### Pick Partition Fields
 
 {{< hint info >}}
-Partition fields must be a subset of primary keys if primary keys are defined.
+Partition keys must be a subset of primary keys if primary keys are defined. If you need cross partition upsert (primary keys not contain all partition fields), you should use [Dynamic Bucket]({{< ref "concepts/primary-key-table#dynamic-bucket">}}) mode.
 {{< /hint >}}
 
 The following three types of fields may be defined as partition fields in the warehouse:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2237

<!-- What is the purpose of the change -->
Partition keys not have to be a subset of primary keys when primary keys are defined if the table is configured with dynamic bucket.

We need to fix this description about partition keys.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
