### PR TITLE
[core] Move convertToRawFiles method from TableScan to Split

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -197,13 +197,4 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
     public List<BinaryRow> listPartitions() {
         return snapshotReader.partitions();
     }
-
-    @Override
-    public Optional<List<RawFile>> convertToRawFiles(Split split) {
-        if (split instanceof DataSplit) {
-            return snapshotReader.convertToRawFiles((DataSplit) split);
-        } else {
-            return Optional.empty();
-        }
-    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -93,13 +94,12 @@ public class DataSplit implements Split {
     }
 
     @Override
-    public boolean needsMerging() {
-        return rawFiles.isEmpty();
-    }
-
-    @Override
-    public List<RawFile> rawFiles() {
-        return rawFiles;
+    public Optional<List<RawFile>> convertToRawFiles() {
+        if (rawFiles.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(rawFiles);
+        }
     }
 
     @Override
@@ -139,6 +139,7 @@ public class DataSplit implements Split {
         this.beforeFiles = other.beforeFiles;
         this.dataFiles = other.dataFiles;
         this.isStreaming = other.isStreaming;
+        this.rawFiles = other.rawFiles;
     }
 
     public void serialize(DataOutputView out) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/RawFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/RawFile.java
@@ -20,7 +20,10 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.io.DataInputView;
+import org.apache.paimon.io.DataOutputView;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -71,6 +74,24 @@ public class RawFile {
     /** Schema id of the file. */
     public long schemaId() {
         return schemaId;
+    }
+
+    public void serialize(DataOutputView out) throws IOException {
+        out.writeUTF(path);
+        out.writeLong(offset);
+        out.writeLong(length);
+        out.writeUTF(format);
+        out.writeLong(schemaId);
+    }
+
+    public static RawFile deserialize(DataInputView in) throws IOException {
+        String path = in.readUTF();
+        long offset = in.readLong();
+        long length = in.readLong();
+        String format = in.readUTF();
+        long schemaId = in.readLong();
+
+        return new RawFile(path, offset, length, format, schemaId);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
@@ -21,6 +21,8 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.annotation.Public;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * An input split for reading.
@@ -31,4 +33,20 @@ import java.io.Serializable;
 public interface Split extends Serializable {
 
     long rowCount();
+
+    /**
+     * If files in this split should be merged before reading, returns {@code true}. Otherwise, if
+     * all files in this split can be read without merging, returns {@code false}.
+     */
+    default boolean needsMerging() {
+        return true;
+    }
+
+    /**
+     * If {@link Split#needsMerging()} is {@code true}, returns an empty list. Otherwise, returns a
+     * list of {@link RawFile}s to be read without merging.
+     */
+    default List<RawFile> rawFiles() {
+        return Collections.emptyList();
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
@@ -21,8 +21,8 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.annotation.Public;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * An input split for reading.
@@ -35,18 +35,11 @@ public interface Split extends Serializable {
     long rowCount();
 
     /**
-     * If files in this split should be merged before reading, returns {@code true}. Otherwise, if
-     * all files in this split can be read without merging, returns {@code false}.
+     * If all files in this split can be read without merging, returns an {@link Optional} wrapping
+     * a list of {@link RawFile}s to be read without merging. Otherwise, returns {@link
+     * Optional#empty()}.
      */
-    default boolean needsMerging() {
-        return true;
-    }
-
-    /**
-     * If {@link Split#needsMerging()} is {@code true}, returns an empty list. Otherwise, returns a
-     * list of {@link RawFile}s to be read without merging.
-     */
-    default List<RawFile> rawFiles() {
-        return Collections.emptyList();
+    default Optional<List<RawFile>> convertToRawFiles() {
+        return Optional.empty();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.table.Table;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A scan of {@link Table} to generate {@link Split} splits.
@@ -38,14 +37,6 @@ public interface TableScan {
 
     /** Get partitions from simple manifest entries. */
     List<BinaryRow> listPartitions();
-
-    /**
-     * If all files in this split can be read without merging, returns an {@link Optional} wrapping
-     * a list of {@link RawFile}s, otherwise returns {@link Optional#empty()}.
-     */
-    default Optional<List<RawFile>> convertToRawFiles(Split split) {
-        return Optional.empty();
-    }
 
     /**
      * Plan of scan.

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
@@ -36,7 +35,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /** Read splits from specified {@link Snapshot} with given configuration. */
 public interface SnapshotReader {
@@ -75,12 +73,6 @@ public interface SnapshotReader {
 
     /** Get partitions from a snapshot. */
     List<BinaryRow> partitions();
-
-    /**
-     * If all files in this split can be read without merging, returns an {@link Optional} wrapping
-     * a list of {@link RawFile}s, otherwise returns {@link Optional#empty()}.
-     */
-    Optional<List<RawFile>> convertToRawFiles(DataSplit split);
 
     /** Result plan of this scan. */
     interface Plan extends TableScan.Plan {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -280,15 +280,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
                         isStreaming
                                 ? splitGenerator.splitForStreaming(bucketFiles)
                                 : splitGenerator.splitForBatch(bucketFiles);
-                splitGroups.stream()
-                        .map(
-                                dataFiles ->
-                                        builder.withDataFiles(dataFiles)
-                                                .rawFiles(
-                                                        convertToRawFiles(
-                                                                partition, bucket, dataFiles)))
-                        .map(DataSplit.Builder::build)
-                        .forEach(splits::add);
+                for (List<DataFileMeta> dataFiles : splitGroups) {
+                    splits.add(
+                            builder.withDataFiles(dataFiles)
+                                    .rawFiles(convertToRawFiles(partition, bucket, dataFiles))
+                                    .build());
+                }
             }
         }
         return splits;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -20,7 +20,6 @@ package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.consumer.ConsumerManager;
@@ -258,6 +257,43 @@ public class SnapshotReaderImpl implements SnapshotReader {
         };
     }
 
+    private List<DataSplit> generateSplits(
+            long snapshotId,
+            boolean isStreaming,
+            SplitGenerator splitGenerator,
+            Map<BinaryRow, Map<Integer, List<DataFileMeta>>> groupedDataFiles) {
+        List<DataSplit> splits = new ArrayList<>();
+        for (Map.Entry<BinaryRow, Map<Integer, List<DataFileMeta>>> entry :
+                groupedDataFiles.entrySet()) {
+            BinaryRow partition = entry.getKey();
+            Map<Integer, List<DataFileMeta>> buckets = entry.getValue();
+            for (Map.Entry<Integer, List<DataFileMeta>> bucketEntry : buckets.entrySet()) {
+                int bucket = bucketEntry.getKey();
+                List<DataFileMeta> bucketFiles = bucketEntry.getValue();
+                DataSplit.Builder builder =
+                        DataSplit.builder()
+                                .withSnapshot(snapshotId)
+                                .withPartition(partition)
+                                .withBucket(bucket)
+                                .isStreaming(isStreaming);
+                List<List<DataFileMeta>> splitGroups =
+                        isStreaming
+                                ? splitGenerator.splitForStreaming(bucketFiles)
+                                : splitGenerator.splitForBatch(bucketFiles);
+                splitGroups.stream()
+                        .map(
+                                dataFiles ->
+                                        builder.withDataFiles(dataFiles)
+                                                .rawFiles(
+                                                        convertToRawFiles(
+                                                                partition, bucket, dataFiles)))
+                        .map(DataSplit.Builder::build)
+                        .forEach(splits::add);
+            }
+        }
+        return splits;
+    }
+
     @Override
     public List<BinaryRow> partitions() {
         List<ManifestEntry> entryList = scan.plan().files();
@@ -273,47 +309,6 @@ public class SnapshotReaderImpl implements SnapshotReader {
                 .map(Optional::get)
                 .map(ManifestEntry::partition)
                 .collect(Collectors.toList());
-    }
-
-    @Override
-    public Optional<List<RawFile>> convertToRawFiles(DataSplit split) {
-        String bucketPath = pathFactory.bucketPath(split.partition(), split.bucket()).toString();
-        List<DataFileMeta> dataFiles = split.dataFiles();
-
-        // bucket with only one file can be returned
-        if (dataFiles.size() == 1) {
-            return Optional.of(
-                    Collections.singletonList(makeRawTableFile(bucketPath, dataFiles.get(0))));
-        }
-
-        // append only files can be returned
-        if (tableSchema.primaryKeys().isEmpty()) {
-            return Optional.of(makeRawTableFiles(bucketPath, dataFiles));
-        }
-
-        // bucket containing only one level (except level 0) can be returned
-        Set<Integer> levels =
-                dataFiles.stream().map(DataFileMeta::level).collect(Collectors.toSet());
-        if (levels.size() == 1 && !levels.contains(0)) {
-            return Optional.of(makeRawTableFiles(bucketPath, dataFiles));
-        }
-
-        return Optional.empty();
-    }
-
-    private List<RawFile> makeRawTableFiles(String bucketPath, List<DataFileMeta> dataFiles) {
-        return dataFiles.stream()
-                .map(f -> makeRawTableFile(bucketPath, f))
-                .collect(Collectors.toList());
-    }
-
-    private RawFile makeRawTableFile(String bucketPath, DataFileMeta meta) {
-        return new RawFile(
-                bucketPath + "/" + meta.fileName(),
-                0,
-                meta.fileSize(),
-                new CoreOptions(tableSchema.options()).formatType().toString().toLowerCase(),
-                meta.schemaId());
     }
 
     @Override
@@ -368,6 +363,7 @@ public class SnapshotReaderImpl implements SnapshotReader {
                                 .withBeforeFiles(before)
                                 .withDataFiles(data)
                                 .isStreaming(isStreaming)
+                                .rawFiles(convertToRawFiles(part, bucket, data))
                                 .build();
                 splits.add(split);
             }
@@ -414,36 +410,42 @@ public class SnapshotReaderImpl implements SnapshotReader {
         return lazyPartitionComparator;
     }
 
-    @VisibleForTesting
-    public static List<DataSplit> generateSplits(
-            long snapshotId,
-            boolean isStreaming,
-            SplitGenerator splitGenerator,
-            Map<BinaryRow, Map<Integer, List<DataFileMeta>>> groupedDataFiles) {
-        List<DataSplit> splits = new ArrayList<>();
-        for (Map.Entry<BinaryRow, Map<Integer, List<DataFileMeta>>> entry :
-                groupedDataFiles.entrySet()) {
-            BinaryRow partition = entry.getKey();
-            Map<Integer, List<DataFileMeta>> buckets = entry.getValue();
-            for (Map.Entry<Integer, List<DataFileMeta>> bucketEntry : buckets.entrySet()) {
-                int bucket = bucketEntry.getKey();
-                List<DataFileMeta> bucketFiles = bucketEntry.getValue();
-                DataSplit.Builder builder =
-                        DataSplit.builder()
-                                .withSnapshot(snapshotId)
-                                .withPartition(partition)
-                                .withBucket(bucket)
-                                .isStreaming(isStreaming);
-                List<List<DataFileMeta>> splitGroups =
-                        isStreaming
-                                ? splitGenerator.splitForStreaming(bucketFiles)
-                                : splitGenerator.splitForBatch(bucketFiles);
-                splitGroups.stream()
-                        .map(builder::withDataFiles)
-                        .map(DataSplit.Builder::build)
-                        .forEach(splits::add);
-            }
+    private List<RawFile> convertToRawFiles(
+            BinaryRow partition, int bucket, List<DataFileMeta> dataFiles) {
+        String bucketPath = pathFactory.bucketPath(partition, bucket).toString();
+
+        // bucket with only one file can be returned
+        if (dataFiles.size() == 1) {
+            return Collections.singletonList(makeRawTableFile(bucketPath, dataFiles.get(0)));
         }
-        return splits;
+
+        // append only files can be returned
+        if (tableSchema.primaryKeys().isEmpty()) {
+            return makeRawTableFiles(bucketPath, dataFiles);
+        }
+
+        // bucket containing only one level (except level 0) can be returned
+        Set<Integer> levels =
+                dataFiles.stream().map(DataFileMeta::level).collect(Collectors.toSet());
+        if (levels.size() == 1 && !levels.contains(0)) {
+            return makeRawTableFiles(bucketPath, dataFiles);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<RawFile> makeRawTableFiles(String bucketPath, List<DataFileMeta> dataFiles) {
+        return dataFiles.stream()
+                .map(f -> makeRawTableFile(bucketPath, f))
+                .collect(Collectors.toList());
+    }
+
+    private RawFile makeRawTableFile(String bucketPath, DataFileMeta meta) {
+        return new RawFile(
+                bucketPath + "/" + meta.fileName(),
+                0,
+                meta.fileSize(),
+                new CoreOptions(tableSchema.options()).formatType().toString().toLowerCase(),
+                meta.schemaId());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -37,11 +37,9 @@ import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.ReadonlyTable;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerStreamTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
-import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
@@ -280,13 +278,6 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         @Override
         public List<BinaryRow> partitions() {
             return snapshotReader.partitions();
-        }
-
-        @Override
-        public Optional<List<RawFile>> convertToRawFiles(DataSplit split) {
-            // we can't return snapshotReader.convertToRawFiles(split),
-            // because AuditLogTable must use its special reader
-            return Optional.empty();
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
@@ -70,7 +70,7 @@ public class SnapshotReaderTest {
     }
 
     @Test
-    public void testGetPrimaryKeyRawTableFiles() throws Exception {
+    public void testGetPrimaryKeyRawFiles() throws Exception {
         RowType rowType =
                 RowType.of(
                         new DataType[] {DataTypes.STRING(), DataTypes.INT(), DataTypes.BIGINT()},
@@ -98,8 +98,8 @@ public class SnapshotReaderTest {
             assertThat(dataSplit.dataFiles()).hasSize(1);
             DataFileMeta meta = dataSplit.dataFiles().get(0);
             String partition = dataSplit.partition().getString(0).toString();
-            assertThat(dataSplit.rawFiles())
-                    .isEqualTo(
+            assertThat(dataSplit.convertToRawFiles())
+                    .hasValue(
                             Collections.singletonList(
                                     new RawFile(
                                             String.format(
@@ -123,7 +123,7 @@ public class SnapshotReaderTest {
         assertThat(dataSplits).hasSize(2);
         for (DataSplit dataSplit : dataSplits) {
             assertThat(dataSplit.dataFiles()).hasSize(2);
-            assertThat(dataSplit.rawFiles()).isEmpty();
+            assertThat(dataSplit.convertToRawFiles()).isNotPresent();
         }
 
         // compact all files
@@ -146,8 +146,8 @@ public class SnapshotReaderTest {
             assertThat(dataSplit.dataFiles()).hasSize(1);
             DataFileMeta meta = dataSplit.dataFiles().get(0);
             String partition = dataSplit.partition().getString(0).toString();
-            assertThat(dataSplit.rawFiles())
-                    .isEqualTo(
+            assertThat(dataSplit.convertToRawFiles())
+                    .hasValue(
                             Collections.singletonList(
                                     new RawFile(
                                             String.format(
@@ -171,7 +171,7 @@ public class SnapshotReaderTest {
         assertThat(dataSplits).hasSize(2);
         for (DataSplit dataSplit : dataSplits) {
             assertThat(dataSplit.dataFiles()).hasSize(2);
-            assertThat(dataSplit.rawFiles()).isEmpty();
+            assertThat(dataSplit.convertToRawFiles()).isNotPresent();
         }
 
         write.close();
@@ -179,7 +179,7 @@ public class SnapshotReaderTest {
     }
 
     @Test
-    public void testGetAppendOnlyRawTableFiles() throws Exception {
+    public void testGetAppendOnlyRawFiles() throws Exception {
         RowType rowType =
                 RowType.of(
                         new DataType[] {DataTypes.INT(), DataTypes.BIGINT()},
@@ -205,8 +205,8 @@ public class SnapshotReaderTest {
         DataSplit dataSplit = dataSplits.get(0);
         assertThat(dataSplit.dataFiles()).hasSize(1);
         DataFileMeta meta = dataSplit.dataFiles().get(0);
-        assertThat(dataSplit.rawFiles())
-                .isEqualTo(
+        assertThat(dataSplit.convertToRawFiles())
+                .hasValue(
                         Collections.singletonList(
                                 new RawFile(
                                         String.format("%s/bucket-0/%s", tablePath, meta.fileName()),
@@ -237,8 +237,8 @@ public class SnapshotReaderTest {
         assertThat(dataSplit.dataFiles()).hasSize(2);
         DataFileMeta meta0 = dataSplit.dataFiles().get(0);
         DataFileMeta meta1 = dataSplit.dataFiles().get(1);
-        assertThat(dataSplit.rawFiles())
-                .isEqualTo(
+        assertThat(dataSplit.convertToRawFiles())
+                .hasValue(
                         Arrays.asList(
                                 new RawFile(
                                         String.format(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
@@ -98,8 +98,8 @@ public class SnapshotReaderTest {
             assertThat(dataSplit.dataFiles()).hasSize(1);
             DataFileMeta meta = dataSplit.dataFiles().get(0);
             String partition = dataSplit.partition().getString(0).toString();
-            assertThat(reader.convertToRawFiles(dataSplit))
-                    .hasValue(
+            assertThat(dataSplit.rawFiles())
+                    .isEqualTo(
                             Collections.singletonList(
                                     new RawFile(
                                             String.format(
@@ -123,7 +123,7 @@ public class SnapshotReaderTest {
         assertThat(dataSplits).hasSize(2);
         for (DataSplit dataSplit : dataSplits) {
             assertThat(dataSplit.dataFiles()).hasSize(2);
-            assertThat(reader.convertToRawFiles(dataSplit)).isNotPresent();
+            assertThat(dataSplit.rawFiles()).isEmpty();
         }
 
         // compact all files
@@ -146,8 +146,8 @@ public class SnapshotReaderTest {
             assertThat(dataSplit.dataFiles()).hasSize(1);
             DataFileMeta meta = dataSplit.dataFiles().get(0);
             String partition = dataSplit.partition().getString(0).toString();
-            assertThat(reader.convertToRawFiles(dataSplit))
-                    .hasValue(
+            assertThat(dataSplit.rawFiles())
+                    .isEqualTo(
                             Collections.singletonList(
                                     new RawFile(
                                             String.format(
@@ -171,7 +171,7 @@ public class SnapshotReaderTest {
         assertThat(dataSplits).hasSize(2);
         for (DataSplit dataSplit : dataSplits) {
             assertThat(dataSplit.dataFiles()).hasSize(2);
-            assertThat(reader.convertToRawFiles(dataSplit)).isNotPresent();
+            assertThat(dataSplit.rawFiles()).isEmpty();
         }
 
         write.close();
@@ -205,8 +205,8 @@ public class SnapshotReaderTest {
         DataSplit dataSplit = dataSplits.get(0);
         assertThat(dataSplit.dataFiles()).hasSize(1);
         DataFileMeta meta = dataSplit.dataFiles().get(0);
-        assertThat(reader.convertToRawFiles(dataSplit))
-                .hasValue(
+        assertThat(dataSplit.rawFiles())
+                .isEqualTo(
                         Collections.singletonList(
                                 new RawFile(
                                         String.format("%s/bucket-0/%s", tablePath, meta.fileName()),
@@ -237,8 +237,8 @@ public class SnapshotReaderTest {
         assertThat(dataSplit.dataFiles()).hasSize(2);
         DataFileMeta meta0 = dataSplit.dataFiles().get(0);
         DataFileMeta meta1 = dataSplit.dataFiles().get(1);
-        assertThat(reader.convertToRawFiles(dataSplit))
-                .hasValue(
+        assertThat(dataSplit.rawFiles())
+                .isEqualTo(
                         Arrays.asList(
                                 new RawFile(
                                         String.format(


### PR DESCRIPTION
### Purpose

It would be more natural to check if a split can be read without merging directly from that split, not from other sources.

This PR moves `convertToRawFiles` method from `TableScan` to `Split`.

### Tests

This PR is a refactor. Existing tests should cover the correctness.

### API and Format

No.

### Documentation

No.
