### PR TITLE
[core] Add toString for Predicate

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CompoundPredicate.java
@@ -87,6 +87,11 @@ public class CompoundPredicate implements Predicate {
         return Objects.hash(function, children);
     }
 
+    @Override
+    public String toString() {
+        return function + "(" + children + ")";
+    }
+
     /** Evaluate the predicate result based on multiple {@link Predicate}s. */
     public abstract static class Function implements Serializable {
 
@@ -112,6 +117,11 @@ public class CompoundPredicate implements Predicate {
                 return true;
             }
             return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName();
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafFunction.java
@@ -50,4 +50,9 @@ public abstract class LeafFunction implements Serializable {
 
     public abstract <T> T visit(
             FunctionVisitor<T> visitor, FieldRef fieldRef, List<Object> literals);
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -145,6 +145,21 @@ public class LeafPredicate implements Predicate {
         return Objects.hash(function, type, fieldIndex, fieldName, literals);
     }
 
+    @Override
+    public String toString() {
+        String literalsStr;
+        if (literals == null || literals.isEmpty()) {
+            literalsStr = "";
+        } else if (literals.size() == 1) {
+            literalsStr = literals.get(0).toString();
+        } else {
+            literalsStr = literals.toString();
+        }
+        return literalsStr.isEmpty()
+                ? function + "(" + fieldName + ")"
+                : function + "(" + fieldName + ", " + literalsStr + ")";
+    }
+
     private ListSerializer<Object> objectsSerializer() {
         return new ListSerializer<>(
                 NullableSerializer.wrapIfNullIsNotSupported(InternalSerializers.create(type)));

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -151,7 +151,7 @@ public class LeafPredicate implements Predicate {
         if (literals == null || literals.isEmpty()) {
             literalsStr = "";
         } else if (literals.size() == 1) {
-            literalsStr = literals.get(0).toString();
+            literalsStr = Objects.toString(literals.get(0));
         } else {
             literalsStr = literals.toString();
         }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -540,5 +540,9 @@ public class PredicateTest {
         PredicateBuilder builder4 = new PredicateBuilder(RowType.of(new IntType(), new IntType()));
         Predicate p4 = PredicateBuilder.or(builder4.equal(0, 3), builder4.equal(1, 5));
         assertThat(p4.toString()).isEqualTo("Or([Equal(f0, 3), Equal(f1, 5)])");
+
+        PredicateBuilder builder5 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p5 = builder5.isNotNull(0);
+        assertThat(p5.toString()).isEqualTo("IsNotNull(f0)");
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -522,4 +522,23 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 4L)}))
                 .isEqualTo(true);
     }
+
+    @Test
+    public void testPredicateToString() {
+        PredicateBuilder builder1 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p1 = builder1.equal(0, 5);
+        assertThat(p1.toString()).isEqualTo("Equal(f0, 5)");
+
+        PredicateBuilder builder2 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p2 = builder2.greaterThan(0, 5);
+        assertThat(p2.toString()).isEqualTo("GreaterThan(f0, 5)");
+
+        PredicateBuilder builder3 = new PredicateBuilder(RowType.of(new IntType(), new IntType()));
+        Predicate p3 = PredicateBuilder.and(builder3.equal(0, 3), builder3.equal(1, 5));
+        assertThat(p3.toString()).isEqualTo("And([Equal(f0, 3), Equal(f1, 5)])");
+
+        PredicateBuilder builder4 = new PredicateBuilder(RowType.of(new IntType(), new IntType()));
+        Predicate p4 = PredicateBuilder.or(builder4.equal(0, 3), builder4.equal(1, 5));
+        assertThat(p4.toString()).isEqualTo("Or([Equal(f0, 3), Equal(f1, 5)])");
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -544,5 +544,33 @@ public class PredicateTest {
         PredicateBuilder builder5 = new PredicateBuilder(RowType.of(new IntType()));
         Predicate p5 = builder5.isNotNull(0);
         assertThat(p5.toString()).isEqualTo("IsNotNull(f0)");
+
+        PredicateBuilder builder6 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p6 = builder6.in(0, Arrays.asList(1, null, 3, 4));
+        assertThat(p6.toString())
+                .isEqualTo(
+                        "Or([Or([Or([Equal(f0, 1), Equal(f0, null)]), Equal(f0, 3)]), Equal(f0, 4)])");
+
+        PredicateBuilder builder7 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p7 = builder7.notIn(0, Arrays.asList(1, null, 3, 4));
+        assertThat(p7.toString())
+                .isEqualTo(
+                        "And([And([And([NotEqual(f0, 1), NotEqual(f0, null)]), NotEqual(f0, 3)]), NotEqual(f0, 4)])");
+
+        PredicateBuilder builder8 = new PredicateBuilder(RowType.of(new IntType()));
+        List<Object> literals = new ArrayList<>();
+        for (int i = 1; i <= 21; i++) {
+            literals.add(i);
+        }
+        Predicate p8 = builder8.in(0, literals);
+        assertThat(p8.toString())
+                .isEqualTo(
+                        "In(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])");
+
+        PredicateBuilder builder9 = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate p9 = builder9.notIn(0, literals);
+        assertThat(p9.toString())
+                .isEqualTo(
+                        "NotIn(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])");
     }
 }

--- a/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -26,6 +26,6 @@ import org.apache.spark.sql.types.StructType
 case class PaimonScan(
     table: Table,
     requiredSchema: StructType,
-    filters: Array[(Filter, Predicate)],
+    filters: Array[Predicate],
     pushDownLimit: Option[Int])
   extends PaimonBaseScan(table, requiredSchema, filters, pushDownLimit)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters._
 abstract class PaimonBaseScan(
     table: Table,
     requiredSchema: StructType,
-    filters: Array[(Filter, Predicate)],
+    filters: Array[Predicate],
     pushDownLimit: Option[Int])
   extends Scan
   with SupportsReportStatistics
@@ -56,7 +56,7 @@ abstract class PaimonBaseScan(
     val projection = readSchema().fieldNames.map(field => tableRowType.getFieldNames.indexOf(field))
     _readBuilder.withProjection(projection)
     if (filters.nonEmpty) {
-      val pushedPredicate = PredicateBuilder.and(filters.map(_._2): _*)
+      val pushedPredicate = PredicateBuilder.and(filters: _*)
       _readBuilder.withFilter(pushedPredicate)
     }
     pushDownLimit.foreach(_readBuilder.withLimit)
@@ -108,7 +108,7 @@ abstract class PaimonBaseScan(
 
   override def description(): String = {
     val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.map(_._1).mkString(",") + "]"
+      ", PushedFilters: [" + filters.mkString(",") + "]"
     } else {
       ""
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.paimon.spark
 
-import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, PredicateBuilder}
+import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate}
 import org.apache.paimon.table.Table
 
 import org.apache.spark.internal.Logging
@@ -40,7 +40,7 @@ abstract class PaimonBaseScanBuilder(table: Table)
   protected var pushDownLimit: Option[Int] = None
 
   override def build(): Scan = {
-    PaimonScan(table, requiredSchema, pushed, pushDownLimit)
+    PaimonScan(table, requiredSchema, pushed.map(_._2), pushDownLimit)
   }
 
   /**

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 case class PaimonScan(
     table: Table,
     requiredSchema: StructType,
-    filters: Array[(Filter, Predicate)],
+    filters: Array[Predicate],
     pushDownLimit: Option[Int])
   extends PaimonBaseScan(table, requiredSchema, filters, pushDownLimit)
   with SupportsRuntimeFiltering {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Implementing `Predicate`'s `toString` can provide convenience for debugging and output

e.g.
```text
Equal(f0, 5)
GreaterThan(f0, 5)
And([Equal(f0, 3), Equal(f1, 5)])
IsNotNull(f0)
```

<!-- What is the purpose of the change -->

### Tests
PredicateTest.testPredicateToString()

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
