### PR TITLE
[hotfix][cdc] Uncheck 'port' of mysql-conf; Fix record null check

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
@@ -95,7 +95,6 @@ public class SyncJobHandler {
                         cdcSourceConfig,
                         MYSQL_CONF,
                         MySqlSourceOptions.HOSTNAME,
-                        MySqlSourceOptions.PORT,
                         MySqlSourceOptions.USERNAME,
                         MySqlSourceOptions.PASSWORD,
                         MySqlSourceOptions.DATABASE_NAME);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
@@ -27,6 +27,7 @@ import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.DateTimeUtils;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.StringUtils;
 
@@ -232,7 +233,7 @@ public class MySqlRecordParser implements FlatMapFunction<String, RichCdcMultipl
     }
 
     private Map<String, String> extractRow(JsonNode recordRow) {
-        if (recordRow == null) {
+        if (JsonSerdeUtil.isNull(recordRow)) {
             return new HashMap<>();
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. port has default value.
2. null value in Json will be parsed into NullNode.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
