### PR TITLE
[core]Loader jaxb-api from parent class loader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/plugin/PluginLoader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/plugin/PluginLoader.java
@@ -44,7 +44,8 @@ public class PluginLoader {
                             Stream.of(
                                     "org.codehaus.janino",
                                     "org.codehaus.commons",
-                                    "org.apache.commons.lang3"))
+                                    "org.apache.commons.lang3",
+                                    "javax.xml.bind"))
                     .toArray(String[]::new);
 
     private static final String[] COMPONENT_CLASSPATH = new String[] {"org.apache.paimon"};


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
like aliyun-sdk-oss depends on javax.xml.bind.JAXBException. When using JDK 11 or higher, you need to additionally import jaxb-api. Therefore, when the dependency cannot be found, attempt to load it from the parent loader.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
