### PR TITLE
[docs] Fix docs confusing point about catalog create

### DIFF
--- a/docs/content/api/flink-api.md
+++ b/docs/content/api/flink-api.md
@@ -199,7 +199,7 @@ public class WriteCdcToTable {
         
         new RichCdcSinkBuilder()
                 .withInput(dataStream)
-                .withTable(createTableIfNotExists(identifier))
+                .withTable(createTableIfNotExists(catalogLoader.load(), identifier))
                 .withIdentifier(identifier)
                 .withCatalogLoader(catalogLoader)
                 .build();
@@ -207,10 +207,7 @@ public class WriteCdcToTable {
         env.execute();
     }
 
-    private static Table createTableIfNotExists(Identifier identifier) throws Exception {
-        CatalogContext context = CatalogContext.create(new Path("..."));
-        Catalog catalog = CatalogFactory.createCatalog(context);
-
+    private static Table createTableIfNotExists(Catalog catalog, Identifier identifier) throws Exception {
         Schema.Builder schemaBuilder = Schema.newBuilder();
         schemaBuilder.primaryKey("order_id");
         schemaBuilder.column("order_id", DataTypes.BIGINT());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Doc code is confusing, there is no need to create catalog in two different methods in two different ways.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
