### PR TITLE
[flink] fix IF EXISTS clause not works when drop table

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -927,7 +927,9 @@ public class FlinkCatalog extends AbstractCatalog {
             throws PartitionNotExistException, CatalogException {
 
         if (!partitionExists(tablePath, partitionSpec)) {
-            throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+            if (!ignoreIfNotExists) {
+                throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+            }
         }
 
         try {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -481,6 +481,11 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                 .hasMessage(
                         "Partition CatalogPartitionSpec{{dt=2020-10-10}} of table default.PartitionTable in catalog PAIMON does not exist.");
 
+        assertThat(
+                        sql("ALTER TABLE PartitionTable DROP IF EXISTS PARTITION (`dt` = '2020-10-10')")
+                                .toString())
+                .isEqualTo("[+I[OK]]");
+
         List<Row> result = sql("SHOW PARTITIONS PartitionTable");
         assertThat(result.toString())
                 .isEqualTo(


### PR DESCRIPTION
### Purpose

Linked issue: close #2616 

### Tests

`org.apache.paimon.flink.CatalogTableITCase#testDropPartition`