### PR TITLE
[core] Optimize snapshot expire loop for consumers

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreExpireImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreExpireImpl.java
@@ -120,12 +120,18 @@ public class FileStoreExpireImpl implements FileStoreExpire {
         for (long id = Math.max(latestSnapshotId - numRetainedMax + 1, earliest);
                 id <= latestSnapshotId - numRetainedMin;
                 id++) {
-            // Quickly exit the loop in advance for consumer
+            // Early exit the loop in advance for consumer
             if (consumerReading.isPresent() && id >= consumerReading.getAsLong()) {
                 long consumerSnapshot = consumerReading.getAsLong();
                 if (consumerSnapshot > earliest) {
                     expireUntil(earliest, consumerSnapshot);
                 }
+                return;
+            }
+
+            // Early exit the loop in advance for expireLimit
+            if (id - earliest >= expireLimit) {
+                expireUntil(earliest, id);
                 return;
             }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Base test class for {@link FileStoreExpireImpl}. */
-public class FileStoreExpireTestBase {
+public abstract class FileStoreExpireTestBase {
 
     protected final FileIO fileIO = new LocalFileIO();
     protected TestKeyValueGenerator gen;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When there are very old consumers, we should quickly exit the loop of snapshot elimination. Otherwise, the performance is very poor.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
