### PR TITLE
[filesystem] Correct the gson dependency after rolling back from jindo sdk to oss sdk

### DIFF
--- a/paimon-filesystems/paimon-hadoop-shaded/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-shaded/pom.xml
@@ -151,6 +151,10 @@
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>

--- a/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-core:4.5.10
 - com.aliyun:aliyun-java-sdk-kms:2.11.0
 - com.aliyun:aliyun-java-sdk-ram:3.1.0
-- com.google.code.gson:gson:2.8.9
+- com.google.code.gson:gson:2.8.6
 - commons-codec:commons-codec:1.9
 - commons-logging:commons-logging:1.1.3
 - io.opentracing:opentracing-api:0.33.0


### PR DESCRIPTION
### Purpose

When rolling back oss sdk from jindo sdk to the old one through #2435 we missed to roll back the gson related dependency, and this PR aims to fix this up. More details refer to #2290 

### Tests

Manually test and make sure the `META-INF/NOTICE` file correctly reflect the dependencies of the `paimon-filesystems/paimon-oss-impl` and `paimon-filesystems/paimon-hadoop-shaded` modules.

### API and Format

No API or storage format change involved.

### Documentation

No documentation required.
