### PR TITLE
[core] Use Flink Managed Memory for RocksDB in cross partition update

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -129,6 +129,12 @@ under the License.
             <td>Sink committer memory to control heap memory of global committer.</td>
         </tr>
         <tr>
+            <td><h5>sink.cross-partition.managed-memory</h5></td>
+            <td style="word-wrap: break-word;">256 mb</td>
+            <td>MemorySize</td>
+            <td>Weight of managed memory for RocksDB in cross-partition update, Flink will compute the memory size according to the weight, the actual memory used depends on the running environment.</td>
+        </tr>
+        <tr>
             <td><h5>sink.managed.writer-buffer-memory</h5></td>
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -143,7 +143,9 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
         rocksdbOptions.set(BLOCK_CACHE_SIZE, new MemorySize(blockCache));
         this.stateFactory =
                 new RocksDBStateFactory(
-                        path.toString(), options, coreOptions.crossPartitionUpsertIndexTtl());
+                        path.toString(),
+                        rocksdbOptions,
+                        coreOptions.crossPartitionUpsertIndexTtl());
         RowType keyType = table.schema().logicalTrimmedPrimaryKeysType();
         this.keyIndex =
                 stateFactory.valueState(

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -109,7 +109,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
     // ================== Start Public API ===================
 
     public void open(
-            long minOffHeapMemory,
+            long offHeapMemory,
             IOManager ioManager,
             int numAssigners,
             int assignId,
@@ -138,8 +138,8 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
         this.path = new File(rocksDBDir, "rocksdb-" + UUID.randomUUID());
 
         Options rocksdbOptions = Options.fromMap(new HashMap<>(options.toMap()));
-        long blockCache =
-                Math.max(minOffHeapMemory, rocksdbOptions.get(BLOCK_CACHE_SIZE).getBytes());
+        // we should avoid too small memory
+        long blockCache = Math.max(offHeapMemory, rocksdbOptions.get(BLOCK_CACHE_SIZE).getBytes());
         rocksdbOptions.set(BLOCK_CACHE_SIZE, new MemorySize(blockCache));
         this.stateFactory =
                 new RocksDBStateFactory(

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/GlobalIndexAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/GlobalIndexAssignerTest.java
@@ -93,7 +93,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
     private void innerTestBucketAssign(boolean enableTtl) throws Exception {
         GlobalIndexAssigner assigner = createAssigner(MergeEngine.DEDUPLICATE, enableTtl);
         List<Integer> output = new ArrayList<>();
-        assigner.open(ioManager(), 2, 0, (row, bucket) -> output.add(bucket));
+        assigner.open(0, ioManager(), 2, 0, (row, bucket) -> output.add(bucket));
         assigner.endBoostrap(false);
 
         // assign
@@ -127,7 +127,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
     public void testUpsert() throws Exception {
         GlobalIndexAssigner assigner = createAssigner(MergeEngine.DEDUPLICATE);
         List<Pair<InternalRow, Integer>> output = new ArrayList<>();
-        assigner.open(ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
+        assigner.open(0, ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
         assigner.endBoostrap(false);
 
         // change partition
@@ -171,7 +171,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
                         : MergeEngine.AGGREGATE;
         GlobalIndexAssigner assigner = createAssigner(mergeEngine);
         List<Pair<InternalRow, Integer>> output = new ArrayList<>();
-        assigner.open(ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
+        assigner.open(0, ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
         assigner.endBoostrap(false);
 
         // change partition
@@ -195,7 +195,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
     public void testFirstRow() throws Exception {
         GlobalIndexAssigner assigner = createAssigner(MergeEngine.FIRST_ROW);
         List<Pair<InternalRow, Integer>> output = new ArrayList<>();
-        assigner.open(ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
+        assigner.open(0, ioManager(), 2, 0, (row, bucket) -> output.add(Pair.of(row, bucket)));
         assigner.endBoostrap(false);
 
         // change partition
@@ -218,6 +218,7 @@ public class GlobalIndexAssignerTest extends TableTestBase {
         GlobalIndexAssigner assigner = createAssigner(MergeEngine.DEDUPLICATE);
         List<List<Integer>> output = new ArrayList<>();
         assigner.open(
+                0,
                 ioManager(),
                 2,
                 0,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -237,6 +237,14 @@ public class FlinkConnectorOptions {
                             "Weight of writer buffer in managed memory, Flink will compute the memory size "
                                     + "for writer according to the weight, the actual memory used depends on the running environment.");
 
+    public static final ConfigOption<MemorySize> SINK_CROSS_PARTITION_MANAGED_MEMORY =
+            ConfigOptions.key("sink.cross-partition.managed-memory")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(256))
+                    .withDescription(
+                            "Weight of managed memory for RocksDB in cross-partition update, Flink will compute the memory size "
+                                    + "according to the weight, the actual memory used depends on the running environment.");
+
     public static final ConfigOption<Boolean> SCAN_PUSH_DOWN =
             ConfigOptions.key("scan.push-down")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -54,6 +53,7 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_COMMITTER_CPU;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_COMMITTER_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_MANAGED_WRITER_BUFFER_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
+import static org.apache.paimon.flink.utils.ManagedMemoryUtils.declareManagedMemory;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Abstract sink of paimon. */
@@ -170,10 +170,7 @@ public abstract class FlinkSink<T> implements Serializable {
 
         Options options = Options.fromMap(table.options());
         if (options.get(SINK_USE_MANAGED_MEMORY)) {
-            MemorySize memorySize = options.get(SINK_MANAGED_WRITER_BUFFER_MEMORY);
-            written.getTransformation()
-                    .declareManagedMemoryUseCaseAtOperatorScope(
-                            ManagedMemoryUseCase.OPERATOR, memorySize.getMebiBytes());
+            declareManagedMemory(written, options.get(SINK_MANAGED_WRITER_BUFFER_MEMORY));
         }
         return written;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
@@ -22,13 +22,11 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.flink.VersionedSerializerWrapper;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.manifest.WrappedManifestCommittable;
-import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -45,6 +43,7 @@ import java.util.UUID;
 
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_MANAGED_WRITER_BUFFER_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
+import static org.apache.paimon.flink.utils.ManagedMemoryUtils.declareManagedMemory;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** A sink for processing multi-tables in dedicated compaction job. */
@@ -105,10 +104,7 @@ public class MultiTablesCompactorSink implements Serializable {
         }
 
         if (options.get(SINK_USE_MANAGED_MEMORY)) {
-            MemorySize memorySize = options.get(SINK_MANAGED_WRITER_BUFFER_MEMORY);
-            written.getTransformation()
-                    .declareManagedMemoryUseCaseAtOperatorScope(
-                            ManagedMemoryUseCase.OPERATOR, memorySize.getMebiBytes());
+            declareManagedMemory(written, options.get(SINK_MANAGED_WRITER_BUFFER_MEMORY));
         }
         return written;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalIndexAssignerOperator.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import static org.apache.paimon.flink.utils.ManagedMemoryUtils.computeManagedMemory;
+
 /** A {@link OneInputStreamOperator} for {@link GlobalIndexAssigner}. */
 public class GlobalIndexAssignerOperator
         extends AbstractStreamOperator<Tuple2<InternalRow, Integer>>
@@ -54,6 +56,7 @@ public class GlobalIndexAssignerOperator
                 getContainingTask().getEnvironment().getIOManager();
         ioManager = IOManager.create(flinkIoManager.getSpillingDirectoriesPaths());
         assigner.open(
+                computeManagedMemory(this),
                 ioManager,
                 getRuntimeContext().getNumberOfParallelSubtasks(),
                 getRuntimeContext().getIndexOfThisSubtask(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/ManagedMemoryUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/ManagedMemoryUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.paimon.options.MemorySize;
+
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+
+/** Utils for using Flink managed memory. */
+public class ManagedMemoryUtils {
+
+    public static void declareManagedMemory(DataStream<?> dataStream, MemorySize memorySize) {
+        dataStream
+                .getTransformation()
+                .declareManagedMemoryUseCaseAtOperatorScope(
+                        ManagedMemoryUseCase.OPERATOR, memorySize.getMebiBytes());
+    }
+
+    public static long computeManagedMemory(AbstractStreamOperator<?> operator) {
+        final Environment environment = operator.getContainingTask().getEnvironment();
+        return environment
+                .getMemoryManager()
+                .computeMemorySize(
+                        operator.getOperatorConfig()
+                                .getManagedMemoryFractionOperatorUseCaseOfSlot(
+                                        ManagedMemoryUseCase.OPERATOR,
+                                        environment.getTaskManagerInfo().getConfiguration(),
+                                        environment.getUserCodeClassLoader().asClassLoader()));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Default block cache of RocksDB is 8MB. It is too small to performance.

We can use Flink managed memory for RocksDB.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
