### PR TITLE
[Hive]  HiveCatalog add hive client pool

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -57,7 +57,7 @@ public final class HiveCatalogOptions {
     public static final ConfigOption<Integer> CLIENT_POOL_SIZE =
             ConfigOptions.key("clients")
                     .intType()
-                    .defaultValue(1)
+                    .defaultValue(2)
                     .withDescription("Setting the client pool's num.\n");
 
     public static final ConfigOption<Long> CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS =

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -21,6 +21,8 @@ package org.apache.paimon.hive;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 
+import java.util.concurrent.TimeUnit;
+
 /** Options for hive catalog. */
 public final class HiveCatalogOptions {
 
@@ -51,6 +53,18 @@ public final class HiveCatalogOptions {
                             "Setting the location in properties of hive table/database.\n"
                                     + "If you don't want to access the location by the filesystem of hive when using a object storage such as s3,oss\n"
                                     + "you can set this option to true.\n");
+
+    public static final ConfigOption<Integer> CLIENT_POOL_SIZE =
+            ConfigOptions.key("clients")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("Setting the client pool's num.\n");
+
+    public static final ConfigOption<Long> CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS =
+            ConfigOptions.key("client.pool.cache.eviction-interval-ms")
+                    .longType()
+                    .defaultValue(TimeUnit.MINUTES.toMillis(5))
+                    .withDescription("Setting the client's pool cache eviction interval(ms).\n");
 
     private HiveCatalogOptions() {}
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveClientPool.java
@@ -22,7 +22,6 @@ package org.apache.paimon.hive;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.hive.pool.ClientPoolImpl;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -40,15 +39,14 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
 
     private final String clientClassName;
 
-    public HiveClientPool(int poolSize, Configuration conf) {
+    public HiveClientPool(int poolSize, HiveConf conf) {
         this(poolSize, conf, "org.apache.hadoop.hive.metastore.HiveMetaStoreClient");
     }
 
-    public HiveClientPool(int poolSize, Configuration conf, String clientClassName) {
+    public HiveClientPool(int poolSize, HiveConf conf, String clientClassName) {
         // Do not allow retry by default as we rely on RetryingHiveClient
         super(poolSize, TTransportException.class, false);
-        this.hiveConf = new HiveConf(conf, HiveClientPool.class);
-        this.hiveConf.addResource(conf);
+        this.hiveConf = conf;
         this.clientClassName = clientClassName;
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveClientPool.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.hive.pool.ClientPoolImpl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * HiveClientPool.
+ *
+ * <p>Mostly copied from iceberg.
+ */
+public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException> {
+
+    private final HiveConf hiveConf;
+
+    private final String clientClassName;
+
+    public HiveClientPool(int poolSize, Configuration conf) {
+        this(poolSize, conf, "org.apache.hadoop.hive.metastore.HiveMetaStoreClient");
+    }
+
+    public HiveClientPool(int poolSize, Configuration conf, String clientClassName) {
+        // Do not allow retry by default as we rely on RetryingHiveClient
+        super(poolSize, TTransportException.class, false);
+        this.hiveConf = new HiveConf(conf, HiveClientPool.class);
+        this.hiveConf.addResource(conf);
+        this.clientClassName = clientClassName;
+    }
+
+    @Override
+    protected IMetaStoreClient newClient() {
+        try {
+            try {
+                return new RetryingMetaStoreClientFactory().createClient(hiveConf, clientClassName);
+            } catch (RuntimeException e) {
+                // any MetaException would be wrapped into RuntimeException during reflection, so
+                // let's double-check type here
+                if (e.getCause() instanceof MetaException) {
+                    throw (MetaException) e.getCause();
+                }
+                throw e;
+            }
+        } catch (MetaException e) {
+            throw new RuntimeException("Failed to connect to Hive Metastore", e);
+        } catch (Throwable t) {
+            if (t.getMessage().contains("Another instance of Derby may have already booted")) {
+                throw new RuntimeException(
+                        "Failed to start an embedded metastore because embedded "
+                                + "Derby supports only one client at a time. To fix this, use a metastore that supports "
+                                + "multiple clients.",
+                        t);
+            }
+
+            throw new RuntimeException("Failed to connect to Hive Metastore", t);
+        }
+    }
+
+    @Override
+    protected IMetaStoreClient reconnect(IMetaStoreClient client) {
+        try {
+            client.close();
+            client.reconnect();
+        } catch (MetaException e) {
+            throw new RuntimeException("Failed to reconnect to Hive Metastore", e);
+        }
+        return client;
+    }
+
+    @Override
+    protected boolean isConnectionException(Exception e) {
+        return super.isConnectionException(e)
+                || (e instanceof MetaException
+                        && e.getMessage()
+                                .contains(
+                                        "Got exception: org.apache.thrift.transport.TTransportException"));
+    }
+
+    @Override
+    protected void close(IMetaStoreClient client) {
+        client.close();
+    }
+
+    @VisibleForTesting
+    HiveConf hiveConf() {
+        return hiveConf;
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.hive.HiveClientPool;
+import org.apache.paimon.options.Options;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.thrift.TException;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.paimon.hive.HiveCatalogOptions.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS;
+import static org.apache.paimon.hive.HiveCatalogOptions.CLIENT_POOL_SIZE;
+
+/**
+ * CachedClientPool.
+ *
+ * <p>Mostly copied from iceberg.
+ */
+public class CachedClientPool implements ClientPool<IMetaStoreClient, TException> {
+
+    private static Cache<String, HiveClientPool> clientPoolCache;
+
+    private final Configuration conf;
+    private final String metastoreUri;
+    private final int clientPoolSize;
+    private final long evictionInterval;
+
+    private final String clientClassName;
+
+    public CachedClientPool(HiveConf conf, Options options, String clientClassName) {
+        this.conf = conf;
+        this.metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
+        this.clientPoolSize = options.get(CLIENT_POOL_SIZE);
+        this.evictionInterval = options.get(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
+        this.clientClassName = clientClassName;
+        init();
+    }
+
+    public HiveClientPool clientPool() {
+        return clientPoolCache.get(
+                metastoreUri, k -> new HiveClientPool(clientPoolSize, conf, clientClassName));
+    }
+
+    private synchronized void init() {
+        if (clientPoolCache == null) {
+            clientPoolCache =
+                    Caffeine.newBuilder()
+                            .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
+                            .removalListener(
+                                    (key, value, cause) -> ((HiveClientPool) value).close())
+                            .build();
+        }
+    }
+
+    @Override
+    public <R> R run(RunAction<R, IMetaStoreClient, TException> action) throws TException {
+        return clientPool().run(action);
+    }
+
+    @Override
+    public <R> R run(RunAction<R, IMetaStoreClient, TException> action, boolean retry)
+            throws TException {
+        return clientPool().run(action, retry);
+    }
+
+    @Override
+    public void execute(ExecuteAction<IMetaStoreClient, TException> action) throws TException {
+        clientPool().execute(action);
+    }
+
+    @Override
+    public void execute(ExecuteAction<IMetaStoreClient, TException> action, boolean retry)
+            throws TException {
+        clientPool().execute(action, retry);
+    }
+
+    @VisibleForTesting
+    static Cache<String, HiveClientPool> clientPoolCache() {
+        return clientPoolCache;
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -25,7 +25,6 @@ import org.apache.paimon.options.Options;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.thrift.TException;
@@ -44,7 +43,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
     private static Cache<String, HiveClientPool> clientPoolCache;
 
-    private final Configuration conf;
+    private final HiveConf conf;
     private final String metastoreUri;
     private final int clientPoolSize;
     private final long evictionInterval;

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ClientPool.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+/**
+ * ClientPool interface.
+ *
+ * <p>Mostly copied from iceberg.
+ */
+public interface ClientPool<C, E extends Exception> {
+    <R> R run(RunAction<R, C, E> action) throws E;
+
+    <R> R run(RunAction<R, C, E> action, boolean retry) throws E;
+
+    void execute(ExecuteAction<C, E> action) throws E;
+
+    void execute(ExecuteAction<C, E> action, boolean retry) throws E;
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ClientPoolImpl.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ClientPoolImpl.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+import org.apache.paimon.utils.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * ClientPoolImpl.
+ *
+ * <p>Mostly copied from iceberg.
+ */
+public abstract class ClientPoolImpl<C, E extends Exception>
+        implements Closeable, ClientPool<C, E> {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientPoolImpl.class);
+
+    private final int poolSize;
+    private final Deque<C> clients;
+    private final Class<? extends E> reconnectExc;
+    private final Object signal = new Object();
+    private final boolean retryByDefault;
+    private volatile int currentSize;
+    private boolean closed;
+
+    public ClientPoolImpl(int poolSize, Class<? extends E> reconnectExc, boolean retryByDefault) {
+        this.poolSize = poolSize;
+        this.reconnectExc = reconnectExc;
+        this.clients = new ArrayDeque<>(poolSize);
+        this.currentSize = 0;
+        this.closed = false;
+        this.retryByDefault = retryByDefault;
+    }
+
+    @Override
+    public <R> R run(RunAction<R, C, E> poolAction) throws E {
+        return run(poolAction, retryByDefault);
+    }
+
+    @Override
+    public <R> R run(RunAction<R, C, E> poolAction, boolean retry) throws E {
+        return executeWithRetry(poolAction, retry);
+    }
+
+    @Override
+    public void execute(ExecuteAction<C, E> action) throws E {
+        execute(action, retryByDefault);
+    }
+
+    @Override
+    public void execute(ExecuteAction<C, E> action, boolean retry) throws E {
+        executeWithRetry(action, retry);
+    }
+
+    private <R> R executeWithRetry(RunAction<R, C, E> action, boolean retry) throws E {
+        C client = get();
+        try {
+            return action.run(client);
+        } catch (Exception exc) {
+            if (retry && isConnectionException(exc)) {
+                return handleRetry(action, client, exc);
+            }
+            throw exc;
+        } finally {
+            release(client);
+        }
+    }
+
+    private void executeWithRetry(ExecuteAction<C, E> action, boolean retry) throws E {
+        C client = get();
+        try {
+            action.run(client);
+        } catch (Exception exc) {
+            if (retry && isConnectionException(exc)) {
+                handleRetry(action, client, exc);
+            }
+            throw exc;
+        } finally {
+            release(client);
+        }
+    }
+
+    private <R> R handleRetry(RunAction<R, C, E> action, C client, Exception originalException)
+            throws E {
+        try {
+            client = reconnect(client);
+            return action.run(client);
+        } catch (Exception e) {
+            throw reconnectExc.cast(originalException);
+        } finally {
+            release(client);
+        }
+    }
+
+    private void handleRetry(ExecuteAction<C, E> action, C client, Exception originalException)
+            throws E {
+        try {
+            client = reconnect(client);
+            action.run(client);
+        } catch (Exception e) {
+            throw reconnectExc.cast(originalException);
+        } finally {
+            release(client);
+        }
+    }
+
+    protected abstract C newClient();
+
+    protected abstract C reconnect(C client);
+
+    protected boolean isConnectionException(Exception exc) {
+        return reconnectExc.isInstance(exc);
+    }
+
+    protected abstract void close(C client);
+
+    @Override
+    public void close() {
+        this.closed = true;
+        try {
+            while (currentSize > 0) {
+                if (!clients.isEmpty()) {
+                    synchronized (this) {
+                        if (!clients.isEmpty()) {
+                            C client = clients.removeFirst();
+                            close(client);
+                            currentSize -= 1;
+                        }
+                    }
+                }
+                if (clients.isEmpty() && currentSize > 0) {
+                    // wake every second in case this missed the signal
+                    synchronized (signal) {
+                        signal.wait(1000);
+                    }
+                }
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while shutting down pool. Some clients may not be closed.", e);
+        }
+    }
+
+    private C get() {
+        Preconditions.checkState(!closed, "Cannot get a client from a closed pool");
+        while (true) {
+            if (!clients.isEmpty() || currentSize < poolSize) {
+                synchronized (this) {
+                    if (!clients.isEmpty()) {
+                        return clients.removeFirst();
+                    } else if (currentSize < poolSize) {
+                        C client = newClient();
+                        currentSize += 1;
+                        return client;
+                    }
+                }
+            }
+            synchronized (signal) {
+                try {
+                    // wake every second in case this missed the signal
+                    signal.wait(1000);
+                } catch (InterruptedException ignored) {
+
+                }
+            }
+        }
+    }
+
+    private void release(C client) {
+        synchronized (this) {
+            clients.addFirst(client);
+        }
+        synchronized (signal) {
+            signal.notify();
+        }
+    }
+
+    public int poolSize() {
+        return poolSize;
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ExecuteAction.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/ExecuteAction.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+/** Action interface with return void. */
+public interface ExecuteAction<C, E extends Exception> {
+    void run(C client) throws E;
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/RunAction.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/RunAction.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+/** Action interface with return object. */
+public interface RunAction<R, C, E extends Exception> {
+    R run(C client) throws E;
+}

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/TestHiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/TestHiveClientPool.java
@@ -19,7 +19,6 @@
 
 package org.apache.paimon.hive;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -66,7 +65,7 @@ public class TestHiveClientPool {
 
     @Before
     public void before() {
-        HiveClientPool clientPool = new HiveClientPool(2, new Configuration());
+        HiveClientPool clientPool = new HiveClientPool(2, new HiveConf());
         clients = Mockito.spy(clientPool);
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/TestHiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/TestHiveClientPool.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
+import org.apache.hadoop.hive.metastore.api.GetAllFunctionsResponse;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hive.com.google.common.collect.Lists;
+import org.apache.thrift.transport.TTransportException;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * TestHiveClientPool.
+ *
+ * <p>Mostly copied from iceberg.
+ */
+public class TestHiveClientPool {
+
+    private static final String HIVE_SITE_CONTENT =
+            "<?xml version=\"1.0\"?>\n"
+                    + "<?xml-stylesheet type=\"text/xsl\" href=\"configuration.xsl\"?>\n"
+                    + "<configuration>\n"
+                    + "  <property>\n"
+                    + "    <name>hive.metastore.sasl.enabled</name>\n"
+                    + "    <value>true</value>\n"
+                    + "  </property>\n"
+                    + "</configuration>\n";
+
+    HiveClientPool clients;
+
+    @Before
+    public void before() {
+        HiveClientPool clientPool = new HiveClientPool(2, new Configuration());
+        clients = Mockito.spy(clientPool);
+    }
+
+    @After
+    public void after() {
+        clients.close();
+        clients = null;
+    }
+
+    @Test
+    public void testConf() {
+        HiveConf conf = createHiveConf();
+        conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:/mywarehouse/");
+
+        try (HiveClientPool clientPool = new HiveClientPool(10, conf)) {
+            HiveConf clientConf = clientPool.hiveConf();
+
+            Assert.assertEquals(
+                    conf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname),
+                    clientConf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
+            Assert.assertEquals(10, clientPool.poolSize());
+
+            // 'hive.metastore.sasl.enabled' should be 'true' as defined in xml
+            Assert.assertEquals(
+                    conf.get(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname),
+                    clientConf.get(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname));
+            Assert.assertTrue(clientConf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL));
+        }
+    }
+
+    private HiveConf createHiveConf() {
+        HiveConf hiveConf = new HiveConf();
+        try (InputStream inputStream =
+                new ByteArrayInputStream(HIVE_SITE_CONTENT.getBytes(StandardCharsets.UTF_8))) {
+            hiveConf.addResource(inputStream, "for_test");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return hiveConf;
+    }
+
+    @Test
+    public void testNewClientFailure() {
+        Mockito.doThrow(new RuntimeException("Connection exception")).when(clients).newClient();
+        assertThrows(
+                "Should throw exception",
+                RuntimeException.class,
+                "Connection exception",
+                () -> clients.run(Object::toString));
+    }
+
+    @Test
+    public void testGetTablesFailsForNonReconnectableException() throws Exception {
+        HiveMetaStoreClient hmsClient = Mockito.mock(HiveMetaStoreClient.class);
+        Mockito.doReturn(hmsClient).when(clients).newClient();
+        Mockito.doThrow(new MetaException("Another meta exception"))
+                .when(hmsClient)
+                .getTables(Mockito.anyString(), Mockito.anyString());
+        assertThrows(
+                "Should throw exception",
+                MetaException.class,
+                "Another meta exception",
+                () -> clients.run(client -> client.getTables("default", "t")));
+    }
+
+    @Test
+    public void testConnectionFailureRestoreForMetaException() throws Exception {
+        HiveMetaStoreClient hmsClient = newClient();
+
+        // Throwing an exception may trigger the client to reconnect.
+        String metaMessage = "Got exception: org.apache.thrift.transport.TTransportException";
+        Mockito.doThrow(new MetaException(metaMessage)).when(hmsClient).getAllDatabases();
+
+        // Create a new client when the reconnect method is called.
+        HiveMetaStoreClient newClient = reconnect(hmsClient);
+
+        List<String> databases = Lists.newArrayList("db1", "db2");
+
+        Mockito.doReturn(databases).when(newClient).getAllDatabases();
+        // The return is OK when the reconnect method is called.
+        Assert.assertEquals(databases, clients.run(IMetaStoreClient::getAllDatabases, true));
+
+        // Verify that the method is called.
+        Mockito.verify(clients).reconnect(hmsClient);
+        Mockito.verify(clients, Mockito.never()).reconnect(newClient);
+    }
+
+    @Test
+    public void testConnectionFailureRestoreForTTransportException() throws Exception {
+        HiveMetaStoreClient hmsClient = newClient();
+        Mockito.doThrow(new TTransportException()).when(hmsClient).getAllFunctions();
+
+        // Create a new client when getAllFunctions() failed.
+        HiveMetaStoreClient newClient = reconnect(hmsClient);
+
+        GetAllFunctionsResponse response = new GetAllFunctionsResponse();
+        response.addToFunctions(
+                new Function(
+                        "concat",
+                        "db1",
+                        "classname",
+                        "root",
+                        PrincipalType.USER,
+                        100,
+                        FunctionType.JAVA,
+                        null));
+        Mockito.doReturn(response).when(newClient).getAllFunctions();
+
+        Assert.assertEquals(response, clients.run(IMetaStoreClient::getAllFunctions, true));
+
+        Mockito.verify(clients).reconnect(hmsClient);
+        Mockito.verify(clients, Mockito.never()).reconnect(newClient);
+    }
+
+    private HiveMetaStoreClient newClient() {
+        HiveMetaStoreClient hmsClient = Mockito.mock(HiveMetaStoreClient.class);
+        Mockito.doReturn(hmsClient).when(clients).newClient();
+        return hmsClient;
+    }
+
+    private HiveMetaStoreClient reconnect(HiveMetaStoreClient obsoleteClient) {
+        HiveMetaStoreClient newClient = Mockito.mock(HiveMetaStoreClient.class);
+        Mockito.doReturn(newClient).when(clients).reconnect(obsoleteClient);
+        return newClient;
+    }
+
+    /**
+     * A convenience method to avoid a large number of @Test(expected=...) tests.
+     *
+     * @param message A String message to describe this assertion
+     * @param expected An Exception class that the Runnable should throw
+     * @param containedInMessage A String that should be contained by the thrown exception's message
+     * @param callable A Callable that is expected to throw the exception
+     */
+    public static void assertThrows(
+            String message,
+            Class<? extends Exception> expected,
+            String containedInMessage,
+            Callable callable) {
+        AbstractThrowableAssert<?, ? extends Throwable> check =
+                Assertions.assertThatThrownBy(callable::call).as(message).isInstanceOf(expected);
+        if (null != containedInMessage) {
+            check.hasMessageContaining(containedInMessage);
+        }
+    }
+}

--- a/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/TestHiveMetastore.java
+++ b/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/TestHiveMetastore.java
@@ -217,7 +217,6 @@ public class TestHiveMetastore {
         conf.set(
                 HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname,
                 "false");
-        conf.set("iceberg.hive.client-pool-size", "2");
         conf.set(
                 HiveConf.ConfVars.HIVE_IN_TEST.varname,
                 HiveConf.ConfVars.HIVE_IN_TEST.getDefaultValue());


### PR DESCRIPTION
For HiveCatalog add hive client pool. Increasing the cache pool is used to reduce the number of access connections requested from HMS, thereby reducing the pressure on the HMS server.

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

`HiveCatalogTest` and `TestHiveClientPool`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
