### PR TITLE
[flink] Throws exception if there is a SinkMaterializer before Paimon sink

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -25,9 +25,11 @@ import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -39,10 +41,15 @@ import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.flink.configuration.ClusterOptions.ENABLE_FINE_GRAINED_RESOURCE_MANAGEMENT;
@@ -139,12 +146,38 @@ public abstract class FlinkSink<T> implements Serializable {
     }
 
     public DataStreamSink<?> sinkFrom(DataStream<T> input, String initialCommitUser) {
+        assertNoSinkMaterializer(input);
+
         // do the actually writing action, no snapshot generated in this stage
         SingleOutputStreamOperator<Committable> written =
                 doWrite(input, initialCommitUser, input.getParallelism());
 
         // commit the committable to generate a new snapshot
         return doCommit(written, initialCommitUser);
+    }
+
+    private void assertNoSinkMaterializer(DataStream<T> input) {
+        // traverse the transformation graph with breadth first search
+        Set<Integer> visited = new HashSet<>();
+        Queue<Transformation<?>> queue = new LinkedList<>();
+        queue.add(input.getTransformation());
+        visited.add(input.getTransformation().getId());
+        while (!queue.isEmpty()) {
+            Transformation<?> transformation = queue.poll();
+            Preconditions.checkArgument(
+                    !transformation.getName().startsWith("SinkMaterializer"),
+                    String.format(
+                            "Sink materializer must not be used with Paimon sink. "
+                                    + "Please set '%s' to '%s' in Flink's config.",
+                            ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE.key(),
+                            ExecutionConfigOptions.UpsertMaterialize.NONE.name()));
+            for (Transformation<?> prev : transformation.getInputs()) {
+                if (!visited.contains(prev.getId())) {
+                    queue.add(prev);
+                    visited.add(prev.getId());
+                }
+            }
+        }
     }
 
     public SingleOutputStreamOperator<Committable> doWrite(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -88,6 +88,10 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
         sEnv.getConfig()
                 .getConfiguration()
                 .set(CHECKPOINTING_INTERVAL, Duration.ofMillis(checkpointIntervalMs));
+        sEnv.getConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE,
+                        ExecutionConfigOptions.UpsertMaterialize.NONE);
         return sEnv;
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -243,7 +243,7 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
         // write update data
         sEnv.executeSql(
                         "INSERT INTO `default_catalog`.`default_database`.`S` "
-                                + "VALUES (1, 'A'), (1, 'B'), (1, 'C'), (1, 'D')")
+                                + "VALUES (1, 'D'), (1, 'C'), (1, 'B'), (1, 'A')")
                 .await();
 
         // read update data


### PR DESCRIPTION
### Purpose

Flink's `SinkMaterializer` is an undesired feature for Paimon, because it will keep all the keys in operator's state and also filter out delete records, which may cause incorrect result.

This PR throws an exception if there is a `SinkMaterializer` before Paimon sink. Thus the user will not forget to remove `SinkMaterializer`.

### Tests

* `PartialUpdateITCase#testNoSinkMaterializer`.

### API and Format

No.

### Documentation

No.
