### PR TITLE
[Catalog]Set auto-create = false when using FilesystemCatalog to create table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileIO;
@@ -178,6 +179,7 @@ public abstract class AbstractCatalog implements Catalog {
         checkNotSystemTable(identifier, "createTable");
         validateIdentifierNameCaseInsensitive(identifier);
         validateFieldNameCaseInsensitive(schema.rowType().getFieldNames());
+        validateAutoCreateClose(schema.options());
 
         if (!databaseExists(identifier.getDatabaseName())) {
             throw new DatabaseNotExistException(identifier.getDatabaseName());
@@ -428,5 +430,16 @@ public abstract class AbstractCatalog implements Catalog {
 
     private void validateFieldNameCaseInsensitive(List<String> fieldNames) {
         validateCaseInsensitive(caseSensitive(), "Field", fieldNames);
+    }
+
+    private void validateAutoCreateClose(Map<String, String> options) {
+        checkArgument(
+                !Boolean.valueOf(
+                        options.getOrDefault(
+                                CoreOptions.AUTO_CREATE.key(),
+                                CoreOptions.AUTO_CREATE.defaultValue().toString())),
+                String.format(
+                        "The value of %s property should be %s.",
+                        CoreOptions.AUTO_CREATE.key(), Boolean.FALSE));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
+import static org.apache.paimon.CoreOptions.AUTO_CREATE;
 import static org.apache.paimon.catalog.FileSystemCatalogOptions.CASE_SENSITIVE;
 
 /** A catalog implementation for {@link FileIO}. */
@@ -122,6 +123,9 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void createTableImpl(Identifier identifier, Schema schema) {
         Path path = getDataTableLocation(identifier);
+        if (schema.options().containsKey(AUTO_CREATE.key())) {
+            schema.options().put(AUTO_CREATE.key(), String.valueOf(Boolean.FALSE));
+        }
         uncheck(() -> new SchemaManager(fileIO, path).createTable(schema));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
-import static org.apache.paimon.CoreOptions.AUTO_CREATE;
 import static org.apache.paimon.catalog.FileSystemCatalogOptions.CASE_SENSITIVE;
 
 /** A catalog implementation for {@link FileIO}. */
@@ -123,9 +122,6 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void createTableImpl(Identifier identifier, Schema schema) {
         Path path = getDataTableLocation(identifier);
-        if (schema.options().containsKey(AUTO_CREATE.key())) {
-            schema.options().put(AUTO_CREATE.key(), String.valueOf(Boolean.FALSE));
-        }
         uncheck(() -> new SchemaManager(fileIO, path).createTable(schema));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -232,8 +232,8 @@ public abstract class CatalogTestBase {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> catalog.createTable(identifier, schema, false))
                 .withMessage("The value of auto-create property should be false.");
-
         schema.options().remove(CoreOptions.AUTO_CREATE.key());
+
         catalog.createTable(identifier, schema, false);
         boolean exists = catalog.tableExists(identifier);
         assertThat(exists).isTrue();

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.CatalogOptions;
@@ -225,6 +226,14 @@ public abstract class CatalogTestBase {
                         .partitionKeys("pk1", "pk2")
                         .primaryKey("pk1", "pk2", "pk3")
                         .build();
+
+        // Create table throws Exception when auto-create = true.
+        schema.options().put(CoreOptions.AUTO_CREATE.key(), Boolean.TRUE.toString());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> catalog.createTable(identifier, schema, false))
+                .withMessage("The value of auto-create property should be false.");
+
+        schema.options().remove(CoreOptions.AUTO_CREATE.key());
         catalog.createTable(identifier, schema, false);
         boolean exists = catalog.tableExists(identifier);
         assertThat(exists).isTrue();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Set auto-create = false when using FilesystemCatalog to create table.

Error:
```
Caused by: com.amazonaws.SdkClientException: Unable to load AWS credentials from any provider in the chain: [EnvironmentVariableCredentialsProvider: Unable to load AWS credentials from environment variables (AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY) and AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY)), SystemPropertiesCredentialsProvider: Unable to load AWS credentials from Java system properties (aws.accessKeyId and aws.secretKey), WebIdentityTokenCredentialsProvider: You must specify a value for roleArn and roleSessionName, com.amazonaws.auth.profile.ProfileCredentialsProvider@610ea73f: profile file cannot be null, com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@180077f2: Failed to connect to service endpoint: ]
	at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:136)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.getCredentialsFromContext(AmazonHttpClient.java:1257)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.runBeforeRequestHandlers(AmazonHttpClient.java:833)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:783)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:704)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:550)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:530)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5259)
	at com.amazonaws.services.s3.AmazonS3Client.getBucketRegionViaHeadRequest(AmazonS3Client.java:6220)
	at com.amazonaws.services.s3.AmazonS3Client.fetchRegionFromCache(AmazonS3Client.java:6193)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5244)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5206)
	at com.amazonaws.services.s3.AmazonS3Client.getObjectMetadata(AmazonS3Client.java:1360)
	at com.amazonaws.services.s3.AmazonS3Client.getObjectMetadata(AmazonS3Client.java:1334)
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.lambda$getS3ObjectMetadata$5(PrestoS3FileSystem.java:667)
	at com.facebook.presto.hive.RetryDriver.run(RetryDriver.java:139)
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.getS3ObjectMetadata(PrestoS3FileSystem.java:664)
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.getS3ObjectMetadata(PrestoS3FileSystem.java:648)
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.getFileStatus(PrestoS3FileSystem.java:353)
	at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1690)
	at org.apache.flink.fs.s3presto.common.HadoopFileSystemWrapper.exists(HadoopFileSystemWrapper.java:79)
	at org.apache.flink.core.fs.PluginFileSystemFactory$ClassLoaderFixingFileSystem.exists(PluginFileSystemFactory.java:148)
	at org.apache.paimon.flink.FlinkFileIO.exists(FlinkFileIO.java:100)
	at org.apache.paimon.fs.FileIOUtils.checkAccess(FileIOUtils.java:37)
	at org.apache.paimon.fs.FileIO.get(FileIO.java:349)
	at org.apache.paimon.flink.FlinkTableFactory.createTableIfNeeded(FlinkTableFactory.java:84)
	... 37 more
```


If the property `auto-create` is true  ,  it will throw exception when the table has been created when using create table ddl in filesystem catalog.  The method `createTableIfNeeded(context)`  is called when using createDynamicTableSource method.
```
SchemaManager schemaManager =
                        new SchemaManager(
                                FileIO.get(tablePath, createCatalogContext(context)), tablePath);

  static CatalogContext createCatalogContext(DynamicTableFactory.Context context) {
        return CatalogContext.create(
                Options.fromMap(context.getCatalogTable().getOptions()), new FlinkFileIOLoader());
    }
```
The `context.getCatalogTable().getOptions()` options belongs to the table attribute rather than the catalog attribute,
so it can not find the  right FileIOLoader when calling ` FileIO.get`  method and using s3 or oss.

![image](https://github.com/apache/incubator-paimon/assets/18002496/9030f988-2993-4e8b-b1df-da9f392b3245)


SQL demo:
```
CREATE CATALOG paimon_catalog WITH (
    'type' = 'paimon',
    'warehouse' = 's3://xxxxx',
    's3.endpoint' = 'xxxxx',
    's3.access-key' = 'xxx',
    's3.secret-key' = 'XXXXX'
);


CREATE TABLE  paimon_catalog.tmp.paimon_test (
   .....
   ......
  PRIMARY KEY (orderDate, id) NOT ENFORCED
) PARTITIONED BY (orderDate)
WITH (
    'auto-create' = 'true',
    'file.format' = 'parquet',
    'bucket' = '30',
    'bucket-key' = 'id',
    'sequence.field' = 'updateCurrentNodeTs'
      .......
);


CREATE TABLE  kakfa_source(
    ......
) WITH (
    'connector' = 'kafka',
    'topic' = 'rxxxx',
    'scan.startup.mode' = 'group-offsets', 
    'format' = 'json',
     ......
);


  INSERT INTO paimon_catalog.tmp.paimon_test
  SELECT *
  FROM default_catalog.default_database.kakfa_source;

```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
