### PR TITLE
Implement currentEmitEventTimeLag for Flink source

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -427,16 +427,16 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
     </thead>
     <tbody>
         <tr>
-            <td>currentFetchEventTimeLag</td>
-            <td>Flink Source Operator</td>
-            <td>Gauge</td>
-            <td>Time difference between reading the data file and file creation.</td>
-        </tr>
-        <tr>
             <td>currentEmitEventTimeLag</td>
             <td>Flink Source Operator</td>
             <td>Gauge</td>
             <td>Time difference between sending the record out of source and file creation.</td>
+        </tr>
+        <tr>
+            <td>currentFetchEventTimeLag</td>
+            <td>Flink Source Operator</td>
+            <td>Gauge</td>
+            <td>Time difference between reading the data file and file creation.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -431,7 +431,13 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
             <td>Flink Source Operator</td>
             <td>Gauge</td>
             <td>Time difference between reading the data file and file creation.</td>
-        </tr>    
+        </tr>
+        <tr>
+            <td>currentEmitEventTimeLag</td>
+            <td>Flink Source Operator</td>
+            <td>Gauge</td>
+            <td>Time difference between sending the record out of source and file creation.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
@@ -55,7 +55,9 @@ public class FileStoreSourceReader
                 () ->
                         new FileStoreSourceSplitReader(
                                 tableRead, RecordLimiter.create(limit), sourceReaderMetrics),
-                FlinkRecordsWithSplitIds::emitRecord,
+                (element, output, state) ->
+                        FlinkRecordsWithSplitIds.emitRecord(
+                                element, output, state, sourceReaderMetrics),
                 readerContext.getConfiguration(),
                 readerContext);
         this.ioManager = ioManager;
@@ -74,7 +76,9 @@ public class FileStoreSourceReader
                 () ->
                         new FileStoreSourceSplitReader(
                                 tableRead, RecordLimiter.create(limit), sourceReaderMetrics),
-                FlinkRecordsWithSplitIds::emitRecord,
+                (element, output, state) ->
+                        FlinkRecordsWithSplitIds.emitRecord(
+                                element, output, state, sourceReaderMetrics),
                 readerContext.getConfiguration(),
                 readerContext);
         this.ioManager = ioManager;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
@@ -49,8 +49,7 @@ public class FileStoreSourceReaderMetrics {
         return UNDEFINED;
     }
 
-    @VisibleForTesting
-    long getLatestFileCreationTime() {
+    public long getLatestFileCreationTime() {
         return latestFileCreationTime;
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIdsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIdsTest.java
@@ -60,7 +60,7 @@ public class FlinkRecordsWithSplitIdsTest {
 
         BulkFormat.RecordIterator<RowData> iterator = records.nextRecordFromSplit();
         assertThat(iterator).isNotNull();
-        FlinkRecordsWithSplitIds.emitRecord(iterator, output, state);
+        FlinkRecordsWithSplitIds.emitRecord(iterator, output, state, null);
         assertThat(output.getEmittedRecords()).containsExactly(rows);
         assertThat(state.recordsToSkip()).isEqualTo(2);
         assertThat(records.nextRecordFromSplit()).isNull();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -72,10 +72,8 @@ public class OperatorSourceTest {
 
     @BeforeEach
     public void before()
-            throws Catalog.TableAlreadyExistException,
-                    Catalog.DatabaseNotExistException,
-                    Catalog.TableNotExistException,
-                    Catalog.DatabaseAlreadyExistException {
+            throws Catalog.TableAlreadyExistException, Catalog.DatabaseNotExistException,
+                    Catalog.TableNotExistException, Catalog.DatabaseAlreadyExistException {
         Catalog catalog =
                 CatalogFactory.createCatalog(
                         CatalogContext.create(new org.apache.paimon.fs.Path(tempDir.toUri())));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -72,8 +72,10 @@ public class OperatorSourceTest {
 
     @BeforeEach
     public void before()
-            throws Catalog.TableAlreadyExistException, Catalog.DatabaseNotExistException,
-                    Catalog.TableNotExistException, Catalog.DatabaseAlreadyExistException {
+            throws Catalog.TableAlreadyExistException,
+                    Catalog.DatabaseNotExistException,
+                    Catalog.TableNotExistException,
+                    Catalog.DatabaseAlreadyExistException {
         Catalog catalog =
                 CatalogFactory.createCatalog(
                         CatalogContext.create(new org.apache.paimon.fs.Path(tempDir.toUri())));
@@ -197,12 +199,23 @@ public class OperatorSourceTest {
                         MetricUtils.getGauge(readerOperatorMetricGroup, "currentFetchEventTimeLag")
                                 .getValue())
                 .isEqualTo(-1L);
+        assertThat(
+                        MetricUtils.getGauge(readerOperatorMetricGroup, "currentEmitEventTimeLag")
+                                .getValue())
+                .isEqualTo(-1L);
         harness.processElement(new StreamRecord<>(splits.get(0)));
         assertThat(
                         (Long)
                                 MetricUtils.getGauge(
                                                 readerOperatorMetricGroup,
                                                 "currentFetchEventTimeLag")
+                                        .getValue())
+                .isGreaterThan(0);
+        assertThat(
+                        (Long)
+                                MetricUtils.getGauge(
+                                                readerOperatorMetricGroup,
+                                                "currentEmitEventTimeLag")
                                         .getValue())
                 .isGreaterThan(0);
     }


### PR DESCRIPTION
### Purpose

This PR implemented a new Flink source metrics, which is `currentEmitEventTimeLag`.

### Tests

* `OperatorSourceTest`.

Also end to end tested by hand.

### API and Format

No.

### Documentation

Yes. Document is also updated.
