### PR TITLE
[Bug] Fix the IndexOutOfBoundsException when  lookup empty sortedRun

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
@@ -59,6 +59,9 @@ public class LookupUtils {
             SortedRun level,
             BiFunctionWithIOE<InternalRow, DataFileMeta, T> lookup)
             throws IOException {
+        if (!level.nonEmpty()) {
+            return null;
+        }
         List<DataFileMeta> files = level.files();
         int left = 0;
         int right = files.size() - 1;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -198,6 +198,22 @@ public class LookupLevelsTest {
         assertThat(lookupLevels.lookupFiles().estimatedSize()).isEqualTo(0);
     }
 
+    @Test
+    public void testLookupEmptyLevel() throws IOException {
+        Levels levels =
+                new Levels(
+                        comparator,
+                        Arrays.asList(
+                                newFile(1, kv(1, 11), kv(3, 33), kv(5, 5)),
+                                // empty level 2
+                                newFile(3, kv(2, 22), kv(5, 55))),
+                        3);
+        LookupLevels lookupLevels = createLookupLevels(levels, MemorySize.ofMebiBytes(10));
+
+        KeyValue kv = lookupLevels.lookup(row(2), 1);
+        assertThat(kv).isNotNull();
+    }
+
     private LookupLevels createLookupLevels(Levels levels, MemorySize maxDiskSize) {
         return new LookupLevels(
                 levels,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2528

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
