### PR TITLE
[flink] Optimize Flink Lookup Join: Bulk load for initialization

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -46,7 +46,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>rocksdb.block.cache-size</h5></td>
-            <td style="word-wrap: break-word;">8 mb</td>
+            <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
             <td>The amount of the cache for data blocks in RocksDB. The default block-cache size is '8MB'.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -48,7 +48,7 @@ under the License.
             <td><h5>rocksdb.block.cache-size</h5></td>
             <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
-            <td>The amount of the cache for data blocks in RocksDB. The default block-cache size is '8MB'.</td>
+            <td>The amount of the cache for data blocks in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>rocksdb.block.metadata-blocksize</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ListDelimitedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ListDelimitedSerializer.java
@@ -74,6 +74,25 @@ public final class ListDelimitedSerializer {
         return dataOutputView.getCopyOfBuffer();
     }
 
+    public byte[] serializeList(List<byte[]> valueList) throws IOException {
+
+        dataOutputView.clear();
+        boolean first = true;
+
+        for (byte[] value : valueList) {
+            checkNotNull(value, "You cannot add null to a value list.");
+
+            if (first) {
+                first = false;
+            } else {
+                dataOutputView.write(DELIMITER);
+            }
+            dataOutputView.write(value);
+        }
+
+        return dataOutputView.getCopyOfBuffer();
+    }
+
     /** Deserializes a single element from a serialized list. */
     public static <T> T deserializeNextElement(
             DataInputDeserializer in, Serializer<T> elementSerializer) {

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -28,7 +28,9 @@ import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.RowCompactedSerializer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.disk.RowBuffer;
+import org.apache.paimon.lookup.BulkLoader;
 import org.apache.paimon.lookup.RocksDBOptions;
+import org.apache.paimon.lookup.RocksDBState;
 import org.apache.paimon.lookup.RocksDBStateFactory;
 import org.apache.paimon.lookup.RocksDBValueState;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
@@ -44,7 +46,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.IDMapping;
-import org.apache.paimon.utils.KeyValueIterator;
 import org.apache.paimon.utils.MutableObjectIterator;
 import org.apache.paimon.utils.OffsetRow;
 import org.apache.paimon.utils.PositiveIntInt;
@@ -59,7 +60,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -162,15 +162,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
 
         // create bootstrap sort buffer
         this.bootstrap = true;
-        this.bootstrapKeys =
-                BinaryExternalSortBuffer.create(
-                        ioManager,
-                        RowType.of(DataTypes.BYTES()),
-                        RowType.of(DataTypes.BYTES(), DataTypes.BYTES()),
-                        coreOptions.writeBufferSize() / 2,
-                        coreOptions.pageSize(),
-                        coreOptions.localSortMaxNumFileHandles());
-
+        this.bootstrapKeys = RocksDBState.createBulkLoadSorter(ioManager, coreOptions);
         this.bootstrapRecords =
                 RowBuffer.getBuffer(
                         ioManager,
@@ -201,35 +193,23 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
         bootstrapRecords.complete();
         boolean isEmpty = true;
         if (bootstrapKeys.size() > 0) {
+            BulkLoader bulkLoader = keyIndex.createBulkLoader();
             MutableObjectIterator<BinaryRow> keyIterator = bootstrapKeys.sortedIterator();
             BinaryRow row = new BinaryRow(2);
-            KeyValueIterator<byte[], byte[]> kvIter =
-                    new KeyValueIterator<byte[], byte[]>() {
+            try {
+                while ((row = keyIterator.next(row)) != null) {
+                    bulkLoader.write(row.getBinary(0), row.getBinary(1));
+                }
+            } catch (BulkLoader.WriteException e) {
+                throw new RuntimeException(
+                        "Exception in bulkLoad, the most suspicious reason is that "
+                                + "your data contains duplicates, please check your sink table. "
+                                + "(The likelihood of duplication is that you used multiple jobs to write the "
+                                + "same dynamic bucket table, it only supports single write)",
+                        e.getCause());
+            }
+            bulkLoader.finish();
 
-                        private BinaryRow current;
-
-                        @Override
-                        public boolean advanceNext() {
-                            try {
-                                current = keyIterator.next(row);
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
-                            }
-                            return current != null;
-                        }
-
-                        @Override
-                        public byte[] getKey() {
-                            return current.getBinary(0);
-                        }
-
-                        @Override
-                        public byte[] getValue() {
-                            return current.getBinary(1);
-                        }
-                    };
-
-            stateFactory.bulkLoad(keyIndex, kvIter);
             isEmpty = false;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/BulkLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/BulkLoader.java
@@ -86,7 +86,9 @@ public class BulkLoader {
             }
 
             if (files.size() > 0) {
-                db.ingestExternalFile(columnFamily, files, new IngestExternalFileOptions());
+                IngestExternalFileOptions ingestOptions = new IngestExternalFileOptions();
+                db.ingestExternalFile(columnFamily, files, ingestOptions);
+                ingestOptions.close();
             }
         } catch (RocksDBException e) {
             throw new RuntimeException(e);

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/BulkLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/BulkLoader.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lookup;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.EnvOptions;
+import org.rocksdb.IngestExternalFileOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileWriter;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/** Bulk loader for RocksDB. */
+public class BulkLoader {
+
+    private final String uuid = UUID.randomUUID().toString();
+
+    private final ColumnFamilyHandle columnFamily;
+    private final String path;
+    private final RocksDB db;
+    private final Options options;
+    private final List<String> files = new ArrayList<>();
+
+    private SstFileWriter writer = null;
+    private int sstIndex = 0;
+    private long recordNum = 0;
+
+    public BulkLoader(RocksDB db, Options options, ColumnFamilyHandle columnFamily, String path) {
+        this.db = db;
+        this.options = options;
+        this.columnFamily = columnFamily;
+        this.path = path;
+    }
+
+    public void write(byte[] key, byte[] value) throws WriteException {
+        try {
+            if (writer == null) {
+                writer = new SstFileWriter(new EnvOptions(), options);
+                String path = new File(this.path, "sst-" + uuid + "-" + (sstIndex++)).getPath();
+                writer.open(path);
+                files.add(path);
+            }
+
+            try {
+                writer.put(key, value);
+            } catch (RocksDBException e) {
+                throw new WriteException(e);
+            }
+
+            recordNum++;
+            if (recordNum % 1000 == 0 && writer.fileSize() >= options.targetFileSizeBase()) {
+                writer.finish();
+                writer = null;
+                recordNum = 0;
+            }
+        } catch (RocksDBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void finish() {
+        try {
+            if (writer != null) {
+                writer.finish();
+            }
+
+            if (files.size() > 0) {
+                db.ingestExternalFile(columnFamily, files, new IngestExternalFileOptions());
+            }
+        } catch (RocksDBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Exception during writing. */
+    public static class WriteException extends Exception {
+        public WriteException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBListState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBListState.java
@@ -22,7 +22,6 @@ import org.apache.paimon.data.serializer.Serializer;
 import org.apache.paimon.utils.ListDelimitedSerializer;
 
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
@@ -35,12 +34,12 @@ public class RocksDBListState<K, V> extends RocksDBState<K, V, List<V>> {
     private final ListDelimitedSerializer listSerializer = new ListDelimitedSerializer();
 
     public RocksDBListState(
-            RocksDB db,
+            RocksDBStateFactory stateFactory,
             ColumnFamilyHandle columnFamily,
             Serializer<K> keySerializer,
             Serializer<V> valueSerializer,
             long lruCacheSize) {
-        super(db, columnFamily, keySerializer, valueSerializer, lruCacheSize);
+        super(stateFactory, columnFamily, keySerializer, valueSerializer, lruCacheSize);
     }
 
     public void add(K key, V value) throws IOException {
@@ -73,9 +72,13 @@ public class RocksDBListState<K, V> extends RocksDBState<K, V, List<V>> {
                 });
     }
 
-    private byte[] serializeValue(V value) throws IOException {
+    public byte[] serializeValue(V value) throws IOException {
         valueOutputView.clear();
         valueSerializer.serialize(value, valueOutputView);
         return valueOutputView.getCopyOfBuffer();
+    }
+
+    public byte[] serializeList(List<byte[]> valueList) throws IOException {
+        return listSerializer.serializeList(valueList);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBOptions.java
@@ -34,7 +34,6 @@ import org.rocksdb.InfoLogLevel;
 import org.rocksdb.PlainTableConfig;
 import org.rocksdb.TableFormatConfig;
 
-import java.io.File;
 import java.time.Duration;
 
 import static org.apache.paimon.options.ConfigOptions.key;
@@ -241,10 +240,8 @@ public class RocksDBOptions {
     public static final ConfigOption<MemorySize> BLOCK_CACHE_SIZE =
             key("rocksdb.block.cache-size")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("8mb"))
-                    .withDescription(
-                            "The amount of the cache for data blocks in RocksDB. "
-                                    + "The default block-cache size is '8MB'.");
+                    .defaultValue(MemorySize.parse("128mb"))
+                    .withDescription("The amount of the cache for data blocks in RocksDB.");
 
     public static final ConfigOption<Boolean> USE_BLOOM_FILTER =
             key("rocksdb.use-bloom-filter")
@@ -283,17 +280,6 @@ public class RocksDBOptions {
         currentOptions.setMaxLogFileSize(options.get(LOG_MAX_FILE_SIZE).getBytes());
         currentOptions.setKeepLogFileNum(options.get(LOG_FILE_NUM));
         return currentOptions;
-    }
-
-    /**
-     * Verify log file location.
-     *
-     * @param logFilePath Path to log file
-     * @return File or null if not a valid log file
-     */
-    private static File resolveFileLocation(String logFilePath) {
-        File logFile = new File(logFilePath);
-        return (logFile.exists() && logFile.canRead()) ? logFile : null;
     }
 
     public static ColumnFamilyOptions createColumnOptions(

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBSetState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBSetState.java
@@ -21,7 +21,6 @@ package org.apache.paimon.lookup;
 import org.apache.paimon.data.serializer.Serializer;
 
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 
@@ -38,12 +37,12 @@ public class RocksDBSetState<K, V> extends RocksDBState<K, V, List<byte[]>> {
     private static final byte[] EMPTY = new byte[0];
 
     public RocksDBSetState(
-            RocksDB db,
+            RocksDBStateFactory stateFactory,
             ColumnFamilyHandle columnFamily,
             Serializer<K> keySerializer,
             Serializer<V> valueSerializer,
             long lruCacheSize) {
-        super(db, columnFamily, keySerializer, valueSerializer, lruCacheSize);
+        super(stateFactory, columnFamily, keySerializer, valueSerializer, lruCacheSize);
     }
 
     public List<V> get(K key) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBValueState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBValueState.java
@@ -21,7 +21,6 @@ package org.apache.paimon.lookup;
 import org.apache.paimon.data.serializer.Serializer;
 
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDB;
 
 import javax.annotation.Nullable;
 
@@ -33,12 +32,12 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class RocksDBValueState<K, V> extends RocksDBState<K, V, RocksDBState.Reference> {
 
     public RocksDBValueState(
-            RocksDB db,
+            RocksDBStateFactory stateFactory,
             ColumnFamilyHandle columnFamily,
             Serializer<K> keySerializer,
             Serializer<V> valueSerializer,
             long lruCacheSize) {
-        super(db, columnFamily, keySerializer, valueSerializer, lruCacheSize);
+        super(stateFactory, columnFamily, keySerializer, valueSerializer, lruCacheSize);
     }
 
     @Nullable

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -18,19 +18,28 @@
 
 package org.apache.paimon.flink.lookup;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.flink.lookup.LookupTable.TableBulkLoader;
 import org.apache.paimon.flink.utils.TableScanUtils;
+import org.apache.paimon.lookup.BulkLoader;
+import org.apache.paimon.lookup.RocksDBState;
 import org.apache.paimon.lookup.RocksDBStateFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateFilter;
 import org.apache.paimon.reader.RecordReaderIterator;
+import org.apache.paimon.sort.BinaryExternalSortBuffer;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileIOUtils;
+import org.apache.paimon.utils.MutableObjectIterator;
 import org.apache.paimon.utils.TypeUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.primitives.Ints;
@@ -145,9 +154,41 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                         options.get(LOOKUP_CACHE_ROWS));
         this.nextLoadTime = -1;
         this.streamingReader = new TableStreamingReader(table, projection, this.predicate);
+        bulkLoad(options);
+    }
 
-        // do first load
-        refresh();
+    private void bulkLoad(Options options) throws Exception {
+        BinaryExternalSortBuffer bulkLoadSorter =
+                RocksDBState.createBulkLoadSorter(
+                        IOManager.create(path.toString()), new CoreOptions(options));
+        try (RecordReaderIterator<InternalRow> batch =
+                new RecordReaderIterator<>(streamingReader.nextBatch())) {
+            while (batch.hasNext()) {
+                InternalRow row = batch.next();
+                if (lookupTable.recordFilter().test(row)) {
+                    bulkLoadSorter.write(
+                            GenericRow.of(
+                                    lookupTable.toKeyBytes(row), lookupTable.toValueBytes(row)));
+                }
+            }
+        }
+
+        MutableObjectIterator<BinaryRow> keyIterator = bulkLoadSorter.sortedIterator();
+        BinaryRow row = new BinaryRow(2);
+        TableBulkLoader bulkLoader = lookupTable.createBulkLoader();
+        try {
+            while ((row = keyIterator.next(row)) != null) {
+                bulkLoader.write(row.getBinary(0), row.getBinary(1));
+            }
+        } catch (BulkLoader.WriteException e) {
+            throw new RuntimeException(
+                    "Exception in bulkLoad, the most suspicious reason is that "
+                            + "your data contains duplicates, please check your lookup table. ",
+                    e.getCause());
+        }
+
+        bulkLoader.finish();
+        bulkLoadSorter.clear();
     }
 
     private PredicateFilter createRecordFilter(int[] projection) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -96,4 +96,10 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
             }
         }
     }
+
+    @Override
+    public void bulkLoadWritePlus(byte[] key, byte[] value) throws IOException {
+        InternalRow row = tableState.deserializeValue(value);
+        indexState.add(secKeyRow.replaceRow(row), primaryKey.replaceRow(row));
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.lookup.RocksDBOptions;
-import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -71,8 +70,6 @@ public class FileStoreLookupFunctionTest {
         SchemaManager schemaManager = new SchemaManager(fileIO, path);
         Options conf = new Options();
         conf.set(CoreOptions.BUCKET, 2);
-        conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
-        conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
         conf.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 3);
         conf.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 2);
         conf.set(RocksDBOptions.LOOKUP_CONTINUOUS_DISCOVERY_INTERVAL, Duration.ofSeconds(1));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When initializing, it is necessary to scan the entire table and then write one by one to RocksDB. This process is too time-consuming because RocksDB writes slowly.

We can optimize it to bulkload mode, sort it first before writing it during full initialization.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
