### PR TITLE
[flink] Introduce parallelism execution for lookup join

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -45,6 +45,12 @@ under the License.
             <td>The thread number for lookup async.</td>
         </tr>
         <tr>
+            <td><h5>lookup.bootstrap-parallelism</h5></td>
+            <td style="word-wrap: break-word;">4</td>
+            <td>Integer</td>
+            <td>The parallelism for bootstrap in a single task for lookup join.</td>
+        </tr>
+        <tr>
             <td><h5>scan.infer-parallelism</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ParallelExecution.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ParallelExecution.java
@@ -183,7 +183,7 @@ public class ParallelExecution<T, E> implements Closeable {
             }
 
             @Override
-            public E extraMesage() {
+            public E extraMessage() {
                 return extraMessage;
             }
         };
@@ -197,6 +197,6 @@ public class ParallelExecution<T, E> implements Closeable {
 
         void releaseBatch();
 
-        E extraMesage();
+        E extraMessage();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/SplitsParallelReadUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SplitsParallelReadUtil.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.ParallelExecution;
+import org.apache.paimon.utils.ParallelExecution.ParallelBatch;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * An util class to wrap {@link ParallelExecution} to parallel execution for {@link Split} reader.
+ */
+public class SplitsParallelReadUtil {
+
+    public static RecordReader<InternalRow> parallelExecute(
+            RowType projectedType,
+            ReadBuilder readBuilder,
+            List<Split> splits,
+            int pageSize,
+            int parallelism) {
+        return parallelExecute(
+                projectedType,
+                readBuilder,
+                splits,
+                pageSize,
+                parallelism,
+                split -> null,
+                (row, unused) -> row);
+    }
+
+    public static <EXTRA> RecordReader<InternalRow> parallelExecute(
+            RowType projectedType,
+            ReadBuilder readBuilder,
+            List<Split> splits,
+            int pageSize,
+            int parallelism,
+            Function<Split, EXTRA> extraFunction,
+            BiFunction<InternalRow, EXTRA, InternalRow> addExtraToRow) {
+        List<Supplier<Pair<RecordReader<InternalRow>, EXTRA>>> suppliers = new ArrayList<>();
+        for (Split split : splits) {
+            suppliers.add(
+                    () -> {
+                        try {
+                            RecordReader<InternalRow> reader =
+                                    readBuilder.newRead().createReader(split);
+                            return Pair.of(reader, extraFunction.apply(split));
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+        }
+
+        ParallelExecution<InternalRow, EXTRA> execution =
+                new ParallelExecution<>(
+                        InternalSerializers.create(projectedType),
+                        pageSize,
+                        parallelism,
+                        suppliers);
+
+        return new RecordReader<InternalRow>() {
+            @Nullable
+            @Override
+            public RecordIterator<InternalRow> readBatch() throws IOException {
+                ParallelBatch<InternalRow, EXTRA> batch;
+                try {
+                    batch = execution.take();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+
+                if (batch == null) {
+                    return null;
+                }
+
+                return new RecordIterator<InternalRow>() {
+                    @Nullable
+                    @Override
+                    public InternalRow next() throws IOException {
+                        InternalRow row = batch.next();
+                        if (row == null) {
+                            return null;
+                        }
+
+                        return addExtraToRow.apply(row, batch.extraMessage());
+                    }
+
+                    @Override
+                    public void releaseBatch() {
+                        batch.releaseBatch();
+                    }
+                };
+            }
+
+            @Override
+            public void close() throws IOException {
+                execution.close();
+            }
+        };
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ParallelExecutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ParallelExecutionTest.java
@@ -170,7 +170,7 @@ public class ParallelExecutionTest {
                         break;
                     }
 
-                    result.add(Pair.of(record, batch.extraMesage()));
+                    result.add(Pair.of(record, batch.extraMessage()));
                 }
             } catch (InterruptedException | IOException e) {
                 Thread.currentThread().interrupt();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -274,6 +274,13 @@ public class FlinkConnectorOptions {
                     .defaultValue(false)
                     .withDescription("Whether to enable async lookup join.");
 
+    public static final ConfigOption<Integer> LOOKUP_BOOTSTRAP_PARALLELISM =
+            ConfigOptions.key("lookup.bootstrap-parallelism")
+                    .intType()
+                    .defaultValue(4)
+                    .withDescription(
+                            "The parallelism for bootstrap in a single task for lookup join.");
+
     public static final ConfigOption<Integer> LOOKUP_ASYNC_THREAD_NUMBER =
             ConfigOptions.key("lookup.async-thread-number")
                     .intType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -162,7 +162,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 RocksDBState.createBulkLoadSorter(
                         IOManager.create(path.toString()), new CoreOptions(options));
         try (RecordReaderIterator<InternalRow> batch =
-                new RecordReaderIterator<>(streamingReader.nextBatch())) {
+                new RecordReaderIterator<>(streamingReader.nextBatch(true))) {
             while (batch.hasNext()) {
                 InternalRow row = batch.next();
                 if (lookupTable.recordFilter().test(row)) {
@@ -252,7 +252,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private void refresh() throws Exception {
         while (true) {
             try (RecordReaderIterator<InternalRow> batch =
-                    new RecordReaderIterator<>(streamingReader.nextBatch())) {
+                    new RecordReaderIterator<>(streamingReader.nextBatch(false))) {
                 if (!batch.hasNext()) {
                     return;
                 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The current lookup join initialization loading is too slow, so we introduce parallelism execution to accelerate it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
