### PR TITLE
[flink][kafka-cdc] Refactor Kafka CDC RecordParser

### DIFF
--- a/docs/content/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/cdc-ingestion/kafka-cdc.md
@@ -63,7 +63,12 @@ If a message in a Kafka topic is a change event captured from another database u
 </table>
 
 {{< hint info >}}
-In Oracle GoldenGate and Maxwell, the data format synchronized to Kafka does not include field data type information. As a result, Paimon sets the data type for all fields to "String" by default.
+The JSON sources possibly missing some information. For example, Ogg and Maxwell format don't contain field types; When 
+you write JSON sources into Flink Kafka sink, it will only reserve data and row type and drop other information. The 
+synchronization will try best to handle the problem as follows:
+1. If missing field types, Paimon will use 'STRING' type as default. Note that the Ogg and Maxwell standard implementation 
+don't contain field types.
+2. If missing database name or table name, you cannot database synchronization. But you can still do table synchronization.
 {{< /hint >}}
 
 ## Synchronizing Tables

--- a/docs/content/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/cdc-ingestion/kafka-cdc.md
@@ -68,6 +68,8 @@ types; When you write JSON sources into Flink Kafka sink, it will only reserve d
 The synchronization job will try best to handle the problem as follows:
 1. If missing field types, Paimon will use 'STRING' type as default. 
 2. If missing database name or table name, you cannot do database synchronization, but you can still do table synchronization.
+3. If missing primary keys, the job might create non primary key table. You can set primary keys when submit job in table 
+synchronization.
 {{< /hint >}}
 
 ## Synchronizing Tables

--- a/docs/content/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/cdc-ingestion/kafka-cdc.md
@@ -63,12 +63,11 @@ If a message in a Kafka topic is a change event captured from another database u
 </table>
 
 {{< hint info >}}
-The JSON sources possibly missing some information. For example, Ogg and Maxwell format don't contain field types; When 
-you write JSON sources into Flink Kafka sink, it will only reserve data and row type and drop other information. The 
-synchronization will try best to handle the problem as follows:
-1. If missing field types, Paimon will use 'STRING' type as default. Note that the Ogg and Maxwell standard implementation 
-don't contain field types.
-2. If missing database name or table name, you cannot database synchronization. But you can still do table synchronization.
+The JSON sources possibly missing some information. For example, Ogg and Maxwell format standards don't contain field 
+types; When you write JSON sources into Flink Kafka sink, it will only reserve data and row type and drop other information. 
+The synchronization job will try best to handle the problem as follows:
+1. If missing field types, Paimon will use 'STRING' type as default. 
+2. If missing database name or table name, you cannot do database synchronization, but you can still do table synchronization.
 {{< /hint >}}
 
 ## Synchronizing Tables

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -150,23 +150,9 @@ public class CdcActionCommonUtils {
             List<String> specifiedPrimaryKeys,
             List<ComputedColumn> computedColumns,
             Map<String, String> tableConfig,
-            Schema sourceSchema) {
-        return buildPaimonSchema(
-                specifiedPartitionKeys,
-                specifiedPrimaryKeys,
-                computedColumns,
-                tableConfig,
-                sourceSchema,
-                new CdcMetadataConverter[] {});
-    }
-
-    public static Schema buildPaimonSchema(
-            List<String> specifiedPartitionKeys,
-            List<String> specifiedPrimaryKeys,
-            List<ComputedColumn> computedColumns,
-            Map<String, String> tableConfig,
             Schema sourceSchema,
-            CdcMetadataConverter[] metadataConverters) {
+            CdcMetadataConverter[] metadataConverters,
+            boolean requirePrimaryKeys) {
         Schema.Builder builder = Schema.newBuilder();
 
         // options
@@ -208,8 +194,7 @@ public class CdcActionCommonUtils {
             builder.primaryKey(specifiedPrimaryKeys);
         } else if (!sourceSchema.primaryKeys().isEmpty()) {
             builder.primaryKey(sourceSchema.primaryKeys());
-        } else {
-            // TODO kafka cdc doesn't need to check
+        } else if (requirePrimaryKeys) {
             throw new IllegalArgumentException(
                     "Primary keys are not specified. "
                             + "Also, can't infer primary keys from source table schemas because "

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -209,6 +209,7 @@ public class CdcActionCommonUtils {
         } else if (!sourceSchema.primaryKeys().isEmpty()) {
             builder.primaryKey(sourceSchema.primaryKeys());
         } else {
+            // TODO kafka cdc doesn't need to check
             throw new IllegalArgumentException(
                     "Primary keys are not specified. "
                             + "Also, can't infer primary keys from source table schemas because "

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
@@ -169,7 +169,9 @@ public abstract class MessageQueueSyncTableActionBase extends ActionBase {
                                 primaryKeys,
                                 computedColumns,
                                 tableConfig,
-                                retrievedSchema);
+                                retrievedSchema,
+                                new CdcMetadataConverter[] {},
+                                false);
                 assertSchemaCompatible(fileStoreTable.schema(), fromMq.fields());
             } catch (MessageQueueSchemaUtils.SchemaRetrievalException e) {
                 LOG.info(
@@ -191,7 +193,9 @@ public abstract class MessageQueueSyncTableActionBase extends ActionBase {
                             primaryKeys,
                             computedColumns,
                             tableConfig,
-                            retrievedSchema);
+                            retrievedSchema,
+                            new CdcMetadataConverter[] {},
+                            false);
 
             catalog.createTable(identifier, fromMq, false);
             fileStoreTable = (FileStoreTable) catalog.getTable(identifier).copy(tableConfig);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalFieldParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalFieldParser.java
@@ -22,9 +22,6 @@ package org.apache.paimon.flink.action.cdc.format.canal;
 public class CanalFieldParser {
 
     protected static byte[] convertGeoType2WkbArray(byte[] mysqlGeomBytes) {
-        if (mysqlGeomBytes == null) {
-            return null;
-        }
         int sridLength = 4;
         boolean hasSrid = false;
         for (int i = 0; i < sridLength; ++i) {
@@ -58,9 +55,6 @@ public class CanalFieldParser {
     }
 
     protected static String convertSet(String value, String mysqlType) {
-        if (value == null) {
-            return null;
-        }
         // mysql set type value can be filled with more than one, value is a bit string conversion
         // from the long
         int indexes = Integer.parseInt(value);
@@ -68,9 +62,6 @@ public class CanalFieldParser {
     }
 
     protected static String convertEnum(String value, String mysqlType) {
-        if (value == null) {
-            return null;
-        }
         int elementIndex = Integer.parseInt(value);
         // enum('a','b','c')
         return getEnumValueByIndex(mysqlType, elementIndex);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -185,12 +186,14 @@ public class CanalRecordParser extends RecordParser {
             for (Map.Entry<String, Object> entry : recordMap.entrySet()) {
                 String fieldName = entry.getKey();
                 String originalType = originalFieldTypes.get(fieldName);
-                rowData.put(fieldName, transformValue(entry.getValue().toString(), originalType));
+                String newValue =
+                        transformValue(Objects.toString(entry.getValue(), null), originalType);
+                rowData.put(fieldName, newValue);
             }
         } else {
             paimonFieldTypes.putAll(fillDefaultStringTypes(record));
             for (Map.Entry<String, Object> entry : recordMap.entrySet()) {
-                rowData.put(entry.getKey(), entry.getValue().toString());
+                rowData.put(entry.getKey(), Objects.toString(entry.getValue(), null));
             }
         }
 
@@ -209,7 +212,11 @@ public class CanalRecordParser extends RecordParser {
                 .collect(Collectors.toMap(newData::get, oldData::get));
     }
 
-    private String transformValue(String oldValue, String mySqlType) {
+    private String transformValue(@Nullable String oldValue, String mySqlType) {
+        if (oldValue == null) {
+            return null;
+        }
+
         String shortType = MySqlTypeUtils.getShortType(mySqlType);
 
         if (MySqlTypeUtils.isSetType(shortType)) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
@@ -25,13 +25,15 @@ import org.apache.paimon.flink.action.cdc.mysql.MySqlTypeUtils;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
-import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
 
-import org.apache.commons.lang3.BooleanUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -43,8 +45,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.paimon.utils.JsonSerdeUtil.getNodeAs;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
  * The {@code CanalRecordParser} class is responsible for parsing records from the Canal-JSON
@@ -61,6 +63,8 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  */
 public class CanalRecordParser extends RecordParser {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CanalRecordParser.class);
+
     private static final String FIELD_IS_DDL = "isDdl";
     private static final String FIELD_MYSQL_TYPE = "mysqlType";
     private static final String FIELD_TYPE = "type";
@@ -71,8 +75,9 @@ public class CanalRecordParser extends RecordParser {
     private static final String OP_ROW = "ROW";
 
     @Override
-    protected Boolean isDDL() {
-        return extractBooleanFromRootJson(FIELD_IS_DDL);
+    protected boolean isDDL() {
+        JsonNode node = root.get(FIELD_IS_DDL);
+        return !isNull(node) && node.asBoolean();
     }
 
     public CanalRecordParser(
@@ -81,32 +86,24 @@ public class CanalRecordParser extends RecordParser {
     }
 
     @Override
-    protected void extractFieldTypesFromDatabaseSchema() {
-        JsonNode schema = root.get(FIELD_MYSQL_TYPE);
-        LinkedHashMap<String, String> fieldTypes = new LinkedHashMap<>();
-
-        schema.fieldNames()
-                .forEachRemaining(
-                        fieldName -> {
-                            String fieldType = schema.get(fieldName).asText();
-                            fieldTypes.put(fieldName, fieldType);
-                        });
-        this.fieldTypes = fieldTypes;
-    }
-
-    @Override
     public List<RichCdcMultiplexRecord> extractRecords() {
-        if (BooleanUtils.isTrue(this.isDDL())) {
+        if (isDDL()) {
             return Collections.emptyList();
         }
+
         List<RichCdcMultiplexRecord> records = new ArrayList<>();
-        ArrayNode arrayData = JsonSerdeUtil.getNodeAs(root, dataField(), ArrayNode.class);
-        String type = extractStringFromRootJson(FIELD_TYPE);
+
+        ArrayNode arrayData = getNodeAs(root, dataField(), ArrayNode.class);
+        checkNotNull(arrayData, dataField());
+
+        String type = getAndCheck(FIELD_TYPE).asText();
+
         for (JsonNode data : arrayData) {
             switch (type) {
                 case OP_UPDATE:
-                    ArrayNode oldArrayData =
-                            JsonSerdeUtil.getNodeAs(root, FIELD_OLD, ArrayNode.class);
+                    ArrayNode oldArrayData = getNodeAs(root, FIELD_OLD, ArrayNode.class);
+                    checkNotNull(oldArrayData, FIELD_OLD, FIELD_TYPE, type);
+
                     Map<JsonNode, JsonNode> matchedOldRecords =
                             matchOldRecords(arrayData, oldArrayData);
                     JsonNode old = matchedOldRecords.get(data);
@@ -128,33 +125,41 @@ public class CanalRecordParser extends RecordParser {
     }
 
     @Override
-    protected LinkedHashMap<String, DataType> setPaimonFieldType() {
-        LinkedHashMap<String, DataType> paimonFieldTypes = new LinkedHashMap<>();
-        fieldTypes.forEach(
-                (name, type) ->
-                        paimonFieldTypes.put(
-                                applyCaseSensitiveFieldName(name),
-                                MySqlTypeUtils.toDataType(type, typeMapping)));
-        return paimonFieldTypes;
+    protected LinkedHashMap<String, DataType> extractPaimonFieldTypes() {
+        LinkedHashMap<String, String> originalFieldTypes = tryExtractOriginalFieldTypes();
+        if (originalFieldTypes != null) {
+            return toPaimonFieldTypes(originalFieldTypes);
+        }
+
+        // fall back to STRING type
+        ArrayNode records = getNodeAs(root, dataField(), ArrayNode.class);
+        checkNotNull(records, dataField());
+        JsonNode record = records.get(0);
+
+        return fillDefaultStringTypes(record);
     }
 
-    @Override
-    protected void validateFormat() {
-        String errorMessageTemplate =
-                "Didn't find '%s' node in json. Only supports canal-json format,"
-                        + "please make sure your topic's format is correct.";
-
-        checkArgument(!isNull(root.get(FIELD_DATABASE)), errorMessageTemplate, FIELD_DATABASE);
-        checkArgument(!isNull(root.get(FIELD_TABLE)), errorMessageTemplate, FIELD_TABLE);
-        checkArgument(!isNull(root.get(FIELD_TYPE)), errorMessageTemplate, FIELD_TYPE);
-        checkArgument(!isNull(root.get(FIELD_IS_DDL)), errorMessageTemplate, FIELD_IS_DDL);
-
-        if (!extractBooleanFromRootJson(FIELD_IS_DDL)) {
-            checkArgument(
-                    !isNull(root.get(FIELD_MYSQL_TYPE)), errorMessageTemplate, FIELD_MYSQL_TYPE);
-            checkArgument(!isNull(root.get(primaryField())), errorMessageTemplate, primaryField());
-            checkArgument(!isNull(root.get(dataField())), errorMessageTemplate, dataField());
+    @Nullable
+    private LinkedHashMap<String, String> tryExtractOriginalFieldTypes() {
+        JsonNode schema = root.get(FIELD_MYSQL_TYPE);
+        if (isNull(schema)) {
+            LOG.debug(
+                    "Cannot get original field types because '{}' field is missing.",
+                    FIELD_MYSQL_TYPE);
+            return null;
         }
+
+        return OBJECT_MAPPER.convertValue(
+                schema, new TypeReference<LinkedHashMap<String, String>>() {});
+    }
+
+    private LinkedHashMap<String, DataType> toPaimonFieldTypes(
+            LinkedHashMap<String, String> originalFieldTypes) {
+        LinkedHashMap<String, DataType> paimonFieldTypes = new LinkedHashMap<>();
+        originalFieldTypes.forEach(
+                (name, type) ->
+                        paimonFieldTypes.put(name, MySqlTypeUtils.toDataType(type, typeMapping)));
+        return paimonFieldTypes;
     }
 
     @Override
@@ -170,38 +175,32 @@ public class CanalRecordParser extends RecordParser {
     @Override
     protected Map<String, String> extractRowData(
             JsonNode record, LinkedHashMap<String, DataType> paimonFieldTypes) {
-        fieldTypes.forEach(
-                (name, type) ->
-                        paimonFieldTypes.put(
-                                applyCaseSensitiveFieldName(name),
-                                MySqlTypeUtils.toDataType(type, typeMapping)));
-        Map<String, Object> jsonMap =
+        LinkedHashMap<String, String> originalFieldTypes = tryExtractOriginalFieldTypes();
+        Map<String, Object> recordMap =
                 OBJECT_MAPPER.convertValue(record, new TypeReference<Map<String, Object>>() {});
-        if (jsonMap == null) {
-            return new HashMap<>();
+        Map<String, String> rowData = new HashMap<>();
+
+        if (originalFieldTypes != null) {
+            paimonFieldTypes.putAll(toPaimonFieldTypes(originalFieldTypes));
+            for (Map.Entry<String, Object> entry : recordMap.entrySet()) {
+                String fieldName = entry.getKey();
+                String originalType = originalFieldTypes.get(fieldName);
+                rowData.put(fieldName, transformValue(entry.getValue().toString(), originalType));
+            }
+        } else {
+            paimonFieldTypes.putAll(fillDefaultStringTypes(record));
+            for (Map.Entry<String, Object> entry : recordMap.entrySet()) {
+                rowData.put(entry.getKey(), entry.getValue().toString());
+            }
         }
 
-        Map<String, String> resultMap =
-                fieldTypes.entrySet().stream()
-                        .filter(entry -> jsonMap.get(entry.getKey()) != null)
-                        .collect(
-                                Collectors.toMap(
-                                        Map.Entry::getKey,
-                                        entry ->
-                                                transformValue(
-                                                        jsonMap.get(entry.getKey()).toString(),
-                                                        entry.getValue())));
+        evalComputedColumns(rowData, paimonFieldTypes);
+        return rowData;
+    }
 
-        // generate values for computed columns
-        for (ComputedColumn computedColumn : computedColumns) {
-            resultMap.put(
-                    computedColumn.columnName(),
-                    computedColumn.eval(resultMap.get(computedColumn.fieldReference())));
-            paimonFieldTypes.put(
-                    applyCaseSensitiveFieldName(computedColumn.columnName()),
-                    computedColumn.columnType());
-        }
-        return resultMap;
+    @Override
+    protected String format() {
+        return "canal-json";
     }
 
     private Map<JsonNode, JsonNode> matchOldRecords(ArrayNode newData, ArrayNode oldData) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
@@ -24,10 +24,13 @@ import org.apache.paimon.flink.action.cdc.format.RecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.types.RowKind;
 
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.shaded.guava30.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
 
 /**
@@ -67,22 +70,20 @@ public class DebeziumRecordParser extends RecordParser {
 
     @Override
     public List<RichCdcMultiplexRecord> extractRecords() {
-        String operation = extractStringFromRootJson(FIELD_TYPE);
+        String operation = getAndCheck(FIELD_TYPE).asText();
         List<RichCdcMultiplexRecord> records = new ArrayList<>();
         switch (operation) {
             case OP_INSERT:
             case OP_READE:
-                processRecord(root.get(dataField()), RowKind.INSERT, records);
+                processRecord(getData(), RowKind.INSERT, records);
                 break;
             case OP_UPDATE:
                 processRecord(
-                        mergeOldRecord(root.get(dataField()), root.get(FIELD_BEFORE)),
-                        RowKind.DELETE,
-                        records);
-                processRecord(root.get(dataField()), RowKind.INSERT, records);
+                        mergeOldRecord(getData(), getBefore(operation)), RowKind.DELETE, records);
+                processRecord(getData(), RowKind.INSERT, records);
                 break;
             case OP_DELETE:
-                processRecord(root.get(FIELD_BEFORE), RowKind.DELETE, records);
+                processRecord(getBefore(operation), RowKind.DELETE, records);
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown record operation: " + operation);
@@ -90,33 +91,12 @@ public class DebeziumRecordParser extends RecordParser {
         return records;
     }
 
-    @Override
-    protected void validateFormat() {
-        String errorMessageTemplate =
-                "Didn't find '%s' node in json. Please make sure your topic's format is correct.";
-        checkArgument(
-                !isNull(root.get(FIELD_SOURCE).get(FIELD_TABLE)),
-                errorMessageTemplate,
-                FIELD_TABLE);
-        checkArgument(
-                !isNull(root.get(FIELD_SOURCE).get(FIELD_DB)),
-                errorMessageTemplate,
-                FIELD_DATABASE);
-        checkArgument(!isNull(root.get(FIELD_TYPE)), errorMessageTemplate, FIELD_TYPE);
-        String operation = root.get(FIELD_TYPE).asText();
-        switch (operation) {
-            case OP_INSERT:
-            case OP_READE:
-                checkArgument(!isNull(root.get(dataField())), errorMessageTemplate, dataField());
-                break;
-            case OP_UPDATE:
-            case OP_DELETE:
-                checkArgument(!isNull(root.get(FIELD_BEFORE)), errorMessageTemplate, FIELD_BEFORE);
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported operation type: " + operation);
-        }
-        checkArgument(!isNull(root.get(primaryField())), errorMessageTemplate, primaryField());
+    private JsonNode getData() {
+        return getAndCheck(dataField());
+    }
+
+    private JsonNode getBefore(String op) {
+        return getAndCheck(FIELD_BEFORE, FIELD_TYPE, op);
     }
 
     @Override
@@ -129,15 +109,31 @@ public class DebeziumRecordParser extends RecordParser {
         return FIELD_AFTER;
     }
 
+    @Nullable
     @Override
-    protected String extractStringFromRootJson(String key) {
-        if (key.equals(FIELD_TABLE)) {
-            tableName = root.get(FIELD_SOURCE).get(FIELD_TABLE).asText();
-            return tableName;
-        } else if (key.equals(FIELD_DATABASE)) {
-            databaseName = root.get(FIELD_SOURCE).get(FIELD_DB).asText();
-            return databaseName;
+    protected String getTableName() {
+        return getFromSourceField(FIELD_TABLE);
+    }
+
+    @Nullable
+    @Override
+    protected String getDatabaseName() {
+        return getFromSourceField(FIELD_DB);
+    }
+
+    @Override
+    protected String format() {
+        return "debezium-json";
+    }
+
+    @Nullable
+    private String getFromSourceField(String key) {
+        JsonNode node = root.get(FIELD_SOURCE);
+        if (isNull(node)) {
+            return null;
         }
-        return root.get(key) != null ? root.get(key).asText() : null;
+
+        node = node.get(key);
+        return isNull(node) ? null : node.asText();
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.ActionBase;
+import org.apache.paimon.flink.action.cdc.CdcMetadataConverter;
 import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.sink.cdc.CdcSinkBuilder;
 import org.apache.paimon.flink.sink.cdc.EventParser;
@@ -140,7 +141,9 @@ public class MongoDBSyncTableAction extends ActionBase {
                         Collections.emptyList(),
                         computedColumns,
                         tableConfig,
-                        mongodbSchema);
+                        mongodbSchema,
+                        new CdcMetadataConverter[] {},
+                        true);
         // Check if table exists before trying to get or create it
         if (catalog.tableExists(identifier)) {
             fileStoreTable = (FileStoreTable) catalog.getTable(identifier);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -253,7 +253,8 @@ public class MySqlSyncDatabaseAction extends ActionBase {
                             Collections.emptyList(),
                             tableConfig,
                             tableInfo.schema(),
-                            metadataConverters);
+                            metadataConverters,
+                            true);
             try {
                 table = (FileStoreTable) catalog.getTable(identifier);
                 table = table.copy(tableConfig);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -201,7 +201,8 @@ public class MySqlSyncTableAction extends ActionBase {
                         computedColumns,
                         tableConfig,
                         tableInfo.schema(),
-                        metadataConverters);
+                        metadataConverters,
+                        true);
         try {
             fileStoreTable = (FileStoreTable) catalog.getTable(identifier);
             fileStoreTable = fileStoreTable.copy(tableConfig);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecord.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecord.java
@@ -20,6 +20,8 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.types.DataType;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -30,15 +32,15 @@ public class RichCdcMultiplexRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final String databaseName;
-    private final String tableName;
+    @Nullable private final String databaseName;
+    @Nullable private final String tableName;
     private final LinkedHashMap<String, DataType> fieldTypes;
     private final List<String> primaryKeys;
     private final CdcRecord cdcRecord;
 
     public RichCdcMultiplexRecord(
-            String databaseName,
-            String tableName,
+            @Nullable String databaseName,
+            @Nullable String tableName,
             LinkedHashMap<String, DataType> fieldTypes,
             List<String> primaryKeys,
             CdcRecord cdcRecord) {
@@ -49,10 +51,12 @@ public class RichCdcMultiplexRecord implements Serializable {
         this.cdcRecord = cdcRecord;
     }
 
+    @Nullable
     public String databaseName() {
         return databaseName;
     }
 
+    @Nullable
     public String tableName() {
         return tableName;
     }
@@ -83,8 +87,8 @@ public class RichCdcMultiplexRecord implements Serializable {
             return false;
         }
         RichCdcMultiplexRecord that = (RichCdcMultiplexRecord) o;
-        return databaseName.equals(that.databaseName)
-                && tableName.equals(that.tableName)
+        return Objects.equals(databaseName, that.databaseName)
+                && Objects.equals(tableName, that.tableName)
                 && Objects.equals(fieldTypes, that.fieldTypes)
                 && Objects.equals(primaryKeys, that.primaryKeys)
                 && Objects.equals(cdcRecord, that.cdcRecord);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.action.cdc.kafka;
 
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.testutils.assertj.AssertionUtils;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -38,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
+import static org.apache.paimon.testutils.assertj.AssertionUtils.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -248,7 +248,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
 
         assertThatThrownBy(action::run)
                 .satisfies(
-                        AssertionUtils.anyCauseMatches(
+                        anyCauseMatches(
                                 IllegalArgumentException.class,
                                 "kafka-conf [topic] must be specified."));
     }
@@ -613,5 +613,33 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                 table,
                 rowType,
                 Collections.singletonList("k1"));
+    }
+
+    @Test
+    @Timeout(60)
+    public void testCannotSynchronizeIncompleteJson() throws Exception {
+        final String topic = "incomplete";
+        createTestTopic(topic, 1, 1);
+
+        writeRecordsToKafka(topic, readLines("kafka/canal/database/incomplete/canal-data-1.txt"));
+
+        Map<String, String> kafkaConfig = getBasicKafkaConfig();
+        kafkaConfig.put("value.format", "canal-json");
+        kafkaConfig.put("topic", topic);
+
+        KafkaSyncDatabaseAction action =
+                syncDatabaseActionBuilder(kafkaConfig)
+                        .withTableConfig(getBasicTableConfig())
+                        .build();
+        action.withStreamExecutionEnvironment(env).build();
+
+        assertThatThrownBy(() -> env.execute())
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Cannot synchronize record when database name or table name is unknown. "
+                                        + "Invalid record is:\n"
+                                        + "{databaseName=null, tableName=null, fieldTypes={k=STRING, v0=STRING, v1=STRING}, "
+                                        + "primaryKeys=[], cdcRecord=+I {v0=five, k=5, v1=50}}"));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncTableActionITCase.java
@@ -1072,4 +1072,36 @@ public class KafkaCanalSyncTableActionITCase extends KafkaActionITCaseBase {
                 rowType,
                 Arrays.asList("_id", "_year"));
     }
+
+    @Test
+    @Timeout(60)
+    public void testSynchronizeIncompleteJson() throws Exception {
+        String topic = "incomplete";
+        createTestTopic(topic, 1, 1);
+        List<String> lines = readLines("kafka/canal/table/incomplete/canal-data-1.txt");
+        writeRecordsToKafka(topic, lines);
+
+        Map<String, String> kafkaConfig = getBasicKafkaConfig();
+        kafkaConfig.put("value.format", "canal-json");
+        kafkaConfig.put("topic", topic);
+        KafkaSyncTableAction action =
+                syncTableActionBuilder(kafkaConfig)
+                        .withPrimaryKeys("k")
+                        .withTableConfig(getBasicTableConfig())
+                        .build();
+
+        runActionWithDefaultEnv(action);
+
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.STRING().notNull(), DataTypes.STRING(),
+                        },
+                        new String[] {"k", "v"});
+        waitForResult(
+                Arrays.asList("+I[1, Hi]", "+I[2, Hello]"),
+                getFileStoreTable(tableName),
+                rowType,
+                Collections.singletonList("k"));
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/incomplete/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/incomplete/canal-data-1.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"5","v0":"five","v1":"50"}],"type":"INSERT"}
+

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/incomplete/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/incomplete/canal-data-1.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v":"Hi"}],"type":"INSERT"}
+{"data":[{"k":"2","v":"Hello"}],"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/nonpk/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/nonpk/canal-data-1.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"v0":"five","v1":"50"}],"database":"non_pk","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"v0":"VARCHAR(10)","v1":"INT"},"old":null,"pkNames":[],"sql":"","sqlType":{"v0":12,"v1":4},"table":"t","ts":1684770072286,"type":"INSERT"}
+{"data":[{"v0":"five","v1":"50"}],"database":"non_pk","es":1684770073000,"id":84,"isDdl":false,"mysqlType":{"v0":"VARCHAR(10)","v1":"INT"},"old":null,"pkNames":[],"sql":"","sqlType":{"v0":12,"v1":4},"table":"t","ts":1684770073254,"type":"INSERT"}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently the RecordParser has strong validation of the Json format. But in some cases, the desired data is not present (data type, table name, etc). We should make sure we can try best to synchronize data. This PR has done:

1. Remove the strong validation before handle data. Now the RecordParser will check specific field when really need it.
2. If the json is invalid, log it before throwing exception (for trouble shooting).
3. Make database, table and primary keys optional.
4. Handle case sensitivity at last.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
