### PR TITLE
 [flink] fix the problem of incorrect timeout logic in testAsyncCompactionWorks.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperatorTest.java
@@ -78,7 +78,7 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
                                         workerOperator.prepareCommit(false, Long.MAX_VALUE));
 
                                 Long now = System.currentTimeMillis();
-                                if (timeStart - now > timeout && committables.size() != 4) {
+                                if (now - timeStart > timeout && committables.size() != 4) {
                                     throw new RuntimeException(
                                             "Timeout waiting for compaction, maybe some error happens in "
                                                     + AppendOnlyTableCompactionWorkerOperator.class


### PR DESCRIPTION
### Purpose

 [flink] fix the problem of incorrect timeout logic in testAsyncCompactionWorks.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
No
### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No