### PR TITLE
[flink] Open write-buffer default for batch mode

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -310,7 +310,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Boolean> WRITE_BUFFER_FOR_APPEND =
             key("write-buffer-for-append")
                     .booleanType()
-                    .defaultValue(false)
+                    .noDefaultValue()
                     .withDescription(
                             "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
 
@@ -1160,8 +1160,8 @@ public class CoreOptions implements Serializable {
         return options.getOptional(WRITE_BUFFER_SPILLABLE).orElse(usingObjectStore || !isStreaming);
     }
 
-    public boolean useWriteBufferForAppend() {
-        return options.get(WRITE_BUFFER_FOR_APPEND);
+    public boolean useWriteBufferForAppend(boolean isStreaming) {
+        return options.getOptional(WRITE_BUFFER_FOR_APPEND).orElse(!isStreaming);
     }
 
     public long sortSpillBufferSize() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -96,7 +96,7 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
         this.commitForceCompact = options.commitForceCompact();
         this.skipCompaction = options.writeOnly();
         this.fileCompression = options.fileCompression();
-        this.useWriteBuffer = options.useWriteBufferForAppend();
+        this.useWriteBuffer = options.useWriteBufferForAppend(isStreamingMode);
         this.spillable = options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode);
         this.statsCollectors =
                 StatsCollectorFactories.createStatsFactories(options, rowType.getFieldNames());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Open writer-buffer for append batch mode by default to avoid out-of-memory issues.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

No influence to user.

### Documentation

<!-- Does this change introduce a new feature -->
