### PR TITLE
[flink] build schema after match in the sync action

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -115,15 +115,15 @@ public class MySqlActionUtils {
                             while (tables.next()) {
                                 String tableName = tables.getString("TABLE_NAME");
                                 String tableComment = tables.getString("REMARKS");
-                                Schema schema =
-                                        MySqlSchemaUtils.buildSchema(
-                                                metaData,
-                                                databaseName,
-                                                tableName,
-                                                tableComment,
-                                                typeMapping);
                                 Identifier identifier = Identifier.create(databaseName, tableName);
                                 if (monitorTablePredication.test(tableName)) {
+                                    Schema schema =
+                                            MySqlSchemaUtils.buildSchema(
+                                                    metaData,
+                                                    databaseName,
+                                                    tableName,
+                                                    tableComment,
+                                                    typeMapping);
                                     mySqlSchemasInfo.addSchema(identifier, schema);
                                 } else {
                                     excludedTables.add(identifier);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

We should build the schema after we do the monitor table check

Otherwise, if there are thousands of tables but we only want to synchronize a few of them, it will build thousands of schemas, which is useless and affects performance, and may even throw exceptions during the process of building schemas



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
