### PR TITLE
[core] Sort the results of the `show tables` command

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.options.CatalogOptions.LINEAGE_META;
 
@@ -145,7 +146,7 @@ public abstract class AbstractCatalog implements Catalog {
             throw new DatabaseNotExistException(databaseName);
         }
 
-        return listTablesImpl(databaseName);
+        return listTablesImpl(databaseName).stream().sorted().collect(Collectors.toList());
     }
 
     protected abstract List<String> listTablesImpl(String databaseName);

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -312,6 +312,16 @@ public class SparkReadITCase extends SparkReadTestBase {
     }
 
     @Test
+    public void testShowTablesSorted() {
+        spark.sql("create table t3(id int, name string)");
+        spark.sql("create table t4(id int, name string)");
+        List<Row> tables = spark.sql("SHOW TABLES").collectAsList();
+        assertThat(tables.toString())
+                .isEqualTo(
+                        "[[default,t1,false], [default,t2,false], [default,t3,false], [default,t4,false]]");
+    }
+
+    @Test
     public void testCreateTableWithNullablePk() {
         spark.sql(
                 "CREATE TABLE PkTable (\n"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


When there are hundreds of tables in the database,  and the results of the `show tables` command are not sorted, we need to search one by one to look up if a table exists.

If the results are sorted, we can quickly locate it based on the dictionary order.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
