### PR TITLE
[flink] supports writing to multiple partitions of kafka in unaware bucket mode.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogSerializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogSerializationSchema.java
@@ -81,6 +81,7 @@ public class KafkaLogSerializationSchema implements KafkaSerializationSchema<Sin
         } else {
             valueBytes = valueSerializer.serialize(new FlinkRowData(element.row()));
         }
-        return new ProducerRecord<>(topic, element.bucket(), primaryKeyBytes, valueBytes);
+        Integer partition = element.bucket() < 0 ? null : element.bucket();
+        return new ProducerRecord<>(topic, partition, primaryKeyBytes, valueBytes);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -146,7 +146,8 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                                         state.stateValueFilter().filter(table.name(), part, bucket))
                         .withIOManager(paimonIOManager)
                         .withIgnorePreviousFiles(ignorePreviousFiles)
-                        .withExecutionMode(isStreamingMode);
+                        .withExecutionMode(isStreamingMode)
+                        .withBucketMode(table.bucketMode());
 
         if (metricGroup != null) {
             tableWrite.withMetricRegistry(new FlinkMetricRegistry(metricGroup));


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2458 

[flink] supports writing to multiple partitions of kafka in unaware bucket mode.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

- org.apache.paimon.flink.kafka.KafkaLogSerializationTest#testUnawareBucket
- org.apache.paimon.flink.kafka.LogSystemITCase#testAppendOnlyWithUnawareBucket

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No
