### PR TITLE
[core] AbstractFileStoreWrite should not be the interface

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
@@ -60,7 +60,7 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
     public BatchTableWrite newWrite() {
         return table.newWrite(commitUser)
                 .withIgnorePreviousFiles(staticPartition != null)
-                .isStreamingMode(false);
+                .withExecutionMode(false);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableWrite.java
@@ -24,5 +24,5 @@ public interface InnerTableWrite extends StreamTableWrite, BatchTableWrite {
     InnerTableWrite withIgnorePreviousFiles(boolean ignorePreviousFiles);
 
     // we detect whether in streaming mode, and do some optimization
-    InnerTableWrite isStreamingMode(boolean isStreamingMode);
+    InnerTableWrite withExecutionMode(boolean isStreamingMode);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -27,8 +27,8 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
-import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite;
+import org.apache.paimon.operation.FileStoreWrite.State;
 import org.apache.paimon.utils.Restorable;
 
 import java.util.List;
@@ -41,10 +41,9 @@ import static org.apache.paimon.utils.Preconditions.checkState;
  *
  * @param <T> type of record to write into {@link FileStore}.
  */
-public class TableWriteImpl<T>
-        implements InnerTableWrite, Restorable<List<AbstractFileStoreWrite.State<T>>> {
+public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State<T>>> {
 
-    private final AbstractFileStoreWrite<T> write;
+    private final FileStoreWrite<T> write;
     private final KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor;
     private final RecordExtractor<T> recordExtractor;
 
@@ -54,7 +53,7 @@ public class TableWriteImpl<T>
             FileStoreWrite<T> write,
             KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor,
             RecordExtractor<T> recordExtractor) {
-        this.write = (AbstractFileStoreWrite<T>) write;
+        this.write = write;
         this.keyAndBucketExtractor = keyAndBucketExtractor;
         this.recordExtractor = recordExtractor;
     }
@@ -66,8 +65,8 @@ public class TableWriteImpl<T>
     }
 
     @Override
-    public TableWriteImpl<T> isStreamingMode(boolean isStreamingMode) {
-        write.isStreamingMode(isStreamingMode);
+    public TableWriteImpl<T> withExecutionMode(boolean isStreamingMode) {
+        write.withExecutionMode(isStreamingMode);
         return this;
     }
 
@@ -183,17 +182,17 @@ public class TableWriteImpl<T>
     }
 
     @Override
-    public List<AbstractFileStoreWrite.State<T>> checkpoint() {
+    public List<State<T>> checkpoint() {
         return write.checkpoint();
     }
 
     @Override
-    public void restore(List<AbstractFileStoreWrite.State<T>> state) {
+    public void restore(List<State<T>> state) {
         write.restore(state);
     }
 
     @VisibleForTesting
-    public AbstractFileStoreWrite<T> getWrite() {
+    public FileStoreWrite<T> getWrite() {
         return write;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/DynamicBucketTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DynamicBucketTableTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.index.HashIndexMaintainer;
+import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -51,8 +52,7 @@ public class DynamicBucketTableTest extends TableTestBase {
         TableWriteImpl batchTableWrite = (TableWriteImpl) builder.withOverwrite().newWrite();
         HashIndexMaintainer indexMaintainer =
                 (HashIndexMaintainer)
-                        batchTableWrite
-                                .getWrite()
+                        ((AbstractFileStoreWrite<?>) (batchTableWrite.getWrite()))
                                 .createWriterContainer(BinaryRow.EMPTY_ROW, 0, true)
                                 .indexMaintainer;
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.utils.MetricUtils;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
@@ -686,7 +687,9 @@ public class CdcRecordStoreMultiWriteOperatorTest {
         List<ExecutorService> compactExecutors = new ArrayList<>();
         for (StoreSinkWrite storeSinkWrite : storeSinkWrites) {
             StoreSinkWriteImpl storeSinkWriteImpl = (StoreSinkWriteImpl) storeSinkWrite;
-            compactExecutors.add(storeSinkWriteImpl.getWrite().getWrite().getCompactExecutor());
+            compactExecutors.add(
+                    ((AbstractFileStoreWrite<?>) storeSinkWriteImpl.getWrite().getWrite())
+                            .getCompactExecutor());
         }
         assertThat(compactExecutors.get(0) == compactExecutors.get(1)).isTrue();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -27,7 +27,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
-import org.apache.paimon.operation.AbstractFileStoreWrite;
+import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.SinkRecord;
@@ -146,7 +146,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                                         state.stateValueFilter().filter(table.name(), part, bucket))
                         .withIOManager(paimonIOManager)
                         .withIgnorePreviousFiles(ignorePreviousFiles)
-                        .isStreamingMode(isStreamingMode);
+                        .withExecutionMode(isStreamingMode);
 
         if (metricGroup != null) {
             tableWrite.withMetricRegistry(new FlinkMetricRegistry(metricGroup));
@@ -240,7 +240,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
             return;
         }
 
-        List<? extends AbstractFileStoreWrite.State<?>> states = write.checkpoint();
+        List<? extends FileStoreWrite.State<?>> states = write.checkpoint();
         write.close();
         write = newTableWrite(newTable);
         write.restore((List) states);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The interface should be `FileStoreWrite`. All invokers should be only rely on `FileStoreWrite` instead of `AbstractFileStoreWrite`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
