### PR TITLE
[cdc] Fix that initializing decimal type that missing precision will throw exception

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -136,6 +136,17 @@ public class MySqlTypeUtils {
 
     private static final List<String> HAVE_SCALE_LIST =
             Arrays.asList(DECIMAL, NUMERIC, DOUBLE, REAL, FIXED);
+    private static final List<String> MAP_TO_DECIMAL_TYPES =
+            Arrays.asList(
+                    NUMERIC,
+                    NUMERIC_UNSIGNED,
+                    NUMERIC_UNSIGNED_ZEROFILL,
+                    FIXED,
+                    FIXED_UNSIGNED,
+                    FIXED_UNSIGNED_ZEROFILL,
+                    DECIMAL,
+                    DECIMAL_UNSIGNED,
+                    DECIMAL_UNSIGNED_ZEROFILL);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -342,6 +353,11 @@ public class MySqlTypeUtils {
         return typeName.toUpperCase().startsWith(SET);
     }
 
+    private static boolean isDecimalType(String typeName) {
+        return MAP_TO_DECIMAL_TYPES.stream()
+                .anyMatch(type -> getShortType(typeName).toUpperCase().startsWith(type));
+    }
+
     /* Get type after the brackets are removed.*/
     public static String getShortType(String typeName) {
 
@@ -371,7 +387,9 @@ public class MySqlTypeUtils {
                                     typeName.indexOf(RIGHT_BRACKETS))
                             .trim());
         } else {
-            return 0;
+            // when missing precision of the decimal, we
+            // use the max precision to avoid parse error
+            return isDecimalType(typeName) ? 38 : 0;
         }
     }
 
@@ -384,7 +402,9 @@ public class MySqlTypeUtils {
                                     typeName.indexOf(COMMA) + 1, typeName.indexOf(RIGHT_BRACKETS))
                             .trim());
         } else {
-            return 0;
+            // When missing scale of the decimal, we
+            // use the max scale to avoid parse error
+            return isDecimalType(typeName) ? 18 : 0;
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/incomplete/canal-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/incomplete/canal-data-2.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v":"1.2"}],"database":"paimon_sync_table","es":1683880554000,"id":2150,"isDdl":false,"mysqlType":{"k":"int","v":"decimal"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v":3},"table":"decimal_missing_precision","ts":1683880554351,"type":"INSERT"}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The decimal type will validate that precision is between 1-38.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

`KafkaCanalSyncTableActionITCase#testMissingDecimalPrecision`

### Documentation

<!-- Does this change introduce a new feature -->
