### PR TITLE
[hive] HiveCatalog infer warehouse from hadoop Conf

### DIFF
--- a/docs/content/engines/hive.md
+++ b/docs/content/engines/hive.md
@@ -103,7 +103,7 @@ CREATE CATALOG my_hive WITH (
   'uri' = 'thrift://<hive-metastore-host-name>:<port>',
   -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
   -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
-  'warehouse' = 'hdfs:///path/to/table/store/warehouse'
+  -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf
 );
 
 -- Use paimon Hive catalog

--- a/docs/content/engines/hive.md
+++ b/docs/content/engines/hive.md
@@ -100,7 +100,7 @@ Execute the following Flink SQL script in Flink SQL client to define a Paimon Hi
 CREATE CATALOG my_hive WITH (
   'type' = 'paimon',
   'metastore' = 'hive',
-  'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+  -- 'uri' = 'thrift://<hive-metastore-host-name>:<port>', default use 'hive.metastore.uris' in HiveConf
   -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
   -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
   -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf

--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -106,7 +106,7 @@ CREATE CATALOG my_hive WITH (
     'uri' = 'thrift://<hive-metastore-host-name>:<port>',
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
-    'warehouse' = 'hdfs:///path/to/warehouse'
+    -- 'warehouse' = 'hdfs:///path/to/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf
 );
 
 USE CATALOG my_hive;

--- a/docs/content/how-to/creating-catalogs.md
+++ b/docs/content/how-to/creating-catalogs.md
@@ -103,7 +103,7 @@ hadoop-conf-dir parameter to the hive-site.xml file path.
 CREATE CATALOG my_hive WITH (
     'type' = 'paimon',
     'metastore' = 'hive',
-    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+    -- 'uri' = 'thrift://<hive-metastore-host-name>:<port>', default use 'hive.metastore.uris' in HiveConf
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'warehouse' = 'hdfs:///path/to/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf

--- a/docs/content/migration/upsert-to-partitioned.md
+++ b/docs/content/migration/upsert-to-partitioned.md
@@ -54,7 +54,7 @@ CREATE CATALOG my_hive WITH (
     'uri' = 'thrift://<hive-metastore-host-name>:<port>',
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
-    'warehouse' = 'hdfs:///path/to/warehouse'
+    -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf
 );
 
 USE CATALOG my_hive;
@@ -115,7 +115,7 @@ CREATE CATALOG my_hive WITH (
     'uri' = 'thrift://<hive-metastore-host-name>:<port>',
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
-    'warehouse' = 'hdfs:///path/to/warehouse'
+    -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf
 );
 
 USE CATALOG my_hive;

--- a/docs/content/migration/upsert-to-partitioned.md
+++ b/docs/content/migration/upsert-to-partitioned.md
@@ -51,7 +51,7 @@ fully compatible with Hive.
 CREATE CATALOG my_hive WITH (
     'type' = 'paimon',
     'metastore' = 'hive',
-    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+    -- 'uri' = 'thrift://<hive-metastore-host-name>:<port>', default use 'hive.metastore.uris' in HiveConf
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf
@@ -112,7 +112,7 @@ need to query the latest data. Therefore, Paimon provides a preview feature:
 CREATE CATALOG my_hive WITH (
     'type' = 'paimon',
     'metastore' = 'hive',
-    'uri' = 'thrift://<hive-metastore-host-name>:<port>',
+    -- 'uri' = 'thrift://<hive-metastore-host-name>:<port>', default use 'hive.metastore.uris' in HiveConf
     -- 'hive-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'hadoop-conf-dir' = '...', this is recommended in the kerberos environment
     -- 'warehouse' = 'hdfs:///path/to/table/store/warehouse', default use 'hive.metastore.warehouse.dir' in HiveConf

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.fs.FileIOUtils.checkAccess;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
  * File IO to read and write file.
@@ -177,6 +178,14 @@ public interface FileIO extends Serializable {
 
     default boolean isDir(Path path) throws IOException {
         return getFileStatus(path).isDir();
+    }
+
+    default void checkOrMkdirs(Path path) throws IOException {
+        if (exists(path)) {
+            checkArgument(isDir(path), "The path '%s' should be a directory.", path);
+        } else {
+            mkdirs(path);
+        }
     }
 
     /** Read file to UTF_8 decoding. */

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -210,19 +210,6 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-exec</artifactId>
-            <version>${hive.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -210,6 +210,19 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${hive.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -551,17 +551,16 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     public static HiveConf createHiveConf(
-            @Nullable String hiveConfDir, @Nullable String hadoopConfDir) {
+            @Nullable String hiveConfDir,
+            @Nullable String hadoopConfDir,
+            Configuration defaultHadoopConf) {
         // try to load from system env.
         if (isNullOrWhitespaceOnly(hiveConfDir)) {
             hiveConfDir = possibleHiveConfPath();
         }
-        if (isNullOrWhitespaceOnly(hadoopConfDir)) {
-            hadoopConfDir = possibleHadoopConfPath();
-        }
 
         // create HiveConf from hadoop configuration with hadoop conf directory configured.
-        Configuration hadoopConf = null;
+        Configuration hadoopConf = defaultHadoopConf;
         if (!isNullOrWhitespaceOnly(hadoopConfDir)) {
             hadoopConf = getHadoopConfiguration(hadoopConfDir);
             if (hadoopConf == null) {
@@ -574,9 +573,6 @@ public class HiveCatalog extends AbstractCatalog {
                                         + possiableUsedConfFiles
                                         + ") exist in the folder."));
             }
-        }
-        if (hadoopConf == null) {
-            hadoopConf = new Configuration();
         }
 
         LOG.info("Setting hive conf dir as {}", hiveConfDir);
@@ -657,22 +653,6 @@ public class HiveCatalog extends AbstractCatalog {
             }
         }
         return null;
-    }
-
-    public static String possibleHadoopConfPath() {
-        String possiblePath = null;
-        if (System.getenv("HADOOP_CONF_DIR") != null) {
-            possiblePath = System.getenv("HADOOP_CONF_DIR");
-        } else if (System.getenv("HADOOP_HOME") != null) {
-            String possiblePath1 = System.getenv("HADOOP_HOME") + "/conf";
-            String possiblePath2 = System.getenv("HADOOP_HOME") + "/etc/hadoop";
-            if (new File(possiblePath1).exists()) {
-                possiblePath = possiblePath1;
-            } else if (new File(possiblePath2).exists()) {
-                possiblePath = possiblePath2;
-            }
-        }
-        return possiblePath;
     }
 
     public static String possibleHiveConfPath() {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogFactory.java
@@ -21,24 +21,12 @@ package org.apache.paimon.hive;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREWAREHOUSE;
-import static org.apache.paimon.hive.HiveCatalogOptions.HADOOP_CONF_DIR;
-import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.IDENTIFIER;
 
 /** Factory to create {@link HiveCatalog}. */
@@ -46,7 +34,7 @@ public class HiveCatalogFactory implements CatalogFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveCatalogFactory.class);
 
-    private static final ConfigOption<String> METASTORE_CLIENT_CLASS =
+    public static final ConfigOption<String> METASTORE_CLIENT_CLASS =
             ConfigOptions.key("metastore.client.class")
                     .stringType()
                     .defaultValue("org.apache.hadoop.hive.metastore.HiveMetaStoreClient")
@@ -62,56 +50,6 @@ public class HiveCatalogFactory implements CatalogFactory {
 
     @Override
     public Catalog create(CatalogContext context) {
-        HiveConf hiveConf = createHiveConf(context);
-        String warehouseStr = context.options().get(CatalogOptions.WAREHOUSE);
-        if (warehouseStr == null) {
-            warehouseStr =
-                    hiveConf.get(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.defaultStrVal);
-        }
-        Path warehouse = new Path(warehouseStr);
-        Path uri =
-                warehouse.toUri().getScheme() == null
-                        ? new Path(FileSystem.getDefaultUri(hiveConf))
-                        : warehouse;
-        FileIO fileIO;
-        try {
-            fileIO = FileIO.get(uri, context);
-            fileIO.checkOrMkdirs(warehouse);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        return new HiveCatalog(
-                fileIO,
-                hiveConf,
-                context.options().get(METASTORE_CLIENT_CLASS),
-                context.options(),
-                warehouse.toUri().toString());
-    }
-
-    private static HiveConf createHiveConf(CatalogContext context) {
-        String uri = context.options().get(CatalogOptions.URI);
-        String hiveConfDir = context.options().get(HIVE_CONF_DIR);
-        String hadoopConfDir = context.options().get(HADOOP_CONF_DIR);
-        HiveConf hiveConf =
-                HiveCatalog.createHiveConf(hiveConfDir, hadoopConfDir, context.hadoopConf());
-
-        // always using user-set parameters overwrite hive-site.xml parameters
-        context.options().toMap().forEach(hiveConf::set);
-        if (uri != null) {
-            hiveConf.set(ConfVars.METASTOREURIS.varname, uri);
-        }
-
-        if (hiveConf.get(ConfVars.METASTOREURIS.varname) == null) {
-            LOG.error(
-                    "Can't find hive metastore uri to connect: "
-                            + " either set "
-                            + CatalogOptions.URI.key()
-                            + " for paimon "
-                            + IDENTIFIER
-                            + " catalog or set hive.metastore.uris in hive-site.xml or hadoop configurations."
-                            + " Will use empty metastore uris, which means we may use a embedded metastore. The may cause unpredictable consensus problem.");
-        }
-
-        return hiveConf;
+        return HiveCatalog.createHiveCatalog(context);
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -20,10 +20,12 @@ package org.apache.paimon.hive;
 
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.CommonTestUtils;
+import org.apache.paimon.utils.HadoopUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 
@@ -104,7 +106,9 @@ public class HiveCatalogTest extends CatalogTestBase {
 
     @Test
     public void testHadoopConfDir() {
-        HiveConf hiveConf = HiveCatalog.createHiveConf(null, HADOOP_CONF_DIR);
+        HiveConf hiveConf =
+                HiveCatalog.createHiveConf(
+                        null, HADOOP_CONF_DIR, HadoopUtils.getHadoopConfiguration(new Options()));
         assertThat(hiveConf.get("fs.defaultFS")).isEqualTo("dummy-fs");
     }
 
@@ -118,7 +122,9 @@ public class HiveCatalogTest extends CatalogTestBase {
     }
 
     private void testHiveConfDirImpl() {
-        HiveConf hiveConf = HiveCatalog.createHiveConf(HIVE_CONF_DIR, null);
+        HiveConf hiveConf =
+                HiveCatalog.createHiveConf(
+                        HIVE_CONF_DIR, null, HadoopUtils.getHadoopConfiguration(new Options()));
         assertThat(hiveConf.get("hive.metastore.uris")).isEqualTo("dummy-hms");
     }
 
@@ -134,7 +140,9 @@ public class HiveCatalogTest extends CatalogTestBase {
         // add HADOOP_CONF_DIR to system environment
         CommonTestUtils.setEnv(newEnv, false);
 
-        HiveConf hiveConf = HiveCatalog.createHiveConf(null, null);
+        HiveConf hiveConf =
+                HiveCatalog.createHiveConf(
+                        null, null, HadoopUtils.getHadoopConfiguration(new Options()));
         assertThat(hiveConf.get("fs.defaultFS")).isEqualTo("dummy-fs");
     }
 
@@ -153,7 +161,9 @@ public class HiveCatalogTest extends CatalogTestBase {
         // add HIVE_CONF_DIR to system environment
         CommonTestUtils.setEnv(newEnv, false);
 
-        HiveConf hiveConf = HiveCatalog.createHiveConf(null, null);
+        HiveConf hiveConf =
+                HiveCatalog.createHiveConf(
+                        null, null, HadoopUtils.getHadoopConfiguration(new Options()));
         assertThat(hiveConf.get("hive.metastore.uris")).isEqualTo("dummy-hms");
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
@@ -109,7 +109,7 @@ public class HiveLocationTest {
         fileIO.mkdirs(warehouse);
 
         HiveCatalogFactory hiveCatalogFactory = new HiveCatalogFactory();
-        catalog = (HiveCatalog) hiveCatalogFactory.create(fileIO, warehouse, catalogContext);
+        catalog = (HiveCatalog) hiveCatalogFactory.create(catalogContext);
 
         hmsClient = catalog.getHmsClient();
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Warehouse can be empty in HiveCatalog, it can infer warehouse from hadoop Conf
2. If the scheme of warehouse is empty, get Default Uri from conf to create FileIO

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
