### PR TITLE
[core] fix streaming read empty table in latest mode

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
@@ -40,16 +41,16 @@ public class ContinuousLatestStartingScanner extends AbstractStartingScanner {
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long lastSnapshotId = snapshotManager.latestSnapshotId();
-        if (lastSnapshotId == null) {
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
+        if (latestSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
             return new NoSnapshot();
         }
 
+        // If there's no snapshot before the reading job starts,
+        // then the first snapshot should be considered as an incremental snapshot
         long nextSnapshot =
-                lastSnapshotId == 1 && startingSnapshotId == null
-                        ? lastSnapshotId
-                        : lastSnapshotId + 1;
+                startingSnapshotId == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshotId + 1;
         return new NextSnapshot(nextSnapshot);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousLatestStartingScanner.java
@@ -40,11 +40,16 @@ public class ContinuousLatestStartingScanner extends AbstractStartingScanner {
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long startingSnapshotId = snapshotManager.latestSnapshotId();
-        if (startingSnapshotId == null) {
+        Long lastSnapshotId = snapshotManager.latestSnapshotId();
+        if (lastSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Wait for the snapshot generation.");
             return new NoSnapshot();
         }
-        return new NextSnapshot(startingSnapshotId + 1);
+
+        long nextSnapshot =
+                lastSnapshotId == 1 && startingSnapshotId == null
+                        ? lastSnapshotId
+                        : lastSnapshotId + 1;
+        return new NextSnapshot(nextSnapshot);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIds.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIds.java
@@ -109,8 +109,7 @@ public class FlinkRecordsWithSplitIds implements RecordsWithSplitIds<RecordItera
             FileStoreSourceSplitState state,
             FileStoreSourceReaderMetrics metrics) {
         long timestamp = TimestampAssigner.NO_TIMESTAMP;
-        if (metrics != null
-                && metrics.getLatestFileCreationTime() != FileStoreSourceReaderMetrics.UNDEFINED) {
+        if (metrics.getLatestFileCreationTime() != FileStoreSourceReaderMetrics.UNDEFINED) {
             timestamp = metrics.getLatestFileCreationTime();
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIds.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIds.java
@@ -109,7 +109,8 @@ public class FlinkRecordsWithSplitIds implements RecordsWithSplitIds<RecordItera
             FileStoreSourceSplitState state,
             FileStoreSourceReaderMetrics metrics) {
         long timestamp = TimestampAssigner.NO_TIMESTAMP;
-        if (metrics.getLatestFileCreationTime() != FileStoreSourceReaderMetrics.UNDEFINED) {
+        if (metrics != null
+                && metrics.getLatestFileCreationTime() != FileStoreSourceReaderMetrics.UNDEFINED) {
             timestamp = metrics.getLatestFileCreationTime();
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
@@ -205,15 +205,38 @@ public class ContinuousFileStoreITCase extends CatalogITCaseBase {
 
     @Test
     public void testContinuousLatest() throws Exception {
-        batchSql("INSERT INTO T1 VALUES ('1', '2', '3'), ('4', '5', '6')");
 
+        // there is only one snapshot before streaming read
+        batchSql("INSERT INTO T1 VALUES ('1', '2', '3'), ('4', '5', '6')");
         BlockingIterator<Row, Row> iterator =
                 BlockingIterator.of(
-                        streamSqlIter("SELECT * FROM T1 /*+ OPTIONS('log.scan'='latest') */"));
+                        streamSqlIter("SELECT * FROM T1 /*+ OPTIONS('scan.mode'='latest') */"));
 
         batchSql("INSERT INTO T1 VALUES ('7', '8', '9'), ('10', '11', '12')");
         assertThat(iterator.collect(2))
                 .containsExactlyInAnyOrder(Row.of("7", "8", "9"), Row.of("10", "11", "12"));
+        iterator.close();
+
+        // there is no snapshot before streaming read
+        sEnv.executeSql("CREATE TABLE T11 (id INT , name STRING)");
+        iterator =
+                BlockingIterator.of(
+                        streamSqlIter("SELECT * FROM T11 /*+ OPTIONS('scan.mode'='latest') */"));
+
+        batchSql("INSERT INTO T11 VALUES (1, 'AAA')");
+        assertThat(iterator.collect(1)).containsExactlyInAnyOrder(Row.of(1, "AAA"));
+        iterator.close();
+
+        // there are more than one snapshot before streaming read
+        sEnv.executeSql("CREATE TABLE T111 (id INT , name STRING)");
+        batchSql("INSERT INTO T111 VALUES (1, 'AAA')");
+        batchSql("INSERT INTO T111 VALUES (2, 'BBB')");
+        iterator =
+                BlockingIterator.of(
+                        streamSqlIter("SELECT * FROM T111 /*+ OPTIONS('scan.mode'='latest') */"));
+
+        batchSql("INSERT INTO T111 VALUES (3, 'CCC')");
+        assertThat(iterator.collect(1)).containsExactlyInAnyOrder(Row.of(3, "CCC"));
         iterator.close();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/incubator-paimon/issues/2588

<!-- What is the purpose of the change -->

### Tests
org.apache.paimon.flink.ContinuousFileStoreITCase

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
