### PR TITLE
[spark] Add 'Paimon' prefix for Call Procedure

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SaveMode.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SaveMode.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark
 import org.apache.spark.sql.{SaveMode => SparkSaveMode}
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 
-sealed trait SaveMode extends Serializable
+sealed private[spark] trait SaveMode extends Serializable
 
 object InsertInto extends SaveMode
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SchemaHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SchemaHelper.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.types.StructType
 
 import scala.collection.JavaConverters._
 
-trait SchemaHelper extends WithFileStoreTable {
+private[spark] trait SchemaHelper extends WithFileStoreTable {
 
   val originTable: FileStoreTable
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -18,7 +18,7 @@
 package org.apache.paimon.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.{CoerceArguments, PaimonAnalysis, PaimonDeleteTable, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonUpdateTable, ResolveProcedures}
+import org.apache.spark.sql.catalyst.analysis.{PaimonAnalysis, PaimonCoerceArguments, PaimonDeleteTable, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable}
 import org.apache.spark.sql.catalyst.parser.extensions.PaimonSparkSqlExtensionsParser
 import org.apache.spark.sql.catalyst.plans.logical.PaimonTableValuedFunctions
 import org.apache.spark.sql.execution.PaimonStrategy
@@ -32,8 +32,8 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // analyzer extensions
     extensions.injectResolutionRule(sparkSession => new PaimonAnalysis(sparkSession))
-    extensions.injectResolutionRule(spark => ResolveProcedures(spark))
-    extensions.injectResolutionRule(_ => CoerceArguments)
+    extensions.injectResolutionRule(spark => PaimonProcedureResolver(spark))
+    extensions.injectResolutionRule(_ => PaimonCoerceArguments)
 
     extensions.injectPostHocResolutionRule(spark => PaimonPostHocResolutionRules(spark))
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
@@ -35,7 +35,7 @@ import scala.collection.mutable
 
 case class IndexedDataSplit(snapshotId: Long, index: Long, entry: DataSplit)
 
-trait StreamHelper {
+private[spark] trait StreamHelper {
 
   def table: DataTable
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/PaimonCoerceArguments.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/analysis/PaimonCoerceArguments.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.Cast
-import org.apache.spark.sql.catalyst.plans.logical.{CallCommand, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, PaimonCallCommand}
 import org.apache.spark.sql.catalyst.rules.Rule
 
 /* This file is based on source code from the Iceberg Project (http://iceberg.apache.org/), licensed by the Apache
@@ -31,10 +31,10 @@ import org.apache.spark.sql.catalyst.rules.Rule
  *
  * <p>Most of the content of this class is referenced from Iceberg's ProcedureArgumentCoercion.
  */
-object CoerceArguments extends Rule[LogicalPlan] {
+object PaimonCoerceArguments extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-    case call @ CallCommand(procedure, arguments) if call.resolved =>
+    case call @ PaimonCallCommand(procedure, arguments) if call.resolved =>
       val parameters = procedure.parameters
       val newArguments = arguments.zipWithIndex.map {
         case (argument, index) =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/PaimonSqlExtensionsAstBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/PaimonSqlExtensionsAstBuilder.scala
@@ -52,25 +52,25 @@ class PaimonSqlExtensionsAstBuilder(delegate: ParserInterface)
     visit(ctx.statement).asInstanceOf[LogicalPlan]
   }
 
-  /** Creates a [[CallStatement]] for a stored procedure call. */
-  override def visitCall(ctx: CallContext): CallStatement = withOrigin(ctx) {
+  /** Creates a [[PaimonCallStatement]] for a stored procedure call. */
+  override def visitCall(ctx: CallContext): PaimonCallStatement = withOrigin(ctx) {
     val name = toSeq(ctx.multipartIdentifier.parts).map(_.getText)
-    val args = toSeq(ctx.callArgument).map(typedVisit[CallArgument])
-    CallStatement(name, args)
+    val args = toSeq(ctx.callArgument).map(typedVisit[PaimonCallArgument])
+    PaimonCallStatement(name, args)
   }
 
   /** Creates a positional argument in a stored procedure call. */
-  override def visitPositionalArgument(ctx: PositionalArgumentContext): CallArgument =
+  override def visitPositionalArgument(ctx: PositionalArgumentContext): PaimonCallArgument =
     withOrigin(ctx) {
       val expression = typedVisit[Expression](ctx.expression)
-      PositionalArgument(expression)
+      PaimonPositionalArgument(expression)
     }
 
   /** Creates a named argument in a stored procedure call. */
-  override def visitNamedArgument(ctx: NamedArgumentContext): CallArgument = withOrigin(ctx) {
+  override def visitNamedArgument(ctx: NamedArgumentContext): PaimonCallArgument = withOrigin(ctx) {
     val name = ctx.identifier.getText
     val expression = typedVisit[Expression](ctx.expression)
-    NamedArgument(name, expression)
+    PaimonNamedArgument(name, expression)
   }
 
   /** Creates a [[Expression]] in a positional and named argument. */

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PaimonCallCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PaimonCallCommand.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.util.truncatedString
 
 /** A CALL command that resolves stored procedure from SQL. */
-case class CallCommand(procedure: Procedure, args: Seq[Expression]) extends LeafCommand {
+case class PaimonCallCommand(procedure: Procedure, args: Seq[Expression]) extends LeafCommand {
 
   override lazy val output: Seq[Attribute] =
     procedure.outputType.map(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PaimonCallStatement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PaimonCallStatement.scala
@@ -20,16 +20,17 @@ package org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 /** A CALL statement parsed from SQL. */
-case class CallStatement(name: Seq[String], args: Seq[CallArgument]) extends LeafParsedStatement
+case class PaimonCallStatement(name: Seq[String], args: Seq[PaimonCallArgument])
+  extends LeafParsedStatement
 
 /** An argument of a CALL statement. */
-sealed trait CallArgument {
+sealed trait PaimonCallArgument {
 
   def expr: Expression
 }
 
 /** An argument identified by name. */
-case class NamedArgument(name: String, expr: Expression) extends CallArgument
+case class PaimonNamedArgument(name: String, expr: Expression) extends PaimonCallArgument
 
 /** An argument identified by position. */
-case class PositionalArgument(expr: Expression) extends CallArgument
+case class PaimonPositionalArgument(expr: Expression) extends PaimonCallArgument

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/PaimonCallExec.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/PaimonCallExec.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
 
-case class CallExec(output: Seq[Attribute], procedure: Procedure, input: InternalRow)
+case class PaimonCallExec(output: Seq[Attribute], procedure: Procedure, input: InternalRow)
   extends LeafV2CommandExec {
 
   override protected def run(): Seq[InternalRow] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/PaimonStrategy.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, PredicateHelper}
-import org.apache.spark.sql.catalyst.plans.logical.{CallCommand, CreateTableAsSelect, LogicalPlan, TableSpec}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, LogicalPlan, PaimonCallCommand, TableSpec}
 import org.apache.spark.sql.execution.shim.PaimonCreateTableAsSelectStrategy
 
 case class PaimonStrategy(spark: SparkSession) extends Strategy with PredicateHelper {
@@ -30,9 +30,9 @@ case class PaimonStrategy(spark: SparkSession) extends Strategy with PredicateHe
     case ctas: CreateTableAsSelect =>
       PaimonCreateTableAsSelectStrategy(spark)(ctas)
 
-    case c @ CallCommand(procedure, args) =>
+    case c @ PaimonCallCommand(procedure, args) =>
       val input = buildInternalRow(args)
-      CallExec(c.output, procedure, input) :: Nil
+      PaimonCallExec(c.output, procedure, input) :: Nil
     case _ => Nil
   }
 

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/extensions/CallStatementParserTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/extensions/CallStatementParserTest.java
@@ -23,10 +23,10 @@ import org.apache.spark.sql.catalyst.expressions.Literal$;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.catalyst.parser.extensions.PaimonParseException;
-import org.apache.spark.sql.catalyst.plans.logical.CallArgument;
-import org.apache.spark.sql.catalyst.plans.logical.CallStatement;
-import org.apache.spark.sql.catalyst.plans.logical.NamedArgument;
-import org.apache.spark.sql.catalyst.plans.logical.PositionalArgument;
+import org.apache.spark.sql.catalyst.plans.logical.PaimonCallArgument;
+import org.apache.spark.sql.catalyst.plans.logical.PaimonCallStatement;
+import org.apache.spark.sql.catalyst.plans.logical.PaimonNamedArgument;
+import org.apache.spark.sql.catalyst.plans.logical.PaimonPositionalArgument;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
@@ -44,7 +44,7 @@ import scala.collection.JavaConverters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test for {@link CallStatement} of {@link PaimonSparkSessionExtensions}. */
+/** Test for {@link PaimonCallStatement} of {@link PaimonSparkSessionExtensions}. */
 public class CallStatementParserTest {
 
     private SparkSession spark = null;
@@ -80,8 +80,8 @@ public class CallStatementParserTest {
 
     @Test
     public void testCallWithNamedArguments() throws ParseException {
-        CallStatement callStatement =
-                (CallStatement)
+        PaimonCallStatement callStatement =
+                (PaimonCallStatement)
                         parser.parsePlan(
                                 "CALL catalog.system.named_args_func(arg1 => 1, arg2 => 'test', arg3 => true)");
         assertThat(JavaConverters.seqAsJavaList(callStatement.name()))
@@ -94,8 +94,8 @@ public class CallStatementParserTest {
 
     @Test
     public void testCallWithPositionalArguments() throws ParseException {
-        CallStatement callStatement =
-                (CallStatement)
+        PaimonCallStatement callStatement =
+                (PaimonCallStatement)
                         parser.parsePlan(
                                 "CALL catalog.system.positional_args_func(1, '${spark.sql.extensions}', 2L, true, 3.0D, 4"
                                         + ".0e1,500e-1BD, "
@@ -124,8 +124,8 @@ public class CallStatementParserTest {
 
     @Test
     public void testCallWithMixedArguments() throws ParseException {
-        CallStatement callStatement =
-                (CallStatement)
+        PaimonCallStatement callStatement =
+                (PaimonCallStatement)
                         parser.parsePlan("CALL catalog.system.mixed_function(arg1 => 1, 'test')");
         assertThat(JavaConverters.seqAsJavaList(callStatement.name()))
                 .isEqualTo(Arrays.asList("catalog", "system", "mixed_function"));
@@ -142,22 +142,22 @@ public class CallStatementParserTest {
     }
 
     private void assertArgument(
-            CallStatement call, int index, Object expectedValue, DataType expectedType) {
+            PaimonCallStatement call, int index, Object expectedValue, DataType expectedType) {
         assertArgument(call, index, null, expectedValue, expectedType);
     }
 
     private void assertArgument(
-            CallStatement callStatement,
+            PaimonCallStatement callStatement,
             int index,
             String expectedName,
             Object expectedValue,
             DataType expectedType) {
         if (expectedName == null) {
-            CallArgument callArgument = callStatement.args().apply(index);
-            assertCast(callArgument, PositionalArgument.class);
+            PaimonCallArgument callArgument = callStatement.args().apply(index);
+            assertCast(callArgument, PaimonPositionalArgument.class);
         } else {
-            NamedArgument namedArgument =
-                    assertCast(callStatement.args().apply(index), NamedArgument.class);
+            PaimonNamedArgument namedArgument =
+                    assertCast(callStatement.args().apply(index), PaimonNamedArgument.class);
             assertThat(namedArgument.name()).isEqualTo(expectedName);
         }
         assertThat(callStatement.args().apply(index).expr())


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/incubator-paimon/issues/2449

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
