### PR TITLE
[core] Lazy deserialize hive conf in metastoreClientFactory

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/SerializableHiveConfTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/SerializableHiveConfTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SerializableHiveConf}. */
+public class SerializableHiveConfTest {
+    @Test
+    public void testSerializeHiveConf() throws IOException, ClassNotFoundException {
+        HiveConf conf = new HiveConf();
+        conf.set("k1", "v1");
+        conf.set("k2", "v2");
+        int size = conf.size();
+        SerializableHiveConf serializableHiveConf = new SerializableHiveConf(conf);
+
+        // serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(serializableHiveConf);
+        oos.close();
+
+        // deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        SerializableHiveConf deserializedHiveConf = (SerializableHiveConf) ois.readObject();
+        ois.close();
+
+        HiveConf deserializedConf = deserializedHiveConf.conf();
+        assertThat(deserializedConf.size()).isEqualTo(size);
+        assertThat(deserializedConf.get("k1")).isEqualTo("v1");
+        assertThat(deserializedConf.get("k2")).isEqualTo("v2");
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

As distributed open read API, `ReadBuilder` supports serialization to each task, and `Table` inside it also support serialization.

During tpcds test, we found that the `hiveConf`'s serialization in `Table/CatalogEnvironment/metastoreClientFactory` was very time-consuming. 

`CatalogEnvironment` is only used by table commit (driver side), in theory it does not need to be serialized, but flink relies it now.

Since there is currently no good way to separate it from the `Table`,  this PR proposes a lazy serialization solution, with it, the spark tpcds result increased by 15%+

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
