### PR TITLE
[flink] fix bug for `show partitions` with date and time type

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -33,6 +33,10 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.RowDataPartitionComputer;
@@ -864,6 +868,26 @@ public class FlinkCatalog extends AbstractCatalog {
                                                 Preconditions.checkNotNull(
                                                         m,
                                                         "Partition row data is null. This is unexpected."));
+
+                                partValues.forEach(
+                                        (k, v) -> {
+                                            DataType dataType =
+                                                    partitionRowType.getTypeAt(
+                                                            partitionRowType.getFieldIndex(k));
+                                            if (dataType instanceof DateType) {
+                                                partValues.put(
+                                                        k,
+                                                        DateTimeUtils.toLocalDate(
+                                                                        Integer.parseInt(v))
+                                                                .toString());
+                                            } else if (dataType instanceof TimeType) {
+                                                partValues.put(
+                                                        k,
+                                                        DateTimeUtils.toLocalTime(
+                                                                        Integer.parseInt(v))
+                                                                .toString());
+                                            }
+                                        });
                                 return new CatalogPartitionSpec(partValues);
                             })
                     .collect(Collectors.toList());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -453,6 +453,20 @@ public class CatalogTableITCase extends CatalogITCaseBase {
 
         result = sql("SHOW PARTITIONS PartitionTable partition (dt='2020-01-02', hh='11')");
         assertThat(result.toString()).isEqualTo("[+I[dt=2020-01-02/hh=11]]");
+
+        // with date and time type
+        sql(
+                "CREATE TABLE PartitionTableDate (\n"
+                        + "    user_id BIGINT,\n"
+                        + "    item_id BIGINT,\n"
+                        + "    behavior STRING,\n"
+                        + "    dt DATE,\n"
+                        + "    hh TIME,\n"
+                        + "    PRIMARY KEY (dt, hh, user_id) NOT ENFORCED\n"
+                        + ") PARTITIONED BY (dt, hh)");
+        sql("INSERT INTO PartitionTableDate select 1,1,'a',DATE '2020-01-01',TIME '10:11:12'");
+        result = sql("SHOW PARTITIONS PartitionTableDate");
+        assertThat(result.toString()).isEqualTo("[+I[dt=2020-01-01/hh=10:11:12]]");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
now ,`show partitions` with date type partition will show number, we should show correct date format.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
