### PR TITLE
[spark] Decoupling of initialBuckets and assignerParallelism for dynamic bucket write

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
@@ -27,9 +27,13 @@ public interface BucketAssigner {
 
     void prepareCommit(long commitIdentifier);
 
-    static int computeAssigner(int partitionHash, int keyHash, int numChannels, int numAssigners) {
+    static int computeHashKey(int partitionHash, int keyHash, int numChannels, int numAssigners) {
         int start = Math.abs(partitionHash % numChannels);
         int id = Math.abs(keyHash % numAssigners);
-        return (start + id) % numChannels;
+        return start + id;
+    }
+
+    static int computeAssigner(int partitionHash, int keyHash, int numChannels, int numAssigners) {
+        return computeHashKey(partitionHash, keyHash, numChannels, numAssigners) % numChannels;
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -18,8 +18,7 @@
 package org.apache.paimon.spark.commands
 
 import org.apache.paimon.CoreOptions.DYNAMIC_PARTITION_OVERWRITE
-import org.apache.paimon.data.BinaryRow
-import org.apache.paimon.index.PartitionIndex
+import org.apache.paimon.index.{BucketAssigner, HashBucketAssigner}
 import org.apache.paimon.options.Options
 import org.apache.paimon.spark._
 import org.apache.paimon.spark.SparkUtils.createIOManager
@@ -29,9 +28,8 @@ import org.apache.paimon.spark.util.{EncoderUtils, SparkRowUtils}
 import org.apache.paimon.table.{BucketMode, FileStoreTable}
 import org.apache.paimon.table.sink.{BatchWriteBuilder, CommitMessageSerializer, RowPartitionKeyExtractor}
 import org.apache.paimon.types.RowType
-import org.apache.paimon.utils.MathUtils
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{Partitioner, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -39,10 +37,9 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.functions._
 
-import java.util.function.IntPredicate
+import java.util.UUID
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 /** Used to write a [[DataFrame]] into a paimon table. */
 case class WriteIntoPaimonTable(
@@ -91,6 +88,35 @@ case class WriteIntoPaimonTable(
     val toRow = withBucketDataEncoder.createSerializer()
     val fromRow = withBucketDataEncoder.createDeserializer()
 
+    def repartitionByKeyPartitionHash(
+        input: DataFrame,
+        sparkRowType: RowType,
+        numParallelism: Int,
+        numAssigners: Int) = {
+      sparkSession.createDataFrame(
+        input.rdd
+          .mapPartitions(
+            iterator => {
+              val rowPartitionKeyExtractor = new RowPartitionKeyExtractor(table.schema)
+              iterator.map(
+                row => {
+                  val sparkRow = new SparkRow(sparkRowType, row)
+                  val partitionHash = rowPartitionKeyExtractor.partition(sparkRow).hashCode
+                  val keyHash = rowPartitionKeyExtractor.trimmedPrimaryKey(sparkRow).hashCode
+                  (
+                    BucketAssigner
+                      .computeHashKey(partitionHash, keyHash, numParallelism, numAssigners),
+                    row)
+                })
+            },
+            preservesPartitioning = true
+          )
+          .partitionBy(ModPartitioner(numParallelism))
+          .map(_._2),
+        withBucketCol.schema
+      )
+    }
+
     def repartitionByBucket(ds: Dataset[Row]) = {
       ds.toDF().repartition(partitionCols ++ Seq(col(BUCKET_COL)): _*)
     }
@@ -105,37 +131,48 @@ case class WriteIntoPaimonTable(
     val df =
       bucketMode match {
         case BucketMode.DYNAMIC =>
+          // Topology: input -> shuffle by special key & partition hash -> bucket-assigner -> shuffle by partition & bucket
+          val numParallelism =
+            if (table.coreOptions.dynamicBucketAssignerParallelism.!=(null))
+              table.coreOptions.dynamicBucketAssignerParallelism.toInt
+            else sparkSession.sparkContext.defaultParallelism
+          val numAssigners =
+            if (table.coreOptions().dynamicBucketInitialBuckets.!=(null))
+              Math.min(table.coreOptions().dynamicBucketInitialBuckets.toInt, numParallelism)
+            else numParallelism
+
           val partitioned = if (primaryKeyCols.nonEmpty) {
-            // Make sure that the records with the same bucket values is within a task.
-            // TODO supports decoupling of initialBuckets and assignerParallelism
-            var assignerParallelism = MathUtils.max(
-              table.coreOptions.dynamicBucketInitialBuckets,
-              table.coreOptions.dynamicBucketAssignerParallelism)
-            if (assignerParallelism != null) {
-              withBucketCol.repartition(assignerParallelism, primaryKeyCols: _*)
-            } else {
-              withBucketCol.repartition(primaryKeyCols: _*)
-            }
+            repartitionByKeyPartitionHash(withBucketCol, rowType, numParallelism, numAssigners)
           } else {
             withBucketCol
           }
-          val numSparkPartitions = partitioned.rdd.getNumPartitions
           val dynamicBucketProcessor =
-            DynamicBucketProcessor(table, rowType, bucketColIdx, numSparkPartitions, toRow, fromRow)
+            DynamicBucketProcessor(
+              table,
+              rowType,
+              bucketColIdx,
+              numParallelism,
+              numAssigners,
+              toRow,
+              fromRow)
           repartitionByBucket(
             partitioned.mapPartitions(dynamicBucketProcessor.processPartition)(
               withBucketDataEncoder))
         case BucketMode.UNAWARE =>
+          // Topology: input -> bucket-assigner
           val unawareBucketProcessor = UnawareBucketProcessor(bucketColIdx, toRow, fromRow)
           withBucketCol
             .mapPartitions(unawareBucketProcessor.processPartition)(withBucketDataEncoder)
             .toDF()
         case BucketMode.FIXED =>
+          // Topology: input -> bucket-assigner -> shuffle by partition & bucket
           val commonBucketProcessor =
             CommonBucketProcessor(writeBuilder, bucketColIdx, toRow, fromRow)
           repartitionByBucket(
             withBucketCol.mapPartitions(commonBucketProcessor.processPartition)(
               withBucketDataEncoder))
+        case _ =>
+          throw new UnsupportedOperationException(s"Unsupported bucket mode $bucketMode")
       }
 
     val commitMessages = df
@@ -205,11 +242,11 @@ case class WriteIntoPaimonTable(
 
 object WriteIntoPaimonTable {
 
-  sealed trait BucketProcessor {
+  sealed private trait BucketProcessor {
     def processPartition(rowIterator: Iterator[Row]): Iterator[Row]
   }
 
-  case class CommonBucketProcessor(
+  private case class CommonBucketProcessor(
       writeBuilder: BatchWriteBuilder,
       bucketColIndex: Int,
       toRow: ExpressionEncoder.Serializer[Row],
@@ -235,24 +272,30 @@ object WriteIntoPaimonTable {
     }
   }
 
-  case class DynamicBucketProcessor(
+  private case class DynamicBucketProcessor(
       fileStoreTable: FileStoreTable,
       rowType: RowType,
       bucketColIndex: Int,
       numSparkPartitions: Int,
+      numAssigners: Int,
       toRow: ExpressionEncoder.Serializer[Row],
       fromRow: ExpressionEncoder.Deserializer[Row]
   ) extends BucketProcessor {
 
     private val targetBucketRowNumber = fileStoreTable.coreOptions.dynamicBucketTargetRowNum
+    private val commitUser = UUID.randomUUID.toString
 
     def processPartition(rowIterator: Iterator[Row]): Iterator[Row] = {
-      val sparkPartitionId = TaskContext.getPartitionId()
-      val indexFileHandler = fileStoreTable.store.newIndexFileHandler
-      val partitionIndex = mutable.Map.empty[BinaryRow, PartitionIndex]
       val rowPartitionKeyExtractor = new RowPartitionKeyExtractor(fileStoreTable.schema)
-      val buckFilter: IntPredicate = bucket =>
-        math.abs(bucket % numSparkPartitions) == sparkPartitionId
+      val assigner = new HashBucketAssigner(
+        fileStoreTable.snapshotManager(),
+        commitUser,
+        fileStoreTable.store.newIndexFileHandler,
+        numSparkPartitions,
+        numAssigners,
+        TaskContext.getPartitionId(),
+        targetBucketRowNumber
+      )
 
       new Iterator[Row]() {
         override def hasNext: Boolean = rowIterator.hasNext
@@ -262,15 +305,7 @@ object WriteIntoPaimonTable {
           val sparkRow = new SparkRow(rowType, row)
           val hash = rowPartitionKeyExtractor.trimmedPrimaryKey(sparkRow).hashCode
           val partition = rowPartitionKeyExtractor.partition(sparkRow)
-          val index = partitionIndex.getOrElseUpdate(
-            partition,
-            PartitionIndex.loadIndex(
-              indexFileHandler,
-              partition,
-              targetBucketRowNumber,
-              (_) => true,
-              buckFilter))
-          val bucket = index.assign(hash, buckFilter)
+          val bucket = assigner.assign(partition, hash)
           val sparkInternalRow = toRow(row)
           sparkInternalRow.setInt(bucketColIndex, bucket)
           fromRow(sparkInternalRow)
@@ -279,7 +314,7 @@ object WriteIntoPaimonTable {
     }
   }
 
-  case class UnawareBucketProcessor(
+  private case class UnawareBucketProcessor(
       bucketColIndex: Int,
       toRow: ExpressionEncoder.Serializer[Row],
       fromRow: ExpressionEncoder.Deserializer[Row])
@@ -297,5 +332,11 @@ object WriteIntoPaimonTable {
         }
       }
     }
+  }
+
+  private case class ModPartitioner(partitions: Int) extends Partitioner {
+    override def numPartitions: Int = partitions
+
+    override def getPartition(key: Any): Int = key.asInstanceOf[Int] % numPartitions
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -172,7 +172,8 @@ case class WriteIntoPaimonTable(
             withBucketCol.mapPartitions(commonBucketProcessor.processPartition)(
               withBucketDataEncoder))
         case _ =>
-          throw new UnsupportedOperationException(s"Unsupported bucket mode $bucketMode")
+          throw new UnsupportedOperationException(
+            s"Write with bucket mode $bucketMode is not supported")
       }
 
     val commitMessages = df
@@ -208,7 +209,7 @@ case class WriteIntoPaimonTable(
     } catch {
       case e: Throwable => throw new RuntimeException(e);
     } finally {
-      tableCommit.close();
+      tableCommit.close()
     }
 
     Seq.empty

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -167,7 +167,8 @@ public class SparkWriteITCase {
     public void testWriteDynamicBucketPartitionedTable() {
         spark.sql(
                 "CREATE TABLE T (a INT, b INT, c STRING) PARTITIONED BY (a) TBLPROPERTIES"
-                        + " ('primary-key'='a,b', 'bucket'='-1', 'dynamic-bucket.target-row-num'='3')");
+                        + " ('primary-key'='a,b', 'bucket'='-1', "
+                        + "'dynamic-bucket.target-row-num'='3', 'dynamic-bucket.initial-buckets'='1')");
 
         spark.sql("INSERT INTO T VALUES (1, 1, '1'), (1, 2, '2')");
         List<Row> rows = spark.sql("SELECT max(bucket) FROM `T$FILES`").collectAsList();

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
@@ -84,4 +84,23 @@ class DynamicBucketTableTest extends PaimonSparkTestBase {
       spark.sql("SELECT DISTINCT bucket FROM `T$FILES`"),
       Row(0) :: Row(1) :: Row(2) :: Nil)
   }
+
+  test(s"Paimon dynamic bucket table: write with global dynamic bucket") {
+    spark.sql(s"""
+                 |CREATE TABLE T (
+                 |  pk STRING,
+                 |  v STRING,
+                 |  pt STRING)
+                 |TBLPROPERTIES (
+                 |  'primary-key' = 'pk',
+                 |  'bucket' = '-1'
+                 |)
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    val error = intercept[UnsupportedOperationException] {
+      spark.sql("INSERT INTO T VALUES ('1', 'a', 'p')")
+    }.getMessage
+    assert(error.contains("Write with bucket mode GLOBAL_DYNAMIC is not supported"))
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
@@ -52,4 +52,36 @@ class DynamicBucketTableTest extends PaimonSparkTestBase {
       spark.sql("SELECT DISTINCT bucket FROM `T$FILES`"),
       Row(0) :: Row(1) :: Row(2) :: Nil)
   }
+
+  test(s"Paimon dynamic bucket table: write with dynamic-bucket.initial-buckets") {
+    spark.sql(s"""
+                 |CREATE TABLE T (
+                 |  pk STRING,
+                 |  v STRING,
+                 |  pt STRING)
+                 |TBLPROPERTIES (
+                 |  'primary-key' = 'pk, pt',
+                 |  'bucket' = '-1',
+                 |  'dynamic-bucket.target-row-num'='3',
+                 |  'dynamic-bucket.initial-buckets'='3',
+                 |  'dynamic-bucket.assigner-parallelism'='10'
+                 |)
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    spark.sql(
+      "INSERT INTO T VALUES ('1', 'a', 'p'), ('2', 'b', 'p'), ('3', 'c', 'p'), ('4', 'd', 'p'), ('5', 'e', 'p')")
+
+    checkAnswer(
+      spark.sql("SELECT * FROM T ORDER BY pk"),
+      Row("1", "a", "p") :: Row("2", "b", "p") :: Row("3", "c", "p") :: Row("4", "d", "p") :: Row(
+        "5",
+        "e",
+        "p") :: Nil)
+
+    // Although `assigner-parallelism` is 10, but because `initial-buckets` is 3, the size of generated buckets is still 3
+    checkAnswer(
+      spark.sql("SELECT DISTINCT bucket FROM `T$FILES`"),
+      Row(0) :: Row(1) :: Row(2) :: Nil)
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

For write dynamic bucket with spark

- support set `dynamic-bucket.initial-buckets`
- only load indexes belonging to the certain bucket

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
