### PR TITLE
[hotfix] Fix append table's default value for spillable parameter on streaming writes is not as expected.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -80,7 +80,6 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     private final Supplier<Comparator<InternalRow>> keyComparatorSupplier;
     private final Supplier<RecordEqualiser> valueEqualiserSupplier;
     private final MergeFunctionFactory<KeyValue> mfFactory;
-    private final CoreOptions options;
     private final FileIO fileIO;
     private final RowType keyType;
     private final RowType valueType;
@@ -130,7 +129,6 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
         this.keyComparatorSupplier = keyComparatorSupplier;
         this.valueEqualiserSupplier = valueEqualiserSupplier;
         this.mfFactory = mfFactory;
-        this.options = options;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -51,7 +51,7 @@ import static org.apache.paimon.CoreOptions.LOOKUP_CACHE_MAX_MEMORY_SIZE;
 public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> {
     private static final Logger LOG = LoggerFactory.getLogger(MemoryFileStoreWrite.class);
 
-    private final CoreOptions options;
+    protected final CoreOptions options;
     protected final CacheManager cacheManager;
     private MemoryPoolFactory writeBufferPool;
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.partition;
 
-import org.apache.paimon.operation.FileStoreCommitImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +48,7 @@ import static java.time.temporal.ChronoField.YEAR;
 /** Time extractor to extract time from partition values. */
 public class PartitionTimeExtractor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionTimeExtractor.class);
     private static final DateTimeFormatter TIMESTAMP_FORMATTER =
             new DateTimeFormatterBuilder()
                     .appendValue(YEAR, 1, 10, SignStyle.NORMAL)


### PR DESCRIPTION
… writes is not as expected.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
add method:

    public boolean bufferSpillable() {
        return options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode);
    }

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
