### PR TITLE
[core] Fix auto process time create snapshot for tag

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -120,7 +120,9 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public boolean forceCreatingSnapshot() {
-        return tagAutoCreation != null && tagAutoCreation.forceCreatingSnapshot();
+        return tagAutoCreation != null
+                && tagAutoCreation.canProceedWithNextTag()
+                && tagAutoCreation.forceCreatingSnapshot();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -120,9 +120,7 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public boolean forceCreatingSnapshot() {
-        return tagAutoCreation != null
-                && tagAutoCreation.canProceedWithNextTag()
-                && tagAutoCreation.forceCreatingSnapshot();
+        return tagAutoCreation != null && tagAutoCreation.forceCreatingSnapshot();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -101,6 +101,12 @@ public class TagAutoCreation {
         }
     }
 
+    public boolean canProceedWithNextTag() {
+        LocalDateTime time = LocalDateTime.now();
+        return nextTag == null
+                || isAfterOrEqual(time.minus(delay), periodHandler.nextTagTime(nextTag));
+    }
+
     private void tryToTag(Snapshot snapshot) {
         Optional<LocalDateTime> timeOptional =
                 timeExtractor.extract(snapshot.timeMillis(), snapshot.watermark());

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -81,7 +81,11 @@ public class TagAutoCreation {
     }
 
     public boolean forceCreatingSnapshot() {
-        return timeExtractor.forceCreatingSnapshot();
+        return timeExtractor.forceCreatingSnapshot()
+                && (nextTag == null
+                        || isAfterOrEqual(
+                                LocalDateTime.now().minus(delay),
+                                periodHandler.nextTagTime(nextTag)));
     }
 
     public void run() {
@@ -99,12 +103,6 @@ public class TagAutoCreation {
                 }
             }
         }
-    }
-
-    public boolean canProceedWithNextTag() {
-        LocalDateTime time = LocalDateTime.now();
-        return nextTag == null
-                || isAfterOrEqual(time.minus(delay), periodHandler.nextTagTime(nextTag));
     }
 
     private void tryToTag(Snapshot snapshot) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -352,10 +352,14 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
     public void testEmptyCommitWithProcessTimeTag() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(
-                        options ->
-                                options.set(
-                                        CoreOptions.TAG_AUTOMATIC_CREATION,
-                                        CoreOptions.TagCreationMode.PROCESS_TIME));
+                        options -> {
+                            options.set(
+                                    CoreOptions.TAG_AUTOMATIC_CREATION,
+                                    CoreOptions.TagCreationMode.PROCESS_TIME);
+                            options.set(
+                                    CoreOptions.TAG_CREATION_PERIOD,
+                                    CoreOptions.TagCreationPeriod.DAILY);
+                        });
 
         OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
                 createRecoverableTestHarness(table);
@@ -366,12 +370,14 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         Snapshot snapshot = table.snapshotManager().latestSnapshot();
         assertThat(snapshot).isNotNull();
         assertThat(snapshot.id()).isEqualTo(1);
+        assertThat(table.tagManager().tagCount()).isEqualTo(1);
 
         testHarness.snapshot(2, 2);
         testHarness.notifyOfCompletedCheckpoint(2);
         snapshot = table.snapshotManager().latestSnapshot();
         assertThat(snapshot).isNotNull();
-        assertThat(snapshot.id()).isEqualTo(2);
+        assertThat(snapshot.id()).isEqualTo(1);
+        assertThat(table.tagManager().tagCount()).isEqualTo(1);
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -519,7 +519,7 @@ class StoreMultiCommitterTest {
         testHarness.snapshot(cpId, timestamp);
         testHarness.notifyOfCompletedCheckpoint(cpId);
         assertThat(Objects.requireNonNull(table1.snapshotManager().latestSnapshot()).id())
-                .isEqualTo(2);
+                .isEqualTo(1);
         assertThat(Objects.requireNonNull(table2.snapshotManager().latestSnapshot()).id())
                 .isEqualTo(1);
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose


https://github.com/apache/incubator-paimon/pull/2188/files
I conducted relevant tests locally using MySQL, and here are the screenshots:
<img width="1280" alt="企业微信截图_9d6c3269-8582-46cf-930a-09bc4d0f7e96" src="https://github.com/apache/incubator-paimon/assets/60029759/4ff87fe4-991e-4f00-86ac-30042cb69572">
There is an issue that arises, for instance, when I set the tag creation to once a day and checkpoints to occur every 2 minutes. This results in a large number of snapshot and manifest files being generated. I believe there is room for optimization. Each time a snapshot is forcefully created, it should be checked whether it coincides with the next scheduled tag creation time. If it does, proceed with the snapshot creation; otherwise, skip it.

The following image is a screenshot taken after conducting tests with the logical corrections applied:
<img width="1236" alt="图片" src="https://github.com/apache/incubator-paimon/assets/60029759/d2640057-9dbd-40c0-a1c3-77fd77d7cd24">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
