### PR TITLE
[core] Optimize HashBucketAssigner to more parallilism with less initialized bucket

### DIFF
--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -53,7 +53,7 @@ an index to determine which key corresponds to which bucket.
 Paimon will automatically expand the number of buckets.
 
 - Option1: `'dynamic-bucket.target-row-num'`: controls the target row number for one bucket.
-- Option2: `'dynamic-bucket.assigner-parallelism'`: controls the number of initialized bucket.
+- Option2: `'dynamic-bucket.initial-buckets'`: controls the number of initialized bucket.
 
 {{< hint info >}}
 Dynamic Bucket only support single write job. Please do not start multiple jobs to write to the same partition 

--- a/docs/content/concepts/primary-key-table.md
+++ b/docs/content/concepts/primary-key-table.md
@@ -53,7 +53,7 @@ an index to determine which key corresponds to which bucket.
 Paimon will automatically expand the number of buckets.
 
 - Option1: `'dynamic-bucket.target-row-num'`: controls the target row number for one bucket.
-- Option2: `'dynamic-bucket.assigner-parallelism'`: Parallelism of assigner operator, controls the number of initialized bucket.
+- Option2: `'dynamic-bucket.assigner-parallelism'`: controls the number of initialized bucket.
 
 {{< hint info >}}
 Dynamic Bucket only support single write job. Please do not start multiple jobs to write to the same partition 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -141,6 +141,12 @@ under the License.
             <td>Whether to ignore delete records in deduplicate mode.</td>
         </tr>
         <tr>
+            <td><h5>dynamic-bucket.initial-buckets</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Initial buckets for a partition in assigner operator for dynamic bucket mode.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.assigner-parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -764,14 +764,12 @@ public class CoreOptions implements Serializable {
                             "If the bucket is -1, for primary key table, is dynamic bucket mode, "
                                     + "this option controls the target row number for one bucket.");
 
-    public static final ConfigOption<Integer> DYNAMIC_BUCKET_INIT_BUCKETS =
-            key("dynamic-bucket.init-buckets")
+    public static final ConfigOption<Integer> DYNAMIC_BUCKET_INITIAL_BUCKETS =
+            key("dynamic-bucket.initial-buckets")
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "Parallelism of assigner operator for dynamic bucket mode, it is"
-                                    + " related to the number of initialized bucket, too small will lead to"
-                                    + " insufficient processing speed of assigner.");
+                            "Initial buckets for a partition in assigner operator for dynamic bucket mode.");
 
     public static final ConfigOption<Integer> DYNAMIC_BUCKET_ASSIGNER_PARALLELISM =
             key("dynamic-bucket.assigner-parallelism")
@@ -1325,6 +1323,10 @@ public class CoreOptions implements Serializable {
 
     public Integer scanManifestParallelism() {
         return options.get(SCAN_MANIFEST_PARALLELISM);
+    }
+
+    public Integer dynamicBucketInitialBuckets() {
+        return options.get(DYNAMIC_BUCKET_INITIAL_BUCKETS);
     }
 
     public Integer dynamicBucketAssignerParallelism() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -764,6 +764,15 @@ public class CoreOptions implements Serializable {
                             "If the bucket is -1, for primary key table, is dynamic bucket mode, "
                                     + "this option controls the target row number for one bucket.");
 
+    public static final ConfigOption<Integer> DYNAMIC_BUCKET_INIT_BUCKETS =
+            key("dynamic-bucket.init-buckets")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Parallelism of assigner operator for dynamic bucket mode, it is"
+                                    + " related to the number of initialized bucket, too small will lead to"
+                                    + " insufficient processing speed of assigner.");
+
     public static final ConfigOption<Integer> DYNAMIC_BUCKET_ASSIGNER_PARALLELISM =
             key("dynamic-bucket.assigner-parallelism")
                     .intType()

--- a/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
@@ -51,4 +51,36 @@ public class MathUtils {
         }
         return 31 - Integer.numberOfLeadingZeros(value);
     }
+
+    public static Integer max(Integer v1, Integer v2) {
+        if (v1 == null && v2 == null) {
+            return null;
+        }
+
+        if (v1 != null && v2 == null) {
+            return v1;
+        }
+
+        if (v1 == null) {
+            return v2;
+        }
+
+        return Math.max(v1, v2);
+    }
+
+    public static Integer min(Integer v1, Integer v2) {
+        if (v1 == null && v2 == null) {
+            return null;
+        }
+
+        if (v1 != null && v2 == null) {
+            return v1;
+        }
+
+        if (v1 == null) {
+            return v2;
+        }
+
+        return Math.min(v1, v2);
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
@@ -26,4 +26,10 @@ public interface BucketAssigner {
     int assign(BinaryRow partition, int hash);
 
     void prepareCommit(long commitIdentifier);
+
+    static int computeAssigner(int partitionHash, int keyHash, int numChannels, int numAssigners) {
+        int start = Math.abs(partitionHash % numChannels);
+        int id = Math.abs(keyHash % numAssigners);
+        return (start + id) % numChannels;
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/index/BucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/BucketAssignerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.junit.jupiter.api.Test;
+
+import static java.lang.Integer.MAX_VALUE;
+import static org.apache.paimon.index.BucketAssigner.computeAssigner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BucketAssignerTest {
+
+    @Test
+    public void testComputeAssigner() {
+        assertThat(computeAssigner(MAX_VALUE, 0, 5, 5)).isEqualTo(2);
+        assertThat(computeAssigner(MAX_VALUE, 1, 5, 5)).isEqualTo(3);
+        assertThat(computeAssigner(MAX_VALUE, 2, 5, 5)).isEqualTo(4);
+        assertThat(computeAssigner(MAX_VALUE, 3, 5, 5)).isEqualTo(0);
+
+        assertThat(computeAssigner(2, 0, 5, 3)).isEqualTo(2);
+        assertThat(computeAssigner(2, 1, 5, 3)).isEqualTo(3);
+        assertThat(computeAssigner(2, 2, 5, 3)).isEqualTo(4);
+        assertThat(computeAssigner(2, 3, 5, 3)).isEqualTo(2);
+
+        assertThat(computeAssigner(3, 1, 5, 1)).isEqualTo(3);
+        assertThat(computeAssigner(3, 2, 5, 1)).isEqualTo(3);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
@@ -55,14 +55,20 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
         commit.close();
     }
 
-    private HashBucketAssigner createAssigner(int numAssigners, int assignId) {
+    private HashBucketAssigner createAssigner(int numChannels, int numAssigners, int assignId) {
         return new HashBucketAssigner(
-                table.snapshotManager(), commitUser, fileHandler, numAssigners, assignId, 5);
+                table.snapshotManager(),
+                commitUser,
+                fileHandler,
+                numChannels,
+                numAssigners,
+                assignId,
+                5);
     }
 
     @Test
     public void testAssign() {
-        HashBucketAssigner assigner = createAssigner(2, 0);
+        HashBucketAssigner assigner = createAssigner(2, 2, 0);
 
         // assign
         assertThat(assigner.assign(row(1), 0)).isEqualTo(0);
@@ -87,7 +93,7 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
 
     @Test
     public void testPartitionCopy() {
-        HashBucketAssigner assigner = createAssigner(1, 0);
+        HashBucketAssigner assigner = createAssigner(1, 1, 0);
 
         BinaryRow partition = row(1);
         assertThat(assigner.assign(partition, 0)).isEqualTo(0);
@@ -113,33 +119,33 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
 
     @Test
     public void testAssignRestore() {
-        IndexFileMeta bucket0 = fileHandler.writeHashIndex(new int[] {0, 2});
-        IndexFileMeta bucket1 = fileHandler.writeHashIndex(new int[] {3, 5});
+        IndexFileMeta bucket0 = fileHandler.writeHashIndex(new int[] {2, 5});
+        IndexFileMeta bucket2 = fileHandler.writeHashIndex(new int[] {4, 7});
         commit.commit(
                 0,
                 Arrays.asList(
                         createCommitMessage(row(1), 0, bucket0),
-                        createCommitMessage(row(1), 1, bucket1)));
+                        createCommitMessage(row(1), 2, bucket2)));
 
-        HashBucketAssigner assigner0 = createAssigner(3, 0);
-        HashBucketAssigner assigner2 = createAssigner(3, 2);
+        HashBucketAssigner assigner0 = createAssigner(3, 3, 0);
+        HashBucketAssigner assigner2 = createAssigner(3, 3, 2);
 
         // read assigned
-        assertThat(assigner0.assign(row(1), 0)).isEqualTo(0);
-        assertThat(assigner2.assign(row(1), 2)).isEqualTo(0);
-        assertThat(assigner0.assign(row(1), 3)).isEqualTo(1);
-        assertThat(assigner2.assign(row(1), 5)).isEqualTo(1);
+        assertThat(assigner0.assign(row(1), 2)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 4)).isEqualTo(2);
+        assertThat(assigner0.assign(row(1), 5)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 7)).isEqualTo(2);
 
         // new assign
-        assertThat(assigner0.assign(row(1), 6)).isEqualTo(0);
-        assertThat(assigner0.assign(row(1), 9)).isEqualTo(0);
-        assertThat(assigner0.assign(row(1), 12)).isEqualTo(0);
-        assertThat(assigner0.assign(row(1), 15)).isEqualTo(3);
+        assertThat(assigner0.assign(row(1), 8)).isEqualTo(0);
+        assertThat(assigner0.assign(row(1), 11)).isEqualTo(0);
+        assertThat(assigner0.assign(row(1), 14)).isEqualTo(0);
+        assertThat(assigner0.assign(row(1), 17)).isEqualTo(3);
     }
 
     @Test
     public void testIndexEliminate() {
-        HashBucketAssigner assigner = createAssigner(1, 0);
+        HashBucketAssigner assigner = createAssigner(1, 1, 0);
 
         // checkpoint 0
         assertThat(assigner.assign(row(1), 0)).isEqualTo(0);

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
@@ -144,6 +144,33 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
     }
 
     @Test
+    public void testAssignDecoupled() {
+        HashBucketAssigner assigner1 = createAssigner(3, 2, 1);
+        assertThat(assigner1.assign(row(1), 0)).isEqualTo(1);
+        assertThat(assigner1.assign(row(1), 2)).isEqualTo(1);
+        assertThat(assigner1.assign(row(1), 4)).isEqualTo(1);
+        assertThat(assigner1.assign(row(1), 6)).isEqualTo(1);
+        assertThat(assigner1.assign(row(1), 8)).isEqualTo(1);
+        assertThat(assigner1.assign(row(1), 10)).isEqualTo(3);
+
+        HashBucketAssigner assigner2 = createAssigner(3, 2, 2);
+        assertThat(assigner2.assign(row(1), 1)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 3)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 5)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 7)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 9)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 11)).isEqualTo(2);
+
+        HashBucketAssigner assigner0 = createAssigner(3, 2, 0);
+        assertThat(assigner0.assign(row(2), 1)).isEqualTo(0);
+        assertThat(assigner0.assign(row(2), 3)).isEqualTo(0);
+        assertThat(assigner0.assign(row(2), 5)).isEqualTo(0);
+        assertThat(assigner0.assign(row(2), 7)).isEqualTo(0);
+        assertThat(assigner0.assign(row(2), 9)).isEqualTo(0);
+        assertThat(assigner0.assign(row(2), 11)).isEqualTo(2);
+    }
+
+    @Test
     public void testIndexEliminate() {
         HashBucketAssigner assigner = createAssigner(1, 1, 0);
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAssignerChannelComputer.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAssignerChannelComputer.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.flink.sink.ChannelComputer;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.utils.MathUtils;
 
 import static org.apache.paimon.index.BucketAssigner.computeAssigner;
 
@@ -42,9 +43,7 @@ public class CdcAssignerChannelComputer implements ChannelComputer<CdcRecord> {
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
-        if (numAssigners == null) {
-            numAssigners = numChannels;
-        }
+        this.numAssigners = MathUtils.min(numAssigners, numChannels);
         this.extractor = new CdcRecordKeyAndBucketExtractor(schema);
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
@@ -41,8 +41,8 @@ public class CdcDynamicBucketSink extends DynamicBucketSink<CdcRecord> {
     }
 
     @Override
-    protected ChannelComputer<CdcRecord> channelComputer1() {
-        return new CdcHashKeyChannelComputer(table.schema());
+    protected ChannelComputer<CdcRecord> assignerChannelComputer(Integer numAssigners) {
+        return new CdcAssignerChannelComputer(table.schema(), numAssigners);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketCompactSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketCompactSink.java
@@ -50,7 +50,7 @@ public class DynamicBucketCompactSink extends RowDynamicBucketSink {
         // bucket-assigner
         HashBucketAssignerOperator<InternalRow> assignerOperator =
                 new HashBucketAssignerOperator<>(
-                        initialCommitUser, table, extractorFunction(), true);
+                        initialCommitUser, table, null, extractorFunction(), true);
         TupleTypeInfo<Tuple2<InternalRow, Integer>> rowWithBucketType =
                 new TupleTypeInfo<>(input.getType(), BasicTypeInfo.INT_TYPE_INFO);
         DataStream<Tuple2<InternalRow, Integer>> bucketAssigned =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
@@ -42,6 +42,7 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
     private final String initialCommitUser;
 
     private final AbstractFileStoreTable table;
+    private final Integer numAssigners;
     private final SerializableFunction<TableSchema, PartitionKeyExtractor<T>> extractorFunction;
     private final boolean overwrite;
 
@@ -51,10 +52,12 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
     public HashBucketAssignerOperator(
             String commitUser,
             Table table,
+            Integer numAssigners,
             SerializableFunction<TableSchema, PartitionKeyExtractor<T>> extractorFunction,
             boolean overwrite) {
         this.initialCommitUser = commitUser;
         this.table = (AbstractFileStoreTable) table;
+        this.numAssigners = numAssigners;
         this.extractorFunction = extractorFunction;
         this.overwrite = overwrite;
     }
@@ -70,19 +73,20 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
 
+        int numberTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+        int taskId = getRuntimeContext().getIndexOfThisSubtask();
+        long targetRowNum = table.coreOptions().dynamicBucketTargetRowNum();
         this.assigner =
                 overwrite
-                        ? new SimpleHashBucketAssigner(
-                                getRuntimeContext().getNumberOfParallelSubtasks(),
-                                getRuntimeContext().getIndexOfThisSubtask(),
-                                table.coreOptions().dynamicBucketTargetRowNum())
+                        ? new SimpleHashBucketAssigner(numberTasks, taskId, targetRowNum)
                         : new HashBucketAssigner(
                                 table.snapshotManager(),
                                 commitUser,
                                 table.store().newIndexFileHandler(),
-                                getRuntimeContext().getNumberOfParallelSubtasks(),
-                                getRuntimeContext().getIndexOfThisSubtask(),
-                                table.coreOptions().dynamicBucketTargetRowNum());
+                                numberTasks,
+                                numAssigners == null ? numberTasks : numAssigners,
+                                taskId,
+                                targetRowNum);
         this.extractor = extractorFunction.apply(table.schema());
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
@@ -25,6 +25,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.AbstractFileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
+import org.apache.paimon.utils.MathUtils;
 import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -84,7 +85,7 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
                                 commitUser,
                                 table.store().newIndexFileHandler(),
                                 numberTasks,
-                                numAssigners == null ? numberTasks : numAssigners,
+                                MathUtils.min(numAssigners, numberTasks),
                                 taskId,
                                 targetRowNum);
         this.extractor = extractorFunction.apply(table.schema());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAssignerChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAssignerChannelComputer.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
+import org.apache.paimon.utils.MathUtils;
 
 import org.apache.flink.table.data.RowData;
 
@@ -45,9 +46,7 @@ public class RowAssignerChannelComputer implements ChannelComputer<InternalRow> 
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
-        if (numAssigners == null) {
-            numAssigners = numChannels;
-        }
+        this.numAssigners = MathUtils.min(numAssigners, numChannels);
         this.extractor = new RowPartitionKeyExtractor(schema);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAssignerChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAssignerChannelComputer.java
@@ -24,30 +24,38 @@ import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 
 import org.apache.flink.table.data.RowData;
 
+import static org.apache.paimon.index.BucketAssigner.computeAssigner;
+
 /** Hash key of a {@link RowData}. */
-public class RowHashKeyChannelComputer implements ChannelComputer<InternalRow> {
+public class RowAssignerChannelComputer implements ChannelComputer<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
     private final TableSchema schema;
+    private Integer numAssigners;
 
     private transient int numChannels;
     private transient RowPartitionKeyExtractor extractor;
 
-    public RowHashKeyChannelComputer(TableSchema schema) {
+    public RowAssignerChannelComputer(TableSchema schema, Integer numAssigners) {
         this.schema = schema;
+        this.numAssigners = numAssigners;
     }
 
     @Override
     public void setup(int numChannels) {
         this.numChannels = numChannels;
+        if (numAssigners == null) {
+            numAssigners = numChannels;
+        }
         this.extractor = new RowPartitionKeyExtractor(schema);
     }
 
     @Override
     public int channel(InternalRow record) {
-        int hash = extractor.trimmedPrimaryKey(record).hashCode();
-        return Math.abs(hash % numChannels);
+        int partitionHash = extractor.partition(record).hashCode();
+        int keyHash = extractor.trimmedPrimaryKey(record).hashCode();
+        return computeAssigner(partitionHash, keyHash, numChannels, numAssigners);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -43,8 +43,8 @@ public class RowDynamicBucketSink extends DynamicBucketSink<InternalRow> {
     }
 
     @Override
-    protected ChannelComputer<InternalRow> channelComputer1() {
-        return new RowHashKeyChannelComputer(table.schema());
+    protected ChannelComputer<InternalRow> assignerChannelComputer(Integer numAssigners) {
+        return new RowAssignerChannelComputer(table.schema(), numAssigners);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
@@ -31,6 +31,7 @@ import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.MathUtils;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -93,7 +94,10 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<InternalRow, 
                         .setParallelism(input.getParallelism());
 
         // 1. shuffle by key hash
-        Integer assignerParallelism = options.dynamicBucketAssignerParallelism();
+        Integer assignerParallelism =
+                MathUtils.max(
+                        options.dynamicBucketInitialBuckets(),
+                        options.dynamicBucketAssignerParallelism());
         if (assignerParallelism == null) {
             assignerParallelism = parallelism;
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
@@ -88,6 +88,15 @@ public class DynamicBucketTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testWriteWithAssignerParallelism1() {
+        sql(
+                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.assigner-parallelism'='1') */ "
+                        + "VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
+        assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
+                .containsExactlyInAnyOrder(Row.of(0), Row.of(1));
+    }
+
+    @Test
     public void testOverwrite() throws Exception {
         sql("INSERT INTO T VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
         assertThat(sql("SELECT * FROM T"))

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
@@ -81,16 +81,17 @@ public class DynamicBucketTableITCase extends CatalogITCaseBase {
     @Test
     public void testWriteWithAssignerParallelism() {
         sql(
-                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.assigner-parallelism'='3') */ "
+                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.initial-buckets'='3') */ "
                         + "VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
+        // initial-buckets is 3, but parallelism is 2, will use 2
         assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
-                .containsExactlyInAnyOrder(Row.of(0), Row.of(1), Row.of(2));
+                .containsExactlyInAnyOrder(Row.of(0), Row.of(1));
     }
 
     @Test
     public void testWriteWithAssignerParallelism1() {
         sql(
-                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.assigner-parallelism'='1') */ "
+                "INSERT INTO T /*+ OPTIONS('dynamic-bucket.initial-buckets'='1') */ "
                         + "VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)");
         assertThat(sql("SELECT DISTINCT bucket FROM T$files"))
                 .containsExactlyInAnyOrder(Row.of(0), Row.of(1));

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -29,6 +29,7 @@ import org.apache.paimon.spark.util.{EncoderUtils, SparkRowUtils}
 import org.apache.paimon.table.{BucketMode, FileStoreTable}
 import org.apache.paimon.table.sink.{BatchWriteBuilder, CommitMessageSerializer, DynamicBucketRow, RowPartitionKeyExtractor}
 import org.apache.paimon.types.RowType
+import org.apache.paimon.utils.MathUtils
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
@@ -106,7 +107,10 @@ case class WriteIntoPaimonTable(
         case BucketMode.DYNAMIC =>
           val partitioned = if (primaryKeyCols.nonEmpty) {
             // Make sure that the records with the same bucket values is within a task.
-            val assignerParallelism = table.coreOptions.dynamicBucketAssignerParallelism
+            // TODO supports decoupling of initialBuckets and assignerParallelism
+            var assignerParallelism = MathUtils.max(
+              table.coreOptions.dynamicBucketInitialBuckets,
+              table.coreOptions.dynamicBucketAssignerParallelism)
             if (assignerParallelism != null) {
               withBucketCol.repartition(assignerParallelism, primaryKeyCols: _*)
             } else {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Assuming we need to write multiple partitions simultaneously:

- At present, setting the dynamic bucket assignment parallelism option too large can result in a large number of buckets.
- Setting it too small will pose a risk to memory and make it prone to OOM

This PR aims to decouple initialized buckets and total parallelism of assigners to avoid the aforementioned issues

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
