### PR TITLE
[core] AppendOnlySplitGenerator skips the check of sequence number overlap in UNAWARE mode to reduce invalid logs.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactManager.java
@@ -70,7 +70,7 @@ public class AppendOnlyCompactManager extends CompactFutureManager {
             CompactRewriter rewriter,
             @Nullable CompactionMetrics metrics) {
         this.executor = executor;
-        this.toCompact = new TreeSet<>(fileComparator());
+        this.toCompact = new TreeSet<>(fileComparator(false));
         this.toCompact.addAll(restored);
         this.minFileNum = minFileNum;
         this.maxFileNum = maxFileNum;
@@ -304,13 +304,13 @@ public class AppendOnlyCompactManager extends CompactFutureManager {
      * may be put after the new files, and this order will be disrupted. We need to ensure this
      * order, so we force the order by sequence.
      */
-    public static Comparator<DataFileMeta> fileComparator() {
+    public static Comparator<DataFileMeta> fileComparator(boolean ignoreOverlap) {
         return (o1, o2) -> {
             if (o1 == o2) {
                 return 0;
             }
 
-            if (isOverlap(o1, o2)) {
+            if (!ignoreOverlap && isOverlap(o1, o2)) {
                 LOG.warn(
                         String.format(
                                 "There should no overlap in append files, but Range1(%s, %s), Range2(%s, %s),"

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendOnlySplitGenerator.java
@@ -46,7 +46,7 @@ public class AppendOnlySplitGenerator implements SplitGenerator {
     @Override
     public List<List<DataFileMeta>> splitForBatch(List<DataFileMeta> input) {
         List<DataFileMeta> files = new ArrayList<>(input);
-        files.sort(fileComparator());
+        files.sort(fileComparator(bucketMode == BucketMode.UNAWARE));
         Function<DataFileMeta, Long> weightFunc = file -> Math.max(file.fileSize(), openFileCost);
         return BinPacking.packForOrdered(files, weightFunc, targetSplitSize);
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2397 

<!-- What is the purpose of the change -->
[core] AppendOnlySplitGenerator skips the check of sequence number overlap in UNAWARE mode to reduce invalid logs.

### Tests

<!-- List UT and IT cases to verify this change -->
No
### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No