### PR TITLE
[core] Check existence for commit files of savepoint recovering

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -21,6 +21,7 @@ package org.apache.paimon.io;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.stats.BinaryTableStats;
 import org.apache.paimon.stats.FieldStatsArraySerializer;
 import org.apache.paimon.types.ArrayType;
@@ -238,6 +239,13 @@ public class DataFileMeta {
                 newLevel,
                 extraFiles,
                 creationTime);
+    }
+
+    public List<Path> collectFiles(DataFilePathFactory pathFactory) {
+        List<Path> paths = new ArrayList<>();
+        paths.add(pathFactory.toPath(fileName));
+        extraFiles.forEach(f -> paths.add(pathFactory.toPath(f)));
+        return paths;
     }
 
     public DataFileMeta copy(List<String> newExtraFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -19,9 +19,11 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.operation.metrics.CommitMetrics;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.utils.FileStorePathFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -82,4 +84,8 @@ public interface FileStoreCommit {
 
     /** With metrics to measure commits. */
     FileStoreCommit withMetrics(CommitMetrics metrics);
+
+    FileStorePathFactory pathFactory();
+
+    FileIO fileIO();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -504,6 +504,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         return this;
     }
 
+    @Override
+    public FileStorePathFactory pathFactory() {
+        return pathFactory;
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return fileIO;
+    }
+
     private void collectChanges(
             List<CommitMessage> commitMessages,
             List<ManifestEntry> appendTableFiles,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If a user restores a Flink job from an old savepoint and the table has been written by another job for a long time, it means that the files in the savepoint may have been deleted.
At present, the commit will still succeed, which results in the table containing deleted files, which is a serious problem.

This PR aims to check the recovered file, and if it does not exist, report an error to the user.

Fix #2273

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
