### PR TITLE
[core] Introduce executeFilter to TableRead

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/And.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/And.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FieldStats;
 
 import java.util.ArrayList;
@@ -37,6 +38,16 @@ public class And extends CompoundPredicate.Function {
     public boolean test(Object[] values, List<Predicate> children) {
         for (Predicate child : children) {
             if (!child.test(values)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean test(InternalRow row, List<Predicate> children) {
+        for (Predicate child : children) {
+            if (!child.test(row)) {
                 return false;
             }
         }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
@@ -55,7 +55,7 @@ public class CompoundPredicate implements Predicate {
 
     @Override
     public boolean test(InternalRow row) {
-        return false;
+        return function.test(row, children);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FieldStats;
 
 import java.io.Serializable;
@@ -53,6 +54,11 @@ public class CompoundPredicate implements Predicate {
     }
 
     @Override
+    public boolean test(InternalRow row) {
+        return false;
+    }
+
+    @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         return function.test(rowCount, fieldStats, children);
     }
@@ -80,6 +86,8 @@ public class CompoundPredicate implements Predicate {
     public abstract static class Function implements Serializable {
 
         public abstract boolean test(Object[] values, List<Predicate> children);
+
+        public abstract boolean test(InternalRow row, List<Predicate> children);
 
         public abstract boolean test(
                 long rowCount, FieldStats[] fieldStats, List<Predicate> children);

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.data.serializer.ListSerializer;
 import org.apache.paimon.data.serializer.NullableSerializer;
@@ -25,6 +26,7 @@ import org.apache.paimon.format.FieldStats;
 import org.apache.paimon.io.DataInputViewStreamWrapper;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.InternalRowUtils;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -82,9 +84,18 @@ public class LeafPredicate implements Predicate {
         return literals;
     }
 
+    public LeafPredicate copyWithNewIndex(int fieldIndex) {
+        return new LeafPredicate(function, type, fieldIndex, fieldName, literals);
+    }
+
     @Override
     public boolean test(Object[] values) {
         return function.test(type, values[fieldIndex], literals);
+    }
+
+    @Override
+    public boolean test(InternalRow row) {
+        return function.test(type, InternalRowUtils.get(row, fieldIndex, type), literals);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Or.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Or.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FieldStats;
 
 import java.util.ArrayList;
@@ -37,6 +38,16 @@ public class Or extends CompoundPredicate.Function {
     public boolean test(Object[] values, List<Predicate> children) {
         for (Predicate child : children) {
             if (child.test(values)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean test(InternalRow row, List<Predicate> children) {
+        for (Predicate child : children) {
+            if (child.test(row)) {
                 return true;
             }
         }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Predicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Predicate.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.predicate;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FieldStats;
 
 import java.io.Serializable;
@@ -39,6 +40,13 @@ public interface Predicate extends Serializable {
      * @return return true when hit, false when not hit.
      */
     boolean test(Object[] values);
+
+    /**
+     * Test based on the specific input row.
+     *
+     * @return return true when hit, false when not hit.
+     */
+    boolean test(InternalRow row);
 
     /**
      * Test based on the statistical information to determine whether a hit is possible.

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateProjectionConverter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateProjectionConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** A {@link PredicateVisitor} which converts {@link Predicate} with projection. */
+public class PredicateProjectionConverter implements PredicateReplaceVisitor {
+
+    private final Map<Integer, Integer> reversed;
+
+    public PredicateProjectionConverter(int[] projection) {
+        this.reversed = new HashMap<>();
+        for (int i = 0; i < projection.length; i++) {
+            reversed.put(projection[i], i);
+        }
+    }
+
+    @Override
+    public Optional<Predicate> visit(LeafPredicate predicate) {
+        int index = predicate.index();
+        Integer adjusted = reversed.get(index);
+        if (adjusted == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(predicate.copyWithNewIndex(adjusted));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -21,7 +21,6 @@ package org.apache.paimon.table;
 import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ManifestCacheFilter;
@@ -34,12 +33,12 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.source.AbstractDataTableRead;
 import org.apache.paimon.table.source.AppendOnlySplitGenerator;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
-import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.Preconditions;
 
@@ -110,28 +109,17 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     }
 
     @Override
-    public InnerTableRead innerRead() {
+    public InnerTableRead newRead() {
         AppendOnlyFileStoreRead read = store().newRead();
-        return new InnerTableRead() {
-            @Override
-            public InnerTableRead withFilter(Predicate predicate) {
-                read.withFilter(predicate);
-                return this;
-            }
+        return new AbstractDataTableRead<InternalRow>(read, schema()) {
 
             @Override
-            public InnerTableRead withProjection(int[][] projection) {
+            public void projection(int[][] projection) {
                 read.withProjection(projection);
-                return this;
             }
 
             @Override
-            public TableRead withIOManager(IOManager ioManager) {
-                return this;
-            }
-
-            @Override
-            public RecordReader<InternalRow> createReader(Split split) throws IOException {
+            public RecordReader<InternalRow> reader(Split split) throws IOException {
                 return read.createReader((DataSplit) split);
             }
         };

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -151,19 +151,12 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
     }
 
     @Override
-    public InnerTableRead innerRead() {
-        return new KeyValueTableRead(store().newRead()) {
+    public InnerTableRead newRead() {
+        return new KeyValueTableRead(store().newRead(), schema()) {
 
             @Override
-            public InnerTableRead withFilter(Predicate predicate) {
-                read.withFilter(predicate);
-                return this;
-            }
-
-            @Override
-            public InnerTableRead withProjection(int[][] projection) {
+            public void projection(int[][] projection) {
                 read.withValueProjection(projection);
-                return this;
             }
 
             @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.operation.DefaultValueAssigner;
+import org.apache.paimon.operation.FileStoreRead;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateProjectionConverter;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.utils.Projection;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/** A {@link InnerTableRead} for data table. */
+public abstract class AbstractDataTableRead<T> implements InnerTableRead {
+
+    private final FileStoreRead<T> fileStoreRead;
+    private final DefaultValueAssigner defaultValueAssigner;
+
+    private int[][] projection;
+    private boolean executeFilter = false;
+    private Predicate predicate;
+
+    public AbstractDataTableRead(FileStoreRead<T> fileStoreRead, TableSchema schema) {
+        this.fileStoreRead = fileStoreRead;
+        this.defaultValueAssigner = schema == null ? null : DefaultValueAssigner.create(schema);
+    }
+
+    public abstract void projection(int[][] projection);
+
+    public abstract RecordReader<InternalRow> reader(Split split) throws IOException;
+
+    @Override
+    public TableRead withIOManager(IOManager ioManager) {
+        return this;
+    }
+
+    @Override
+    public final InnerTableRead withFilter(Predicate predicate) {
+        this.predicate = predicate;
+        if (defaultValueAssigner != null) {
+            predicate = defaultValueAssigner.handlePredicate(predicate);
+        }
+        fileStoreRead.withFilter(predicate);
+        return this;
+    }
+
+    @Override
+    public TableRead executeFilter() {
+        this.executeFilter = true;
+        return this;
+    }
+
+    @Override
+    public final InnerTableRead withProjection(int[][] projection) {
+        this.projection = projection;
+        this.defaultValueAssigner.handleProject(projection);
+        projection(projection);
+        return this;
+    }
+
+    @Override
+    public final RecordReader<InternalRow> createReader(Split split) throws IOException {
+        RecordReader<InternalRow> reader = reader(split);
+        if (defaultValueAssigner != null) {
+            reader = defaultValueAssigner.assignFieldsDefaultValue(reader);
+        }
+        if (executeFilter) {
+            reader = executeFilter(reader);
+        }
+
+        return reader;
+    }
+
+    private RecordReader<InternalRow> executeFilter(RecordReader<InternalRow> reader) {
+        if (predicate == null) {
+            return reader;
+        }
+
+        Predicate predicate = this.predicate;
+        if (projection != null) {
+            Optional<Predicate> optional =
+                    predicate.visit(
+                            new PredicateProjectionConverter(
+                                    Projection.of(projection).toTopLevelIndexes()));
+            if (!optional.isPresent()) {
+                return reader;
+            }
+            predicate = optional.get();
+        }
+
+        Predicate finalFilter = predicate;
+        return reader.filter(finalFilter::test);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -50,4 +50,9 @@ public interface InnerTableRead extends TableRead {
     default InnerTableRead forceKeepDelete() {
         return this;
     }
+
+    @Override
+    default TableRead executeFilter() {
+        return this;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.KeyValueFileStoreRead;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.TableSchema;
 
 import javax.annotation.Nullable;
 
@@ -32,11 +33,12 @@ import java.io.IOException;
  * An abstraction layer above {@link KeyValueFileStoreRead} to provide reading of {@link
  * InternalRow}.
  */
-public abstract class KeyValueTableRead implements InnerTableRead {
+public abstract class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
 
     protected final KeyValueFileStoreRead read;
 
-    protected KeyValueTableRead(KeyValueFileStoreRead read) {
+    protected KeyValueTableRead(KeyValueFileStoreRead read, TableSchema schema) {
+        super(read, schema);
         this.read = read;
     }
 
@@ -47,7 +49,7 @@ public abstract class KeyValueTableRead implements InnerTableRead {
     }
 
     @Override
-    public RecordReader<InternalRow> createReader(Split split) throws IOException {
+    public final RecordReader<InternalRow> reader(Split split) throws IOException {
         return new RowDataRecordReader(read.createReader((DataSplit) split));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
@@ -37,6 +37,8 @@ import java.util.List;
 @Public
 public interface TableRead {
 
+    TableRead executeFilter();
+
     TableRead withIOManager(IOManager ioManager);
 
     RecordReader<InternalRow> createReader(Split split) throws IOException;

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -168,15 +168,9 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 PredicateBuilder.or(builder.equal(2, 201L), builder.equal(0, 1)))
                         .withProjection(new int[] {3, 2})
                         .executeFilter();
-        assertThat(getResult(read, splits, binaryRow(1), 0, toString)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, toString))
                 .hasSameElementsAs(
-                        Arrays.asList(
-                                "100|binary",
-                                "101|binary",
-                                "102|binary",
-                                "101|binary",
-                                "102|binary"));
+                        Arrays.asList("200|binary", "201|binary", "202|binary", "201|binary"));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.sink.KeyAndBucketExtractor.bucket;
@@ -123,16 +124,59 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
         PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());
 
-        Predicate predicate = builder.equal(2, 201L);
-        List<Split> splits =
-                toSplits(table.newSnapshotReader().withFilter(predicate).read().dataSplits());
-        TableRead read = table.newRead().withFilter(predicate).executeFilter();
+        List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
+
+        // simple
+        TableRead read = table.newRead().withFilter(builder.equal(2, 201L)).executeFilter();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
                         Arrays.asList(
                                 "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
                                 "2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
+
+        // or
+        read =
+                table.newRead()
+                        .withFilter(
+                                PredicateBuilder.or(builder.equal(2, 201L), builder.equal(2, 500L)))
+                        .executeFilter();
+        assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING)).isEmpty();
+        assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
+                .hasSameElementsAs(
+                        Arrays.asList(
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
+
+        // projection all in
+        read =
+                table.newRead()
+                        .withFilter(
+                                PredicateBuilder.or(builder.equal(2, 201L), builder.equal(2, 500L)))
+                        .withProjection(new int[] {3, 2})
+                        .executeFilter();
+        Function<InternalRow, String> toString =
+                rowData -> rowData.getLong(1) + "|" + new String(rowData.getBinary(0));
+        assertThat(getResult(read, splits, binaryRow(1), 0, toString)).isEmpty();
+        assertThat(getResult(read, splits, binaryRow(2), 0, toString))
+                .hasSameElementsAs(Arrays.asList("201|binary", "201|binary"));
+
+        // projection contains unknown index
+        read =
+                table.newRead()
+                        .withFilter(
+                                PredicateBuilder.or(builder.equal(2, 201L), builder.equal(0, 1)))
+                        .withProjection(new int[] {3, 2})
+                        .executeFilter();
+        assertThat(getResult(read, splits, binaryRow(1), 0, toString)).isEmpty();
+        assertThat(getResult(read, splits, binaryRow(2), 0, toString))
+                .hasSameElementsAs(
+                        Arrays.asList(
+                                "100|binary",
+                                "101|binary",
+                                "102|binary",
+                                "101|binary",
+                                "102|binary"));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -161,7 +161,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(2), 0, toString))
                 .hasSameElementsAs(Arrays.asList("201|binary", "201|binary"));
 
-        // projection contains unknown index
+        // projection contains unknown index or
         read =
                 table.newRead()
                         .withFilter(
@@ -171,6 +171,17 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(2), 0, toString))
                 .hasSameElementsAs(
                         Arrays.asList("200|binary", "201|binary", "202|binary", "201|binary"));
+
+        // projection contains unknown index and
+        read =
+                table.newRead()
+                        .withFilter(
+                                PredicateBuilder.and(builder.equal(2, 201L), builder.equal(0, 1)))
+                        .withProjection(new int[] {3, 2})
+                        .executeFilter();
+        assertThat(getResult(read, splits, binaryRow(1), 0, toString)).isEmpty();
+        assertThat(getResult(read, splits, binaryRow(2), 0, toString))
+                .hasSameElementsAs(Arrays.asList("201|binary", "201|binary"));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -34,7 +34,6 @@ import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.operation.KeyValueFileStoreRead;
 import org.apache.paimon.operation.KeyValueFileStoreWrite;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
@@ -131,14 +130,10 @@ public class TestChangelogDataReadWrite {
                         pathFactory,
                         EXTRACTOR,
                         new CoreOptions(new HashMap<>()));
-        return new KeyValueTableRead(read) {
-            @Override
-            public KeyValueTableRead withFilter(Predicate predicate) {
-                throw new UnsupportedOperationException();
-            }
+        return new KeyValueTableRead(read, null) {
 
             @Override
-            public KeyValueTableRead withProjection(int[][] projection) {
+            public void projection(int[][] projection) {
                 throw new UnsupportedOperationException();
             }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Computing engines such as Trino need to convert a row into Trino's own data structure after reading it, which is costly. We can actually perform filtering before returning to Trino to reduce the amount of data that needs to be converted.

Trino Connector can just use `TableRead.executeFilter()` to enable this feature.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
