### PR TITLE
[spark] It is more reasonable import class ImmutableMap from package:org.apache.paimon.shade.guava30.com.google.common.collect

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
@@ -21,10 +21,10 @@ package org.apache.paimon.tests.cdc;
 import org.apache.paimon.flink.action.cdc.mysql.MySqlContainer;
 import org.apache.paimon.flink.action.cdc.mysql.MySqlVersion;
 import org.apache.paimon.tests.E2eTestBase;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
-import org.apache.hadoop.shaded.org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -25,7 +25,7 @@ import org.apache.paimon.spark.procedure.Procedure;
 import org.apache.paimon.spark.procedure.ProcedureBuilder;
 import org.apache.paimon.spark.procedure.RollbackProcedure;
 
-import org.apache.hadoop.shaded.com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
 import java.util.Map;

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -132,6 +132,12 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="message"
 					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
 		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.hadoop\.shaded"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+				value="Use Paimon's shade instead of hadoop's shade"/>
+		</module>
 		<!-- forbid the use of com.google.common.annotations.VisibleForTesting -->
 		<module name="Regexp">
 			<property name="format"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2382

<!-- What is the purpose of the change -->
It is more reasonable import class ImmutableMap from package:org.apache.paimon.shade.guava30.com.google.common.collect which is from jar: org.apache.paimon:paimon-shade-guava-30
, instead of org.apache.hadoop.shaded.com.google.common.collect.ImmutableMap
### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
