### PR TITLE
[flink] fix unstable test: testAsyncCompactionFileDeletedWhenShutdown

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperator.java
@@ -109,7 +109,8 @@ public class AppendOnlyTableCompactionWorkerOperator
         result.add(workerExecutor().submit(() -> task.doCompact(write)));
     }
 
-    private ExecutorService workerExecutor() {
+    @VisibleForTesting
+    ExecutorService workerExecutor() {
         if (lazyCompactExecutor == null) {
             lazyCompactExecutor =
                     Executors.newSingleThreadScheduledExecutor(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2231 

<!-- What is the purpose of the change -->
[flink] fix unstable test: testAsyncCompactionFileDeletedWhenShutdown.

In the original implementation,  `Thread.sleep(2_000)` is used to wait for the thread pool to finish, which does not strictly guarantee that the thread pool is finished. I modified it to use `ExecutorService#awaitTermination` and increased the timeout to 2 minutes.

### Tests

<!-- List UT and IT cases to verify this change -->
No
### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No