### PR TITLE
[WIP][core][spark] Support analyze table

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/DataFieldStats.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataFieldStats.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.apache.paimon.data.Decimal;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Table level col stats, supports the following stats.
+ *
+ * <ul>
+ *   <li>distinctCount: distinct count
+ *   <li>min: min value
+ *   <li>max: max value
+ *   <li>nullCount: null count
+ *   <li>avgLen: average length
+ *   <li>maxLen: max length
+ * </ul>
+ */
+public class DataFieldStats implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final @Nullable Long distinctCount;
+    private final @Nullable Object min;
+    private final @Nullable Object max;
+    private final @Nullable Long nullCount;
+    private final @Nullable Long avgLen;
+    private final @Nullable Long maxLen;
+
+    public DataFieldStats(
+            @Nullable Long distinctCount,
+            @Nullable Object min,
+            @Nullable Object max,
+            @Nullable Long nullCount,
+            @Nullable Long avgLen,
+            @Nullable Long maxLen) {
+        this.distinctCount = distinctCount;
+        this.min = min;
+        this.max = max;
+        this.nullCount = nullCount;
+        this.avgLen = avgLen;
+        this.maxLen = maxLen;
+    }
+
+    public @Nullable Long distinctCount() {
+        return distinctCount;
+    }
+
+    public @Nullable Object min() {
+        return min;
+    }
+
+    public @Nullable Object max() {
+        return max;
+    }
+
+    public @Nullable Long nullCount() {
+        return nullCount;
+    }
+
+    public @Nullable Long avgLen() {
+        return avgLen;
+    }
+
+    public @Nullable Long maxLen() {
+        return maxLen;
+    }
+
+    public void serializeJson(JsonGenerator generator) throws IOException {
+        generator.writeStartObject();
+        if (distinctCount != null) {
+            generator.writeNumberField("distinctCount", distinctCount);
+        }
+        // todo: just for quick test, need to find a more reasonable serialization method
+        if (min != null) {
+            Object o = min;
+            if (o instanceof String) {
+                generator.writeStringField("min", (String) o);
+            } else if (o instanceof Long) {
+                generator.writeNumberField("min", (Long) o);
+            } else if (o instanceof Integer) {
+                generator.writeNumberField("min", (Integer) o);
+            } else if (o instanceof Double) {
+                generator.writeNumberField("min", (Double) o);
+            } else if (o instanceof Float) {
+                generator.writeNumberField("min", (Float) o);
+            } else if (o instanceof Boolean) {
+                generator.writeBooleanField("min", (Boolean) o);
+            } else if (o instanceof Byte) {
+                generator.writeNumberField("min", (Byte) o);
+            } else if (o instanceof Short) {
+                generator.writeNumberField("min", (Short) o);
+            } else if (o instanceof Decimal) {
+                generator.writeBinaryField("min", ((Decimal) o).toUnscaledBytes());
+            }
+        }
+        if (max != null) {
+            Object o = max;
+            if (o instanceof String) {
+                generator.writeStringField("max", (String) o);
+            } else if (o instanceof Long) {
+                generator.writeNumberField("max", (Long) o);
+            } else if (o instanceof Integer) {
+                generator.writeNumberField("max", (Integer) o);
+            } else if (o instanceof Double) {
+                generator.writeNumberField("max", (Double) o);
+            } else if (o instanceof Float) {
+                generator.writeNumberField("max", (Float) o);
+            } else if (o instanceof Boolean) {
+                generator.writeBooleanField("max", (Boolean) o);
+            } else if (o instanceof Byte) {
+                generator.writeNumberField("max", (Byte) o);
+            } else if (o instanceof Short) {
+                generator.writeNumberField("max", (Short) o);
+            } else if (o instanceof Decimal) {
+                generator.writeBinaryField("max", ((Decimal) o).toUnscaledBytes());
+            }
+        }
+        if (nullCount != null) {
+            generator.writeNumberField("nullCount", nullCount);
+        }
+        if (avgLen != null) {
+            generator.writeNumberField("avgLen", avgLen);
+        }
+        if (maxLen != null) {
+            generator.writeNumberField("maxLen", maxLen);
+        }
+        generator.writeEndObject();
+    }
+
+    public static DataFieldStats deserializeJson(JsonNode jsonNode, DataType type) {
+        Object min = null;
+        Object max = null;
+        if (jsonNode.get("min") != null && jsonNode.get("max") != null) {
+            if (type.getTypeRoot().equals(DataTypeRoot.BIGINT)) {
+                min = jsonNode.get("min").asLong();
+                max = jsonNode.get("max").asLong();
+            } else if (type.getTypeRoot().equals(DataTypeRoot.INTEGER)
+                    || type.getTypeRoot().equals(DataTypeRoot.DATE)) {
+                min = jsonNode.get("min").asInt();
+                max = jsonNode.get("max").asInt();
+            } else if (type.getTypeRoot().equals(DataTypeRoot.DECIMAL)) {
+                try {
+                    DecimalType d = (DecimalType) type;
+                    min =
+                            Decimal.fromUnscaledBytes(
+                                    jsonNode.get("min").binaryValue(),
+                                    d.getPrecision(),
+                                    d.getScale());
+                    max =
+                            Decimal.fromUnscaledBytes(
+                                    jsonNode.get("max").binaryValue(),
+                                    d.getPrecision(),
+                                    d.getScale());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        return new DataFieldStats(
+                jsonNode.get("distinctCount") != null
+                        ? jsonNode.get("distinctCount").asLong()
+                        : null,
+                min,
+                max,
+                jsonNode.get("nullCount") != null ? jsonNode.get("nullCount").asLong() : null,
+                jsonNode.get("avgLen") != null ? jsonNode.get("avgLen").asLong() : null,
+                jsonNode.get("maxLen") != null ? jsonNode.get("maxLen").asLong() : null);
+    }
+
+    public DataFieldStats copy() {
+        return new DataFieldStats(distinctCount, min, max, nullCount, avgLen, maxLen);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        DataFieldStats that = (DataFieldStats) object;
+        return Objects.equals(distinctCount, that.distinctCount)
+                && Objects.equals(min, that.min)
+                && Objects.equals(max, that.max)
+                && Objects.equals(nullCount, that.nullCount)
+                && Objects.equals(avgLen, that.avgLen)
+                && Objects.equals(maxLen, that.maxLen);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(distinctCount, min, max, nullCount, avgLen, maxLen);
+    }
+
+    @Override
+    public String toString() {
+        return "DataFieldStats{"
+                + "distinctCount="
+                + distinctCount
+                + ", min="
+                + min
+                + ", max="
+                + max
+                + ", nullCount="
+                + nullCount
+                + ", avgLen="
+                + avgLen
+                + ", maxLen="
+                + maxLen
+                + '}';
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
@@ -40,11 +40,16 @@ public final class DataTypeJsonParser {
         String name = json.get("name").asText();
         DataType type = parseDataType(json.get("type"));
         JsonNode descriptionNode = json.get("description");
+        JsonNode statsNode = json.get("stats");
         String description = null;
         if (descriptionNode != null) {
             description = descriptionNode.asText();
         }
-        return new DataField(id, name, type, description);
+        DataFieldStats fieldStats = null;
+        if (statsNode != null) {
+            fieldStats = DataFieldStats.deserializeJson(statsNode, type);
+        }
+        return new DataField(id, name, type, description, fieldStats);
     }
 
     public static DataType parseDataType(JsonNode json) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.OptionalLong;
+
+/** Utils for Optional. * */
+public class OptionalUtils {
+    public static OptionalLong of(Long value) {
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -51,7 +51,7 @@ import java.util.Optional;
  * <ul>
  *   <li>Version 1: Initial version for paimon <= 0.2. There is no "version" field in json file.
  *   <li>Version 2: Introduced in paimon 0.3. Add "version" field and "changelogManifestList" field.
- *   <li>Version 3: Introduced in paimon 0.4. Add "baseRecordCount" field, "deltaRecordCount" field
+ *   <li>Version 3: Introduced in paimon 0.4. Add "totalRecordCount" field, "deltaRecordCount" field
  *       and "changelogRecordCount" field.
  * </ul>
  *

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.schema;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.types.DataFieldStats;
 import org.apache.paimon.types.DataType;
 
 import javax.annotation.Nullable;
@@ -89,6 +90,10 @@ public interface SchemaChange extends Serializable {
 
     static SchemaChange updateColumnPosition(Move move) {
         return new UpdateColumnPosition(move);
+    }
+
+    static SchemaChange updateColumnStats(String fieldName, DataFieldStats newStats) {
+        return new UpdateColumnStats(fieldName, newStats);
     }
 
     /** A SchemaChange to set a table option. */
@@ -547,6 +552,46 @@ public interface SchemaChange extends Serializable {
             int result = Objects.hash(newDescription);
             result = 31 * result + Arrays.hashCode(fieldNames);
             return result;
+        }
+    }
+
+    /** A SchemaChange to update field stats. */
+    final class UpdateColumnStats implements SchemaChange {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String fieldName;
+        private final DataFieldStats newStats;
+
+        public UpdateColumnStats(String fieldName, DataFieldStats newStats) {
+            this.fieldName = fieldName;
+            this.newStats = newStats;
+        }
+
+        public String fieldName() {
+            return fieldName;
+        }
+
+        public DataFieldStats newStats() {
+            return newStats;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            UpdateColumnStats that = (UpdateColumnStats) o;
+            return Objects.equals(fieldName, that.fieldName)
+                    && Objects.equals(newStats, that.newStats);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fieldName, newStats);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/FieldStatsArraySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/FieldStatsArraySerializer.java
@@ -53,7 +53,9 @@ public class FieldStatsArraySerializer {
     }
 
     public FieldStatsArraySerializer(
-            RowType type, int[] indexMapping, CastExecutor<Object, Object>[] converterMapping) {
+            RowType type,
+            @Nullable int[] indexMapping,
+            @Nullable CastExecutor<Object, Object>[] converterMapping) {
         RowType safeType = toAllFieldsNullableRowType(type);
         this.serializer = new InternalRowSerializer(safeType);
         this.fieldGetters =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeSerializationTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeSerializationTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.types.DataFieldStats;
 import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,9 @@ public class SchemaChangeSerializationTest {
         runTest(SchemaChange.updateColumnComment(new String[] {"col1", "col2"}, "comment"));
         runTest(SchemaChange.updateColumnPosition(SchemaChange.Move.after("col", "ref")));
         runTest(SchemaChange.updateComment("comment"));
+        runTest(
+                SchemaChange.updateColumnStats(
+                        "col1", new DataFieldStats(1L, null, null, 2L, 3L, 4L)));
     }
 
     private void runTest(SchemaChange schemaChange) throws Exception {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -435,7 +435,7 @@ public class SparkCatalog extends SparkBaseCatalog {
         }
     }
 
-    private boolean isValidateNamespace(String[] namespace) {
+    private static boolean isValidateNamespace(String[] namespace) {
         return namespace.length == 1;
     }
 
@@ -453,7 +453,7 @@ public class SparkCatalog extends SparkBaseCatalog {
 
     // --------------------- tools ------------------------------------------
 
-    protected org.apache.paimon.catalog.Identifier toIdentifier(Identifier ident)
+    public static org.apache.paimon.catalog.Identifier toIdentifier(Identifier ident)
             throws NoSuchTableException {
         if (!isValidateNamespace(ident.namespace())) {
             throw new NoSuchTableException(ident);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
 import org.apache.paimon.spark.sources.PaimonMicroBatchStream
 import org.apache.paimon.table.{DataTable, FileStoreTable, Table}
 import org.apache.paimon.table.source.{ReadBuilder, Split}
+import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read.{Batch, Scan, Statistics, SupportsReportStatistics}
@@ -40,7 +41,7 @@ abstract class PaimonBaseScan(
   with SupportsReportStatistics
   with ScanHelper {
 
-  private val tableRowType = table.rowType
+  val tableRowType: RowType = table.rowType
 
   private lazy val tableSchema = SparkTypeUtils.fromPaimonRowType(tableRowType)
 
@@ -49,6 +50,8 @@ abstract class PaimonBaseScan(
   protected var splits: Array[Split] = _
 
   override val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
+
+  val options: java.util.Map[String, String] = table.options()
 
   lazy val readBuilder: ReadBuilder = {
     val _readBuilder = table.newReadBuilder()
@@ -105,6 +108,8 @@ abstract class PaimonBaseScan(
     }
     super.supportedCustomMetrics() ++ paimonMetrics
   }
+
+  override def toString: String = description()
 
   override def description(): String = {
     val pushedFiltersStr = if (filters.nonEmpty) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeColumnCommand.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.commands
+
+import org.apache.paimon.schema.SchemaChange
+import org.apache.paimon.spark.{SparkCatalog, SparkTable}
+import org.apache.paimon.spark.catalog.WithPaimonCatalog
+import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
+import org.apache.paimon.table.FileStoreTable
+import org.apache.paimon.types.DataFieldStats
+
+import org.apache.spark.sql.{Row, SparkSession, Utils}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.ColumnStat
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType, TimestampType}
+
+import java.util
+
+case class PaimonAnalyzeColumnCommand(
+    catalog: TableCatalog,
+    identifier: Identifier,
+    v2Table: SparkTable,
+    columnNames: Option[Seq[String]],
+    allColumns: Boolean)
+  extends PaimonLeafRunnableCommand
+  with WithFileStoreTable {
+
+  override def table: FileStoreTable = v2Table.getTable.asInstanceOf[FileStoreTable]
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val relation = DataSourceV2Relation.create(v2Table, Some(catalog), Some(identifier))
+    val attributes = getColumnsToAnalyze(relation, columnNames, allColumns)
+
+    val totalSize = Utils.calculateTotalSize(
+      sparkSession.sessionState,
+      table.name(),
+      Some(table.location().toUri))
+    val (rowCount, colStats) = Utils.computeColumnStats(sparkSession, relation, attributes)
+
+    val changes = new util.ArrayList[SchemaChange]()
+
+    // todo: just for quick test, need to find a more suitable place to restore it
+    changes.add(SchemaChange.setOption("totalSize", totalSize.toString))
+    changes.add(SchemaChange.setOption("rowCount", rowCount.toString))
+
+    colStats.foreach {
+      case (attr, stats) =>
+        changes.add(
+          SchemaChange.updateColumnStats(
+            attr.name,
+            sparkColumnStatsToPaimonDataFieldStats(attr.dataType, stats)))
+    }
+
+    if (changes.size() > 0) {
+      catalog
+        .asInstanceOf[WithPaimonCatalog]
+        .paimonCatalog()
+        .alterTable(SparkCatalog.toIdentifier(identifier), changes, false)
+    }
+
+    Seq.empty[Row]
+  }
+
+  private def getColumnsToAnalyze(
+      relation: DataSourceV2Relation,
+      columnNames: Option[Seq[String]],
+      allColumns: Boolean): Seq[Attribute] = {
+    if (columnNames.isDefined && allColumns) {
+      throw new UnsupportedOperationException(
+        "Parameter `columnNames` and `allColumns` are " +
+          "mutually exclusive. Only one of them should be specified.")
+    }
+    val columnsToAnalyze = if (allColumns) {
+      relation.output
+    } else {
+      columnNames.get.map {
+        col =>
+          val exprOption = relation.output.find(attr => conf.resolver(attr.name, col))
+          exprOption.getOrElse(
+            throw new RuntimeException(s"Column $col not found in ${relation.table.name()}."))
+      }
+    }
+    columnsToAnalyze.foreach {
+      attr =>
+        if (!Utils.analyzeSupportsType(attr.dataType)) {
+          throw new UnsupportedOperationException(s"not supported")
+        }
+    }
+    columnsToAnalyze
+  }
+
+  private def sparkColumnStatsToPaimonDataFieldStats(
+      dataType: DataType,
+      columnStat: ColumnStat): DataFieldStats = {
+    new DataFieldStats(
+      if (columnStat.distinctCount.isDefined) columnStat.distinctCount.get.longValue else null,
+      if (columnStat.min.isDefined) sparkDataToPaimonData(columnStat.min.get, dataType) else null,
+      if (columnStat.max.isDefined) sparkDataToPaimonData(columnStat.max.get, dataType) else null,
+      if (columnStat.nullCount.isDefined) columnStat.nullCount.get.longValue else null,
+      if (columnStat.avgLen.isDefined) columnStat.avgLen.get else null,
+      if (columnStat.maxLen.isDefined) columnStat.maxLen.get else null)
+  }
+
+  private def sparkDataToPaimonData(o: Any, dataType: DataType): Any = {
+    dataType match {
+      case _: DecimalType =>
+        val d = o.asInstanceOf[Decimal]
+        org.apache.paimon.data.Decimal.fromBigDecimal(d.toJavaBigDecimal, d.precision, d.scale)
+      case _: TimestampType =>
+        val l = o.asInstanceOf[Long]
+        org.apache.paimon.data.Timestamp.fromEpochMillis(l)
+      case _ => o
+    }
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableCommand.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.commands
+
+import org.apache.paimon.spark.SparkTable
+import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
+import org.apache.paimon.table.FileStoreTable
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+case class PaimonAnalyzeTableCommand(catalog: TableCatalog, v2Table: SparkTable, noScan: Boolean)
+  extends PaimonLeafRunnableCommand
+  with PaimonCommand {
+
+  override def table: FileStoreTable = v2Table.getTable.asInstanceOf[FileStoreTable]
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    // todo
+    Seq.empty[Row]
+  }
+
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/Utils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/Utils.scala
@@ -17,12 +17,19 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LogicalPlan}
 import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
+import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.internal.SessionState
 import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, DatetimeType, DecimalType, DoubleType, FloatType, IntegralType, StringType}
 import org.apache.spark.util.{Utils => SparkUtils}
+
+import java.net.URI
 
 /**
  * Some classes or methods defined in the spark project are marked as private under
@@ -67,5 +74,33 @@ object Utils {
 
   def bytesToString(size: Long): String = {
     SparkUtils.bytesToString(size)
+  }
+
+  // for analyze
+  def calculateTotalSize(
+      sessionState: SessionState,
+      tableName: String,
+      locationUri: Option[URI]): Long = {
+    CommandUtils.calculateSingleLocationSize(
+      sessionState,
+      new TableIdentifier(tableName),
+      locationUri)
+  }
+
+  def computeColumnStats(
+      sparkSession: SparkSession,
+      relation: LogicalPlan,
+      columns: Seq[Attribute]): (Long, Map[Attribute, ColumnStat]) = {
+    CommandUtils.computeColumnStats(sparkSession, relation, columns)
+  }
+
+  def analyzeSupportsType(dataType: DataType): Boolean = dataType match {
+    case _: IntegralType => true
+    case _: DecimalType => true
+    case DoubleType | FloatType => true
+    case BooleanType => true
+    case _: DatetimeType => true
+    case BinaryType | StringType => true
+    case _ => false
   }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.data.Decimal
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.types.{DataField, DataFieldStats}
+
+import org.apache.spark.sql.Row
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions
+
+import java.util
+import java.util.Objects
+
+class AnalyzeTableTest extends PaimonSparkTestBase {
+  test(s"test update with primary key") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = 'deduplicate')
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22'), (3, 'c', '33')")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS id")
+
+//    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS")
+
+    print()
+
+  }
+
+  test("Paimon analyze: analyze all supported cols") {
+    spark.sql(
+      s"""
+         |CREATE TABLE T (id STRING, name STRING, byte_col BYTE, short_col SHORT, int_col INT, long_col LONG,
+         |float_col FLOAT, double_col DOUBLE, decimal_col DECIMAL(10, 5), boolean_col BOOLEAN, date_col DATE,
+         |timestamp_col TIMESTAMP, binary_col BINARY)
+         |USING PAIMON
+         |TBLPROPERTIES ('primary-key'='id')
+         |""".stripMargin)
+
+    spark.sql(
+      s"INSERT INTO T VALUES ('1', 'a', 1, 1, 1, 1, 1.0, 1.0, 12.12345, true, to_date('2020-01-01'), to_timestamp('2020-01-01 00:00:00'), binary('example binary1'))")
+    spark.sql(
+      s"INSERT INTO T VALUES ('2', 'aaa', 1, null, 1, 1, 1.0, 1.0, 12.12345, true, to_date('2020-01-02'), to_timestamp('2020-01-02 00:00:00'), binary('example binary1'))")
+    spark.sql(
+      s"INSERT INTO T VALUES ('3', 'bbbb', 2, 1, 1, 1, 1.0, 1.0, 22.12345, true, to_date('2020-01-02'), to_timestamp('2020-01-02 00:00:00'), null)")
+    spark.sql(
+      s"INSERT INTO T VALUES ('4', 'bbbbbbbb', 2, 2, 2, 2, 2.0, 2.0, 22.12345, false, to_date('2020-01-01'), to_timestamp('2020-01-01 00:00:00'), binary('example binary2'))")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    val options = loadTable("T").options()
+    Assertions.assertEquals(options.get("rowCount"), "4")
+
+    var fields = loadTable("T").schema().fields()
+    assertStatsEqual(fields, "id", new DataFieldStats(4, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "name", new DataFieldStats(4, null, null, 0, 4, 8))
+    assertStatsEqual(fields, "byte_col", new DataFieldStats(2, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "short_col", new DataFieldStats(2, null, null, 1, 2, 2))
+    assertStatsEqual(fields, "int_col", new DataFieldStats(2, 1, 2, 0, 4, 4))
+    assertStatsEqual(fields, "long_col", new DataFieldStats(2, 1L, 2L, 0, 8, 8))
+    assertStatsEqual(fields, "float_col", new DataFieldStats(2, null, null, 0, 4, 4))
+    assertStatsEqual(fields, "double_col", new DataFieldStats(2, null, null, 0, 8, 8))
+    assertStatsEqual(
+      fields,
+      "decimal_col",
+      new DataFieldStats(
+        2,
+        Decimal.fromBigDecimal(new java.math.BigDecimal("12.12345"), 10, 5),
+        Decimal.fromBigDecimal(new java.math.BigDecimal("22.12345"), 10, 5),
+        0,
+        8,
+        8)
+    )
+    assertStatsEqual(fields, "boolean_col", new DataFieldStats(2, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "date_col", new DataFieldStats(2, 18262, 18263, 0, 4, 4))
+    assertStatsEqual(fields, "timestamp_col", new DataFieldStats(2, null, null, 0, 8, 8))
+    assertStatsEqual(fields, "binary_col", new DataFieldStats(2, null, null, 1, 15, 15))
+
+    spark.sql(
+      s"INSERT INTO T VALUES ('5', 'bbbbbbbbbbbbbbbb', 3, 3, 3, 3, 3.0, 3.0, 32.12345, false, to_date('2020-01-01'), to_timestamp('2020-01-01 00:00:00'), binary('binary3'))")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+    fields = loadTable("T").schema().fields()
+    assertStatsEqual(fields, "id", new DataFieldStats(5, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "name", new DataFieldStats(5, null, null, 0, 7, 16))
+    assertStatsEqual(fields, "byte_col", new DataFieldStats(3, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "short_col", new DataFieldStats(3, null, null, 1, 2, 2))
+    assertStatsEqual(fields, "int_col", new DataFieldStats(3, 1, 3, 0, 4, 4))
+    assertStatsEqual(fields, "long_col", new DataFieldStats(3, 1L, 3L, 0, 8, 8))
+    assertStatsEqual(fields, "float_col", new DataFieldStats(3, null, null, 0, 4, 4))
+    assertStatsEqual(fields, "double_col", new DataFieldStats(3, null, null, 0, 8, 8))
+    assertStatsEqual(
+      fields,
+      "decimal_col",
+      new DataFieldStats(
+        3,
+        Decimal.fromBigDecimal(new java.math.BigDecimal("12.12345"), 10, 5),
+        Decimal.fromBigDecimal(new java.math.BigDecimal("32.12345"), 10, 5),
+        0,
+        8,
+        8)
+    )
+    assertStatsEqual(fields, "boolean_col", new DataFieldStats(2, null, null, 0, 1, 1))
+    assertStatsEqual(fields, "date_col", new DataFieldStats(2, 18262, 18263, 0, 4, 4))
+    assertStatsEqual(fields, "timestamp_col", new DataFieldStats(2, null, null, 0, 8, 8))
+    assertStatsEqual(fields, "binary_col", new DataFieldStats(3, null, null, 1, 13, 15))
+
+    spark.sql(s"select * from T")
+  }
+
+  test("Paimon analyze: analyze specialized cols") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    assertThatThrownBy(() => spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS fake_col"))
+      .hasMessageContaining("not found")
+  }
+
+  test("Paimon analyze: analyze unsupported cols") {
+    spark.sql(
+      s"""
+         |CREATE TABLE T (id STRING, m MAP<INT, STRING>, l ARRAY<INT>, s STRUCT<i:INT, s:STRING>)
+         |USING PAIMON
+         |TBLPROPERTIES ('primary-key'='id')
+         |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', map(1, 'a'), array(1), struct(1, 'a'))")
+
+    assertThatThrownBy(() => spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS m"))
+      .hasMessageContaining("not supported")
+
+    assertThatThrownBy(() => spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS l"))
+      .hasMessageContaining("not supported")
+
+    assertThatThrownBy(() => spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS s"))
+      .hasMessageContaining("not supported")
+  }
+
+  test("Paimon analyze: analyze non-exist cols") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a', 1, 1)")
+    spark.sql(s"INSERT INTO T VALUES ('2', 'aaa', 1, 2)")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS name, i")
+    val fields = loadTable("T").schema().fields()
+    assertStatsEqual(fields, "id", null)
+    assertStatsEqual(fields, "name", new DataFieldStats(2, null, null, 0, 2, 3))
+    assertStatsEqual(fields, "i", new DataFieldStats(1, 1, 1, 0, 4, 4))
+    assertStatsEqual(fields, "l", null)
+
+    checkAnswer(
+      spark.sql(s"SELECT * from T ORDER BY id"),
+      Row("1", "a", 1, 1) :: Row("2", "aaa", 1, 2) :: Nil)
+  }
+
+  def assertStatsEqual(lst: util.List[DataField], name: String, stats: DataFieldStats): Unit = {
+    Assertions.assertTrue(
+      Objects
+        .equals(lst.stream().filter(f => f.name().equals(name)).findFirst().get.stats(), stats))
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support `ANALYZE TABLE T COMPUTE STATISTICS` and `ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS` to collect the following stats:

table level: totalSize, rowCount
col level: distinctCount, min, max, nullCount, avgLen, maxLen

e.g. schema-1 (after analyze)

```text
{
  "id" : 1,
  "fields" : [ ... {
    "id" : 4,
    "name" : "s_closed_date_sk",
    "type" : "BIGINT",
    "stats" : {
      "distinctCount" : 142,
      "min" : 2450820,
      "max" : 2451313,
      "nullCount" : 729,
      "avgLen" : 8,
      "maxLen" : 8
    }
  }, ... ],
  "highestFieldId" : 28,
  "partitionKeys" : [ ],
  "primaryKeys" : [ ],
  "options" : {
    "bucket" : "-1",
    "owner" : "root",
    "file.compression" : "snappy",
    "write-mode" : "append-only",
    "totalSize" : "249027",
    "provider" : "paimon",
    "file.format" : "parquet",
    "rowCount" : "1002"
  },
  "timeMillis" : 1704179150521
}
```

Spark wil collect and use them for CBO, note:

- spark support collect stats for Integral, Decimal, Double, Float, Boolean, Date, Timestamp, Binary, String
- only Integral, Decimal, Double, Float, Boolean, Date support collect min&max

todo:

- find a more suitable place to restore table stats and col stats
- add a config to control read with analyzed stats

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
