### PR TITLE
[core] Primary key table only max level can convert to raw files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -417,20 +417,13 @@ public class SnapshotReaderImpl implements SnapshotReader {
             BinaryRow partition, int bucket, List<DataFileMeta> dataFiles) {
         String bucketPath = pathFactory.bucketPath(partition, bucket).toString();
 
-        // bucket with only one file can be returned
-        if (dataFiles.size() == 1) {
-            return Collections.singletonList(makeRawTableFile(bucketPath, dataFiles.get(0)));
-        }
-
         // append only files can be returned
         if (tableSchema.primaryKeys().isEmpty()) {
             return makeRawTableFiles(bucketPath, dataFiles);
         }
 
-        // bucket containing only one level (except level 0) can be returned
-        Set<Integer> levels =
-                dataFiles.stream().map(DataFileMeta::level).collect(Collectors.toSet());
-        if (levels.size() == 1 && !levels.contains(0)) {
+        int maxLevel = options.numLevels() - 1;
+        if (dataFiles.stream().map(DataFileMeta::level).allMatch(l -> l == maxLevel)) {
             return makeRawTableFiles(bucketPath, dataFiles);
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/SnapshotReaderTest.java
@@ -100,18 +100,7 @@ public class SnapshotReaderTest {
             assertThat(dataSplit.dataFiles()).hasSize(1);
             DataFileMeta meta = dataSplit.dataFiles().get(0);
             String partition = dataSplit.partition().getString(0).toString();
-            assertThat(dataSplit.convertToRawFiles())
-                    .hasValue(
-                            Collections.singletonList(
-                                    new RawFile(
-                                            String.format(
-                                                    "%s/pt=%s/bucket-0/%s",
-                                                    tablePath, partition, meta.fileName()),
-                                            0,
-                                            meta.fileSize(),
-                                            "avro",
-                                            meta.schemaId(),
-                                            meta.rowCount())));
+            assertThat(dataSplit.convertToRawFiles()).isNotPresent();
         }
 
         // write another file on level 0


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
1. Append only table always can convert to raw files
2. Primary key table only max level can convert to raw files, Because other level may contain data with RowKind not INSERT, other engines cannot natively read it.

The main change compared to before is that individual level 0 files can not be convert to raw files

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
