### PR TITLE
[hive] add table_type parameter for hive db

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -95,6 +95,9 @@ public class HiveCatalog extends AbstractCatalog {
 
     // we don't include paimon-hive-connector as dependencies because it depends on
     // hive-exec
+    public static final String TABLE_TYPE_PROP = "table_type";
+    public static final String PAIMON_TABLE_TYPE_VALUE = "paimon";
+
     private static final String INPUT_FORMAT_CLASS_NAME =
             "org.apache.paimon.hive.mapred.PaimonInputFormat";
     private static final String OUTPUT_FORMAT_CLASS_NAME =
@@ -459,6 +462,7 @@ public class HiveCatalog extends AbstractCatalog {
                         null,
                         null,
                         tableType.toString().toUpperCase(Locale.ROOT) + "_TABLE");
+        table.getParameters().put(TABLE_TYPE_PROP, PAIMON_TABLE_TYPE_VALUE.toUpperCase());
         table.getParameters()
                 .put(hive_metastoreConstants.META_TABLE_STORAGE, STORAGE_HANDLER_CLASS_NAME);
         if (TableType.EXTERNAL.equals(tableType)) {

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -42,10 +42,13 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY;
+import static org.apache.paimon.hive.HiveCatalog.PAIMON_TABLE_TYPE_VALUE;
+import static org.apache.paimon.hive.HiveCatalog.TABLE_TYPE_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -207,6 +210,9 @@ public class HiveCatalogTest extends CatalogTestBase {
             // Verify the transformed parameters
             assertThat(tableProperties).containsEntry("table.owner", "Jon");
             assertThat(tableProperties).containsEntry("storage.format", "ORC");
+            assertThat(tableProperties)
+                    .containsEntry(
+                            TABLE_TYPE_PROP, PAIMON_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT));
         } catch (Exception e) {
             fail("Test failed due to exception: " + e.getMessage());
         }


### PR DESCRIPTION
Add `table_type` parameter to hive database to distinguish `paimon` and `iceberg` tables.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
`HiveCatalogTest::testAddHiveTableParameters`

### API and Format

<!-- Does this change affect API or storage format -->
None.

### Documentation

<!-- Does this change introduce a new feature -->
None.
