### PR TITLE
[flink] [fix] Flink add computed column should be nullable

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/FlinkCatalogPropertiesUtil.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/FlinkCatalogPropertiesUtil.java
@@ -77,6 +77,7 @@ public class FlinkCatalogPropertiesUtil {
         return serialized;
     }
 
+    // new Column api
     public static List<SchemaChange> serializeNonPhysicalColumns(
             Map<String, Integer> indexMap, Column c) {
         List<SchemaChange> schemaChanges = new ArrayList<>();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -268,8 +268,10 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         assertThat(sql("SHOW CREATE TABLE T").get(0).toString())
                 .contains("`__proc_time` AS PROCTIME()");
         sql("INSERT INTO T VALUES(1)");
-        assertThatCode(() -> sql("SELECT * FROM T").get(0).getField(1).toString())
-                .doesNotThrowAnyException();
+        List<Row> rows =
+                sql(
+                        "SELECT * FROM T WHERE __proc_time = PROCTIME() UNION ALL SELECT 1, PROCTIME()");
+        assertThat(rows.get(0)).isEqualTo(rows.get(1));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test case for append-only managed table. */
@@ -257,6 +258,15 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES (2)");
         // Only fetch latest snapshot is, dynamic option worked
         assertThat(iterator.collect(1)).containsExactlyInAnyOrder(Row.of(2));
+    }
+
+    @Test
+    public void testAlterTable() {
+        sql("CREATE TABLE T (id INT) WITH ('write-mode'='append-only')");
+        assertThatCode(() -> sql("ALTER TABLE T add (__proc_time AS PROCTIME())"))
+                .doesNotThrowAnyException();
+        assertThat(sql("SHOW CREATE TABLE T").get(0).toString())
+                .contains("`__proc_time` TIMESTAMP");
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -266,7 +266,10 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         assertThatCode(() -> sql("ALTER TABLE T add (__proc_time AS PROCTIME())"))
                 .doesNotThrowAnyException();
         assertThat(sql("SHOW CREATE TABLE T").get(0).toString())
-                .contains("`__proc_time` TIMESTAMP");
+                .contains("`__proc_time` AS PROCTIME()");
+        sql("INSERT INTO T VALUES(1)");
+        assertThatCode(() -> sql("SELECT * FROM T").get(0).getField(1).toString())
+                .doesNotThrowAnyException();
     }
 
     @Override


### PR DESCRIPTION


### Purpose


sql "ALTER TABLE T add (__proc_time AS PROCTIME())" should be work well with paimon. And the clumn __proc_time which is ComputedColumn should be nullable.
