### PR TITLE
[flink] Add config "table-conf sink.parallelism" for ordinary compact

### DIFF
--- a/docs/content/maintenance/dedicated-compaction.md
+++ b/docs/content/maintenance/dedicated-compaction.md
@@ -93,6 +93,7 @@ Run the following command to submit a compaction job for the table.
     --database <database-name> \ 
     --table <table-name> \
     [--partition <partition-name>] \
+    [--table-conf <table-conf>] \
     [--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] \
 ```
 
@@ -107,6 +108,7 @@ Example: compact table
     --table test_table \
     --partition dt=20221126,hh=08 \
     --partition dt=20221127,hh=09 \
+    --table-conf sink.parallelism=10 \
     --catalog-conf s3.endpoint=https://****.com \
     --catalog-conf s3.access-key=***** \
     --catalog-conf s3.secret-key=*****


### PR DESCRIPTION

### Purpose

Enable table-conf sink.parallelism for ordinary dedicated compact job. We can use --table-conf sink.parallelism=xxx to modify the parallelism of dedicated compaction job.


### API and Format

Example: 
```sql
flink run ./paimon-flink-action-0.6-SNAPSHOT.jar compact \
--warehouse \
/Users/paimontest/GlobalBatchReadWrite \
--database \
my_db \
--table \
Orders1 \
--table-conf sink.parallelism=4
```

### Documentation

Added documentation for dedicated compaction job.
