### PR TITLE
[license] Fix license in paimon-hadoop-shaded, paimon-oss and paimon-s3 modules

### DIFF
--- a/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
+- com.fasterxml.jackson.core:jackson-annotations:2.12.7
+- com.fasterxml.jackson.core:jackson-core:2.12.7
+- com.fasterxml.jackson.core:jackson-databind:2.12.7
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
@@ -16,12 +16,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.8.0
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
-- org.apache.commons:commons-text:1.10.0
+- org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4
@@ -31,13 +31,15 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.3
+- org.xerial.snappy:snappy-java:1.1.8.2
+- com.google.code.findbugs:jsr305:1.3.9
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT).
 You find them under licenses/LICENSE.checker-framework-qualifiers and licenses/LICENSE.animal-sniffer.
 
 - org.checkerframework:checker-qual:2.5.2
 - org.codehaus.mojo:animal-sniffer-annotations:1.17
+- org.slf4j:slf4j-api:1.7.32
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 You find it under licenses/LICENSE.dnsjava.
@@ -53,3 +55,8 @@ This project bundles the following dependencies under BSD License (https://opens
 You find it under licenses/LICENSE.stax2api.
 
 - org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
+
+This project bundles the following dependencies under the Eclipse Distribution License - v 1.0
+You find it under licenses/LICENSE.jakarta
+
+- jakarta.activation:jakarta.activation-api:1.2.1

--- a/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/licenses/LICENSE.jakarta
+++ b/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/licenses/LICENSE.jakarta
@@ -1,0 +1,28 @@
+Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/paimon-filesystems/paimon-oss/pom.xml
+++ b/paimon-filesystems/paimon-oss/pom.xml
@@ -75,6 +75,16 @@
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/classes/paimon-plugin-oss</outputDirectory>
+                                    <excludes>META-INF/**</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.paimon</groupId>
+                                    <artifactId>paimon-oss-impl</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes/paimon-plugin-oss</outputDirectory>
+                                    <includes>META-INF/services/**,META-INF/versions/**</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/paimon-filesystems/paimon-s3/pom.xml
+++ b/paimon-filesystems/paimon-s3/pom.xml
@@ -113,6 +113,16 @@
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/classes/paimon-plugin-s3</outputDirectory>
+                                    <excludes>META-INF/**</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.paimon</groupId>
+                                    <artifactId>paimon-s3-impl</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes/paimon-plugin-s3</outputDirectory>
+                                    <includes>META-INF/services/**,META-INF/versions/**</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>


### PR DESCRIPTION
### Purpose

This PR fixes #2468 by the following:

* Add missing dependencies in the NOTICE file of paimon-hadoop-shaded module. (paimon-hadoop-shaded is merely an intermediate build artifact and it is not be deployed to maven central)
* Remove license related files from the nested META-INF directory of paimon-oss and paimon-s3 modules.

<!-- What is the purpose of the change -->

### Tests

Tested by hand.

### API and Format

No.

### Documentation

No.
