### PR TITLE
[flink][kafka-cdc] Improve KafkaActionUtils#getKafkaEarliestConsumer exception message and fix test timeout excption

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
@@ -291,10 +291,14 @@ public class KafkaActionUtils {
 
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
 
+        // the return may be null in older versions of the Kafka client
         List<PartitionInfo> partitionInfos = consumer.partitionsFor(topic);
-        if (partitionInfos.isEmpty()) {
+        if (partitionInfos == null || partitionInfos.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Failed to find partition information for topic " + topic);
+                    String.format(
+                            "Failed to find partition information for topic '%s'. Please check your "
+                                    + "'topic' and 'bootstrap.servers' config.",
+                            topic));
         }
         int firstPartition =
                 partitionInfos.stream().map(PartitionInfo::partition).sorted().findFirst().get();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -209,6 +209,7 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
         standardProps.put("max.partition.fetch.bytes", 256);
         standardProps.put("zookeeper.session.timeout.ms", zkTimeoutMills);
         standardProps.put("zookeeper.connection.timeout.ms", zkTimeoutMills);
+        standardProps.put("default.api.timeout.ms", "120000");
         return standardProps;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Older versions of the Kafka clients api may return null value for the partition info, thus throws a NPE.
This PR improve the error message.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
