### PR TITLE
[Hive] Using hive table location when catalog is HiveCatalog

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -167,15 +167,22 @@ public class HiveCatalog extends AbstractCatalog {
             String databaseName = identifier.getDatabaseName();
             String tableName = identifier.getObjectName();
             if (client.tableExists(databaseName, tableName)) {
-                return new Path(
-                        locationHelper.getTableLocation(client.getTable(databaseName, tableName)));
+                String location =
+                        locationHelper.getTableLocation(client.getTable(databaseName, tableName));
+                if (location != null) {
+                    return new Path(location);
+                }
             } else {
                 // If the table does not exist,
                 // we should use the database path to generate the table path.
-                return new Path(
-                        locationHelper.getDatabaseLocation(client.getDatabase(databaseName)),
-                        tableName);
+                String dbLocation =
+                        locationHelper.getDatabaseLocation(client.getDatabase(databaseName));
+                if (dbLocation != null) {
+                    return new Path(dbLocation, tableName);
+                }
             }
+
+            return super.getDataTableLocation(identifier);
         } catch (TException e) {
             throw new RuntimeException("Can not get table " + identifier + " from metastore.", e);
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -164,12 +164,21 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public Path getDataTableLocation(Identifier identifier) {
         try {
-            return new Path(
+            if (tableExists(identifier)) {
+                return new Path(
                     client.getTable(identifier.getDatabaseName(), identifier.getObjectName())
-                            .getSd()
-                            .getLocation());
+                        .getSd()
+                        .getLocation());
+            } else {
+                // If the table does not exist,
+                // we should use the database path to generate the table path.
+                return new Path(
+                    client.getDatabase(identifier.getDatabaseName()).getLocationUri(),
+                    identifier.getObjectName());
+            }
         } catch (TException e) {
-            throw new RuntimeException("Failed to get table location", e);
+            LOG.warn("Can not get table location from metastore", e);
+            return super.getDataTableLocation(identifier);
         }
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -162,6 +162,18 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
+    public Path getDataTableLocation(Identifier identifier) {
+        try {
+            return new Path(
+                    client.getTable(identifier.getDatabaseName(), identifier.getObjectName())
+                            .getSd()
+                            .getLocation());
+        } catch (TException e) {
+            throw new RuntimeException("Failed to get table location", e);
+        }
+    }
+
+    @Override
     public List<String> listDatabases() {
         try {
             return client.getAllDatabases();

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -173,7 +173,8 @@ public class HiveCatalog extends AbstractCatalog {
                 // If the table does not exist,
                 // we should use the database path to generate the table path.
                 return new Path(
-                        locationHelper.getDatabaseLocation(client.getDatabase(databaseName)));
+                        locationHelper.getDatabaseLocation(client.getDatabase(databaseName)),
+                        tableName);
             }
         } catch (TException e) {
             throw new RuntimeException("Can not get table " + identifier + " from metastore.", e);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -167,15 +167,16 @@ public class HiveCatalog extends AbstractCatalog {
             String databaseName = identifier.getDatabaseName();
             String tableName = identifier.getObjectName();
             if (client.tableExists(databaseName, tableName)) {
-                return new Path(client.getTable(databaseName, tableName).getSd().getLocation());
+                return new Path(
+                        locationHelper.getTableLocation(client.getTable(databaseName, tableName)));
             } else {
                 // If the table does not exist,
                 // we should use the database path to generate the table path.
-                return new Path(client.getDatabase(databaseName).getLocationUri(), tableName);
+                return new Path(
+                        locationHelper.getDatabaseLocation(client.getDatabase(databaseName)));
             }
         } catch (TException e) {
-            LOG.warn("Can not get table location from metastore", e);
-            return super.getDataTableLocation(identifier);
+            throw new RuntimeException("Can not get table " + identifier + " from metastore.", e);
         }
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -164,17 +164,14 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public Path getDataTableLocation(Identifier identifier) {
         try {
-            if (tableExists(identifier)) {
-                return new Path(
-                    client.getTable(identifier.getDatabaseName(), identifier.getObjectName())
-                        .getSd()
-                        .getLocation());
+            String databaseName = identifier.getDatabaseName();
+            String tableName = identifier.getObjectName();
+            if (client.tableExists(databaseName, tableName)) {
+                return new Path(client.getTable(databaseName, tableName).getSd().getLocation());
             } else {
                 // If the table does not exist,
                 // we should use the database path to generate the table path.
-                return new Path(
-                    client.getDatabase(identifier.getDatabaseName()).getLocationUri(),
-                    identifier.getObjectName());
+                return new Path(client.getDatabase(databaseName).getLocationUri(), tableName);
             }
         } catch (TException e) {
             LOG.warn("Can not get table location from metastore", e);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/LocationHelper.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/LocationHelper.java
@@ -28,11 +28,16 @@ import java.io.IOException;
 
 /** helper for specifying the storage location of hive table. */
 public interface LocationHelper {
+
     void createPathIfRequired(Path dbPath, FileIO fileIO) throws IOException;
 
     void dropPathIfRequired(Path path, FileIO fileIO) throws IOException;
 
     void specifyTableLocation(Table table, String location);
 
+    String getTableLocation(Table table);
+
     void specifyDatabaseLocation(Path path, Database database);
+
+    String getDatabaseLocation(Database database);
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/StorageLocationHelper.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/StorageLocationHelper.java
@@ -24,20 +24,18 @@ import org.apache.paimon.fs.Path;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Table;
 
-import java.io.IOException;
-
 /** Helper for Setting Location in Hive Table Storage. */
 public final class StorageLocationHelper implements LocationHelper {
 
     public StorageLocationHelper() {}
 
     @Override
-    public void createPathIfRequired(Path dbPath, FileIO fileIO) throws IOException {
+    public void createPathIfRequired(Path dbPath, FileIO fileIO) {
         // do nothing
     }
 
     @Override
-    public void dropPathIfRequired(Path path, FileIO fileIO) throws IOException {
+    public void dropPathIfRequired(Path path, FileIO fileIO) {
         // do nothing
     }
 
@@ -47,7 +45,17 @@ public final class StorageLocationHelper implements LocationHelper {
     }
 
     @Override
+    public String getTableLocation(Table table) {
+        return table.getSd().getLocation();
+    }
+
+    @Override
     public void specifyDatabaseLocation(Path path, Database database) {
         database.setLocationUri(path.toString());
+    }
+
+    @Override
+    public String getDatabaseLocation(Database database) {
+        return database.getLocationUri();
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/TBPropertiesLocationHelper.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/TBPropertiesLocationHelper.java
@@ -52,6 +52,16 @@ public final class TBPropertiesLocationHelper implements LocationHelper {
     }
 
     @Override
+    public String getTableLocation(Table table) {
+        String location = table.getParameters().get(LocationKeyExtractor.TBPROPERTIES_LOCATION_KEY);
+        if (location != null) {
+            return location;
+        }
+
+        return table.getSd().getLocation();
+    }
+
+    @Override
     public void specifyDatabaseLocation(Path path, Database database) {
         HashMap<String, String> properties = new HashMap<>();
         if (database.getParameters() != null) {
@@ -59,5 +69,16 @@ public final class TBPropertiesLocationHelper implements LocationHelper {
         }
         properties.put(LocationKeyExtractor.TBPROPERTIES_LOCATION_KEY, path.toString());
         database.setParameters(properties);
+    }
+
+    @Override
+    public String getDatabaseLocation(Database database) {
+        String location =
+                database.getParameters().get(LocationKeyExtractor.TBPROPERTIES_LOCATION_KEY);
+        if (location != null) {
+            return location;
+        }
+
+        return database.getLocationUri();
     }
 }

--- a/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
@@ -71,6 +71,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                                 "  'type' = 'paimon',",
                                 "  'metastore' = 'hive',",
                                 "  'uri' = '',",
+                                "  'default-database' = 'test_db',",
                                 "  'warehouse' = '" + path + "',",
                                 "  'metastore.client.class' = '"
                                         + TestHiveMetaStoreClient.class.getName()
@@ -95,6 +96,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                         "  'type' = 'paimon',",
                         "  'metastore' = 'hive',",
                         "  'uri' = '',",
+                        "  'default-database' = 'test_db',",
                         "  'warehouse' = '" + path + "',",
                         "  'metastore.client.class' = '"
                                 + CreateFailHiveMetaStoreClient.class.getName()
@@ -113,7 +115,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                         new SchemaManager(
                                         LocalFileIO.create(),
                                         new org.apache.paimon.fs.Path(
-                                                path, "default.db/hive_table"))
+                                                path, "test_db.db/hive_table"))
                                 .listAllIds())
                 .isEmpty();
     }
@@ -127,6 +129,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                                 "  'type' = 'paimon',",
                                 "  'metastore' = 'hive',",
                                 "  'uri' = '',",
+                                "  'default-database' = 'test_db',",
                                 "  'warehouse' = '" + path + "',",
                                 "  'metastore.client.class' = '"
                                         + AlterFailHiveMetaStoreClient.class.getName()
@@ -146,7 +149,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                         new SchemaManager(
                                         LocalFileIO.create(),
                                         new org.apache.paimon.fs.Path(
-                                                path, "default.db/alter_failed_table"))
+                                                path, "test_db.db/alter_failed_table"))
                                 .latest()
                                 .get()
                                 .options())

--- a/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
@@ -110,7 +110,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                                         .await())
                 .isInstanceOf(TableException.class)
                 .hasMessage(
-                        "Could not execute CreateTable in path `my_hive_custom_client`.`default`.`hive_table`");
+                        "Could not execute CreateTable in path `my_hive_custom_client`.`test_db`.`hive_table`");
         assertThat(
                         new SchemaManager(
                                         LocalFileIO.create(),
@@ -143,7 +143,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
                                 TableException.class,
-                                "Could not execute AlterTable in path `my_alter_hive`.`default`.`alter_failed_table`"));
+                                "Could not execute AlterTable in path `my_alter_hive`.`test_db`.`alter_failed_table`"));
 
         assertThat(
                         new SchemaManager(

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -109,7 +109,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                                         .await())
                 .isInstanceOf(TableException.class)
                 .hasMessage(
-                        "Could not execute CreateTable in path `my_hive_custom_client`.`default`.`hive_table`");
+                        "Could not execute CreateTable in path `my_hive_custom_client`.`test_db`.`hive_table`");
         assertThat(
                         new SchemaManager(
                                         LocalFileIO.create(),
@@ -142,7 +142,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
                                 TableException.class,
-                                "Could not execute AlterTable in path `my_alter_hive`.`default`.`alter_failed_table`"));
+                                "Could not execute AlterTable in path `my_alter_hive`.`test_db`.`alter_failed_table`"));
 
         assertThat(
                         new SchemaManager(

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -95,6 +95,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                         "  'type' = 'paimon',",
                         "  'metastore' = 'hive',",
                         "  'uri' = '',",
+                        "  'default-database' = 'test_db',",
                         "  'warehouse' = '" + path + "',",
                         "  'metastore.client.class' = '"
                                 + CreateFailHiveMetaStoreClient.class.getName()
@@ -113,7 +114,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                         new SchemaManager(
                                         LocalFileIO.create(),
                                         new org.apache.paimon.fs.Path(
-                                                path, "default.db/hive_table"))
+                                                path, "test_db.db/hive_table"))
                                 .listAllIds())
                 .isEmpty();
     }
@@ -127,6 +128,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                                 "  'type' = 'paimon',",
                                 "  'metastore' = 'hive',",
                                 "  'uri' = '',",
+                                "  'default-database' = 'test_db',",
                                 "  'warehouse' = '" + path + "',",
                                 "  'metastore.client.class' = '"
                                         + AlterFailHiveMetaStoreClient.class.getName()
@@ -146,7 +148,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                         new SchemaManager(
                                         LocalFileIO.create(),
                                         new org.apache.paimon.fs.Path(
-                                                path, "default.db/alter_failed_table"))
+                                                path, "test_db.db/alter_failed_table"))
                                 .latest()
                                 .get()
                                 .options())

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
@@ -90,51 +90,13 @@ public class HiveWriteITCase {
         hiveShell.execute("DROP DATABASE IF EXISTS test_db CASCADE");
     }
 
-    private String createChangelogExternalTable(
-            RowType rowType,
-            List<String> partitionKeys,
-            List<String> primaryKeys,
-            List<InternalRow> data)
-            throws Exception {
-
-        return createChangelogExternalTable(rowType, partitionKeys, primaryKeys, data, "");
-    }
-
-    private String createChangelogExternalTable(
-            RowType rowType,
-            List<String> partitionKeys,
-            List<String> primaryKeys,
-            List<InternalRow> data,
-            String tableName)
-            throws Exception {
-        String path = folder.newFolder().toURI().toString();
-        String tableNameNotNull =
-                StringUtils.isNullOrWhitespaceOnly(tableName) ? TABLE_NAME : tableName;
-        String tablePath = String.format("%s/default.db/%s", path, tableNameNotNull);
-        Options conf = new Options();
-        conf.set(CatalogOptions.WAREHOUSE, path);
-        conf.set(CoreOptions.BUCKET, 1);
-        conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);
-        Identifier identifier = Identifier.create(DATABASE_NAME, tableNameNotNull);
-        Table table =
-                FileStoreTestUtils.createFileStoreTable(
-                        conf, rowType, partitionKeys, primaryKeys, identifier);
-
-        return writeData(table, tablePath, data);
-    }
-
-    private String createAppendOnlyExternalTable(
-            RowType rowType, List<String> partitionKeys, List<InternalRow> data) throws Exception {
-        return createAppendOnlyExternalTable(rowType, partitionKeys, data, "");
-    }
-
     private String createAppendOnlyExternalTable(
             RowType rowType, List<String> partitionKeys, List<InternalRow> data, String tableName)
             throws Exception {
         String path = folder.newFolder().toURI().toString();
         String tableNameNotNull =
                 StringUtils.isNullOrWhitespaceOnly(tableName) ? TABLE_NAME : tableName;
-        String tablePath = String.format("%s/default.db/%s", path, tableNameNotNull);
+        String tablePath = String.format("%s/test_db.db/%s", path, tableNameNotNull);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.BUCKET, 2);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FileStoreTestUtils.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FileStoreTestUtils.java
@@ -35,7 +35,7 @@ public class FileStoreTestUtils {
 
     public static final String TABLE_NAME = "hive_test_table";
 
-    public static final String DATABASE_NAME = "default";
+    public static final String DATABASE_NAME = "test_db";
 
     public static Table createFileStoreTable(
             Options conf, RowType rowType, List<String> partitionKeys, List<String> primaryKeys)

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -86,7 +86,8 @@ public abstract class HiveCatalogITCaseBase {
     @Minio private static MinioTestContainer minioTestContainer;
 
     private void before(boolean locationInProperties) throws Exception {
-        hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
+        hiveShell.execute("DROP DATABASE IF EXISTS test_db");
+        hiveShell.execute("CREATE DATABASE test_db");
         hiveShell.execute("USE test_db");
         hiveShell.execute("CREATE TABLE hive_table ( a INT, b STRING )");
         hiveShell.execute("INSERT INTO hive_table VALUES (100, 'Hive'), (200, 'Table')");

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -86,13 +86,6 @@ public abstract class HiveCatalogITCaseBase {
     @Minio private static MinioTestContainer minioTestContainer;
 
     private void before(boolean locationInProperties) throws Exception {
-        hiveShell.execute("DROP DATABASE IF EXISTS test_db");
-        hiveShell.execute("CREATE DATABASE test_db");
-        hiveShell.execute("USE test_db");
-        hiveShell.execute("CREATE TABLE hive_table ( a INT, b STRING )");
-        hiveShell.execute("INSERT INTO hive_table VALUES (100, 'Hive'), (200, 'Table')");
-        hiveShell.executeQuery("SHOW TABLES");
-
         Map<String, String> catalogProperties = new HashMap<>();
         catalogProperties.put("type", "paimon");
         catalogProperties.put("metastore", "hive");
@@ -123,7 +116,12 @@ public abstract class HiveCatalogITCaseBase {
                                 ")"))
                 .await();
         tEnv.executeSql("USE CATALOG my_hive").await();
+        tEnv.executeSql("DROP DATABASE IF EXISTS test_db CASCADE");
+        tEnv.executeSql("CREATE DATABASE test_db").await();
         tEnv.executeSql("USE test_db").await();
+        hiveShell.execute("USE test_db");
+        hiveShell.execute("CREATE TABLE hive_table ( a INT, b STRING )");
+        hiveShell.execute("INSERT INTO hive_table VALUES (100, 'Hive'), (200, 'Table')");
     }
 
     private void after() {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
@@ -129,7 +129,7 @@ public class HiveWriteITCase {
         String path = folder.newFolder().toURI().toString();
         String tableNameNotNull =
                 StringUtils.isNullOrWhitespaceOnly(tableName) ? TABLE_NAME : tableName;
-        String tablePath = String.format("%s/default.db/%s", path, tableNameNotNull);
+        String tablePath = String.format("%s/test_db.db/%s", path, tableNameNotNull);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.BUCKET, 2);
@@ -153,7 +153,7 @@ public class HiveWriteITCase {
         String path = folder.newFolder().toURI().toString();
         String tableNameNotNull =
                 StringUtils.isNullOrWhitespaceOnly(tableName) ? TABLE_NAME : tableName;
-        String tablePath = String.format("%s/default.db/%s", path, tableNameNotNull);
+        String tablePath = String.format("%s/test_db.db/%s", path, tableNameNotNull);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.BUCKET, 2);
@@ -223,7 +223,7 @@ public class HiveWriteITCase {
         String innerName = "hive_test_table_output";
 
         String path = folder.newFolder().toURI().toString();
-        String tablePath = String.format("%s/default.db/%s", path, innerName);
+        String tablePath = String.format("%s/test_db.db/%s", path, innerName);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.BUCKET, 1);
@@ -267,7 +267,7 @@ public class HiveWriteITCase {
         String innerName = "hive_test_table_output";
         int maxCompact = 3;
         String path = folder.newFolder().toURI().toString();
-        String tablePath = String.format("%s/default.db/%s", path, innerName);
+        String tablePath = String.format("%s/test_db.db/%s", path, innerName);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.BUCKET, 1);
@@ -611,7 +611,7 @@ public class HiveWriteITCase {
     public void testInsertAllSupportedTypes() throws Exception {
 
         String root = folder.newFolder().toString();
-        String tablePath = String.format("%s/default.db/hive_test_table", root);
+        String tablePath = String.format("%s/test_db.db/hive_test_table", root);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, root);
         conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FileFormatType.AVRO);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonStorageHandlerITCase.java
@@ -118,7 +118,7 @@ public class PaimonStorageHandlerITCase {
         hiveShell.execute("USE test_db");
 
         warehouse = folder.newFolder().toURI().toString();
-        tablePath = String.format("%s/default.db/%s", warehouse, TABLE_NAME);
+        tablePath = String.format("%s/test_db.db/%s", warehouse, TABLE_NAME);
         identifier = Identifier.create(DATABASE_NAME, TABLE_NAME);
         externalTable = "test_table_" + UUID.randomUUID().toString().substring(0, 4);
         commitIdentifier = 0;


### PR DESCRIPTION
### Purpose

We want to query Paimon tables with Presto, but our Paimon tables are scattered across different warehouse directories(such as `/user1/warehouse`, `/user2/warehouse`).

Therefore, we use Hive catalog to discover the addresses of different Paimon warehouses. However, in the current implementation of the Hive catalog, it does not use the Hive table's location as the location for Paimon tables.

In this pull request, we have re-implemented the `org.apache.paimon.hive.HiveCatalog#getDataTableLocation` method, which achieves the desired effect.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
