### PR TITLE
[hive] In hiveCatalog we do not need catalog.warehouse config

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
@@ -21,8 +21,10 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.table.TableType;
+import org.apache.paimon.utils.Preconditions;
 
 import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
+import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 
 /** Factory to create {@link FileSystemCatalog}. */
 public class FileSystemCatalogFactory implements CatalogFactory {
@@ -36,6 +38,7 @@ public class FileSystemCatalogFactory implements CatalogFactory {
 
     @Override
     public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
+        Preconditions.checkNotNull(warehouse, "Paimon '" + WAREHOUSE.key() + "' path must be set");
         if (!TableType.MANAGED.equals(context.options().get(TABLE_TYPE))) {
             throw new IllegalArgumentException(
                     "Only managed table is supported in File system catalog.");

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -556,29 +556,7 @@ public class HiveCatalog extends AbstractCatalog {
         if (isNullOrWhitespaceOnly(hiveConfDir)) {
             hiveConfDir = possibleHiveConfPath();
         }
-        if (isNullOrWhitespaceOnly(hadoopConfDir)) {
-            hadoopConfDir = possibleHadoopConfPath();
-        }
-
-        // create HiveConf from hadoop configuration with hadoop conf directory configured.
-        Configuration hadoopConf = null;
-        if (!isNullOrWhitespaceOnly(hadoopConfDir)) {
-            hadoopConf = getHadoopConfiguration(hadoopConfDir);
-            if (hadoopConf == null) {
-                String possiableUsedConfFiles =
-                        "core-site.xml | hdfs-site.xml | yarn-site.xml | mapred-site.xml";
-                throw new RuntimeException(
-                        "Failed to load the hadoop conf from specified path:" + hadoopConfDir,
-                        new FileNotFoundException(
-                                "Please check the path none of the conf files ("
-                                        + possiableUsedConfFiles
-                                        + ") exist in the folder."));
-            }
-        }
-        if (hadoopConf == null) {
-            hadoopConf = new Configuration();
-        }
-
+        Configuration hadoopConf = createHadoopConfiguration(hadoopConfDir);
         LOG.info("Setting hive conf dir as {}", hiveConfDir);
         if (hiveConfDir != null) {
             // ignore all the static conf file URLs that HiveConf may have set
@@ -613,6 +591,36 @@ public class HiveCatalog extends AbstractCatalog {
             }
             return hiveConf;
         }
+    }
+
+    public static Configuration createHadoopConfiguration(@Nullable String hadoopConfDir) {
+
+        LOG.info("Setting hadoop conf dir as {}", hadoopConfDir);
+
+        if (isNullOrWhitespaceOnly(hadoopConfDir)) {
+            hadoopConfDir = possibleHadoopConfPath();
+        }
+
+        // create HiveConf from hadoop configuration with hadoop conf directory configured.
+        Configuration hadoopConf = null;
+        if (!isNullOrWhitespaceOnly(hadoopConfDir)) {
+            hadoopConf = getHadoopConfiguration(hadoopConfDir);
+            if (hadoopConf == null) {
+                String possiableUsedConfFiles =
+                        "core-site.xml | hdfs-site.xml | yarn-site.xml | mapred-site.xml";
+                throw new RuntimeException(
+                        "Failed to load the hadoop conf from specified path:" + hadoopConfDir,
+                        new FileNotFoundException(
+                                "Please check the path none of the conf files ("
+                                        + possiableUsedConfFiles
+                                        + ") exist in the folder."));
+            }
+        }
+        if (hadoopConf == null) {
+            hadoopConf = new Configuration();
+        }
+
+        return hadoopConf;
     }
 
     public static boolean isEmbeddedMetastore(HiveConf hiveConf) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2407

<!-- What is the purpose of the change -->
In hiveCatalog we do not need catalog.warehouse config, it makes confused
### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
