### PR TITLE
[flink] Support source reader metrics when consumer-id is set

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -359,6 +359,10 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
     </tbody>
 </table>
 
+{{< hint info >}}
+Please note that if you specified `consumer-id` in your streaming query, the level of source metrics should turn into the reader operator, which is behind the `Monitor` operator.
+{{< /hint >}}
+
 #### Sink Metrics (Flink)
 
 <table class="table table-bordered">


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2466 

### Tests

OperatorSourceTest#testReadOperatorMetricsRegisterAndUpdate

