### PR TITLE
[hotfix] Fix unstable test ProductAggregation#testMergeInMemory caused by disorder and scale

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
@@ -884,6 +884,8 @@ public class PreAggregationITCase {
 
         @Test
         public void testMergeInMemory() {
+            batchSql("ALTER TABLE T1 MODIFY b DECIMAL(5, 3)");
+
             batchSql(
                     "INSERT INTO T1 VALUES "
                             + "(1, 2, CAST(NULL AS INT), 1.01, CAST(1 AS TINYINT), CAST(-1 AS SMALLINT), "
@@ -899,7 +901,7 @@ public class PreAggregationITCase {
                                     1,
                                     2,
                                     6,
-                                    new BigDecimal("11.10"),
+                                    new BigDecimal("11.110"),
                                     (byte) 2,
                                     (short) -2,
                                     1000000000000000L,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This is because if insert values have `CAST`, it will cause disorder (cannot be solved by setting parallelism to 1); And in this test, the old DECIMAL(4, 2) will truncate result, so the final result will be affected by the order of input.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
