### PR TITLE
[fs] HadoopFileIO should cache FileSystem by scheme and authority

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/fs/HadoopLocalFileIOBehaviorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/HadoopLocalFileIOBehaviorTest.java
@@ -39,7 +39,7 @@ class HadoopLocalFileIOBehaviorTest extends FileIOBehaviorTestBase {
         org.apache.hadoop.fs.FileSystem fs = new RawLocalFileSystem();
         fs.initialize(URI.create("file:///"), new Configuration());
         HadoopFileIO fileIO = new HadoopFileIO();
-        fileIO.setFileSystem(fs);
+        fileIO.setFileSystem(getBasePath(), fs);
         return fileIO;
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fs/HdfsBehaviorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/HdfsBehaviorTest.java
@@ -60,10 +60,10 @@ class HdfsBehaviorTest extends FileIOBehaviorTestBase {
         hdfsCluster = builder.build();
 
         org.apache.hadoop.fs.FileSystem hdfs = hdfsCluster.getFileSystem();
-        fs = new HadoopFileIO();
-        fs.setFileSystem(hdfs);
 
         basePath = new Path(hdfs.getUri().toString() + "/tests");
+        fs = new HadoopFileIO();
+        fs.setFileSystem(basePath, hdfs);
     }
 
     @AfterAll

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/HadoopCompliantFileIO.java
@@ -118,6 +118,9 @@ public abstract class HadoopCompliantFileIO implements FileIO {
         Map<String, FileSystem> map = fsMap;
 
         String authority = path.toUri().getAuthority();
+        if (authority == null) {
+            authority = "DEFAULT";
+        }
         FileSystem fs = map.get(authority);
         if (fs == null) {
             fs = createFileSystem(path);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
for example, hdfs and viewfs should have different FileSystem classes.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
