### PR TITLE
[flink] Fix delete exception with lookup changelog-producer and pk as delete key(push down to client).

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
@@ -53,7 +53,7 @@ public class TableUtils {
         long hit = 0;
         try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits);
                 BatchTableWrite write = writeBuilder.newWrite();
-                // we create temp io manager to for writer
+                // we create temp io manager for writer
                 IOManager ioManager = new IOManagerImpl(TEMP_DIR);
                 BatchTableCommit commit = writeBuilder.newCommit()) {
             write.withIOManager(ioManager);

--- a/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/TableUtils.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateFilter;
 import org.apache.paimon.reader.RecordReader;
@@ -35,6 +37,8 @@ import java.util.List;
 /** Utils for Table. TODO we can introduce LocalAction maybe? */
 public class TableUtils {
 
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+
     /**
      * Delete according to filters.
      *
@@ -49,7 +53,10 @@ public class TableUtils {
         long hit = 0;
         try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits);
                 BatchTableWrite write = writeBuilder.newWrite();
+                // we create temp io manager to for writer
+                IOManager ioManager = new IOManagerImpl(TEMP_DIR);
                 BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.withIOManager(ioManager);
             CloseableIterator<InternalRow> iterator = reader.toCloseableIterator();
             PredicateFilter filter = new PredicateFilter(table.rowType(), filters);
             while (iterator.hasNext()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -389,6 +389,23 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testDeleteWithPkLookup() throws Exception {
+        sql(
+                "CREATE TABLE ignore_delete (pk INT PRIMARY KEY NOT ENFORCED, v STRING) "
+                        + "WITH ('changelog-producer' = 'lookup')");
+        BlockingIterator<Row, Row> iterator = streamSqlBlockIter("SELECT * FROM ignore_delete");
+
+        sql("INSERT INTO ignore_delete VALUES (1, 'A'), (2, 'B')");
+        sql("DELETE FROM ignore_delete WHERE pk = 1");
+        sql("INSERT INTO ignore_delete VALUES (1, 'B')");
+
+        assertThat(iterator.collect(2))
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, 1, "B"), Row.ofKind(RowKind.INSERT, 2, "B"));
+        iterator.close();
+    }
+
+    @Test
     public void testScanFromOldSchema() throws InterruptedException {
         sql("CREATE TABLE select_old (f0 INT PRIMARY KEY NOT ENFORCED, f1 STRING)");
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Table a is a primary key table with lookup changelog-producer
Delete from table a where pk = xxx will cause an error
Fix this problem

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
