### PR TITLE
[core] generate doc and source jar when compile 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,47 @@ under the License.
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>docs-and-source</id>
+            <activation>
+                <property>
+                    <name>docs-and-source</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <quiet>true</quiet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -42,6 +42,6 @@ fi
 cd ${PROJECT_ROOT}
 
 echo "Deploying to repository.apache.org"
-${MVN} clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10 $CUSTOM_OPTIONS
+${MVN} clean deploy -Papache-release,docs-and-source -DskipTests -DretryFailedDeploymentCount=10 $CUSTOM_OPTIONS
 
 cd ${CURR_DIR}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When I debug my code with the official paimon jar in my IDE , I want to download the paimon jar source , but I found it failed, so I think we should build the source jar and upload to maven repository.

We can add an optional parameter to the profile, and we will generate and upload the source jar in every released, user can skip the operation when compile the code in their computer.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
