### PR TITLE
[flink] Fixed deserialization failure when kafka cdc records contain nested structures

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -229,4 +229,20 @@ public class TypeUtils {
                 return t1.copy(true).equals(t2.copy(true));
         }
     }
+
+    public static boolean isBasicType(Object obj) {
+        Class<?> clazz = obj.getClass();
+        return clazz.isPrimitive() || isWrapperType(clazz) || clazz.equals(String.class);
+    }
+
+    private static boolean isWrapperType(Class<?> clazz) {
+        return clazz.equals(Boolean.class)
+                || clazz.equals(Character.class)
+                || clazz.equals(Byte.class)
+                || clazz.equals(Short.class)
+                || clazz.equals(Integer.class)
+                || clazz.equals(Long.class)
+                || clazz.equals(Float.class)
+                || clazz.equals(Double.class);
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
@@ -41,7 +41,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
@@ -41,11 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -141,10 +137,16 @@ public abstract class RecordParser implements FlatMapFunction<String, RichCdcMul
     protected Map<String, String> extractRowData(
             JsonNode record, LinkedHashMap<String, DataType> paimonFieldTypes) {
         paimonFieldTypes.putAll(fillDefaultStringTypes(record));
-        Map<String, String> recordMap =
-                OBJECT_MAPPER.convertValue(record, new TypeReference<Map<String, String>>() {});
+        Map<String, Object> recordMap =
+                OBJECT_MAPPER.convertValue(record, new TypeReference<Map<String, Object>>() {});
 
-        Map<String, String> rowData = new HashMap<>(recordMap);
+        Map<String, String> rowData =
+                recordMap.entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        entry -> Objects.toString(entry.getValue(), null)));
+
         evalComputedColumns(rowData, paimonFieldTypes);
         return rowData;
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
@@ -212,7 +212,7 @@ public class KafkaDebeziumSyncTableActionITCase extends KafkaActionITCaseBase {
     }
 
     @Test
-    @Timeout(160)
+    @Timeout(60)
     public void testRecordWithNestedDataType() throws Exception {
         String topic = "nested_type";
         createTestTopic(topic, 1, 1);
@@ -238,11 +238,13 @@ public class KafkaDebeziumSyncTableActionITCase extends KafkaActionITCaseBase {
 
         RowType rowType =
                 RowType.of(
-                        new DataType[] {DataTypes.STRING().notNull(), DataTypes.STRING()},
+                        new DataType[] {
+                            DataTypes.STRING().notNull(), DataTypes.STRING(), DataTypes.STRING()
+                        },
                         new String[] {"id", "name", "row"});
         List<String> primaryKeys = Collections.singletonList("id");
         List<String> expected =
-                Collections.singletonList("+I[101, scooter, {\"row_key\":\"value\"}]");
+                Collections.singletonList("+I[101, hammer, {\"row_key\":\"value\"}]");
         waitForResult(expected, table, rowType, primaryKeys);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
@@ -141,35 +141,6 @@ public class KafkaDebeziumSyncTableActionITCase extends KafkaActionITCaseBase {
                         "+I[105, hammer, 14oz carpenter's hammer, 0.875, NULL, Beijing]",
                         "+I[107, rocks, box of assorted rocks, 5.3, NULL, NULL]");
         waitForResult(expected, table, rowType, primaryKeys);
-
-        try {
-            writeRecordsToKafka(
-                    topic,
-                    readLines(
-                            String.format(
-                                    "kafka/debezium/table/%s/debezium-data-4.txt", sourceDir)));
-        } catch (Exception e) {
-            throw new Exception("Failed to write debezium data to Kafka.", e);
-        }
-        rowType =
-                RowType.of(
-                        new DataType[] {
-                            DataTypes.STRING().notNull(),
-                            DataTypes.STRING(),
-                            DataTypes.STRING(),
-                            DataTypes.STRING(),
-                            DataTypes.STRING(),
-                            DataTypes.STRING()
-                        },
-                        new String[] {"id", "name", "row"});
-        expected =
-                Arrays.asList(
-                        "+I[102, car battery, 12V car battery, 8.1, NULL, NULL]",
-                        "+I[103, 12-pack drill bits, 12-pack of drill bits with sizes ranging from #40 to #3, 0.8, 18, NULL]",
-                        "+I[104, hammer, 12oz carpenter's hammer, 0.75, 24, NULL]",
-                        "+I[105, hammer, 14oz carpenter's hammer, 0.875, NULL, Beijing]",
-                        "+I[107, rocks, box of assorted rocks, 5.3, NULL, NULL]");
-        waitForResult(expected, table, rowType, primaryKeys);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumSyncTableActionITCase.java
@@ -154,12 +154,12 @@ public class KafkaDebeziumSyncTableActionITCase extends KafkaActionITCaseBase {
         rowType =
                 RowType.of(
                         new DataType[] {
-                                DataTypes.STRING().notNull(),
-                                DataTypes.STRING(),
-                                DataTypes.STRING(),
-                                DataTypes.STRING(),
-                                DataTypes.STRING(),
-                                DataTypes.STRING()
+                            DataTypes.STRING().notNull(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING()
                         },
                         new String[] {"id", "name", "row"});
         expected =
@@ -238,15 +238,11 @@ public class KafkaDebeziumSyncTableActionITCase extends KafkaActionITCaseBase {
 
         RowType rowType =
                 RowType.of(
-                        new DataType[] {
-                                DataTypes.STRING().notNull(),
-                                DataTypes.STRING()
-                        },
+                        new DataType[] {DataTypes.STRING().notNull(), DataTypes.STRING()},
                         new String[] {"id", "name", "row"});
         List<String> primaryKeys = Collections.singletonList("id");
         List<String> expected =
-                Collections.singletonList(
-                        "+I[101, scooter, {\"row_key\":\"value\"}]");
+                Collections.singletonList("+I[101, scooter, {\"row_key\":\"value\"}]");
         waitForResult(expected, table, rowType, primaryKeys);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/debezium/table/nestedtype/debezium-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/debezium/table/nestedtype/debezium-data-1.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"before": null, "after": {"id": 101, "name": "hammer", "row": {"row_key":"value"} }, "source": {"version": "1.9.7.Final", "connector": "mysql", "name": "mysql_binlog_source", "ts_ms": 1596684883000, "snapshot": "false", "db": "test", "sequence": null, "table": "product", "server_id": 0, "gtid": null, "file": "", "pos": 0, "row": 0, "thread": null, "query": null}, "op": "c", "ts_ms": 1596684883000, "transaction": null}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
records：
{
    "before": {},
    "after": {
        "_id": 1004,
        "first_name": "Anne Marie",
        "last_name": "Kretchmar",
        "email": "annek@noanswer.org",
        "bool_field": true,
        "row":{"row_key":"value"}
    },
    "source": {
        "version": "1.3.1.Final",
        "connector": "mysql",
        "name": "mysql-server-1",
        "ts_sec": 1465581,
        "snapshot": false,
        "db": "",
        "table": "paimon_cdc_test",
        "server_id": 223344,
        "gtid": null,
        "file": "mysql-bin.000003",
        "pos": 805,
        "row": 0,
        "thread": 7,
        "query": "DELETE FROM customers WHERE id=1004"
    },
    "op": "c",
    "ts_ms": 1465581902461
}


2023-12-18 18:21:26
java.io.IOException: Failed to deserialize consumer record due to
at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:56)
at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:33)
at org.apache.flink.connector.base.source.reader.SourceReaderBase.pollNext(SourceReaderBase.java:160)
at org.apache.flink.streaming.api.operators.SourceOperator.emitNext(SourceOperator.java:419)
at org.apache.flink.streaming.runtime.io.StreamTaskSourceInput.emitNext(StreamTaskSourceInput.java:68)
at org.apache.flink.streaming.runtime.io.StreamOneInputProcessor.processInput(StreamOneInputProcessor.java:65)
at org.apache.flink.streaming.runtime.tasks.StreamTask.processInput(StreamTask.java:562)
at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:231)
at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:858)
at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:807)
at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:953)
at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:932)
at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:746)
at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
at java.base/java.lang.Thread.run(Unknown Source)
Caused by: org.apache.flink.streaming.runtime.tasks.ExceptionInChainedOperatorException: Could not forward element to next operator
at org.apache.flink.streaming.runtime.tasks.ChainingOutput.pushToOperator(ChainingOutput.java:110)
at org.apache.flink.streaming.runtime.tasks.ChainingOutput.collect(ChainingOutput.java:77)
at org.apache.flink.streaming.runtime.tasks.ChainingOutput.collect(ChainingOutput.java:39)
at org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask$AsyncDataOutputToOutput.emitRecord(SourceOperatorStreamTask.java:309)
at org.apache.flink.streaming.api.operators.source.SourceOutputWithWatermarks.collect(SourceOutputWithWatermarks.java:110)
at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter$SourceOutputWrapper.collect(KafkaR ecordEmitter.java:67)
at org.apache.flink.api.common.serialization.DeserializationSchema.deserialize(DeserializationSchema.java:84)
at org.apache.flink.connector.kafka.source.reader.deserializer.KafkaValueOnlyDeserializationSchemaWrapper.deserialize(KafkaValueOnlyDeserializationSchemaWrapper.java:51)
at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:53)
... 14 more
Caused by: java.lang.IllegalArgumentException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.LinkedHashMap["row"])
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4449)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4390)
at org.apache.paimon.flink.action.cdc.format.RecordParser.extractRowData(RecordParser.java:145)
at org.apache.paimon.flink.action.cdc.format.RecordParser.processRecord(RecordParser.java:178)
at org.apache.paimon.flink.action.cdc.format.debezium.DebeziumRecordParser.extractRecords(DebeziumRecordParser.java:81)
at org.apache.paimon.flink.action.cdc.format.RecordParser.flatMap(RecordParser.java:134)
at org.apache.paimon.flink.action.cdc.format.RecordParser.flatMap(RecordParser.java:67)
at org.apache.flink.streaming.api.operators.StreamFlatMap.processElement(StreamFlatMap.java:47)
at org.apache.flink.streaming.runtime.tasks.ChainingOutput.pushToOperator(ChainingOutput.java:108)
... 22 more
Caused by: org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.LinkedHashMap["row"])
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1746)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1520)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1425)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext.extractScalarFromObject(DeserializationContext.java:937)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer._parseString(StdDeserializer.java:1421)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:48)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:623)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:449)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4444)
... 30 more

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
