### PR TITLE
[flink] Resolve bounded stream input finished in multiple checkpoint interval then cause commit failed

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -41,6 +41,9 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
     GlobalCommitT combine(long checkpointId, long watermark, List<CommitT> committables)
             throws IOException;
 
+    GlobalCommitT combine(
+            long checkpointId, long watermark, GlobalCommitT t, List<CommitT> committables);
+
     /** Commits the given {@link GlobalCommitT}. */
     void commit(List<GlobalCommitT> globalCommittables) throws IOException, InterruptedException;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -193,7 +193,14 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         for (Map.Entry<Long, List<CommitT>> entry : grouped.entrySet()) {
             Long cp = entry.getKey();
             List<CommitT> committables = entry.getValue();
+            // To prevent the asynchronous completion of tasks with multiple concurrent bounded
+            // stream inputs, which leads to some tasks passing a Committable with cp =
+            // Long.MAX_VALUE during the endInput method call of the current checkpoint, while other
+            // tasks pass a Committable with Long.MAX_VALUE during other checkpoints hence causing
+            // an error here, we have a special handling for Committables with Long.MAX_VALUE:
+            // instead of throwing an error, we merge them.
             if (cp != null && cp == Long.MAX_VALUE && committablesPerCheckpoint.containsKey(cp)) {
+                // Merge the Long.MAX_VALUE committables here.
                 GlobalCommitT commitT =
                         committer.combine(
                                 cp,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -69,20 +69,18 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     public ManifestCommittable combine(
             long checkpointId, long watermark, List<Committable> committables) {
         ManifestCommittable manifestCommittable = new ManifestCommittable(checkpointId, watermark);
-        for (Committable committable : committables) {
-            switch (committable.kind()) {
-                case FILE:
-                    CommitMessage file = (CommitMessage) committable.wrappedCommittable();
-                    manifestCommittable.addFileCommittable(file);
-                    break;
-                case LOG_OFFSET:
-                    LogOffsetCommittable offset =
-                            (LogOffsetCommittable) committable.wrappedCommittable();
-                    manifestCommittable.addLogOffset(offset.bucket(), offset.offset());
-                    break;
-            }
-        }
+        addFile(manifestCommittable, committables);
         return manifestCommittable;
+    }
+
+    @Override
+    public ManifestCommittable combine(
+            long checkpointId,
+            long watermark,
+            ManifestCommittable oldCommitable,
+            List<Committable> committables) {
+        addFile(oldCommitable, committables);
+        return oldCommitable;
     }
 
     @Override
@@ -109,6 +107,22 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public void close() throws Exception {
         commit.close();
+    }
+
+    private void addFile(ManifestCommittable manifestCommittable, List<Committable> committables) {
+        for (Committable committable : committables) {
+            switch (committable.kind()) {
+                case FILE:
+                    CommitMessage file = (CommitMessage) committable.wrappedCommittable();
+                    manifestCommittable.addFileCommittable(file);
+                    break;
+                case LOG_OFFSET:
+                    LogOffsetCommittable offset =
+                            (LogOffsetCommittable) committable.wrappedCommittable();
+                    manifestCommittable.addLogOffset(offset.bucket(), offset.offset());
+                    break;
+            }
+        }
     }
 
     private void calcNumBytesAndRecordsOut(List<ManifestCommittable> committables) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -345,13 +345,15 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                         })
                 .doesNotThrowAnyException();
 
-        Assertions.assertThat(
-                        ((ManifestCommittable)
-                                        ((CommitterOperator) operator)
-                                                .committablesPerCheckpoint.get(Long.MAX_VALUE))
-                                .fileCommittables()
-                                .size())
-                .isEqualTo(3);
+        if (operator instanceof CommitterOperator) {
+            Assertions.assertThat(
+                            ((ManifestCommittable)
+                                            ((CommitterOperator) operator)
+                                                    .committablesPerCheckpoint.get(Long.MAX_VALUE))
+                                    .fileCommittables()
+                                    .size())
+                    .isEqualTo(3);
+        }
 
         Assertions.assertThatCode(
                         () -> {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -25,10 +25,13 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.VersionedSerializerWrapper;
 import org.apache.paimon.flink.utils.MetricUtils;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.NewFilesIncrement;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestCommittableSerializer;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
@@ -276,6 +279,136 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         Assertions.assertThat(actual.size()).isEqualTo(1);
 
         Assertions.assertThat(actual).hasSameElementsAs(Lists.newArrayList(commitUser));
+    }
+
+    @Test
+    public void testCommitInputEnd() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+        String commitUser = UUID.randomUUID().toString();
+        OneInputStreamOperator<Committable, Committable> operator =
+                createCommitterOperator(table, commitUser, new NoopCommittableStateManager());
+        OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
+                createTestHarness(operator);
+        testHarness.open();
+        Assertions.assertThatCode(
+                        () -> {
+                            long time = System.currentTimeMillis();
+                            long cp = 0L;
+                            testHarness.processElement(
+                                    new Committable(
+                                            Long.MAX_VALUE,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.snapshot(cp++, time++);
+                            testHarness.processElement(
+                                    new Committable(
+                                            Long.MAX_VALUE,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.processElement(
+                                    new Committable(
+                                            Long.MAX_VALUE,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.snapshot(cp++, time++);
+                            testHarness.snapshot(cp, time);
+                        })
+                .doesNotThrowAnyException();
+
+        Assertions.assertThat(
+                        ((ManifestCommittable)
+                                        ((CommitterOperator) operator)
+                                                .committablesPerCheckpoint.get(Long.MAX_VALUE))
+                                .fileCommittables()
+                                .size())
+                .isEqualTo(3);
+
+        Assertions.assertThatCode(
+                        () -> {
+                            long time = System.currentTimeMillis();
+                            long cp = 0L;
+                            testHarness.processElement(
+                                    new Committable(
+                                            0L,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.snapshot(cp++, time++);
+                            testHarness.processElement(
+                                    new Committable(
+                                            0L,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.processElement(
+                                    new Committable(
+                                            Long.MAX_VALUE,
+                                            Committable.Kind.FILE,
+                                            new CommitMessageImpl(
+                                                    BinaryRow.EMPTY_ROW,
+                                                    0,
+                                                    new NewFilesIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()),
+                                                    new CompactIncrement(
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList()))),
+                                    cp);
+                            testHarness.snapshot(cp++, time++);
+                            testHarness.snapshot(cp, time);
+                        })
+                .hasRootCauseInstanceOf(RuntimeException.class)
+                .cause()
+                .hasMessageContaining("Repeatedly commit the same checkpoint files.");
     }
 
     private static OperatorSubtaskState writeAndSnapshot(


### PR DESCRIPTION

### Purpose

Stop call end input if streaming checkpoint enabled. Because prepareCheckpointBarrier will handle the last checkpoint method.

Do as `CommitterOperator`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
