### PR TITLE
[flink] New external catalog for storing paimon and non-paimon tables

### DIFF
--- a/docs/content/engines/flink.md
+++ b/docs/content/engines/flink.md
@@ -180,6 +180,35 @@ CREATE TABLE word_count (
 
 {{< /tab >}}
 
+{{< tab "External-Catalog" >}}
+Unlike FlikGenericCatalog, FlinkExternalCatalog saves tables that using other connectors like jdbc to the Paimon 
+filesystem, eliminating the need to create temporary tables repeatedly.
+```sql
+CREATE CATALOG my_catalog WITH (
+    'type'='paimon-external',
+    'warehouse'='file:/tmp/paimon'
+);
+
+USE CATALOG my_catalog;
+
+-- create a word count table
+CREATE TABLE word_count (
+    word STRING PRIMARY KEY NOT ENFORCED,
+    cnt BIGINT
+) WITH (
+    'connector'='paimon'
+);
+
+-- create a word count table with jdbc connector
+CREATE TABLE word_count (
+    word STRING PRIMARY KEY NOT ENFORCED,
+    cnt BIGINT
+) WITH (
+   'connector'='jdbc',
+   ...
+);
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 **Step 6: Write Data**

--- a/docs/content/engines/flink.md
+++ b/docs/content/engines/flink.md
@@ -181,7 +181,7 @@ CREATE TABLE word_count (
 {{< /tab >}}
 
 {{< tab "External-Catalog" >}}
-Unlike FlikGenericCatalog, FlinkExternalCatalog saves tables that using other connectors like jdbc to the Paimon 
+Unlike FlikGenericCatalog, FlinkExternalCatalog saves tables that use other connectors like jdbc to the Paimon 
 filesystem, eliminating the need to create temporary tables repeatedly.
 ```sql
 CREATE CATALOG my_catalog WITH (

--- a/docs/content/engines/flink.md
+++ b/docs/content/engines/flink.md
@@ -181,7 +181,7 @@ CREATE TABLE word_count (
 {{< /tab >}}
 
 {{< tab "External-Catalog" >}}
-Unlike FlikGenericCatalog, FlinkExternalCatalog saves tables that use other connectors like jdbc to the Paimon 
+Unlike FlikGenericCatalog, FlinkExternalCatalog saves tables that used other connectors like jdbc to the Paimon 
 filesystem, eliminating the need to create temporary tables repeatedly.
 ```sql
 CREATE CATALOG my_catalog WITH (

--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -52,11 +52,23 @@ USE CATALOG my_catalog;
 
 You can define any default table options with the prefix `table-default.` for tables created in the catalog.
 
+Additionally, you can also use FlinkExternalCatalog to save tables using other connectors to paimon.
+
+```sql
+CREATE CATALOG my_catalog WITH (
+    'type' = 'paimon-external',
+    'warehouse' = 'hdfs:///path/to/warehouse'
+);
+
+USE CATALOG my_catalog;
+```
+
 {{< /tab >}}
 
 {{< tab "Spark3" >}}
 
 The following shell command registers a paimon catalog named `paimon`. Metadata and table files are stored under `hdfs:///path/to/warehouse`.
+
 
 ```bash
 spark-sql ... \

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -190,7 +190,9 @@ public class FlinkExternalCatalog extends AbstractCatalog {
     public CatalogBaseTable getTable(ObjectPath tablePath)
             throws TableNotExistException, CatalogException {
         try {
-            return paimon.getTable(tablePath);
+            CatalogTable table = paimon.getTable(tablePath);
+            table.getOptions().put("connector","paimon");
+            return table;
         } catch (TableNotExistException | CatalogException e) {
             Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");
             try {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -191,7 +191,6 @@ public class FlinkExternalCatalog extends AbstractCatalog {
             throws TableNotExistException, CatalogException {
         try {
             CatalogTable table = paimon.getTable(tablePath);
-            Map<String, String> options = table.getOptions();
             if (!(table instanceof SystemCatalogTable)) {
                 table.getOptions().put("connector", "paimon");
             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
@@ -63,6 +64,7 @@ import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.paimon.catalog.AbstractCatalog.DB_SUFFIX;
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 
+/** Catalog for persisting external tables  */
 public class FlinkExternalCatalog extends AbstractCatalog {
 
     private final FlinkCatalog paimon;
@@ -87,6 +89,10 @@ public class FlinkExternalCatalog extends AbstractCatalog {
         } catch (IOException ignore) {
 
         }
+    }
+
+    public org.apache.paimon.catalog.Catalog catalog() {
+        return paimon.catalog();
     }
 
     private String systemDb() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -57,6 +57,7 @@ import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.factories.Factory;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -64,6 +65,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
@@ -125,6 +127,11 @@ public class FlinkExternalCatalog extends AbstractCatalog {
     @Override
     public void close() throws CatalogException {
         paimon.close();
+    }
+
+    @Override
+    public Optional<Factory> getFactory() {
+        return Optional.of(new FlinkTableFactory());
     }
 
     @Override
@@ -190,11 +197,7 @@ public class FlinkExternalCatalog extends AbstractCatalog {
     public CatalogBaseTable getTable(ObjectPath tablePath)
             throws TableNotExistException, CatalogException {
         try {
-            CatalogTable table = paimon.getTable(tablePath);
-            if (!(table instanceof SystemCatalogTable)) {
-                table.getOptions().put("connector", "paimon");
-            }
-            return table;
+            return paimon.getTable(tablePath);
         } catch (TableNotExistException | CatalogException e) {
             Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");
             try {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 
-/** Catalog for persisting external tables */
+/** Catalog for persisting external tables. */
 public class FlinkExternalCatalog extends AbstractCatalog {
 
     private final FlinkCatalog paimon;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -1,0 +1,468 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.StringUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionAlreadyExistsException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.table.catalog.exceptions.TablePartitionedException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.expressions.Expression;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+import static org.apache.paimon.catalog.AbstractCatalog.DB_SUFFIX;
+import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
+
+public class FlinkExternalCatalog extends AbstractCatalog {
+
+    private final FlinkCatalog paimon;
+    private final String warehousePath;
+
+    private static final String EXTERNAL_TABLE_STORE_PATH = ".FLINK_EXTERNAL_TABLE";
+    private static final String EXTERNAL_FUNCTION_STORE_PATH = ".FLINK_EXTERNAL_FUNCTION";
+    private final FileIO fileIO;
+
+    public FlinkExternalCatalog(FlinkCatalog paimon, FileIO fileIO, String warehousePath) {
+        super(paimon.getName(), paimon.getDefaultDatabase());
+        this.paimon = paimon;
+        this.fileIO = fileIO;
+        this.warehousePath = warehousePath;
+        try {
+            fileIO.mkdirs(new Path(externalTableDir()));
+        } catch (IOException ignore) {
+
+        }
+        try {
+            fileIO.mkdirs(new Path(externalFunctionDir()));
+        } catch (IOException ignore) {
+
+        }
+    }
+
+    private String systemDb() {
+        return this.warehousePath
+                + Path.SEPARATOR
+                + SYSTEM_DATABASE_NAME
+                + DB_SUFFIX
+                + Path.SEPARATOR;
+    }
+
+    private String externalTableDir() {
+        return systemDb() + EXTERNAL_TABLE_STORE_PATH + Path.SEPARATOR;
+    }
+
+    private String externalFunctionDir() {
+        return systemDb() + EXTERNAL_FUNCTION_STORE_PATH + Path.SEPARATOR;
+    }
+
+    private String externalTableSchemaDir(ObjectPath table) {
+        return externalTableDir()
+                + Path.SEPARATOR
+                + table.getDatabaseName()
+                + Path.SEPARATOR
+                + table.getObjectName()
+                + Path.SEPARATOR;
+    }
+
+    @Override
+    public void open() throws CatalogException {
+        paimon.open();
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        paimon.close();
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        return paimon.listDatabases();
+    }
+
+    @Override
+    public CatalogDatabase getDatabase(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        return paimon.getDatabase(databaseName);
+    }
+
+    @Override
+    public boolean databaseExists(String databaseName) throws CatalogException {
+        return paimon.databaseExists(databaseName);
+    }
+
+    @Override
+    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+            throws DatabaseAlreadyExistException, CatalogException {
+        paimon.createDatabase(name, database, ignoreIfExists);
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+            throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        paimon.dropDatabase(name, ignoreIfNotExists, cascade);
+    }
+
+    @Override
+    public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+            throws DatabaseNotExistException, CatalogException {
+        paimon.alterDatabase(name, newDatabase, ignoreIfNotExists);
+    }
+
+    private boolean isPaimonTable(CatalogBaseTable catalogBaseTable) {
+        Map<String, String> options = catalogBaseTable.getOptions();
+        String connector = options.get(CONNECTOR.key());
+        return StringUtils.isNullOrWhitespaceOnly(connector)
+                || FlinkCatalogFactory.IDENTIFIER.equals(connector);
+    }
+
+    @Override
+    public List<String> listTables(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        Path databasePath = new Path(externalTableDir() + Path.SEPARATOR + databaseName);
+        try {
+            FileStatus[] fileStatuses = fileIO.listStatus(databasePath);
+            List<String> tableList =
+                    Arrays.stream(fileStatuses)
+                            .map(FileStatus::getPath)
+                            .map(Path::getName)
+                            .collect(Collectors.toList());
+            tableList.addAll(paimon.listTables(databaseName));
+            return tableList;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public CatalogBaseTable getTable(ObjectPath tablePath)
+            throws TableNotExistException, CatalogException {
+        try {
+            return paimon.getTable(tablePath);
+        } catch (TableNotExistException | CatalogException e) {
+            Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");
+            try {
+                if (!fileIO.exists(tableSchemaPath)) {
+                    throw new TableNotExistException(getName(), tablePath);
+                }
+                String schemaStr = fileIO.readFileUtf8(tableSchemaPath);
+                Map<String, Object> propertiesMap =
+                        new ObjectMapper()
+                                .readValue(
+                                        schemaStr, new TypeReference<HashMap<String, Object>>() {});
+                Map<String, String> properties = new HashMap<>();
+                propertiesMap.forEach(
+                        (key, value) -> {
+                            properties.put(key, String.valueOf(value));
+                        });
+                return CatalogTable.fromProperties(properties);
+            } catch (IOException ex) {
+                throw new CatalogException("can not read external table", ex);
+            }
+        }
+    }
+
+    @Override
+    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+        try {
+            return getTable(tablePath) != null;
+        } catch (TableNotExistException e) {
+            throw new CatalogException(e);
+        }
+    }
+
+    @Override
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        CatalogBaseTable table = getTable(tablePath);
+        if (isPaimonTable(table)) {
+            paimon.dropTable(tablePath, ignoreIfNotExists);
+        }
+        Path path = new Path(externalTableSchemaDir(tablePath));
+        try {
+            fileIO.delete(path, true);
+        } catch (IOException e) {
+            throw new CatalogException("can not delete external table", e);
+        }
+    }
+
+    @Override
+    public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+            throws TableNotExistException, TableAlreadyExistException, CatalogException {
+        if (isPaimonTable(getTable(tablePath))) {
+            paimon.renameTable(tablePath, newTableName, ignoreIfNotExists);
+            return;
+        }
+        ObjectPath newObjectPath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
+        Path newPath = new Path(externalTableSchemaDir(newObjectPath));
+        Path oldPath = new Path(externalTableSchemaDir(tablePath));
+        try {
+            fileIO.rename(oldPath, newPath);
+        } catch (IOException e) {
+            throw new CatalogException("can not rename table to" + newTableName, e);
+        }
+    }
+
+    @Override
+    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+        if (isPaimonTable(table)) {
+            paimon.createTable(tablePath, table, ignoreIfExists);
+            return;
+        }
+        if (!(table instanceof CatalogTable)) {
+            throw new UnsupportedOperationException(
+                    "Only support CatalogTable, but is: " + table.getClass());
+        }
+        String databaseName = tablePath.getDatabaseName();
+        if (!databaseExists(databaseName)) {
+            throw new DatabaseNotExistException(getName(), databaseName);
+        }
+        CatalogTable catalogTable = (CatalogTable) table;
+        Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");
+        try {
+            if (fileIO.exists(tableSchemaPath) && !ignoreIfExists) {
+                throw new TableAlreadyExistException(getName(), tablePath);
+            }
+            String tableMetaJson = JsonSerdeUtil.toJson(catalogTable.toProperties());
+            fileIO.writeFileUtf8(tableSchemaPath, tableMetaJson);
+        } catch (IOException e) {
+            throw new CatalogException("can not create external table", e);
+        }
+    }
+
+    @Override
+    public void alterTable(
+            ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        CatalogBaseTable table = getTable(tablePath);
+        if (isPaimonTable(table)) {
+            paimon.alterTable(tablePath, newTable, ignoreIfNotExists);
+        } else {
+            dropTable(tablePath, ignoreIfNotExists);
+            try {
+                createTable(tablePath, newTable, ignoreIfNotExists);
+            } catch (TableAlreadyExistException | DatabaseNotExistException ignore) {
+
+            }
+        }
+    }
+
+    @Override
+    public List<String> listViews(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        return paimon.listViews(databaseName);
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
+            throws TableNotExistException, TableNotPartitionedException, CatalogException {
+        return paimon.listPartitions(tablePath);
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws TableNotExistException, TableNotPartitionedException,
+                    PartitionSpecInvalidException, CatalogException {
+        return paimon.listPartitions(tablePath, partitionSpec);
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitionsByFilter(
+            ObjectPath tablePath, List<Expression> filters)
+            throws TableNotExistException, TableNotPartitionedException, CatalogException {
+        return paimon.listPartitionsByFilter(tablePath, filters);
+    }
+
+    @Override
+    public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException, CatalogException {
+        return paimon.getPartition(tablePath, partitionSpec);
+    }
+
+    @Override
+    public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws CatalogException {
+        return paimon.partitionExists(tablePath, partitionSpec);
+    }
+
+    @Override
+    public void createPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition partition,
+            boolean ignoreIfExists)
+            throws TableNotExistException, TableNotPartitionedException,
+                    PartitionSpecInvalidException, PartitionAlreadyExistsException,
+                    CatalogException {
+        paimon.createPartition(tablePath, partitionSpec, partition, ignoreIfExists);
+    }
+
+    @Override
+    public void dropPartition(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
+            throws PartitionNotExistException, CatalogException {
+        paimon.dropPartition(tablePath, partitionSpec, ignoreIfNotExists);
+    }
+
+    @Override
+    public void alterPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition newPartition,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException, CatalogException {
+        paimon.alterPartition(tablePath, partitionSpec, newPartition, ignoreIfNotExists);
+    }
+
+    @Override
+    public List<String> listFunctions(String dbName)
+            throws DatabaseNotExistException, CatalogException {
+        return paimon.listFunctions(dbName);
+    }
+
+    @Override
+    public CatalogFunction getFunction(ObjectPath functionPath)
+            throws FunctionNotExistException, CatalogException {
+        return paimon.getFunction(functionPath);
+    }
+
+    @Override
+    public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+        return paimon.functionExists(functionPath);
+    }
+
+    @Override
+    public void createFunction(
+            ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists)
+            throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
+        paimon.createFunction(functionPath, function, ignoreIfExists);
+    }
+
+    @Override
+    public void alterFunction(
+            ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists)
+            throws FunctionNotExistException, CatalogException {
+        paimon.alterFunction(functionPath, newFunction, ignoreIfNotExists);
+    }
+
+    @Override
+    public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
+            throws FunctionNotExistException, CatalogException {
+        paimon.dropFunction(functionPath, ignoreIfNotExists);
+    }
+
+    @Override
+    public CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
+            throws TableNotExistException, CatalogException {
+        return paimon.getTableStatistics(tablePath);
+    }
+
+    @Override
+    public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
+            throws TableNotExistException, CatalogException {
+        return paimon.getTableColumnStatistics(tablePath);
+    }
+
+    @Override
+    public CatalogTableStatistics getPartitionStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException, CatalogException {
+        return paimon.getPartitionStatistics(tablePath, partitionSpec);
+    }
+
+    @Override
+    public CatalogColumnStatistics getPartitionColumnStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException, CatalogException {
+        return paimon.getPartitionColumnStatistics(tablePath, partitionSpec);
+    }
+
+    @Override
+    public void alterTableStatistics(
+            ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        paimon.alterTableStatistics(tablePath, tableStatistics, ignoreIfNotExists);
+    }
+
+    @Override
+    public void alterTableColumnStatistics(
+            ObjectPath tablePath,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException, TablePartitionedException {
+        paimon.alterTableColumnStatistics(tablePath, columnStatistics, ignoreIfNotExists);
+    }
+
+    @Override
+    public void alterPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogTableStatistics partitionStatistics,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException, CatalogException {
+        paimon.alterPartitionStatistics(
+                tablePath, partitionSpec, partitionStatistics, ignoreIfNotExists);
+    }
+
+    @Override
+    public void alterPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException, CatalogException {
+        paimon.alterPartitionColumnStatistics(
+                tablePath, partitionSpec, columnStatistics, ignoreIfNotExists);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -191,7 +191,7 @@ public class FlinkExternalCatalog extends AbstractCatalog {
             throws TableNotExistException, CatalogException {
         try {
             CatalogTable table = paimon.getTable(tablePath);
-            table.getOptions().put("connector","paimon");
+            table.getOptions().put("connector", "paimon");
             return table;
         } catch (TableNotExistException | CatalogException e) {
             Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalog.java
@@ -191,7 +191,10 @@ public class FlinkExternalCatalog extends AbstractCatalog {
             throws TableNotExistException, CatalogException {
         try {
             CatalogTable table = paimon.getTable(tablePath);
-            table.getOptions().put("connector", "paimon");
+            Map<String, String> options = table.getOptions();
+            if (!(table instanceof SystemCatalogTable)) {
+                table.getOptions().put("connector", "paimon");
+            }
             return table;
         } catch (TableNotExistException | CatalogException e) {
             Path tableSchemaPath = new Path(externalTableSchemaDir(tablePath) + "schema");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalogFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.factories.FactoryUtil;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.factories.CatalogFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.flink.FlinkCatalogOptions.DEFAULT_DATABASE;
+import static org.apache.paimon.options.CatalogOptions.METASTORE;
+
+public class FlinkExternalCatalogFactory implements CatalogFactory {
+
+    public static final String IDENTIFIER = "paimon-external";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public FlinkExternalCatalog createCatalog(Context context) {
+        return createCatalog(context.getClassLoader(), context.getOptions(), context.getName());
+    }
+
+    @VisibleForTesting
+    public static FlinkExternalCatalog createCatalog(
+            ClassLoader cl, Map<String, String> optionMap, String name) {
+        Options options = Options.fromMap(optionMap);
+        FlinkFileIOLoader fallbackIOLoader = new FlinkFileIOLoader();
+        CatalogContext context = CatalogContext.create(options, fallbackIOLoader);
+        String metastore = context.options().get(METASTORE);
+        org.apache.paimon.catalog.CatalogFactory catalogFactory =
+                FactoryUtil.discoverFactory(
+                        cl, org.apache.paimon.catalog.CatalogFactory.class, metastore);
+        String warehouse =
+                org.apache.paimon.catalog.CatalogFactory.warehouse(context).toUri().toString();
+        Path warehousePath = new Path(warehouse);
+        try {
+            FileIO fileIO = FileIO.get(warehousePath, context);
+            FlinkCatalog paimon =
+                    new FlinkCatalog(
+                            catalogFactory.create(fileIO, warehousePath, context),
+                            name,
+                            options.get(DEFAULT_DATABASE),
+                            cl,
+                            options);
+            return new FlinkExternalCatalog(paimon, fileIO, warehouse);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return CatalogFactory.super.requiredOptions();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return CatalogFactory.super.optionalOptions();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkExternalCatalogFactory.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static org.apache.paimon.flink.FlinkCatalogOptions.DEFAULT_DATABASE;
 import static org.apache.paimon.options.CatalogOptions.METASTORE;
 
+/** Factory for {@link FlinkExternalCatalog}. */
 public class FlinkExternalCatalogFactory implements CatalogFactory {
 
     public static final String IDENTIFIER = "paimon-external";

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -16,3 +16,4 @@
 org.apache.paimon.flink.FlinkTableFactory
 org.apache.paimon.flink.FlinkCatalogFactory
 org.apache.paimon.flink.FlinkGenericCatalogFactory
+org.apache.paimon.flink.FlinkExternalCatalogFactory

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Integration test for {@link FlinkExternalCatalog}. */
+public class FlinkExternalCatalogITCase {
+
+    protected TableEnvironment tEnv;
+
+    @TempDir public static java.nio.file.Path path;
+
+    @TempDir public static java.nio.file.Path path2;
+
+    @BeforeEach
+    public void setup() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+        env.setParallelism(1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        String catalog = "PAIMON_EXTERNAL";
+        Map<String, String> options = new HashMap<>();
+        options.put("type", "paimon-external");
+        options.put("warehouse", path.toUri().getPath());
+        tEnv = StreamTableEnvironment.create(env);
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, false);
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG %s WITH (" + "%s" + ")",
+                        catalog,
+                        options.entrySet().stream()
+                                .map(e -> String.format("'%s'='%s'", e.getKey(), e.getValue()))
+                                .collect(Collectors.joining(","))));
+        tEnv.useCatalog(catalog);
+    }
+
+    @Test
+    public void testUseExternalTable() {
+        tEnv.executeSql(
+                "CREATE TABLE word_count (\n"
+                        + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
+                        + "    cnt BIGINT\n"
+                        + ") with (\n"
+                        + "\t'connector'='paimon'\n"
+                        + ")");
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE file (\n"
+                                + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
+                                + "    cnt BIGINT\n"
+                                + ") with (\n"
+                                + "    'connector'='filesystem',\n"
+                                + "    'path'='file://%s', \n"
+                                + "    'format'='json' \n"
+                                + ")",
+                        path2.toUri().getPath()));
+        tEnv.executeSql("insert into file select * from `word_count`");
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
@@ -87,4 +87,28 @@ public class FlinkExternalCatalogITCase {
                         path2.toUri().getPath()));
         tEnv.executeSql("insert into file select * from `word_count`");
     }
+
+    @Test
+    public void testUseSystemTable() {
+        tEnv.executeSql(
+                "CREATE TABLE word_count (\n"
+                        + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
+                        + "    cnt BIGINT\n"
+                        + ") with (\n"
+                        + "\t'connector'='paimon'\n"
+                        + ")");
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE file (\n"
+                                + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
+                                + "    rowkind String,\n"
+                                + "    cnt BIGINT\n"
+                                + ") with (\n"
+                                + "    'connector'='filesystem',\n"
+                                + "    'path'='file://%s', \n"
+                                + "    'format'='json' \n"
+                                + ")",
+                        path2.toUri().getPath()));
+        tEnv.executeSql("insert into file select * from word_count$audit_log");
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,10 +33,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Integration test for {@link FlinkExternalCatalog}. */
 public class FlinkExternalCatalogITCase {
 
-    protected TableEnvironment tEnv;
+    private TableEnvironment tEnv;
+    private String catalog = "PAIMON_EXTERNAL";
+    private String catalog2 = "PAIMON_EXTERNAL2";
 
     @TempDir public static java.nio.file.Path path;
 
@@ -47,7 +52,7 @@ public class FlinkExternalCatalogITCase {
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
         env.setParallelism(1);
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
-        String catalog = "PAIMON_EXTERNAL";
+
         Map<String, String> options = new HashMap<>();
         options.put("type", "paimon-external");
         options.put("warehouse", path.toUri().getPath());
@@ -62,13 +67,20 @@ public class FlinkExternalCatalogITCase {
                         options.entrySet().stream()
                                 .map(e -> String.format("'%s'='%s'", e.getKey(), e.getValue()))
                                 .collect(Collectors.joining(","))));
-        tEnv.useCatalog(catalog);
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG %s WITH (" + "%s" + ")",
+                        catalog2,
+                        options.entrySet().stream()
+                                .map(e -> String.format("'%s'='%s'", e.getKey(), e.getValue()))
+                                .collect(Collectors.joining(","))));
     }
 
     @Test
-    public void testUseExternalTable() {
+    public void testMix() {
+        tEnv.useCatalog(catalog);
         tEnv.executeSql(
-                "CREATE TABLE word_count (\n"
+                "CREATE TABLE word_count1 (\n"
                         + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
                         + "    cnt BIGINT\n"
                         + ") with (\n"
@@ -76,7 +88,7 @@ public class FlinkExternalCatalogITCase {
                         + ")");
         tEnv.executeSql(
                 String.format(
-                        "CREATE TABLE file (\n"
+                        "CREATE TABLE file1 (\n"
                                 + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
                                 + "    cnt BIGINT\n"
                                 + ") with (\n"
@@ -85,13 +97,14 @@ public class FlinkExternalCatalogITCase {
                                 + "    'format'='json' \n"
                                 + ")",
                         path2.toUri().getPath()));
-        tEnv.executeSql("insert into file select * from `word_count`");
+        tEnv.executeSql("insert into file1 select * from `word_count1`");
     }
 
     @Test
     public void testUseSystemTable() {
+        tEnv.useCatalog(catalog);
         tEnv.executeSql(
-                "CREATE TABLE word_count (\n"
+                "CREATE TABLE word_count2 (\n"
                         + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
                         + "    cnt BIGINT\n"
                         + ") with (\n"
@@ -99,7 +112,7 @@ public class FlinkExternalCatalogITCase {
                         + ")");
         tEnv.executeSql(
                 String.format(
-                        "CREATE TABLE file (\n"
+                        "CREATE TABLE file2 (\n"
                                 + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
                                 + "    rowkind String,\n"
                                 + "    cnt BIGINT\n"
@@ -109,6 +122,27 @@ public class FlinkExternalCatalogITCase {
                                 + "    'format'='json' \n"
                                 + ")",
                         path2.toUri().getPath()));
-        tEnv.executeSql("insert into file select * from word_count$audit_log");
+        tEnv.executeSql("insert into file2 select * from word_count2$audit_log");
+    }
+
+    @Test
+    public void testUseExternalTable() {
+        tEnv.useCatalog(catalog);
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE file3 (\n"
+                                + "    word STRING PRIMARY KEY NOT ENFORCED,\n"
+                                + "    rowkind String,\n"
+                                + "    cnt BIGINT\n"
+                                + ") with (\n"
+                                + "    'connector'='filesystem',\n"
+                                + "    'path'='file://%s', \n"
+                                + "    'format'='json' \n"
+                                + ")",
+                        path2.toUri().getPath()));
+        Table fileTable = tEnv.from("file3");
+        tEnv.useCatalog(catalog2);
+        Table fileTable2 = tEnv.from("file3");
+        assertThat(fileTable.getResolvedSchema()).isEqualTo(fileTable2.getResolvedSchema());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -192,7 +192,6 @@ public class FlinkExternalCatalogTest {
                         .getDataTableLocation(FlinkCatalog.toIdentifier(path));
         Map<String, String> options = new HashMap<>(t1.getOptions());
         options.put("path", tablePath.toString());
-        options.put("connector", "paimon");
         t1 = ((ResolvedCatalogTable) t1).copy(options);
         checkEquals(t1, t2);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -135,18 +135,18 @@ public class FlinkExternalCatalogTest {
 
     @Test
     public void testListDatabases() throws Exception {
-        assertThat(catalog.listDatabases().size()).isEqualTo(2);
+        assertThat(catalog.listDatabases().size()).isEqualTo(1);
         catalog.createDatabase(database1, null, true);
         catalog.createDatabase(database2, null, false);
-        assertThat(catalog.listDatabases().size()).isEqualTo(4);
+        assertThat(catalog.listDatabases().size()).isEqualTo(3);
     }
 
     @Test
     public void dropDatabase() throws Exception {
         catalog.createDatabase(database1, null, true);
-        assertThat(catalog.listDatabases().size()).isEqualTo(3);
-        catalog.dropDatabase(database1, true);
         assertThat(catalog.listDatabases().size()).isEqualTo(2);
+        catalog.dropDatabase(database1, true);
+        assertThat(catalog.listDatabases().size()).isEqualTo(1);
     }
 
     @Test
@@ -205,6 +205,15 @@ public class FlinkExternalCatalogTest {
         assertThat(t2.getOptions()).isEqualTo(t1.getOptions());
     }
 
+    private static void checkOriginEquals(CatalogTable t1,CatalogTable t2){
+        assertThat(t2.getTableKind()).isEqualTo(t1.getTableKind());
+        assertThat(t2.getUnresolvedSchema()).isEqualTo(t1.getUnresolvedSchema());
+        assertThat(t2.getComment()).isEqualTo(t1.getComment());
+        assertThat(t2.getPartitionKeys()).isEqualTo(t1.getPartitionKeys());
+        assertThat(t2.isPartitioned()).isEqualTo(t1.isPartitioned());
+        assertThat(t2.getOptions()).isEqualTo(t1.getOptions());
+    }
+
     @Test
     public void testAlterTable() throws Exception {
         HashMap<String, String> options = new HashMap<>();
@@ -224,11 +233,11 @@ public class FlinkExternalCatalogTest {
         externalTableOptions.put("connector","kafka");
         CatalogTable table = this.createTable(externalTableOptions);
         catalog.createTable(externalTable1, table, false);
-        checkEquals(externalTable1,((CatalogTable) catalog.getTable(externalTable1)),  table);
+        checkOriginEquals(((CatalogTable) catalog.getTable(externalTable1)),  table);
         HashMap<String, String> options = new HashMap<>();
-        externalTableOptions.put("connector","kafka");
+        externalTableOptions.put("connector","paimon");
         CatalogTable paimonTable = this.createTable(options);
         catalog.createTable(paimonTable1, paimonTable, false);
-        checkEquals(paimonTable1,table, (CatalogTable) catalog.getTable(paimonTable1));
+        checkEquals(paimonTable1,paimonTable, (CatalogTable) catalog.getTable(paimonTable1));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.paimon.catalog.AbstractCatalog;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test for {@link FlinkExternalCatalog}.
+ */
+public class FlinkExternalCatalogTest {
+
+    private static String defaultDatabase = "default";
+    private static String database1 = "d1";
+
+    private static String database2 = "d2";
+
+    private static ObjectPath paimonTable1 = new ObjectPath(defaultDatabase, "t1");
+
+    private static ObjectPath paimonTable2 = new ObjectPath(database1, "t2");
+
+    private static ObjectPath paimonTable3 = new ObjectPath(database1, "t3");
+    private static ObjectPath externalTable1 = new ObjectPath(defaultDatabase, "et1");
+
+    private static ObjectPath externalTable2 = new ObjectPath(database1, "et2");
+    private Catalog catalog;
+
+    @TempDir
+    public static java.nio.file.Path temporaryFolder;
+
+    private ResolvedSchema createSchema() {
+        return new ResolvedSchema(
+                Arrays.asList(
+                        Column.physical("first", DataTypes.STRING()),
+                        Column.physical("second", DataTypes.INT()),
+                        Column.physical("third", DataTypes.STRING()),
+                        Column.physical(
+                                "four",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("f1", DataTypes.STRING()),
+                                        DataTypes.FIELD("f2", DataTypes.INT()),
+                                        DataTypes.FIELD(
+                                                "f3",
+                                                DataTypes.MAP(
+                                                        DataTypes.STRING(), DataTypes.INT()))))),
+                Collections.emptyList(),
+                null);
+    }
+
+    private CatalogTable createTable(Map<String, String> options) {
+        ResolvedSchema resolvedSchema = this.createSchema();
+        CatalogTable origin =
+                CatalogTable.of(
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        "test comment",
+                        Collections.emptyList(),
+                        options);
+        return new ResolvedCatalogTable(origin, resolvedSchema);
+    }
+
+    @BeforeEach
+    public void beforeEach() throws IOException {
+        String path = new File(temporaryFolder.toFile(), UUID.randomUUID().toString()).toString();
+        Options conf = new Options();
+        conf.setString("warehouse", path);
+        catalog =
+                FlinkExternalCatalogFactory.createCatalog(
+                        FlinkCatalogTest.class.getClassLoader(),
+                        conf.toMap(),
+                        "test-external-catalog");
+    }
+
+    private CatalogTable createAnotherTable(Map<String, String> options) {
+        ResolvedSchema resolvedSchema = this.createSchema();
+        CatalogTable origin =
+                CatalogTable.of(
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        "test comment",
+                        Collections.emptyList(),
+                        options);
+        return new ResolvedCatalogTable(origin, resolvedSchema);
+    }
+
+    @Test
+    public void testCreateDataBase() throws Exception {
+        catalog.createDatabase(database1, null, true);
+        assertThatThrownBy(() -> catalog.createDatabase(database1, null, false))
+                .isInstanceOf(DatabaseAlreadyExistException.class)
+                .hasMessageContaining("already exists in Catalog test-external-catalog");
+        catalog.createDatabase(database2, null, false);
+    }
+
+    @Test
+    public void testListDatabases() throws Exception {
+        assertThat(catalog.listDatabases().size()).isEqualTo(2);
+        catalog.createDatabase(database1, null, true);
+        catalog.createDatabase(database2, null, false);
+        assertThat(catalog.listDatabases().size()).isEqualTo(4);
+    }
+
+    @Test
+    public void dropDatabase() throws Exception {
+        catalog.createDatabase(database1, null, true);
+        assertThat(catalog.listDatabases().size()).isEqualTo(3);
+        catalog.dropDatabase(database1, true);
+        assertThat(catalog.listDatabases().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void createTable() throws Exception {
+        HashMap<String, String> paimonOptions = new HashMap<>();
+        CatalogTable table = createTable(paimonOptions);
+        HashMap<String, String> externalTableOptions = new HashMap<>();
+        externalTableOptions.put("connector","kafka");
+        CatalogTable externalTable = createTable(externalTableOptions);
+        catalog.createTable(paimonTable1, table, true);
+        assertThat(catalog.listTables(defaultDatabase).size()).isEqualTo(1);
+        catalog.createTable(externalTable1, table, true);
+        assertThat(catalog.listTables(defaultDatabase).size()).isEqualTo(2);
+        assertThatThrownBy(() -> catalog.createTable(paimonTable2, table, true))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessageContaining("Database d1 does not exist in Catalog test-external-catalog");
+        catalog.createDatabase(database1, null, true);
+        catalog.createTable(paimonTable2, table, true);
+        catalog.createTable(paimonTable3, table, true);
+        catalog.createTable(externalTable2, externalTable, true);
+        assertThat(catalog.listTables(database1).size()).isEqualTo(3);
+        assertThatThrownBy(() -> catalog.createTable(externalTable2, externalTable, false))
+                .isInstanceOf(TableAlreadyExistException.class)
+                .hasMessageContaining("Table (or view) d1.et2 already exists in Catalog test-external-catalog");
+    }
+
+    @Test
+    public void dropTable() throws Exception {
+        HashMap<String, String> externalTableOptions = new HashMap<>();
+        externalTableOptions.put("connector","kafka");
+        CatalogTable externalTable = createTable(externalTableOptions);
+        catalog.createTable(externalTable1, externalTable, true);
+        assertThatThrownBy(() -> catalog.createTable(externalTable1, externalTable, false))
+                .isInstanceOf(TableAlreadyExistException.class)
+                .hasMessageContaining("Table (or view) default.et1 already exists in Catalog test-external-catalog");
+        catalog.dropTable(externalTable1,true);
+        catalog.createTable(externalTable1, externalTable, false);
+    }
+
+
+
+    private static void checkEquals(CatalogTable t1, CatalogTable t2) {
+        assertThat(t2.getTableKind()).isEqualTo(t1.getTableKind());
+        assertThat(t2.getSchema()).isEqualTo(t1.getSchema());
+        assertThat(t2.getComment()).isEqualTo(t1.getComment());
+        assertThat(t2.getPartitionKeys()).isEqualTo(t1.getPartitionKeys());
+        assertThat(t2.isPartitioned()).isEqualTo(t1.isPartitioned());
+        assertThat(t2.getOptions()).isEqualTo(t1.getOptions());
+    }
+
+    @Test
+    public void testAlterTable() throws Exception {
+        HashMap<String, String> options = new HashMap<>();
+        CatalogTable table = this.createTable(options);
+        catalog.createTable(paimonTable1, table, false);
+        checkEquals(table, (CatalogTable) catalog.getTable(paimonTable1));
+        CatalogTable newTable = this.createAnotherTable(options);
+        catalog.alterTable(paimonTable1, newTable, false);
+        assertThat(catalog.getTable(paimonTable1)).isNotEqualTo(table);
+        checkEquals(newTable, (CatalogTable) catalog.getTable(paimonTable1));
+        catalog.dropTable(paimonTable1, false);
+    }
+
+    @Test
+    public void testGetTable() throws Exception{
+        HashMap<String, String> externalTableOptions = new HashMap<>();
+        externalTableOptions.put("connector","kafka");
+        CatalogTable table = this.createTable(externalTableOptions);
+        catalog.createTable(externalTable1, table, false);
+        checkEquals(((CatalogTable) catalog.getTable(externalTable1)),  table);
+        HashMap<String, String> options = new HashMap<>();
+        externalTableOptions.put("connector","kafka");
+        CatalogTable paimonTable = this.createTable(options);
+        catalog.createTable(paimonTable1, paimonTable, false);
+        checkEquals(table, (CatalogTable) catalog.getTable(paimonTable1));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -192,6 +192,7 @@ public class FlinkExternalCatalogTest {
                         .getDataTableLocation(FlinkCatalog.toIdentifier(path));
         Map<String, String> options = new HashMap<>(t1.getOptions());
         options.put("path", tablePath.toString());
+        options.put("connector","paimon");
         t1 = ((ResolvedCatalogTable) t1).copy(options);
         checkEquals(t1, t2);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -192,7 +192,7 @@ public class FlinkExternalCatalogTest {
                         .getDataTableLocation(FlinkCatalog.toIdentifier(path));
         Map<String, String> options = new HashMap<>(t1.getOptions());
         options.put("path", tablePath.toString());
-        options.put("connector","paimon");
+        options.put("connector", "paimon");
         t1 = ((ResolvedCatalogTable) t1).copy(options);
         checkEquals(t1, t2);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkExternalCatalogTest.java
@@ -186,7 +186,15 @@ public class FlinkExternalCatalogTest {
         catalog.createTable(externalTable1, externalTable, false);
     }
 
-
+    private void checkEquals(ObjectPath path, CatalogTable t1, CatalogTable t2) {
+        Path tablePath =
+                ((AbstractCatalog) ((FlinkExternalCatalog) catalog).catalog())
+                        .getDataTableLocation(FlinkCatalog.toIdentifier(path));
+        Map<String, String> options = new HashMap<>(t1.getOptions());
+        options.put("path", tablePath.toString());
+        t1 = ((ResolvedCatalogTable) t1).copy(options);
+        checkEquals(t1, t2);
+    }
 
     private static void checkEquals(CatalogTable t1, CatalogTable t2) {
         assertThat(t2.getTableKind()).isEqualTo(t1.getTableKind());
@@ -202,11 +210,11 @@ public class FlinkExternalCatalogTest {
         HashMap<String, String> options = new HashMap<>();
         CatalogTable table = this.createTable(options);
         catalog.createTable(paimonTable1, table, false);
-        checkEquals(table, (CatalogTable) catalog.getTable(paimonTable1));
+        checkEquals(paimonTable1,table, (CatalogTable) catalog.getTable(paimonTable1));
         CatalogTable newTable = this.createAnotherTable(options);
         catalog.alterTable(paimonTable1, newTable, false);
         assertThat(catalog.getTable(paimonTable1)).isNotEqualTo(table);
-        checkEquals(newTable, (CatalogTable) catalog.getTable(paimonTable1));
+        checkEquals(paimonTable1,newTable, (CatalogTable) catalog.getTable(paimonTable1));
         catalog.dropTable(paimonTable1, false);
     }
 
@@ -216,11 +224,11 @@ public class FlinkExternalCatalogTest {
         externalTableOptions.put("connector","kafka");
         CatalogTable table = this.createTable(externalTableOptions);
         catalog.createTable(externalTable1, table, false);
-        checkEquals(((CatalogTable) catalog.getTable(externalTable1)),  table);
+        checkEquals(externalTable1,((CatalogTable) catalog.getTable(externalTable1)),  table);
         HashMap<String, String> options = new HashMap<>();
         externalTableOptions.put("connector","kafka");
         CatalogTable paimonTable = this.createTable(options);
         catalog.createTable(paimonTable1, paimonTable, false);
-        checkEquals(table, (CatalogTable) catalog.getTable(paimonTable1));
+        checkEquals(paimonTable1,table, (CatalogTable) catalog.getTable(paimonTable1));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

close issue #1804
Supports the use of paimon external catalog to persist non-paimon tables so that users do not need to create their other tables after they have created them.


### Tests

Added unit tests for FlinkExternalCatalog

### Documentation

<!-- Does this change introduce a new feature -->
