### PR TITLE
[flink] Parameter prompts are not supported

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.paimon.flink.action.MultiTablesSinkMode.COMBINED;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
@@ -124,6 +125,9 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
         Preconditions.checkNotNull(parserFactory);
         Preconditions.checkNotNull(database);
         Preconditions.checkNotNull(catalogLoader);
+        Preconditions.checkArgument(
+                !Optional.ofNullable(dynamicOptions.get("bucket-key")).isPresent(),
+                "The 'bucket-key' parameter is not supported for full database synchronization operations.");
 
         if (mode == COMBINED) {
             buildCombinedCdcSink();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

At present, database synchronization operations does not support the configuration of `bucket-key`, because the `bucket-key` is set for a table.
<img width="1032" alt="图片" src="https://github.com/apache/incubator-paimon/assets/60029759/99f1f626-2a5e-4744-96fe-bc3c9fdd6c09">
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
