### PR TITLE
[flink] Fix that schema validation fails when using 'scan.x' options to do time travel on schema changed tables

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -407,7 +407,7 @@ public class DateTimeUtils {
     // Format
     // --------------------------------------------------------------------------------------------
 
-    private static String formatTimestamp(Timestamp ts, int precision) {
+    public static String formatTimestamp(Timestamp ts, int precision) {
         LocalDateTime ldt = ts.toLocalDateTime();
 
         String fraction = pad(9, ldt.getNano());

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -79,6 +79,9 @@ public interface FileStoreTable extends DataTable {
     @Override
     FileStoreTable copy(Map<String, String> dynamicOptions);
 
+    /** Doesn't change table schema even when there exists time travel scan options. */
+    FileStoreTable copyWithoutTimeTravel(Map<String, String> dynamicOptions);
+
     /** Sometimes we have to change some Immutable options to implement features. */
     FileStoreTable internalCopyWithoutCheck(Map<String, String> dynamicOptions);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -248,10 +248,14 @@ public abstract class AbstractFlinkTableFactory
         newOptions.putAll(origin.getOptions());
         newOptions.putAll(dynamicOptions);
 
+        // notice that the Paimon table schema must be the same with the Flink's
         if (origin instanceof DataCatalogTable) {
-            table = ((DataCatalogTable) origin).table().copy(newOptions);
+            FileStoreTable fileStoreTable = (FileStoreTable) ((DataCatalogTable) origin).table();
+            table = fileStoreTable.copyWithoutTimeTravel(newOptions);
         } else {
-            table = FileStoreTableFactory.create(createCatalogContext(context)).copy(newOptions);
+            table =
+                    FileStoreTableFactory.create(createCatalogContext(context))
+                            .copyWithoutTimeTravel(newOptions);
         }
 
         Schema schema = FlinkCatalog.fromCatalogTable(context.getCatalogTable());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.BlockingIterator;
+import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -385,5 +386,34 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                 .containsExactlyInAnyOrder(
                         Row.ofKind(RowKind.INSERT, 1, "B"), Row.ofKind(RowKind.INSERT, 2, "B"));
         iterator.close();
+    }
+
+    @Test
+    public void testScanFromOldSchema() throws InterruptedException {
+        sql("CREATE TABLE select_old (f0 INT PRIMARY KEY NOT ENFORCED, f1 STRING)");
+
+        sql("INSERT INTO select_old VALUES (1, 'a'), (2, 'b')");
+
+        Thread.sleep(1_000);
+        long timestamp = System.currentTimeMillis();
+
+        sql("ALTER TABLE select_old ADD f2 STRING");
+        sql("INSERT INTO select_old VALUES (3, 'c', 'C')");
+
+        // this way will initialize source with the latest schema
+        assertThat(
+                        sql(
+                                "SELECT * FROM select_old /*+ OPTIONS('scan.timestamp-millis'='%s') */",
+                                timestamp))
+                // old schema doesn't have column f2
+                .containsExactlyInAnyOrder(Row.of(1, "a", null), Row.of(2, "b", null));
+
+        // this way will initialize source with time-travelled schema
+        assertThat(
+                        sql(
+                                "SELECT * FROM select_old FOR SYSTEM_TIME AS OF TIMESTAMP '%s'",
+                                DateTimeUtils.formatTimestamp(
+                                        DateTimeUtils.toInternal(timestamp, 0), 0)))
+                .containsExactlyInAnyOrder(Row.of(1, "a"), Row.of(2, "b"));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

`BatchFileStoreITCase#testScanFromOldSchema`
`testScanFromOldSchema#testScanFromOldSchema`

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
