### PR TITLE
[flink] reset currentFetchEventTimeLag after splits are all consumed

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -165,6 +165,10 @@ public class FileStoreSourceSplitReader
                 currentReader.lazyRecordReader.close();
             }
         }
+
+        if (sourceReaderMetrics != null) {
+            sourceReaderMetrics.nothingAvailable();
+        }
     }
 
     private void checkSplitOrStartNext() throws IOException {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.source.operator;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.flink.source.align.PlaceholderSplit;
 import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
@@ -74,6 +75,12 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
     @Override
     public void processElement(StreamRecord<Split> record) throws Exception {
         Split split = record.getValue();
+        // There is no split from source currently.
+        if (split instanceof PlaceholderSplit) {
+            sourceReaderMetrics.nothingAvailable();
+            return;
+        }
+
         // update metric when reading a new split
         long eventTime =
                 ((DataSplit) split)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
@@ -52,4 +52,19 @@ class FileStoreSourceReaderMetricsTest {
         assertThat(sourceReaderMetrics.getFetchTimeLag())
                 .isNotEqualTo(FileStoreSourceReaderMetrics.UNDEFINED);
     }
+
+    @Test
+    public void testNoSplits() {
+        MetricListener metricListener = new MetricListener();
+        final FileStoreSourceReaderMetrics sourceReaderMetrics =
+                new FileStoreSourceReaderMetrics(metricListener.getMetricGroup());
+        assertThat(sourceReaderMetrics.getFetchTimeLag())
+                .isEqualTo(FileStoreSourceReaderMetrics.UNDEFINED);
+        sourceReaderMetrics.recordSnapshotUpdate(123);
+        sourceReaderMetrics.nothingAvailable();
+        sourceReaderMetrics.setLastSplitUpdateTime(System.currentTimeMillis() - 70000);
+        assertThat(sourceReaderMetrics.getFetchTimeLag()).isEqualTo(0);
+        sourceReaderMetrics.recordSnapshotUpdate(1234);
+        assertThat(sourceReaderMetrics.getFetchTimeLag()).isGreaterThan(0);
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2560

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
