### PR TITLE
[spark]Support change default database

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -65,10 +66,16 @@ public class SparkCatalog extends SparkBaseCatalog {
 
     private String name = null;
     protected Catalog catalog = null;
+    private String defaultNamespace = null;
 
     @Override
     public void initialize(String name, CaseInsensitiveStringMap options) {
         this.name = name;
+        defaultNamespace =
+                SQLConf.get()
+                        .getConfString(
+                                String.format("spark.sql.catalog.%s.defaultDatabase", name),
+                                Catalog.DEFAULT_DATABASE);
         CatalogContext catalogContext =
                 CatalogContext.create(
                         Options.fromMap(options),
@@ -94,7 +101,7 @@ public class SparkCatalog extends SparkBaseCatalog {
 
     @Override
     public String[] defaultNamespace() {
-        return new String[] {Catalog.DEFAULT_DATABASE};
+        return new String[] {defaultNamespace};
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -74,7 +74,8 @@ public class SparkGenericCatalog<T extends TableCatalog & SupportsNamespaces>
 
     private static final Logger LOG = LoggerFactory.getLogger(SparkGenericCatalog.class);
 
-    private static final String[] DEFAULT_NAMESPACE = new String[] {"default"};
+    private static final String[] DEFAULT_NAMESPACE =
+            new String[] {SQLConf.get().defaultDatabase()};
 
     private String catalogName = null;
     private SparkCatalog sparkCatalog = null;

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkDefaultDatabaseTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkDefaultDatabaseTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.hive.TestHiveMetastore;
+
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for change spark default database. */
+public class SparkDefaultDatabaseTest {
+    private static TestHiveMetastore testHiveMetastore;
+
+    @BeforeAll
+    public static void startMetastore() {
+        testHiveMetastore = new TestHiveMetastore();
+        testHiveMetastore.start();
+    }
+
+    @AfterAll
+    public static void closeMetastore() throws Exception {
+        testHiveMetastore.stop();
+    }
+
+    @Test
+    public void testChangeDefaultDbWithHive(@TempDir java.nio.file.Path tempDir) {
+        // firstly, we use hive metastore to creata table, and check the result.
+        Path warehousePath = new Path("file:" + tempDir.toString());
+        SparkSession spark =
+                SparkSession.builder()
+                        .config("spark.sql.warehouse.dir", warehousePath.toString())
+                        // with hive metastore
+                        .config("spark.sql.catalogImplementation", "hive")
+                        .config(
+                                "spark.sql.catalog.spark_catalog",
+                                SparkGenericCatalog.class.getName())
+                        .master("local[2]")
+                        .getOrCreate();
+
+        spark.sql("CREATE DATABASE my_default_db");
+        spark.sql("USE my_default_db");
+        spark.sql(
+                "CREATE TABLE IF NOT EXISTS t1 (a INT, b INT, c STRING) USING paimon TBLPROPERTIES"
+                        + " ('file.format'='avro')");
+
+        assertThat(spark.sql("SHOW NAMESPACES").collectAsList().stream().map(Object::toString))
+                .containsExactlyInAnyOrder("[default]", "[my_default_db]");
+
+        assertThat(
+                        spark.sql("SHOW TABLES").collectAsList().stream()
+                                .map(s -> s.get(1))
+                                .map(Object::toString))
+                .containsExactlyInAnyOrder("t1");
+        spark.close();
+
+        SparkSession spark2 =
+                SparkSession.builder()
+                        .config("spark.sql.warehouse.dir", warehousePath.toString())
+                        // with hive metastore
+                        .config("spark.sql.catalogImplementation", "hive")
+                        .config(
+                                "spark.sql.catalog.spark_catalog",
+                                SparkGenericCatalog.class.getName())
+                        .config("spark.sql.catalog.spark_catalog.defaultDatabase", "my_default_db")
+                        .master("local[2]")
+                        .getOrCreate();
+        assertThat(
+                        spark2.sql("SHOW CURRENT NAMESPACE").collectAsList().stream()
+                                .map(Object::toString))
+                .containsExactlyInAnyOrder("[spark_catalog,my_default_db]");
+        assertThat(
+                        spark2.sql("SHOW TABLES").collectAsList().stream()
+                                .map(s -> s.get(1))
+                                .map(Object::toString))
+                .containsExactlyInAnyOrder("t1");
+        spark2.close();
+
+        SparkSession spark3 =
+                SparkSession.builder()
+                        .config("spark.sql.catalog.paimon.warehouse", warehousePath.toString())
+                        .config("spark.sql.catalogImplementation", "in-memory")
+                        .config("spark.sql.catalog.paimon", SparkCatalog.class.getName())
+                        .config("spark.sql.catalog.paimon.defaultDatabase", "my_default_db")
+                        .master("local[2]")
+                        .getOrCreate();
+        spark3.sql("USE paimon");
+        assertThat(
+                        spark3.sql("SHOW CURRENT NAMESPACE").collectAsList().stream()
+                                .map(Object::toString))
+                .containsExactlyInAnyOrder("[paimon,my_default_db]");
+        assertThat(
+                        spark3.sql("SHOW TABLES").collectAsList().stream()
+                                .map(s -> s.get(1))
+                                .map(Object::toString))
+                .containsExactlyInAnyOrder("t1");
+        spark3.close();
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2627 

<!-- What is the purpose of the change -->
Sometimes `default` can't be accessed, we need support change default database.
### Tests

<!-- List UT and IT cases to verify this change -->
Add testChangeDefaultDbWithHive
### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No
