### PR TITLE
[core] Sort partition before batch insert to avoid out-of-memory error.

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -540,6 +540,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Specify the sort engine for table with primary key.<br /><br />Possible values:<ul><li>"min-heap": Use min-heap for multiway sorting.</li><li>"loser-tree": Use loser-tree for multiway sorting. Compared with heapsort, loser-tree has fewer comparisons and is more efficient.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>sort-partition-before-batch-insert</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Batch inserting lots of data without partition specified among huge number of partitions, sort the records by partitions before inserting.Set this to true to avoid out-of-memory by opening two many writers in lots of partitions.</td>
+        </tr>
+        <tr>
             <td><h5>sort-spill-buffer-size</h5></td>
             <td style="word-wrap: break-word;">64 mb</td>
             <td>MemorySize</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -270,6 +270,14 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MemorySize.parse("64 mb"))
                     .withDescription("Amount of data to spill records to disk in spilled sort.");
 
+    public static final ConfigOption<Boolean> SORT_PARTITION_BEFORE_BATCH_INSERT =
+            key("sort-partition-before-batch-insert")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Batch inserting lots of data without partition specified among huge number of partitions, sort the records by partitions before inserting."
+                                    + "Set this to true to avoid out-of-memory by opening two many writers in lots of partitions.");
+
     public static final ConfigOption<Boolean> WRITE_ONLY =
             key("write-only")
                     .booleanType()
@@ -1159,6 +1167,10 @@ public class CoreOptions implements Serializable {
 
     public long sortSpillBufferSize() {
         return options.get(SORT_SPILL_BUFFER_SIZE).getBytes();
+    }
+
+    public boolean sortPartitionBeforeBatchInsert() {
+        return options.get(SORT_PARTITION_BEFORE_BATCH_INSERT);
     }
 
     public Duration continuousDiscoveryInterval() {

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -104,6 +104,14 @@ public final class RowType extends DataType {
                 isNullable, fields.stream().map(DataField::copy).collect(Collectors.toList()));
     }
 
+    public RowType project(int[] selected) {
+        List<DataField> newFields = new ArrayList<>();
+        for (int i : selected) {
+            newFields.add(fields.get(i));
+        }
+        return new RowType(newFields);
+    }
+
     @Override
     public String asSQLString() {
         return withNullability(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -229,7 +229,12 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                         bucketIter.remove();
                     }
                 } else {
-                    writerContainer.lastModifiedCommitIdentifier = commitIdentifier;
+                    // To support close writer while huge number of partitions batch inserting, we
+                    // set the lastModifiedCommitIdentifier to Long.MIN_VALUE
+                    // Modify here is only for convenient of close writers, see
+                    // `TableWriteImpl.prepareCommit` for detail.
+                    writerContainer.lastModifiedCommitIdentifier =
+                            commitIdentifier == Long.MAX_VALUE ? Long.MIN_VALUE : commitIdentifier;
                 }
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/sort/ExternalRowSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/ExternalRowSortBuffer.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sort;
+
+import org.apache.paimon.codegen.CodeGenUtils;
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.MutableObjectIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * External sort for Interval Row. This is a wrapper of {@link BinaryExternalSortBuffer}, in
+ * difference that, BinaryExternalSortBuffer could only sort the buffer by key and value,
+ * ExternalInternalRowSortBuffer could sort row by specified column. We can just use this to avoid
+ * complex process about constructing the sort key, dropping the sort key after sorting.
+ *
+ * <p>For example, table (f0 String, f1 int, f2 int), we sort rows by f2 :
+ *
+ * <pre>
+ *    a, 3, 1
+ *    a, 3, 2
+ *    a, 3, 100
+ *    a, 3, 0
+ * </pre>
+ *
+ * <p>We get:
+ *
+ * <pre>
+ *     a, 3, 0
+ *     a, 3, 1
+ *     a, 3, 2
+ *     a, 3, 100
+ * </pre>
+ *
+ * <p>We don't need to care about constructing the row: KEY_f2, f0, f1, f2, Then sort by KEY_f2,
+ * Then drop KEY_f2
+ *
+ * <p>The whole process is finished by this class. We just need to tell it which columns are sorted
+ * by.
+ */
+public class ExternalRowSortBuffer implements SortBuffer {
+
+    private static final String KEY_PREFIX = "_SORT_KEY_";
+
+    private final BinaryExternalSortBuffer binaryExternalSortBuffer;
+    private final int fullSize;
+    Projection rowPartitionKeyExtractor;
+    Projection valueProjection;
+
+    public ExternalRowSortBuffer(
+            IOManager ioManager,
+            RowType rowType,
+            int[] fieldsIndex,
+            long bufferSize,
+            int pageSize,
+            int maxNumFileHandles) {
+        RowType partitionType = org.apache.paimon.utils.Projection.of(fieldsIndex).project(rowType);
+        List<DataField> rowFields = rowType.getFields();
+        List<DataField> fields = new ArrayList<>();
+
+        // construct the partition extractor to extract partition row from whole row.
+        rowPartitionKeyExtractor = CodeGenUtils.newProjection(rowType, fieldsIndex);
+
+        // construct the value projection to extract origin row from extended key_value row.
+        for (int i : fieldsIndex) {
+            // we put the KEY_PREFIX ahead of origin field name to avoid conflict
+            fields.add(rowFields.get(i).newName(KEY_PREFIX + rowFields.get(i).name()));
+        }
+        fields.addAll(rowType.getFields());
+        int[] valueFields = new int[rowType.getFieldCount()];
+        int keySize = fieldsIndex.length;
+        for (int i = 0; i < valueFields.length; i++) {
+            valueFields[i] = keySize + i;
+        }
+        valueProjection = CodeGenUtils.newProjection(new RowType(fields), valueFields);
+
+        // construct the binary sorter to sort the extended key_value row
+        binaryExternalSortBuffer =
+                BinaryExternalSortBuffer.create(
+                        ioManager,
+                        partitionType,
+                        new RowType(fields),
+                        bufferSize,
+                        pageSize,
+                        maxNumFileHandles);
+
+        this.fullSize = rowType.getFieldCount() + fieldsIndex.length;
+    }
+
+    @Override
+    public int size() {
+        return binaryExternalSortBuffer.size();
+    }
+
+    @Override
+    public void clear() {
+        binaryExternalSortBuffer.clear();
+    }
+
+    @Override
+    public long getOccupancy() {
+        return binaryExternalSortBuffer.getOccupancy();
+    }
+
+    @Override
+    public boolean flushMemory() throws IOException {
+        return binaryExternalSortBuffer.flushMemory();
+    }
+
+    @Override
+    public boolean write(InternalRow record) throws IOException {
+        BinaryRow partition = rowPartitionKeyExtractor.apply(record);
+        JoinedRow joinedRow = new JoinedRow(partition, record);
+        binaryExternalSortBuffer.write(joinedRow);
+        return false;
+    }
+
+    @Override
+    public MutableObjectIterator<BinaryRow> sortedIterator() throws IOException {
+        MutableObjectIterator<BinaryRow> iterator = binaryExternalSortBuffer.sortedIterator();
+        return new MutableObjectIterator<BinaryRow>() {
+            private BinaryRow binaryRow = new BinaryRow(fullSize);
+
+            @Override
+            public BinaryRow next(BinaryRow reuse) throws IOException {
+                // use internal reuse object
+                return next();
+            }
+
+            @Override
+            public BinaryRow next() throws IOException {
+                binaryRow = iterator.next(binaryRow);
+                return binaryRow == null ? null : valueProjection.apply(binaryRow);
+            }
+        };
+    }
+
+    public static ExternalRowSortBuffer create(
+            IOManager ioManager,
+            RowType rowType,
+            int[] fields,
+            long bufferSize,
+            int pageSize,
+            int maxNumFileHandles) {
+        return new ExternalRowSortBuffer(
+                ioManager, rowType, fields, bufferSize, pageSize, maxNumFileHandles);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/sort/SortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/SortBuffer.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.sort;
 
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.utils.MutableObjectIterator;
 
@@ -40,5 +39,5 @@ public interface SortBuffer {
     boolean write(InternalRow record) throws IOException;
 
     /** @return iterator with sorting. */
-    MutableObjectIterator<BinaryRow> sortedIterator() throws IOException;
+    <T extends InternalRow> MutableObjectIterator<T> sortedIterator() throws IOException;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -145,6 +145,9 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                             "Append only writer can not accept row with RowKind %s",
                             record.row().getRowKind());
                     return record.row();
-                });
+                },
+                rowType(),
+                schema().projection(schema().partitionKeys()),
+                coreOptions());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -202,6 +202,9 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
                                     ? row.getRowKind()
                                     : rowKindGenerator.generate(row);
                     return kv.replace(record.primaryKey(), sequenceNumber, rowKind, row);
-                });
+                },
+                rowType(),
+                schema().projection(schema.partitionKeys()),
+                coreOptions());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -221,9 +221,9 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
         List<CommitMessage> commitMessages = new ArrayList<>();
         if (externalRowSortBuffer != null && externalRowSortBuffer.size() != 0) {
             // flush external row sort buffer.
-            MutableObjectIterator<BinaryRow> iterator = externalRowSortBuffer.sortedIterator();
+            MutableObjectIterator<InternalRow> iterator = externalRowSortBuffer.sortedIterator();
             BinaryRow lastPartition = new BinaryRow(fields.length);
-            BinaryRow binaryRow;
+            InternalRow binaryRow;
             while ((binaryRow = iterator.next()) != null) {
                 SinkRecord record = toSinkRecord(binaryRow);
                 if (!lastPartition.equals(record.partition())) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -22,7 +22,9 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
@@ -32,8 +34,11 @@ import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite.State;
 import org.apache.paimon.sort.ExternalRowSortBuffer;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.MutableObjectIterator;
+import org.apache.paimon.utils.OffsetRow;
 import org.apache.paimon.utils.Restorable;
 
 import javax.annotation.Nullable;
@@ -54,10 +59,12 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     private final FileStoreWrite<T> write;
     private final KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor;
     private final RecordExtractor<T> recordExtractor;
-
     private final RowType rowType;
-    private final int[] fields;
+    private final int[] partitionFields;
     private final CoreOptions coreOptions;
+    private final JoinedRow reusedJoinedRow;
+    private final GenericRow reusedBucketRow;
+    private final OffsetRow reusedOffsetRow;
 
     private @Nullable ExternalRowSortBuffer externalRowSortBuffer;
 
@@ -71,15 +78,18 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
             KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor,
             RecordExtractor<T> recordExtractor,
             RowType rowType,
-            int[] fields,
+            int[] partitionFields,
             CoreOptions coreOptions) {
         this.write = write;
         this.keyAndBucketExtractor = keyAndBucketExtractor;
         this.recordExtractor = recordExtractor;
-
         this.rowType = rowType;
-        this.fields = fields;
+        this.partitionFields = partitionFields;
         this.coreOptions = coreOptions;
+
+        this.reusedJoinedRow = new JoinedRow();
+        this.reusedBucketRow = new GenericRow(1);
+        this.reusedOffsetRow = new OffsetRow(rowType.getFieldCount(), 1);
     }
 
     @Override
@@ -100,12 +110,23 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     public TableWriteImpl<T> withIOManager(IOManager ioManager) {
         if (coreOptions.sortPartitionBeforeBatchInsert()
                 && externalRowSortBuffer == null
-                && fields.length != 0) {
+                && partitionFields.length != 0) {
+            List<DataField> dataFields = new ArrayList<>();
+            dataFields.add(new DataField(0, "_BUCKET_", DataTypes.INT()));
+            dataFields.addAll(rowType.getFields());
+
+            // add bucket field in front of row, and selected field should include the bucket
+            int[] sortField = new int[partitionFields.length + 1];
+            for (int i = 0; i < sortField.length - 1; i++) {
+                sortField[i] = partitionFields[i] + 1;
+            }
+            // add bucket field to sort
+            sortField[sortField.length - 1] = 0;
             externalRowSortBuffer =
                     ExternalRowSortBuffer.create(
                             ioManager,
-                            rowType,
-                            fields,
+                            new RowType(dataFields),
+                            sortField,
                             coreOptions.writeBufferSize(),
                             coreOptions.pageSize(),
                             coreOptions.localSortMaxNumFileHandles());
@@ -160,11 +181,26 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
 
     private void writeInternal(InternalRow row) throws Exception {
         if (externalRowSortBuffer != null && !streamingMode && !ignorePreviousFiles) {
-            externalRowSortBuffer.write(row);
+            externalRowSortBuffer.write(toRowWithBucket(row));
         } else {
             SinkRecord record = toSinkRecord(row);
             write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
         }
+    }
+
+    private InternalRow toRowWithBucket(InternalRow row) {
+        keyAndBucketExtractor.setRecord(row);
+        reusedBucketRow.setField(0, keyAndBucketExtractor.bucket());
+        reusedJoinedRow.replace(reusedBucketRow, row);
+        return reusedJoinedRow;
+    }
+
+    private int bucket(InternalRow rowWithBucket) {
+        return rowWithBucket.getInt(0);
+    }
+
+    private InternalRow toOriginRow(InternalRow row) {
+        return reusedOffsetRow.replace(row);
     }
 
     @VisibleForTesting
@@ -180,6 +216,15 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
         return new SinkRecord(
                 keyAndBucketExtractor.partition(),
                 keyAndBucketExtractor.bucket(),
+                keyAndBucketExtractor.trimmedPrimaryKey(),
+                row);
+    }
+
+    private SinkRecord toSinkRecord(InternalRow row, int bucket) {
+        keyAndBucketExtractor.setRecord(row);
+        return new SinkRecord(
+                keyAndBucketExtractor.partition(),
+                bucket,
                 keyAndBucketExtractor.trimmedPrimaryKey(),
                 row);
     }
@@ -207,7 +252,7 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     /**
      * Notify that some new files are created at given snapshot in given bucket.
      *
-     * <p>Most probably, these files are created by another job. Currently this method is only used
+     * <p>Most probably, these files are created by another job. Currently, this method is only used
      * by the dedicated compact job to see files created by writer jobs.
      */
     public void notifyNewFiles(
@@ -222,15 +267,18 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
         if (externalRowSortBuffer != null && externalRowSortBuffer.size() != 0) {
             // flush external row sort buffer.
             MutableObjectIterator<InternalRow> iterator = externalRowSortBuffer.sortedIterator();
-            BinaryRow lastPartition = new BinaryRow(fields.length);
+            BinaryRow lastPartition = new BinaryRow(partitionFields.length);
             InternalRow binaryRow;
+            int lastBucket = -1;
             while ((binaryRow = iterator.next()) != null) {
-                SinkRecord record = toSinkRecord(binaryRow);
-                if (!lastPartition.equals(record.partition())) {
+                int bucket = bucket(binaryRow);
+                SinkRecord record = toSinkRecord(toOriginRow(binaryRow), bucket);
+                if (!lastPartition.equals(record.partition()) || lastBucket != bucket) {
                     commitMessages.addAll(write.prepareCommit(waitCompaction, commitIdentifier));
                 }
                 write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
                 record.partition().copy(lastPartition);
+                lastBucket = bucket;
             }
             externalRowSortBuffer.clear();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.sink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
@@ -29,9 +30,15 @@ import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite.State;
+import org.apache.paimon.sort.ExternalRowSortBuffer;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.MutableObjectIterator;
 import org.apache.paimon.utils.Restorable;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -48,32 +55,61 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     private final KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor;
     private final RecordExtractor<T> recordExtractor;
 
+    private final RowType rowType;
+    private final int[] fields;
+    private final CoreOptions coreOptions;
+
+    private @Nullable ExternalRowSortBuffer externalRowSortBuffer;
+
     private boolean batchCommitted = false;
     private BucketMode bucketMode;
+    private boolean streamingMode = true;
+    private boolean ignorePreviousFiles = true;
 
     public TableWriteImpl(
             FileStoreWrite<T> write,
             KeyAndBucketExtractor<InternalRow> keyAndBucketExtractor,
-            RecordExtractor<T> recordExtractor) {
+            RecordExtractor<T> recordExtractor,
+            RowType rowType,
+            int[] fields,
+            CoreOptions coreOptions) {
         this.write = write;
         this.keyAndBucketExtractor = keyAndBucketExtractor;
         this.recordExtractor = recordExtractor;
+
+        this.rowType = rowType;
+        this.fields = fields;
+        this.coreOptions = coreOptions;
     }
 
     @Override
     public TableWriteImpl<T> withIgnorePreviousFiles(boolean ignorePreviousFiles) {
+        this.ignorePreviousFiles = ignorePreviousFiles;
         write.withIgnorePreviousFiles(ignorePreviousFiles);
         return this;
     }
 
     @Override
     public TableWriteImpl<T> withExecutionMode(boolean isStreamingMode) {
+        this.streamingMode = isStreamingMode;
         write.withExecutionMode(isStreamingMode);
         return this;
     }
 
     @Override
     public TableWriteImpl<T> withIOManager(IOManager ioManager) {
+        if (coreOptions.sortPartitionBeforeBatchInsert()
+                && externalRowSortBuffer == null
+                && fields.length != 0) {
+            externalRowSortBuffer =
+                    ExternalRowSortBuffer.create(
+                            ioManager,
+                            rowType,
+                            fields,
+                            coreOptions.writeBufferSize(),
+                            coreOptions.pageSize(),
+                            coreOptions.localSortMaxNumFileHandles());
+        }
         write.withIOManager(ioManager);
         return this;
     }
@@ -118,15 +154,24 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
 
     public SinkRecord writeAndReturn(InternalRow row) throws Exception {
         SinkRecord record = toSinkRecord(row);
-        write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
+        writeInternal(row);
         return record;
+    }
+
+    private void writeInternal(InternalRow row) throws Exception {
+        if (externalRowSortBuffer != null && !streamingMode && !ignorePreviousFiles) {
+            externalRowSortBuffer.write(row);
+        } else {
+            SinkRecord record = toSinkRecord(row);
+            write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
+        }
     }
 
     @VisibleForTesting
     public T writeAndReturnData(InternalRow row) throws Exception {
         SinkRecord record = toSinkRecord(row);
         T data = recordExtractor.extract(record);
-        write.write(record.partition(), record.bucket(), data);
+        writeInternal(row);
         return data;
     }
 
@@ -173,7 +218,24 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     @Override
     public List<CommitMessage> prepareCommit(boolean waitCompaction, long commitIdentifier)
             throws Exception {
-        return write.prepareCommit(waitCompaction, commitIdentifier);
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        if (externalRowSortBuffer != null && externalRowSortBuffer.size() != 0) {
+            // flush external row sort buffer.
+            MutableObjectIterator<BinaryRow> iterator = externalRowSortBuffer.sortedIterator();
+            BinaryRow lastPartition = new BinaryRow(fields.length);
+            BinaryRow binaryRow;
+            while ((binaryRow = iterator.next()) != null) {
+                SinkRecord record = toSinkRecord(binaryRow);
+                if (!lastPartition.equals(record.partition())) {
+                    commitMessages.addAll(write.prepareCommit(waitCompaction, commitIdentifier));
+                }
+                write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
+                record.partition().copy(lastPartition);
+            }
+            externalRowSortBuffer.clear();
+        }
+        commitMessages.addAll(write.prepareCommit(waitCompaction, commitIdentifier));
+        return commitMessages;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
@@ -65,7 +65,7 @@ public class ExternalRowSortBufferTest {
                 ExternalRowSortBuffer.create(
                         ioManager,
                         schema.rowType(),
-                        new int[] {0, 2},
+                        new int[] {2, 0},
                         MemorySize.parse("10 mb").getBytes(),
                         coreOptions.pageSize(),
                         coreOptions.localSortMaxNumFileHandles());
@@ -77,8 +77,8 @@ public class ExternalRowSortBufferTest {
 
         TreeSet<BinaryRow> treeSet =
                 new TreeSet<>(
-                        Comparator.comparingLong((BinaryRow o) -> o.getLong(0))
-                                .thenComparingLong(o -> o.getLong(2)));
+                        Comparator.comparingLong((BinaryRow o) -> o.getLong(2))
+                                .thenComparingLong(o -> o.getLong(0)));
         treeSet.addAll(datas);
         MutableObjectIterator<InternalRow> iterator = externalRowSortBuffer.sortedIterator();
         InternalRow row;

--- a/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sort;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.MutableObjectIterator;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.TreeSet;
+
+/** Tests for {@link ExternalRowSortBuffer}. */
+public class ExternalRowSortBufferTest {
+
+    private static final Random RANDOM = new Random();
+
+    @TempDir private Path dir;
+
+    @Test
+    public void testFunctionRandom() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.BIGINT())
+                        .column("f1", DataTypes.STRING())
+                        .column("f2", DataTypes.BIGINT())
+                        .build();
+        IOManager ioManager = new IOManagerImpl(dir.toString());
+        CoreOptions coreOptions = new CoreOptions(new Options());
+
+        ExternalRowSortBuffer externalRowSortBuffer =
+                ExternalRowSortBuffer.create(
+                        ioManager,
+                        schema.rowType(),
+                        new int[] {0, 2},
+                        MemorySize.parse("10 mb").getBytes(),
+                        coreOptions.pageSize(),
+                        coreOptions.localSortMaxNumFileHandles());
+
+        List<BinaryRow> datas = data(Math.abs(RANDOM.nextInt(1000)) + 1000);
+        for (BinaryRow data : datas) {
+            externalRowSortBuffer.write(data);
+        }
+
+        TreeSet<BinaryRow> treeSet =
+                new TreeSet<>(
+                        Comparator.comparingLong((BinaryRow o) -> o.getLong(0))
+                                .thenComparingLong(o -> o.getLong(2)));
+        treeSet.addAll(datas);
+        List<BinaryRow> sorted = new ArrayList<>();
+        MutableObjectIterator<BinaryRow> iterator = externalRowSortBuffer.sortedIterator();
+        BinaryRow row;
+        while ((row = iterator.next()) != null) {
+            sorted.add(row.copy());
+        }
+
+        Iterator<BinaryRow> treeIterator = treeSet.iterator();
+        for (BinaryRow sortRow : sorted) {
+            long f0 = sortRow.getLong(0);
+            BinaryString f1 = sortRow.getString(1);
+            long f2 = sortRow.getLong(2);
+
+            BinaryRow treeRow = treeIterator.next();
+            long t0 = treeRow.getLong(0);
+            BinaryString t1 = treeRow.getString(1);
+            long t2 = treeRow.getLong(2);
+
+            Assertions.assertThat(f0).isEqualTo(t0);
+            Assertions.assertThat(f1).isEqualTo(t1);
+            Assertions.assertThat(f2).isEqualTo(t2);
+        }
+    }
+
+    private List<BinaryRow> data(int size) {
+        List<BinaryRow> datas = new ArrayList<>();
+        BinaryRow binaryRow = new BinaryRow(3);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        byte[] bytes = new byte[1024];
+
+        for (int i = 0; i < size; i++) {
+            writer.writeLong(0, RANDOM.nextLong());
+            RANDOM.nextBytes(bytes);
+            writer.writeString(1, BinaryString.fromBytes(bytes));
+            writer.writeLong(2, RANDOM.nextLong());
+            writer.complete();
+            datas.add(binaryRow.copy());
+        }
+
+        return datas;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/ExternalRowSortBufferTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.options.MemorySize;
@@ -69,7 +70,7 @@ public class ExternalRowSortBufferTest {
                         coreOptions.pageSize(),
                         coreOptions.localSortMaxNumFileHandles());
 
-        List<BinaryRow> datas = data(Math.abs(RANDOM.nextInt(1000)) + 1000);
+        List<BinaryRow> datas = data(Math.abs(RANDOM.nextInt(100)) + 100);
         for (BinaryRow data : datas) {
             externalRowSortBuffer.write(data);
         }
@@ -79,18 +80,14 @@ public class ExternalRowSortBufferTest {
                         Comparator.comparingLong((BinaryRow o) -> o.getLong(0))
                                 .thenComparingLong(o -> o.getLong(2)));
         treeSet.addAll(datas);
-        List<BinaryRow> sorted = new ArrayList<>();
-        MutableObjectIterator<BinaryRow> iterator = externalRowSortBuffer.sortedIterator();
-        BinaryRow row;
-        while ((row = iterator.next()) != null) {
-            sorted.add(row.copy());
-        }
-
+        MutableObjectIterator<InternalRow> iterator = externalRowSortBuffer.sortedIterator();
+        InternalRow row;
         Iterator<BinaryRow> treeIterator = treeSet.iterator();
-        for (BinaryRow sortRow : sorted) {
-            long f0 = sortRow.getLong(0);
-            BinaryString f1 = sortRow.getString(1);
-            long f2 = sortRow.getLong(2);
+        while ((row = iterator.next()) != null) {
+            //            sorted.add(row.copy());
+            long f0 = row.getLong(0);
+            BinaryString f1 = row.getString(1);
+            long f2 = row.getLong(2);
 
             BinaryRow treeRow = treeIterator.next();
             long t0 = treeRow.getLong(0);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -299,7 +299,7 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         return Arrays.asList(
                 "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING)",
                 "CREATE TABLE IF NOT EXISTS part_table (id INT, data STRING, dt STRING) PARTITIONED BY (dt)",
-                "CREATE TABLE IF NOT EXISTS part_table2 (pk INT, data STRING, data2 STRING) PARTITIONED BY (pk)",
+                "CREATE TABLE IF NOT EXISTS part_table2 (pk INT, data STRING, data2 STRING) PARTITIONED BY (pk) WITH ('bucket' = '2')",
                 "CREATE TABLE IF NOT EXISTS complex_table (id INT, data MAP<INT, INT>)");
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test case for append-only managed table. */
@@ -154,6 +155,40 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testLotsPartitionBatchInsert() {
+        long maxMemory = Runtime.getRuntime().maxMemory();
+        long size = maxMemory / 2 / 102400 + 10;
+        batchSql(
+                "CREATE TEMPORARY TABLE Orders_in (\n"
+                        + "    f0        INT,\n"
+                        + "    f1        STRING,\n"
+                        + "    f2        STRING\n"
+                        + ") WITH (\n"
+                        + "    'connector' = 'datagen',\n"
+                        + "    'fields.f0.min' = '0',\n"
+                        + "    'fields.f0.max' = '100',\n"
+                        + "    'fields.f1.length' = '102400',\n"
+                        + "    'fields.f1.length' = '102400',\n"
+                        + "    'number-of-rows' = '"
+                        + size
+                        + "'\n"
+                        + ")");
+
+        assertThatCode(
+                        () ->
+                                tEnv.executeSql(
+                                                "INSERT INTO part_table2 /*+ OPTIONS('sort-partition-before-batch-insert' = 'false') */ SELECT * FROM Orders_in")
+                                        .await())
+                .hasRootCauseInstanceOf(OutOfMemoryError.class);
+        assertThatCode(
+                        () ->
+                                tEnv.executeSql("INSERT INTO part_table2 SELECT * FROM Orders_in")
+                                        .await())
+                .doesNotThrowAnyException();
+        assertThat(batchSql("SELECT count(*) FROM part_table2").get(0).getField(0)).isEqualTo(size);
+    }
+
+    @Test
     public void testAutoCompaction() {
         batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
         batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
@@ -264,6 +299,7 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         return Arrays.asList(
                 "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING)",
                 "CREATE TABLE IF NOT EXISTS part_table (id INT, data STRING, dt STRING) PARTITIONED BY (dt)",
+                "CREATE TABLE IF NOT EXISTS part_table2 (pk INT, data STRING, data2 STRING) PARTITIONED BY (pk)",
                 "CREATE TABLE IF NOT EXISTS complex_table (id INT, data MAP<INT, INT>)");
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Sort partitions before batch insert without partition specified (e.g. insert overwrite and insert from a batch table source).

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

Add options `sort-partition-before-batch-insert` default true. If set this to false, will disable this feature.

No influence to user if no bugs.

### Documentation

<!-- Does this change introduce a new feature -->
