### PR TITLE
[core] Add auto increase sequence padding

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -489,7 +489,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>sequence.auto-padding</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specify the way of padding precision, if the provided sequence field is used to indicate "time" but doesn't meet the precise.<ul><li>You can specific:</li><li>1. "row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>2. "second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>3. "millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li><li>4. Composite pattern: for example, "second-to-micro,row-kind-flag".</li></ul></td>
+            <td>Specify the way of padding precision, if the provided sequence field is used to indicate "time" but doesn't meet the precise.<ul><li>You can specific:</li><li>1. "row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>2. "second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>3. "millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li><li>4. "inc-seq": Pads the sequence field with auto increase sequence.</li><li>5. Composite pattern: for example, "second-to-micro,row-kind-flag".</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence.field</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -459,7 +459,9 @@ public class CoreOptions implements Serializable {
                                             text(
                                                     "3. \"millis-to-micro\": Pads the sequence field that indicates time with precision of milli-second to micro-second."),
                                             text(
-                                                    "4. Composite pattern: for example, \"second-to-micro,row-kind-flag\"."))
+                                                    "4. \"inc-seq\": Pads the sequence field with auto increase sequence."),
+                                            text(
+                                                    "5. Composite pattern: for example, \"second-to-micro,row-kind-flag\"."))
                                     .build());
 
     public static final ConfigOption<StartupMode> SCAN_MODE =
@@ -1338,6 +1340,10 @@ public class CoreOptions implements Serializable {
         return Arrays.asList(padding.split(","));
     }
 
+    public boolean incSeqPadding() {
+        return SequenceAutoPadding.INC_SEQ.value.equals(options.get(SEQUENCE_AUTO_PADDING));
+    }
+
     public boolean writeOnly() {
         return options.get(WRITE_ONLY);
     }
@@ -1933,7 +1939,8 @@ public class CoreOptions implements Serializable {
                 "Pads the sequence field that indicates time with precision of seconds to micro-second."),
         MILLIS_TO_MICRO(
                 "millis-to-micro",
-                "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
+                "Pads the sequence field that indicates time with precision of milli-second to micro-second."),
+        INC_SEQ("inc-seq", "Pads the sequence field with auto increase sequence.");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -176,7 +176,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 options.commitForceCompact(),
                 options.changelogProducer(),
                 restoreIncrement,
-                getWriterMetrics(partition, bucket));
+                getWriterMetrics(partition, bucket),
+                options.incSeqPadding());
     }
 
     @VisibleForTesting

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -425,7 +425,8 @@ public abstract class MergeTreeTestBase {
                         options.commitForceCompact(),
                         ChangelogProducer.NONE,
                         null,
-                        null);
+                        null,
+                        false);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
         return writer;

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.paimon.CoreOptions.SequenceAutoPadding.INC_SEQ;
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO;
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.ROW_KIND_FLAG;
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO;
@@ -236,6 +237,23 @@ public class SequenceGeneratorTest {
                 .isBetween(2001L, 3999L);
         assertThat(generateWithPaddingOnMicrosAndRowKind(1L, RowKind.UPDATE_BEFORE))
                 .isBetween(2000L, 3998L);
+    }
+
+    @Test
+    public void testGenerateWithIncSeq() {
+        GenericRow genericRow =
+                GenericRow.of(
+                        1,
+                        Timestamp.fromEpochMillis(4294967295000L) /* max ts 2106-02-07T06:28:15 */);
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.TIMESTAMP(0)},
+                        new String[] {"id", "ts"});
+
+        assertThat(
+                        new SequenceGenerator("ts", rowType, Collections.singletonList(INC_SEQ))
+                                .generate(genericRow))
+                .isEqualTo(4294967295L);
     }
 
     private SequenceGenerator getGenerator(String field) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2471

Add a new seq pad mode `inc-seq`, pads the sequence field with auto increase sequence, to solve the following problems: 

When user defines `sequence.field`
1. For the same seq (for example, `sequence.field` is timestamp of second, and records in the same second), the order of records cannot be determined.
2. When performing row level changes, `sequence.field` must be the same, and its order cannot be guaranteed.

A better solution is to introduce a new comparison field, this PR is a trade-off, it reuses the `_SEQUENCE_NUMBER` and divides it into two parts: one part stores the auto-increment sequence (upper 32-bits) and the other part stores the user-defined `sequence.field` (transform to long) (lower 32-bits).

Notice !!!
1. Since we only use 32-bits to store user seq, it will be truncated to 32 bits. This will result in loss of accuracy, e.g. for timestamp, only second accuracy is supported, and supports up to 2106-02-07T06:28:15
2. The upper limit of the auto-increment sequence length is 32 bits.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
