### PR TITLE
[core] Refactory code about MutableObjectIterator and remove  method: E next(E reuse)

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.utils.Preconditions;
 
 import java.nio.ByteOrder;
 
@@ -412,6 +413,14 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
 
     public BinaryRow copy(BinaryRow reuse) {
         return copyInternal(reuse);
+    }
+
+    public BinaryRow share(BinaryRow reuse) {
+        Preconditions.checkArgument(reuse != null);
+        this.segments = reuse.segments;
+        this.offset = reuse.offset;
+        this.sizeInBytes = reuse.sizeInBytes;
+        return this;
     }
 
     private BinaryRow copyInternal(BinaryRow reuse) {

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -202,7 +202,6 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
         boolean isEmpty = true;
         if (bootstrapKeys.size() > 0) {
             MutableObjectIterator<BinaryRow> keyIterator = bootstrapKeys.sortedIterator();
-            BinaryRow row = new BinaryRow(2);
             KeyValueIterator<byte[], byte[]> kvIter =
                     new KeyValueIterator<byte[], byte[]>() {
 
@@ -211,7 +210,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
                         @Override
                         public boolean advanceNext() {
                             try {
-                                current = keyIterator.next(row);
+                                current = keyIterator.next();
                             } catch (IOException e) {
                                 throw new UncheckedIOException(e);
                             }
@@ -347,7 +346,6 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
                         throw new RuntimeException(e);
                     }
 
-                    BinaryRow reuseBinaryRow = new BinaryRow(keyWithRowType.getFieldCount());
                     OffsetRow row =
                             new OffsetRow(rowType.getFieldCount(), keyWithIdType.getFieldCount());
                     return new RowIterator() {
@@ -356,7 +354,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
                         public InternalRow next() {
                             BinaryRow keyWithRow;
                             try {
-                                keyWithRow = iterator.next(reuseBinaryRow);
+                                keyWithRow = iterator.next();
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }

--- a/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileReaderInputView.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileReaderInputView.java
@@ -76,24 +76,21 @@ public class BufferFileReaderInputView extends AbstractPagedInputView {
 
         protected final BinaryRowSerializer serializer;
 
+        private final BinaryRow reuse;
+
         public BinaryRowChannelInputViewIterator(BinaryRowSerializer serializer) {
             this.serializer = serializer;
+            this.reuse = new BinaryRow(serializer.getArity());
         }
 
         @Override
-        public BinaryRow next(BinaryRow reuse) throws IOException {
+        public BinaryRow next() throws IOException {
             try {
                 return this.serializer.deserializeFromPages(reuse, BufferFileReaderInputView.this);
             } catch (EOFException e) {
                 close();
                 return null;
             }
-        }
-
-        @Override
-        public BinaryRow next() throws IOException {
-            throw new UnsupportedOperationException(
-                    "This method is disabled due to performance issue!");
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
@@ -189,7 +189,6 @@ public class ExternalBuffer implements RowBuffer {
     public class BufferIterator implements RowBufferIterator {
 
         private MutableObjectIterator<BinaryRow> currentIterator;
-        private final BinaryRow reuse = binaryRowSerializer.createInstance();
 
         private int currentChannelID = -1;
         private BinaryRow row;
@@ -228,7 +227,7 @@ public class ExternalBuffer implements RowBuffer {
             try {
                 // get from curr iterator or new iterator.
                 while (true) {
-                    if (currentIterator != null && (row = currentIterator.next(reuse)) != null) {
+                    if (currentIterator != null && (row = currentIterator.next()) != null) {
                         return true;
                     } else {
                         if (!nextIterator()) {

--- a/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
@@ -158,7 +158,6 @@ public class InMemoryBuffer implements RowBuffer {
         private final RandomAccessInputView recordBuffer;
         private final AbstractRowDataSerializer<InternalRow> serializer;
         private final BinaryRow reuse;
-        private BinaryRow row;
 
         private InMemoryBufferIterator(
                 RandomAccessInputView recordBuffer,
@@ -171,8 +170,7 @@ public class InMemoryBuffer implements RowBuffer {
         @Override
         public boolean advanceNext() {
             try {
-                row = next(reuse);
-                return row != null;
+                return next() != null;
             } catch (IOException ioException) {
                 throw new RuntimeException(ioException);
             }
@@ -180,21 +178,16 @@ public class InMemoryBuffer implements RowBuffer {
 
         @Override
         public BinaryRow getRow() {
-            return row;
+            return reuse;
         }
 
         @Override
-        public BinaryRow next(BinaryRow reuse) throws IOException {
+        public BinaryRow next() throws IOException {
             try {
                 return (BinaryRow) serializer.mapFromPages(reuse, recordBuffer);
             } catch (EOFException e) {
                 return null;
             }
-        }
-
-        @Override
-        public BinaryRow next() throws IOException {
-            return next(reuse);
         }
 
         @Override
@@ -217,11 +210,6 @@ public class InMemoryBuffer implements RowBuffer {
         @Override
         public BinaryRow getRow() {
             throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public BinaryRow next(BinaryRow reuse) {
-            return null;
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -225,7 +225,8 @@ public class SortBufferWriteBuffer implements WriteBuffer {
 
         private boolean readOnce() throws IOException {
             try {
-                currentRow = kvIter.next(currentRow);
+                BinaryRow next = kvIter.next();
+                currentRow = next == null ? null : currentRow.share(next);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalMerger.java
@@ -84,8 +84,8 @@ public class BinaryExternalMerger extends AbstractBinaryExternalMerger<BinaryRow
             MutableObjectIterator<BinaryRow> mergeIterator, AbstractPagedOutputView output)
             throws IOException {
         // read the merged stream and write the data back
-        BinaryRow rec = serializer.createInstance();
-        while ((rec = mergeIterator.next(rec)) != null) {
+        BinaryRow rec;
+        while ((rec = mergeIterator.next()) != null) {
             serializer.serialize(rec, output);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryMergeIterator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryMergeIterator.java
@@ -49,12 +49,6 @@ public class BinaryMergeIterator<Entry> implements MutableObjectIterator<Entry> 
     }
 
     @Override
-    public Entry next(Entry reuse) throws IOException {
-        // Ignore reuse, because each HeadStream has its own reuse BinaryRow.
-        return next();
-    }
-
-    @Override
     public Entry next() throws IOException {
         if (currHead != null) {
             if (currHead.noMoreHead()) {
@@ -90,7 +84,7 @@ public class BinaryMergeIterator<Entry> implements MutableObjectIterator<Entry> 
         }
 
         private boolean noMoreHead() throws IOException {
-            return (this.head = this.iterator.next(head)) == null;
+            return (this.head = this.iterator.next()) == null;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/MutableObjectIterator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/MutableObjectIterator.java
@@ -33,21 +33,10 @@ import java.io.IOException;
  * @param <E> The element type of the collection iterated over.
  */
 public interface MutableObjectIterator<E> {
-
-    /**
-     * Gets the next element from the collection. The contents of that next element is put into the
-     * given reuse object, if the type is mutable.
-     *
-     * @param reuse The target object into which to place next element if E is mutable.
-     * @return The filled object or <code>null</code> if the iterator is exhausted.
-     * @throws IOException Thrown, if a problem occurred in the underlying I/O layer or in the
-     *     serialization / deserialization logic
-     */
-    E next(E reuse) throws IOException;
-
     /**
      * Gets the next element from the collection. The iterator implementation must obtain a new
-     * instance.
+     * instance. The method should use reuse object itself, which means, the return value point to
+     * the same object always.
      *
      * @return The object or <code>null</code> if the iterator is exhausted.
      * @throws IOException Thrown, if a problem occurred in the underlying I/O layer or in the

--- a/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
@@ -109,9 +109,9 @@ public class BinaryExternalSortBufferTest {
 
         MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
-            next = iterator.next(next);
+            next = iterator.next();
             assertThat(next.getInt(0)).isEqualTo(i);
             assertThat(next.getString(1).toString()).isEqualTo(getString(i));
         }
@@ -134,9 +134,9 @@ public class BinaryExternalSortBufferTest {
 
         MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
-            next = iterator.next(next);
+            next = iterator.next();
             assertThat(next.getInt(0)).isEqualTo(i);
             assertThat(next.getString(1).toString()).isEqualTo(getString(i));
         }
@@ -161,10 +161,10 @@ public class BinaryExternalSortBufferTest {
 
         MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
             for (int j = 0; j < 3; j++) {
-                next = iterator.next(next);
+                next = iterator.next();
                 assertThat(next.getInt(0)).isEqualTo(i);
                 assertThat(next.getString(1).toString()).isEqualTo(getString(i));
             }
@@ -195,9 +195,9 @@ public class BinaryExternalSortBufferTest {
 
         MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
-            next = iterator.next(next);
+            next = iterator.next();
             assertThat(next.getInt(0)).isEqualTo(i);
             assertThat(next.getString(1).toString()).isEqualTo(getString(i));
         }
@@ -217,9 +217,9 @@ public class BinaryExternalSortBufferTest {
 
         MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
-            next = iterator.next(next);
+            next = iterator.next();
             assertThat(next.getInt(0)).isEqualTo(i);
             assertThat(next.getString(1).toString()).isEqualTo(getString(i));
         }
@@ -236,9 +236,9 @@ public class BinaryExternalSortBufferTest {
         BinaryExternalSortBuffer sorter = createBuffer(8);
 
         List<BinaryRow> data = new ArrayList<>();
-        BinaryRow row = serializer.createInstance();
+        BinaryRow row;
         for (int i = 0; i < size; i++) {
-            row = reader.next(row);
+            row = reader.next();
             data.add(row.copy());
         }
 
@@ -252,9 +252,9 @@ public class BinaryExternalSortBufferTest {
 
         data.sort(Comparator.comparingInt(o -> o.getInt(0)));
 
-        BinaryRow next = serializer.createInstance();
+        BinaryRow next;
         for (int i = 0; i < size; i++) {
-            next = iterator.next(next);
+            next = iterator.next();
             assertThat(next.getInt(0)).isEqualTo(data.get(i).getInt(0));
             assertThat(next.getString(1).toString()).isEqualTo(data.get(i).getString(1).toString());
         }
@@ -296,11 +296,6 @@ public class BinaryExternalSortBufferTest {
             this.size = size;
             this.row = new BinaryRow(2);
             this.writer = new BinaryRowWriter(row);
-        }
-
-        @Override
-        public BinaryRow next(BinaryRow reuse) {
-            return next();
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
@@ -82,8 +82,8 @@ public class SortOperator extends TableStreamOperator<InternalRow>
     public void endInput() throws Exception {
         if (buffer.size() > 0) {
             MutableObjectIterator<BinaryRow> iterator = buffer.sortedIterator();
-            BinaryRow binaryRow = new BinaryRow(arity);
-            while ((binaryRow = iterator.next(binaryRow)) != null) {
+            BinaryRow binaryRow;
+            while ((binaryRow = iterator.next()) != null) {
                 output.collect(new StreamRecord<>(binaryRow));
             }
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sorter/SortOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sorter/SortOperatorTest.java
@@ -78,9 +78,8 @@ public class SortOperatorTest {
         BinaryExternalSortBuffer externalSortBuffer = sortOperator.getBuffer();
         MutableObjectIterator<BinaryRow> iterator = externalSortBuffer.sortedIterator();
         BinaryRow row;
-        BinaryRow reuse = new BinaryRow(3);
         long i = 1;
-        while ((row = iterator.next(reuse)) != null) {
+        while ((row = iterator.next()) != null) {
             Assertions.assertThat(row.getLong(0)).isEqualTo(i++);
         }
 


### PR DESCRIPTION
### Purpose

Refactory code about MutableObjectIterator. And remove method:
```code
    /**
     * Gets the next element from the collection. The contents of that next element is put into the
     * given reuse object, if the type is mutable.
     *
     * @param reuse The target object into which to place next element if E is mutable.
     * @return The filled object or <code>null</code> if the iterator is exhausted.
     * @throws IOException Thrown, if a problem occurred in the underlying I/O layer or in the
     *     serialization / deserialization logic
     */
    E next(E reuse) throws IOException;
```

Reason:
* This method is confusing. After code `row = next(row)`, we don't know exactly what `row` is point to. Does it stay itself, or something else.
* Every `MutableObjectIterator` deserves its own reuse object, it is simple to understand and maintain.
* Sometimes `next(reuse)` throws UnSupportException, sometimes `next()` throws that, behavior confusing.


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
