### PR TITLE
[core] Close CompactMetrics after closing its corresponding writer

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
@@ -195,7 +195,11 @@ public class AppendOnlyCompactManager extends CompactFutureManager {
     }
 
     @Override
-    public void close() throws IOException {}
+    public void close() throws IOException {
+        if (metrics != null) {
+            metrics.close();
+        }
+    }
 
     /** A {@link CompactTask} impl for full compaction of append-only table. */
     public static class FullCompactTask extends CompactTask {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
@@ -23,8 +23,6 @@ import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.NewFilesIncrement;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
-import org.apache.paimon.operation.metrics.CompactionMetrics;
-import org.apache.paimon.operation.metrics.CompactionStats;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.utils.Preconditions;
@@ -63,27 +61,15 @@ public class AppendOnlyCompactionTask {
     }
 
     public CommitMessage doCompact(AppendOnlyFileStoreWrite write) throws Exception {
-        CompactionMetrics metrics = write.getCompactionMetrics(partition, 0);
-        long startMillis = System.currentTimeMillis();
-        try {
-            compactAfter.addAll(write.compactRewriter(partition, 0).rewrite(compactBefore));
-            CompactIncrement compactIncrement =
-                    new CompactIncrement(compactBefore, compactAfter, Collections.emptyList());
-            return new CommitMessageImpl(
-                    partition,
-                    0, // bucket 0 is bucket for unaware-bucket table for compatibility with the old
-                    // design
-                    NewFilesIncrement.emptyIncrement(),
-                    compactIncrement);
-        } finally {
-            if (metrics != null) {
-                long duration = System.currentTimeMillis() - startMillis;
-                CompactionStats compactionStats =
-                        new CompactionStats(
-                                duration, compactBefore, compactAfter, Collections.emptyList());
-                metrics.reportCompaction(compactionStats);
-            }
-        }
+        compactAfter.addAll(write.compactRewriter(partition, 0).rewrite(compactBefore));
+        CompactIncrement compactIncrement =
+                new CompactIncrement(compactBefore, compactAfter, Collections.emptyList());
+        return new CommitMessageImpl(
+                partition,
+                0, // bucket 0 is bucket for unaware-bucket table for compatibility with the old
+                // design
+                NewFilesIncrement.emptyIncrement(),
+                compactIncrement);
     }
 
     public int hashCode() {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -210,5 +210,8 @@ public class MergeTreeCompactManager extends CompactFutureManager {
     @Override
     public void close() throws IOException {
         rewriter.close();
+        if (metrics != null) {
+            metrics.close();
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroup.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroup.java
@@ -68,4 +68,7 @@ public interface MetricGroup {
 
     /** Returns all the metrics the group carries. */
     Map<String, Metric> getMetrics();
+
+    /** Close the metric group and release related resources. */
+    void close();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroupImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroupImpl.java
@@ -119,4 +119,7 @@ public class MetricGroupImpl implements MetricGroup {
     public Map<String, Metric> getMetrics() {
         return Collections.unmodifiableMap(metrics);
     }
+
+    @Override
+    public void close() {}
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -50,7 +50,6 @@ import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.MergeTreeCompactManager;
 import org.apache.paimon.mergetree.compact.MergeTreeCompactRewriter;
 import org.apache.paimon.mergetree.compact.UniversalCompaction;
-import org.apache.paimon.operation.metrics.CompactionMetrics;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.types.RowType;
@@ -163,13 +162,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         ? new LookupCompaction(universalCompaction)
                         : universalCompaction;
         CompactManager compactManager =
-                createCompactManager(
-                        partition,
-                        bucket,
-                        compactStrategy,
-                        compactExecutor,
-                        levels,
-                        getCompactionMetrics(partition, bucket));
+                createCompactManager(partition, bucket, compactStrategy, compactExecutor, levels);
         return new MergeTreeWriter(
                 bufferSpillable(),
                 options.localSortMaxNumFileHandles(),
@@ -194,8 +187,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             int bucket,
             CompactStrategy compactStrategy,
             ExecutorService compactExecutor,
-            Levels levels,
-            @Nullable CompactionMetrics metrics) {
+            Levels levels) {
         if (options.writeOnly()) {
             return new NoopCompactManager();
         } else {
@@ -209,7 +201,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                     options.compactionFileSize(),
                     options.numSortedRunStopTrigger(),
                     rewriter,
-                    metrics);
+                    getCompactionMetrics(partition, bucket));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
@@ -26,7 +26,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 /** Metrics to measure a commit. */
 public class CommitMetrics {
 
-    private static final int HISTOGRAM_WINDOW_SIZE = 10_000;
+    private static final int HISTOGRAM_WINDOW_SIZE = 100;
     private static final String GROUP_NAME = "commit";
 
     private final MetricGroup metricGroup;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
@@ -23,13 +23,10 @@ import org.apache.paimon.metrics.Histogram;
 import org.apache.paimon.metrics.MetricGroup;
 import org.apache.paimon.metrics.MetricRegistry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /** Metrics to measure a compaction. */
 public class CompactionMetrics {
-    private static final Logger LOG = LoggerFactory.getLogger(CompactionMetrics.class);
-    private static final int HISTOGRAM_WINDOW_SIZE = 10_000;
+
+    private static final int HISTOGRAM_WINDOW_SIZE = 100;
     private static final String GROUP_NAME = "compaction";
 
     private final MetricGroup metricGroup;
@@ -106,5 +103,9 @@ public class CompactionMetrics {
     public void reportCompaction(CompactionStats compactionStats) {
         latestCompaction = compactionStats;
         durationHistogram.update(compactionStats.getDuration());
+    }
+
+    public void close() {
+        metricGroup.close();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -25,8 +25,10 @@ import org.apache.paimon.metrics.MetricRegistry;
 
 /** Metrics to measure scan operation. */
 public class ScanMetrics {
-    private static final int HISTOGRAM_WINDOW_SIZE = 10_000;
+
+    private static final int HISTOGRAM_WINDOW_SIZE = 100;
     @VisibleForTesting protected static final String GROUP_NAME = "scan";
+
     private final MetricGroup metricGroup;
 
     public ScanMetrics(MetricRegistry registry, String tableName) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
@@ -89,4 +89,11 @@ public class FlinkMetricGroup implements MetricGroup {
                 "FlinkMetricGroup does not support fetching all metrics. "
                         + "Please read the metrics through Flink's metric system.");
     }
+
+    @Override
+    public void close() {
+        if (wrapped instanceof org.apache.flink.runtime.metrics.groups.AbstractMetricGroup) {
+            ((org.apache.flink.runtime.metrics.groups.AbstractMetricGroup<?>) wrapped).close();
+        }
+    }
 }


### PR DESCRIPTION
### Purpose

Currently we don't have a `close` method in `MetricGroup`. When using bucket-wise metric groups (for example `CompactMetrics`), because more and more buckets will be written as the job runs, we need to clean up the resources (for example, their corresponding Flink metric group) in time.

This PR closes `CompactMetrics` after its corresponding writer is closed.

### Tests

As `CompactMetrics` is not bridged into Flink's metrics system at this time, we can't come up with unit tests. This should be tested in the PR when bridging `CompactMetrics` with Flink's metrics system.

### API and Format

No.

### Documentation

No.
