### PR TITLE
[spark] Add hashcode for PaimonBatch

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
@@ -82,6 +82,11 @@ public class CompoundPredicate implements Predicate {
         return Objects.equals(function, that.function) && Objects.equals(children, that.children);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(function, children);
+    }
+
     /** Evaluate the predicate result based on multiple {@link Predicate}s. */
     public abstract static class Function implements Serializable {
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/RawFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/RawFile.java
@@ -120,6 +120,11 @@ public class RawFile {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(path, offset, length, format, schemaId);
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "{path = %s, offset = %d, length = %d, format = %s, schemaId = %d}",

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartition.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInputPartition.java
@@ -22,6 +22,8 @@ import org.apache.paimon.table.source.Split;
 
 import org.apache.spark.sql.connector.read.InputPartition;
 
+import java.util.Objects;
+
 /** A Spark {@link InputPartition} for paimon. */
 public class SparkInputPartition implements InputPartition {
 
@@ -49,5 +51,10 @@ public class SparkInputPartition implements InputPartition {
 
         SparkInputPartition that = (SparkInputPartition) o;
         return this.split.equals(that.split);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(split);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkReaderFactory.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkReaderFactory.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 
 import static org.apache.paimon.spark.SparkUtils.createIOManager;
 
@@ -74,5 +75,10 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
         SparkReaderFactory that = (SparkReaderFactory) o;
         return this.readBuilder.equals(that.readBuilder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(readBuilder);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBatch.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBatch.scala
@@ -21,7 +21,9 @@ import org.apache.paimon.table.source.{ReadBuilder, Split}
 
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
 
-/** A Spark {@link Batch} for paimon. */
+import java.util.Objects
+
+/** A Spark [[Batch]] for paimon. */
 case class PaimonBatch(splits: Array[Split], readBuilder: ReadBuilder) extends Batch {
 
   override def planInputPartitions(): Array[InputPartition] =
@@ -37,5 +39,9 @@ case class PaimonBatch(splits: Array[Split], readBuilder: ReadBuilder) extends B
 
       case _ => false
     }
+  }
+
+  override def hashCode(): Int = {
+    Objects.hashCode(splits.toSeq, readBuilder)
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In `AdaptiveSparkPlanExec`  spark will use TrieMap to cache sparkplan, we need to add hashcode and equals for `PaimonBatch` for plan reuse

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
