### PR TITLE
[core] Fix that tag deletion might delete used data files

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
@@ -110,11 +110,18 @@ public class FileStoreExpireTestBase {
     protected void assertSnapshot(
             int snapshotId, List<KeyValue> allData, List<Integer> snapshotPositions)
             throws Exception {
+        assertSnapshot(snapshotManager.snapshot(snapshotId), allData, snapshotPositions);
+    }
+
+    protected void assertSnapshot(
+            Snapshot snapshot, List<KeyValue> allData, List<Integer> snapshotPositions)
+            throws Exception {
+        int snapshotId = (int) snapshot.id();
         Map<BinaryRow, BinaryRow> expected =
                 store.toKvMap(allData.subList(0, snapshotPositions.get(snapshotId - 1)));
         List<KeyValue> actualKvs =
                 store.readKvsFromManifestEntries(
-                        store.newScan().withSnapshot(snapshotId).plan().files(), false);
+                        store.newScan().withSnapshot(snapshot).plan().files(), false);
         gen.sort(actualKvs);
         Map<BinaryRow, BinaryRow> actual = store.toKvMap(actualKvs);
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Currently, when we delete a tag, the data manifest entries are not merged, so the result may contains data files that should not be deleted. For example, a tag base is (+A, -A, +B), if we don't merge it, we will get candidate deleted file set (A, B).
This PR fix it.

### Tests

`UncleanedFileStoreExpireTest#testMixedSnapshotAndTagDeletion`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
