### PR TITLE
[cdc] Fix bug that computed columns work abnormally with case-insensitive

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -220,7 +220,7 @@ public class CdcActionCommonUtils {
             for (String key : specifiedPrimaryKeys) {
                 checkArgument(
                         sourceColumns.contains(key),
-                        "Specified primary '%s' does not exist in source tables or computed columns.",
+                        "Specified primary key '%s' does not exist in source tables or computed columns.",
                         key);
             }
             builder.primaryKey(listCaseConvert(specifiedPrimaryKeys, caseSensitive));

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.action.cdc;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,12 @@ public class ComputedColumnUtils {
 
     public static List<ComputedColumn> buildComputedColumns(
             List<String> computedColumnArgs, List<DataField> physicFields) {
+        return buildComputedColumns(computedColumnArgs, physicFields, true);
+    }
+
+    /** The caseSensitive only affects check. We don't change field names at building phase. */
+    public static List<ComputedColumn> buildComputedColumns(
+            List<String> computedColumnArgs, List<DataField> physicFields, boolean caseSensitive) {
         Map<String, DataType> typeMapping =
                 physicFields.stream()
                         .collect(
@@ -67,11 +74,13 @@ public class ComputedColumnUtils {
             String fieldReference = args[0].trim();
             String[] literals =
                     Arrays.stream(args).skip(1).map(String::trim).toArray(String[]::new);
+            String fieldReferenceCheckForm =
+                    StringUtils.caseSensitiveConversion(fieldReference, caseSensitive);
             checkArgument(
-                    typeMapping.containsKey(fieldReference),
+                    typeMapping.containsKey(fieldReferenceCheckForm),
                     String.format(
                             "Referenced field '%s' is not in given fields: %s.",
-                            fieldReference, typeMapping.keySet()));
+                            fieldReferenceCheckForm, typeMapping.keySet()));
 
             computedColumns.add(
                     new ComputedColumn(

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
@@ -72,12 +72,14 @@ public abstract class MessageQueueSyncTableActionBase extends SyncTableActionBas
     @Override
     protected Schema buildPaimonSchema(Schema retrievedSchema) {
         return CdcActionCommonUtils.buildPaimonSchema(
+                table,
                 partitionKeys,
                 primaryKeys,
                 computedColumns,
                 tableConfig,
                 retrievedSchema,
                 metadataConverters,
+                caseSensitive,
                 false);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
@@ -65,7 +65,7 @@ public class MongoDBSyncTableAction extends SyncTableActionBase {
 
     @Override
     protected Schema retrieveSchema() {
-        return MongodbSchemaUtils.getMongodbSchema(cdcSourceConfig, caseSensitive);
+        return MongodbSchemaUtils.getMongodbSchema(cdcSourceConfig);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -88,8 +88,7 @@ public class MySqlActionUtils {
             Configuration mySqlConfig,
             Predicate<String> monitorTablePredication,
             List<Identifier> excludedTables,
-            TypeMapping typeMapping,
-            boolean caseSensitive)
+            TypeMapping typeMapping)
             throws Exception {
         Pattern databasePattern =
                 Pattern.compile(mySqlConfig.get(MySqlSourceOptions.DATABASE_NAME));
@@ -113,8 +112,7 @@ public class MySqlActionUtils {
                                                 databaseName,
                                                 tableName,
                                                 tableComment,
-                                                typeMapping,
-                                                caseSensitive);
+                                                typeMapping);
                                 Identifier identifier = Identifier.create(databaseName, tableName);
                                 if (monitorTablePredication.test(tableName)) {
                                     mySqlSchemasInfo.addSchema(identifier, schema);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -122,7 +122,6 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
 
     @Override
     protected void beforeBuildingSourceSink() throws Exception {
-        boolean caseSensitive = catalog.caseSensitive();
         Pattern includingPattern = Pattern.compile(includingTables);
         Pattern excludingPattern =
                 excludingTables == null ? null : Pattern.compile(excludingTables);
@@ -132,8 +131,7 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
                         tableName ->
                                 shouldMonitorTable(tableName, includingPattern, excludingPattern),
                         excludedTables,
-                        typeMapping,
-                        caseSensitive);
+                        typeMapping);
 
         logNonPkTables(mySqlSchemasInfo.nonPkTables());
         List<MySqlTableInfo> mySqlTableInfos = mySqlSchemasInfo.toMySqlTableInfos(mergeShards);
@@ -153,12 +151,14 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
             FileStoreTable table;
             Schema fromMySql =
                     CdcActionCommonUtils.buildPaimonSchema(
+                            identifier.getFullName(),
                             Collections.emptyList(),
                             Collections.emptyList(),
                             Collections.emptyList(),
                             tableConfig,
                             tableInfo.schema(),
                             metadataConverters,
+                            caseSensitive,
                             true);
             try {
                 table = (FileStoreTable) catalog.getTable(identifier);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -99,11 +99,7 @@ public class MySqlSyncTableAction extends SyncTableActionBase {
     protected Schema retrieveSchema() throws Exception {
         this.mySqlSchemasInfo =
                 MySqlActionUtils.getMySqlTableInfos(
-                        cdcSourceConfig,
-                        monitorTablePredication(),
-                        new ArrayList<>(),
-                        typeMapping,
-                        caseSensitive);
+                        cdcSourceConfig, monitorTablePredication(), new ArrayList<>(), typeMapping);
         validateMySqlTableInfos(mySqlSchemasInfo);
         MySqlTableInfo tableInfo = mySqlSchemasInfo.mergeAll();
         return tableInfo.schema();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -55,7 +55,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -239,32 +238,7 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
             extends SyncTableActionBuilder<KafkaSyncTableAction> {
 
         public KafkaSyncTableActionBuilder(Map<String, String> kafkaConfig) {
-            super(kafkaConfig);
-        }
-
-        public KafkaSyncTableAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "kafka_sync_table",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database,
-                                    "--table",
-                                    tableName));
-
-            args.addAll(mapToArgs("--kafka-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(listToArgs("--partition-keys", partitionKeys));
-            args.addAll(listToArgs("--primary-keys", primaryKeys));
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-
-            args.addAll(listToMultiArgs("--computed-column", computedColumnArgs));
-
-            return createAction(KafkaSyncTableAction.class, args);
+            super(KafkaSyncTableAction.class, kafkaConfig);
         }
     }
 
@@ -273,43 +247,7 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
             extends SyncDatabaseActionBuilder<KafkaSyncDatabaseAction> {
 
         public KafkaSyncDatabaseActionBuilder(Map<String, String> kafkaConfig) {
-            super(kafkaConfig);
-        }
-
-        public KafkaSyncDatabaseActionBuilder ignoreIncompatible(boolean ignoreIncompatible) {
-            throw new UnsupportedOperationException();
-        }
-
-        public KafkaSyncDatabaseActionBuilder mergeShards(boolean mergeShards) {
-            throw new UnsupportedOperationException();
-        }
-
-        public KafkaSyncDatabaseActionBuilder withMode(String mode) {
-            throw new UnsupportedOperationException();
-        }
-
-        public KafkaSyncDatabaseAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "kafka_sync_database",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database));
-
-            args.addAll(mapToArgs("--kafka-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(nullableToArgs("--table-prefix", tablePrefix));
-            args.addAll(nullableToArgs("--table-suffix", tableSuffix));
-            args.addAll(nullableToArgs("--including-tables", includingTables));
-            args.addAll(nullableToArgs("--excluding-tables", excludingTables));
-
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-
-            return createAction(KafkaSyncDatabaseAction.class, args);
+            super(KafkaSyncDatabaseAction.class, kafkaConfig);
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionITCaseBase.java
@@ -30,10 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -95,37 +92,7 @@ public abstract class MongoDBActionITCaseBase extends CdcActionITCaseBase {
             extends SyncTableActionBuilder<MongoDBSyncTableAction> {
 
         public MongoDBSyncTableActionBuilder(Map<String, String> mongodbConfig) {
-            super(mongodbConfig);
-        }
-
-        public MongoDBSyncTableActionBuilder withPrimaryKeys(String... primaryKeys) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncTableActionBuilder withTypeMappingModes(String... typeMappingModes) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncTableAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "mongodb_sync_table",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database,
-                                    "--table",
-                                    tableName));
-
-            args.addAll(mapToArgs("--mongodb-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-            args.addAll(listToArgs("--computed-column", computedColumnArgs));
-
-            args.addAll(listToArgs("--partition-keys", partitionKeys));
-
-            return createAction(MongoDBSyncTableAction.class, args);
+            super(MongoDBSyncTableAction.class, mongodbConfig);
         }
     }
 
@@ -134,45 +101,7 @@ public abstract class MongoDBActionITCaseBase extends CdcActionITCaseBase {
             extends SyncDatabaseActionBuilder<MongoDBSyncDatabaseAction> {
 
         public MongoDBSyncDatabaseActionBuilder(Map<String, String> mongodbConfig) {
-            super(mongodbConfig);
-        }
-
-        public MongoDBSyncDatabaseActionBuilder ignoreIncompatible(boolean ignoreIncompatible) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncDatabaseActionBuilder mergeShards(boolean mergeShards) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncDatabaseActionBuilder withMode(String mode) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncDatabaseActionBuilder withTypeMappingModes(String... typeMappingModes) {
-            throw new UnsupportedOperationException();
-        }
-
-        public MongoDBSyncDatabaseAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "mongodb_sync_database",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database));
-
-            args.addAll(mapToArgs("--mongodb-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(nullableToArgs("--table-prefix", tablePrefix));
-            args.addAll(nullableToArgs("--table-suffix", tableSuffix));
-            args.addAll(nullableToArgs("--including-tables", includingTables));
-            args.addAll(nullableToArgs("--excluding-tables", excludingTables));
-
-            return createAction(MongoDBSyncDatabaseAction.class, args);
+            super(MongoDBSyncDatabaseAction.class, mongodbConfig);
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongodbSchemaITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongodbSchemaITCase.java
@@ -83,7 +83,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.setString(MongoDBSourceOptions.CONNECTION_OPTIONS, "authSource=admin");
         mongodbConfig.setString(MongoDBSourceOptions.DATABASE, "testDatabase");
         mongodbConfig.setString(MongoDBSourceOptions.COLLECTION, "testCollection");
-        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true);
+        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig);
         assertNotNull(schema);
     }
 
@@ -99,8 +99,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.setString(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         assertThrows(
-                RuntimeException.class,
-                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true));
+                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -111,7 +110,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         // Expect an exception to be thrown due to missing necessary settings
         assertThrows(
                 NullPointerException.class,
-                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true));
+                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -127,7 +126,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.setString(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         // Call the method and check the results
-        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true);
+        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig);
 
         // Verify the schema
         assertNotNull(schema);
@@ -152,8 +151,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.setString(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         assertThrows(
-                RuntimeException.class,
-                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true));
+                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -168,7 +166,6 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.setString(MongoDBSourceOptions.COLLECTION, "invalidCollection");
 
         assertThrows(
-                RuntimeException.class,
-                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig, true));
+                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionITCaseBase.java
@@ -31,10 +31,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -104,33 +101,7 @@ public class MySqlActionITCaseBase extends CdcActionITCaseBase {
             extends SyncTableActionBuilder<MySqlSyncTableAction> {
 
         public MySqlSyncTableActionBuilder(Map<String, String> mySqlConfig) {
-            super(mySqlConfig);
-        }
-
-        public MySqlSyncTableAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "mysql_sync_table",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database,
-                                    "--table",
-                                    tableName));
-
-            args.addAll(mapToArgs("--mysql-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(listToArgs("--partition-keys", partitionKeys));
-            args.addAll(listToArgs("--primary-keys", primaryKeys));
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-
-            args.addAll(listToMultiArgs("--computed-column", computedColumnArgs));
-            args.addAll(listToMultiArgs("--metadata-column", metadataColumns));
-
-            return createAction(MySqlSyncTableAction.class, args);
+            super(MySqlSyncTableAction.class, mySqlConfig);
         }
     }
 
@@ -139,35 +110,7 @@ public class MySqlActionITCaseBase extends CdcActionITCaseBase {
             extends SyncDatabaseActionBuilder<MySqlSyncDatabaseAction> {
 
         public MySqlSyncDatabaseActionBuilder(Map<String, String> mySqlConfig) {
-            super(mySqlConfig);
-        }
-
-        public MySqlSyncDatabaseAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "mysql_sync_database",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database));
-
-            args.addAll(mapToArgs("--mysql-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(nullableToArgs("--ignore-incompatible", ignoreIncompatible));
-            args.addAll(nullableToArgs("--merge-shards", mergeShards));
-            args.addAll(nullableToArgs("--table-prefix", tablePrefix));
-            args.addAll(nullableToArgs("--table-suffix", tableSuffix));
-            args.addAll(nullableToArgs("--including-tables", includingTables));
-            args.addAll(nullableToArgs("--excluding-tables", excludingTables));
-            args.addAll(nullableToArgs("--mode", mode));
-
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-            args.addAll(listToArgs("--metadata-column", metadataColumn));
-
-            return createAction(MySqlSyncDatabaseAction.class, args);
+            super(MySqlSyncDatabaseAction.class, mySqlConfig);
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/pulsar/PulsarActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/pulsar/PulsarActionITCaseBase.java
@@ -48,7 +48,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -269,32 +268,7 @@ public class PulsarActionITCaseBase extends CdcActionITCaseBase {
             extends SyncTableActionBuilder<PulsarSyncTableAction> {
 
         public PulsarSyncTableActionBuilder(Map<String, String> pulsarConfig) {
-            super(pulsarConfig);
-        }
-
-        public PulsarSyncTableAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "pulsar_sync_table",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database,
-                                    "--table",
-                                    tableName));
-
-            args.addAll(mapToArgs("--pulsar-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(listToArgs("--partition-keys", partitionKeys));
-            args.addAll(listToArgs("--primary-keys", primaryKeys));
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-
-            args.addAll(listToMultiArgs("--computed-column", computedColumnArgs));
-
-            return createAction(PulsarSyncTableAction.class, args);
+            super(PulsarSyncTableAction.class, pulsarConfig);
         }
     }
 
@@ -303,43 +277,7 @@ public class PulsarActionITCaseBase extends CdcActionITCaseBase {
             extends SyncDatabaseActionBuilder<PulsarSyncDatabaseAction> {
 
         public PulsarSyncDatabaseActionBuilder(Map<String, String> pulsarConfig) {
-            super(pulsarConfig);
-        }
-
-        public PulsarSyncDatabaseActionBuilder ignoreIncompatible(boolean ignoreIncompatible) {
-            throw new UnsupportedOperationException();
-        }
-
-        public PulsarSyncDatabaseActionBuilder mergeShards(boolean mergeShards) {
-            throw new UnsupportedOperationException();
-        }
-
-        public PulsarSyncDatabaseActionBuilder withMode(String mode) {
-            throw new UnsupportedOperationException();
-        }
-
-        public PulsarSyncDatabaseAction build() {
-            List<String> args =
-                    new ArrayList<>(
-                            Arrays.asList(
-                                    "pulsar_sync_database",
-                                    "--warehouse",
-                                    warehouse,
-                                    "--database",
-                                    database));
-
-            args.addAll(mapToArgs("--pulsar-conf", sourceConfig));
-            args.addAll(mapToArgs("--catalog-conf", catalogConfig));
-            args.addAll(mapToArgs("--table-conf", tableConfig));
-
-            args.addAll(nullableToArgs("--table-prefix", tablePrefix));
-            args.addAll(nullableToArgs("--table-suffix", tableSuffix));
-            args.addAll(nullableToArgs("--including-tables", includingTables));
-            args.addAll(nullableToArgs("--excluding-tables", excludingTables));
-
-            args.addAll(listToArgs("--type-mapping", typeMappingModes));
-
-            return createAction(PulsarSyncDatabaseAction.class, args);
+            super(PulsarSyncDatabaseAction.class, pulsarConfig);
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/computedcolumn/canal-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/table/computedcolumn/canal-data-2.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"_ID":"1","_DATE":"2023-03-23"},{"_ID":"2","_DATE":null}],"database":"paimon_sync_table","es":1683006706000,"id":92,"isDdl":false,"mysqlType":{"_ID":"INT","_DATE":"DATE"},"old":null,"pkNames":["_ID"],"sql":"","sqlType":{"_ID":4,"_DATE":91},"table":"computed_column_with_case_insensitive","ts":1683006706728,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mongodb/table/computedcolumn/test-table-2.js
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mongodb/table/computedcolumn/test-table-2.js
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+//  -- this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+db.getCollection('computed_column_with_case_insensitive').insertMany([
+    {
+        "_id": ObjectId("100000000000000000000101"),
+        "_DATE": "2023-12-11"
+    },
+    {
+        "_id": ObjectId("100000000000000000000102")
+    }
+]);

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
@@ -348,3 +348,30 @@ CREATE TABLE t (
     v VARCHAR(10),
     PRIMARY KEY (pk)
 );
+
+-- ################################################################################
+--  testComputedColumnWithCaseInsensitive
+-- ################################################################################
+
+CREATE DATABASE computed_column_with_case_insensitive;
+USE computed_column_with_case_insensitive;
+
+CREATE TABLE t (
+    PK INT,
+    UPPERCASE_STRING VARCHAR(10),
+    PRIMARY KEY (pk)
+);
+
+-- ################################################################################
+--  testSpecifyKeysWithCaseInsensitive
+-- ################################################################################
+
+CREATE DATABASE specify_key_with_case_insensitive;
+USE specify_key_with_case_insensitive;
+
+CREATE TABLE t (
+    ID0 INT,
+    ID1 INT,
+    PART INT,
+    PRIMARY KEY (ID0)
+);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We cannot retrieve schema with case sensitive because the computed columns rely on the original schema. 
I refactor the flow: 
1. case-sensitive is not involved in the validation, schema retrieving and computed columns building phases; 
2. building Paimon schema uses case-sensitive;
3. when parsing records, first we parse all field and evaluate all computed columns, and then we apply case-sensitive conversion.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
`KafkaCanalSyncTableActionITCase#testComputedColumnWithCaseInsensitive`
`MongoDBSyncTableActionITCase#testComputedColumnWithCaseInsensitive`
`MySqlSyncTableActionITCase#testComputedColumnWithCaseInsensitive`
`MySqlSyncTableActionITCase#testSpecifyKeysWithCaseInsensitive`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
