### PR TITLE
[core] Introduce serializeToString and deserializeFromString for internal data structure

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryStringSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryStringSerializer.java
@@ -61,4 +61,14 @@ public final class BinaryStringSerializer extends SerializerSingleton<BinaryStri
         source.readFully(bytes);
         return BinaryString.fromBytes(bytes);
     }
+
+    @Override
+    public String serializeToString(BinaryString record) {
+        return record.toString();
+    }
+
+    @Override
+    public BinaryString deserializeFromString(String s) {
+        return BinaryString.fromString(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BooleanSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BooleanSerializer.java
@@ -45,4 +45,14 @@ public final class BooleanSerializer extends SerializerSingleton<Boolean> {
     public Boolean deserialize(DataInputView source) throws IOException {
         return source.readBoolean();
     }
+
+    @Override
+    public String serializeToString(Boolean record) {
+        return record.toString();
+    }
+
+    @Override
+    public Boolean deserializeFromString(String s) {
+        return Boolean.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/ByteSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/ByteSerializer.java
@@ -45,4 +45,14 @@ public final class ByteSerializer extends SerializerSingleton<Byte> {
     public Byte deserialize(DataInputView source) throws IOException {
         return source.readByte();
     }
+
+    @Override
+    public String serializeToString(Byte record) {
+        return record.toString();
+    }
+
+    @Override
+    public Byte deserializeFromString(String s) {
+        return Byte.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/DecimalSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/DecimalSerializer.java
@@ -23,6 +23,7 @@ import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataOutputView;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 /** Serializer for {@link Decimal}. */
 public final class DecimalSerializer implements Serializer<Decimal> {
@@ -62,6 +63,16 @@ public final class DecimalSerializer implements Serializer<Decimal> {
             byte[] bytes = BinarySerializer.INSTANCE.deserialize(source);
             return Decimal.fromUnscaledBytes(bytes, precision, scale);
         }
+    }
+
+    @Override
+    public String serializeToString(Decimal record) {
+        return record.toString();
+    }
+
+    @Override
+    public Decimal deserializeFromString(String s) {
+        return Decimal.fromBigDecimal(new BigDecimal(s), precision, scale);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/DoubleSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/DoubleSerializer.java
@@ -45,4 +45,14 @@ public final class DoubleSerializer extends SerializerSingleton<Double> {
     public Double deserialize(DataInputView source) throws IOException {
         return source.readDouble();
     }
+
+    @Override
+    public String serializeToString(Double record) {
+        return record.toString();
+    }
+
+    @Override
+    public Double deserializeFromString(String s) {
+        return Double.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/FloatSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/FloatSerializer.java
@@ -45,4 +45,14 @@ public final class FloatSerializer extends SerializerSingleton<Float> {
     public Float deserialize(DataInputView source) throws IOException {
         return source.readFloat();
     }
+
+    @Override
+    public String serializeToString(Float record) {
+        return record.toString();
+    }
+
+    @Override
+    public Float deserializeFromString(String s) {
+        return Float.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/IntSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/IntSerializer.java
@@ -45,4 +45,14 @@ public final class IntSerializer extends SerializerSingleton<Integer> {
     public Integer deserialize(DataInputView source) throws IOException {
         return source.readInt();
     }
+
+    @Override
+    public String serializeToString(Integer record) {
+        return record.toString();
+    }
+
+    @Override
+    public Integer deserializeFromString(String s) {
+        return Integer.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/LongSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/LongSerializer.java
@@ -45,4 +45,14 @@ public final class LongSerializer extends SerializerSingleton<Long> {
     public Long deserialize(DataInputView source) throws IOException {
         return source.readLong();
     }
+
+    @Override
+    public String serializeToString(Long record) {
+        return record.toString();
+    }
+
+    @Override
+    public Long deserializeFromString(String s) {
+        return Long.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/Serializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/Serializer.java
@@ -65,4 +65,26 @@ public interface Serializer<T> extends Serializable {
      *     it reads.
      */
     T deserialize(DataInputView source) throws IOException;
+
+    /**
+     * Serializes the given record to string.
+     *
+     * @param record The record to serialize.
+     * @return The serialized element.
+     */
+    default String serializeToString(T record) {
+        throw new UnsupportedOperationException(
+                String.format("serialize %s to string is unsupported", record));
+    }
+
+    /**
+     * De-serializes a record from string.
+     *
+     * @param s The string to de-serialize.
+     * @return The deserialized element.
+     */
+    default T deserializeFromString(String s) {
+        throw new UnsupportedOperationException(
+                String.format("deserialize %s from string is unsupported", s));
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/ShortSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/ShortSerializer.java
@@ -45,4 +45,14 @@ public final class ShortSerializer extends SerializerSingleton<Short> {
     public Short deserialize(DataInputView source) throws IOException {
         return source.readShort();
     }
+
+    @Override
+    public String serializeToString(Short record) {
+        return record.toString();
+    }
+
+    @Override
+    public Short deserializeFromString(String s) {
+        return Short.valueOf(s);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/TimestampSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/TimestampSerializer.java
@@ -21,9 +21,9 @@ package org.apache.paimon.data.serializer;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataOutputView;
+import org.apache.paimon.utils.DateTimeUtils;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 /**
  * Serializer for {@link Timestamp}.
@@ -76,12 +76,12 @@ public class TimestampSerializer implements Serializer<Timestamp> {
 
     @Override
     public String serializeToString(Timestamp record) {
-        return record.toLocalDateTime().toString();
+        return DateTimeUtils.formatTimestamp(record, precision);
     }
 
     @Override
     public Timestamp deserializeFromString(String s) {
-        return Timestamp.fromLocalDateTime(LocalDateTime.parse(s));
+        return DateTimeUtils.parseTimestampData(s, precision);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/TimestampSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/TimestampSerializer.java
@@ -23,6 +23,7 @@ import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataOutputView;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 /**
  * Serializer for {@link Timestamp}.
@@ -71,6 +72,16 @@ public class TimestampSerializer implements Serializer<Timestamp> {
             int intVal = source.readInt();
             return Timestamp.fromEpochMillis(longVal, intVal);
         }
+    }
+
+    @Override
+    public String serializeToString(Timestamp record) {
+        return record.toLocalDateTime().toString();
+    }
+
+    @Override
+    public Timestamp deserializeFromString(String s) {
+        return Timestamp.fromLocalDateTime(LocalDateTime.parse(s));
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryStringSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryStringSerializerTest.java
@@ -19,8 +19,10 @@
 package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.utils.Pair;
 
 import java.util.Arrays;
+import java.util.List;
 
 /** Test for {@link BinaryStringSerializer}. */
 public class BinaryStringSerializerTest extends SerializerTestBase<BinaryString> {
@@ -43,5 +45,16 @@ public class BinaryStringSerializerTest extends SerializerTestBase<BinaryString>
                         })
                 .map(BinaryString::fromString)
                 .toArray(BinaryString[]::new);
+    }
+
+    @Override
+    protected List<Pair<BinaryString, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(BinaryString.fromString("a"), "a"),
+                Pair.of(BinaryString.fromString(""), ""),
+                Pair.of(
+                        BinaryString.fromString("jbmbmner8 jhk hj \n \t üäßß@µ"),
+                        "jbmbmner8 jhk hj \n \t üäßß@µ"),
+                Pair.of(BinaryString.fromString("non-empty"), "non-empty"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BooleanSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BooleanSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link BooleanSerializer}. */
@@ -40,5 +44,10 @@ public class BooleanSerializerTest extends SerializerTestBase<Boolean> {
         return new Boolean[] {
             Boolean.TRUE, Boolean.FALSE, rnd.nextBoolean(), rnd.nextBoolean(), rnd.nextBoolean()
         };
+    }
+
+    @Override
+    protected List<Pair<Boolean, String>> getSerializableToStringTestData() {
+        return Arrays.asList(Pair.of(Boolean.TRUE, "true"), Pair.of(Boolean.FALSE, "false"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/ByteSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/ByteSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link ByteSerializer}. */
@@ -39,5 +43,15 @@ public class ByteSerializerTest extends SerializerTestBase<Byte> {
         byte rndShort = (byte) rnd.nextInt();
 
         return new Byte[] {0, 1, -1, Byte.MAX_VALUE, Byte.MIN_VALUE, rndShort, (byte) -rndShort};
+    }
+
+    @Override
+    protected List<Pair<Byte, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of((byte) 0, "0"),
+                Pair.of((byte) 1, "1"),
+                Pair.of((byte) -1, "-1"),
+                Pair.of(Byte.MAX_VALUE, "127"),
+                Pair.of(Byte.MIN_VALUE, "-128"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/DecimalSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/DecimalSerializerTest.java
@@ -21,15 +21,16 @@ package org.apache.paimon.data.serializer;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.utils.Pair;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
 /** Test for {@link DecimalSerializer}. */
-public class DecimalSerializerTest extends SerializerTestBase<Decimal> {
+public abstract class DecimalSerializerTest extends SerializerTestBase<Decimal> {
 
     @Override
     protected DecimalSerializer createSerializer() {
-        return new DecimalSerializer(5, 2);
+        return new DecimalSerializer(getPrecision(), getScale());
     }
 
     @Override
@@ -37,22 +38,80 @@ public class DecimalSerializerTest extends SerializerTestBase<Decimal> {
         return t1.equals(t2);
     }
 
+    protected abstract int getPrecision();
+
+    protected abstract int getScale();
+
     @Override
     protected Decimal[] getTestData() {
         return new Decimal[] {
-            Decimal.fromUnscaledLong(1, 5, 2),
-            Decimal.fromUnscaledLong(2, 5, 2),
-            Decimal.fromUnscaledLong(3, 5, 2),
-            Decimal.fromUnscaledLong(4, 5, 2)
+            Decimal.fromUnscaledLong(1, getPrecision(), getScale()),
+            Decimal.fromUnscaledLong(2, getPrecision(), getScale()),
+            Decimal.fromUnscaledLong(3, getPrecision(), getScale()),
+            Decimal.fromUnscaledLong(4, getPrecision(), getScale())
         };
+    }
+
+    static final class DecimalSerializer2Test extends DecimalSerializerTest {
+        @Override
+        protected int getPrecision() {
+            return 5;
+        }
+
+        @Override
+        protected int getScale() {
+            return 2;
+        }
     }
 
     @Override
     protected List<Pair<Decimal, String>> getSerializableToStringTestData() {
         return Arrays.asList(
-                Pair.of(Decimal.fromUnscaledLong(1, 5, 2), "0.01"),
-                Pair.of(Decimal.fromUnscaledLong(2, 5, 2), "0.02"),
-                Pair.of(Decimal.fromUnscaledLong(3, 5, 2), "0.03"),
-                Pair.of(Decimal.fromUnscaledLong(4, 5, 2), "0.04"));
+                Pair.of(
+                        Decimal.fromBigDecimal(new BigDecimal("0.01"), getPrecision(), getScale()),
+                        "0.01"),
+                Pair.of(
+                        Decimal.fromBigDecimal(new BigDecimal("22.02"), getPrecision(), getScale()),
+                        "22.02"),
+                Pair.of(
+                        Decimal.fromBigDecimal(new BigDecimal("33.30"), getPrecision(), getScale()),
+                        "33.30"),
+                Pair.of(
+                        Decimal.fromBigDecimal(
+                                new BigDecimal("444.40"), getPrecision(), getScale()),
+                        "444.40"));
+    }
+
+    static final class DecimalSerializer3Test extends DecimalSerializerTest {
+        @Override
+        protected int getPrecision() {
+            return 6;
+        }
+
+        @Override
+        protected int getScale() {
+            return 3;
+        }
+
+        @Override
+        protected List<Pair<Decimal, String>> getSerializableToStringTestData() {
+            return Arrays.asList(
+                    Pair.of(
+                            Decimal.fromBigDecimal(
+                                    new BigDecimal("0.001"), getPrecision(), getScale()),
+                            "0.001"),
+                    Pair.of(
+                            Decimal.fromBigDecimal(
+                                    new BigDecimal("22.002"), getPrecision(), getScale()),
+                            "22.002"),
+                    Pair.of(
+                            Decimal.fromBigDecimal(
+                                    new BigDecimal("33.030"), getPrecision(), getScale()),
+                            "33.030"),
+                    Pair.of(
+                            Decimal.fromBigDecimal(
+                                    new BigDecimal("444.400"), getPrecision(), getScale()),
+                            "444.400"));
+        }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/DecimalSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/DecimalSerializerTest.java
@@ -19,6 +19,10 @@
 package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.Decimal;
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 
 /** Test for {@link DecimalSerializer}. */
 public class DecimalSerializerTest extends SerializerTestBase<Decimal> {
@@ -41,5 +45,14 @@ public class DecimalSerializerTest extends SerializerTestBase<Decimal> {
             Decimal.fromUnscaledLong(3, 5, 2),
             Decimal.fromUnscaledLong(4, 5, 2)
         };
+    }
+
+    @Override
+    protected List<Pair<Decimal, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(Decimal.fromUnscaledLong(1, 5, 2), "0.01"),
+                Pair.of(Decimal.fromUnscaledLong(2, 5, 2), "0.02"),
+                Pair.of(Decimal.fromUnscaledLong(3, 5, 2), "0.03"),
+                Pair.of(Decimal.fromUnscaledLong(4, 5, 2), "0.04"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/DoubleSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/DoubleSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link DoubleSerializer}. */
@@ -50,5 +54,18 @@ public class DoubleSerializerTest extends SerializerTestBase<Double> {
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY
         };
+    }
+
+    @Override
+    protected List<Pair<Double, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(0.0, "0.0"),
+                Pair.of(1.0, "1.0"),
+                Pair.of(-1.0, "-1.0"),
+                Pair.of(Double.MAX_VALUE, "1.7976931348623157E308"),
+                Pair.of(Double.MIN_VALUE, "4.9E-324"),
+                Pair.of(Double.NaN, "NaN"),
+                Pair.of(Double.NEGATIVE_INFINITY, "-Infinity"),
+                Pair.of(Double.POSITIVE_INFINITY, "Infinity"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/FloatSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/FloatSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link FloatSerializer}. */
@@ -50,5 +54,18 @@ public class FloatSerializerTest extends SerializerTestBase<Float> {
             Float.NEGATIVE_INFINITY,
             Float.POSITIVE_INFINITY
         };
+    }
+
+    @Override
+    protected List<Pair<Float, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of((float) 0, "0.0"),
+                Pair.of(1F, "1.0"),
+                Pair.of((float) -1, "-1.0"),
+                Pair.of(Float.MAX_VALUE, "3.4028235E38"),
+                Pair.of(Float.MIN_VALUE, "1.4E-45"),
+                Pair.of(Float.NaN, "NaN"),
+                Pair.of(Float.NEGATIVE_INFINITY, "-Infinity"),
+                Pair.of(Float.POSITIVE_INFINITY, "Infinity"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/FloatSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/FloatSerializerTest.java
@@ -43,9 +43,9 @@ public class FloatSerializerTest extends SerializerTestBase<Float> {
         float rndFloat = rnd.nextFloat() * Float.MAX_VALUE;
 
         return new Float[] {
-            (float) 0,
+            0F,
             1F,
-            (float) -1,
+            -1F,
             Float.MAX_VALUE,
             Float.MIN_VALUE,
             rndFloat,
@@ -59,9 +59,9 @@ public class FloatSerializerTest extends SerializerTestBase<Float> {
     @Override
     protected List<Pair<Float, String>> getSerializableToStringTestData() {
         return Arrays.asList(
-                Pair.of((float) 0, "0.0"),
+                Pair.of(0F, "0.0"),
                 Pair.of(1F, "1.0"),
-                Pair.of((float) -1, "-1.0"),
+                Pair.of(-1F, "-1.0"),
                 Pair.of(Float.MAX_VALUE, "3.4028235E38"),
                 Pair.of(Float.MIN_VALUE, "1.4E-45"),
                 Pair.of(Float.NaN, "NaN"),

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/IntSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/IntSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link IntSerializer}. */
@@ -39,5 +43,17 @@ public class IntSerializerTest extends SerializerTestBase<Integer> {
         int rndInt = rnd.nextInt();
 
         return new Integer[] {0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, rndInt, -rndInt};
+    }
+
+    @Override
+    protected List<Pair<Integer, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(0, "0"),
+                Pair.of(1, "1"),
+                Pair.of(-1, "-1"),
+                Pair.of(Integer.MAX_VALUE, "2147483647"),
+                Pair.of(Integer.MIN_VALUE, "-2147483648"),
+                Pair.of(123456789, "123456789"),
+                Pair.of(-123456789, "-123456789"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/LongSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/LongSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link LongSerializer}. */
@@ -39,5 +43,17 @@ public class LongSerializerTest extends SerializerTestBase<Long> {
         long rndLong = rnd.nextLong();
 
         return new Long[] {0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, rndLong, -rndLong};
+    }
+
+    @Override
+    protected List<Pair<Long, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(0L, "0"),
+                Pair.of(1L, "1"),
+                Pair.of(-1L, "-1"),
+                Pair.of(Long.MAX_VALUE, "9223372036854775807"),
+                Pair.of(Long.MIN_VALUE, "-9223372036854775808"),
+                Pair.of(1234567890123456789L, "1234567890123456789"),
+                Pair.of(-1234567890123456789L, "-1234567890123456789"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/ShortSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/ShortSerializerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.data.serializer;
 
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /** Test for {@link ShortSerializer}. */
@@ -41,5 +45,17 @@ public class ShortSerializerTest extends SerializerTestBase<Short> {
         return new Short[] {
             0, 1, -1, Short.MAX_VALUE, Short.MIN_VALUE, rndShort, (short) -rndShort
         };
+    }
+
+    @Override
+    protected List<Pair<Short, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of((short) 0, "0"),
+                Pair.of((short) 1, "1"),
+                Pair.of((short) -1, "-1"),
+                Pair.of(Short.MAX_VALUE, "32767"),
+                Pair.of(Short.MIN_VALUE, "-32768"),
+                Pair.of((short) 12345, "12345"),
+                Pair.of((short) -12345, "-12345"));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/TimestampSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/TimestampSerializerTest.java
@@ -19,6 +19,10 @@
 package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.utils.Pair;
+
+import java.util.Arrays;
+import java.util.List;
 
 /** Test for {@link TimestampSerializer}. */
 public abstract class TimestampSerializerTest extends SerializerTestBase<Timestamp> {
@@ -41,6 +45,15 @@ public abstract class TimestampSerializerTest extends SerializerTestBase<Timesta
             Timestamp.fromEpochMillis(3),
             Timestamp.fromEpochMillis(4)
         };
+    }
+
+    @Override
+    protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
+        return Arrays.asList(
+                Pair.of(Timestamp.fromEpochMillis(1), "1970-01-01T00:00:00.001"),
+                Pair.of(Timestamp.fromEpochMillis(2), "1970-01-01T00:00:00.002"),
+                Pair.of(Timestamp.fromEpochMillis(3), "1970-01-01T00:00:00.003"),
+                Pair.of(Timestamp.fromEpochMillis(4, 1), "1970-01-01T00:00:00.004000001"));
     }
 
     protected abstract int getPrecision();

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/TimestampSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/TimestampSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.Pair;
 
 import java.util.Arrays;
@@ -47,21 +48,23 @@ public abstract class TimestampSerializerTest extends SerializerTestBase<Timesta
         };
     }
 
-    @Override
-    protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
-        return Arrays.asList(
-                Pair.of(Timestamp.fromEpochMillis(1), "1970-01-01T00:00:00.001"),
-                Pair.of(Timestamp.fromEpochMillis(2), "1970-01-01T00:00:00.002"),
-                Pair.of(Timestamp.fromEpochMillis(3), "1970-01-01T00:00:00.003"),
-                Pair.of(Timestamp.fromEpochMillis(4, 1), "1970-01-01T00:00:00.004000001"));
-    }
-
     protected abstract int getPrecision();
 
     static final class TimestampSerializer0Test extends TimestampSerializerTest {
         @Override
         protected int getPrecision() {
             return 0;
+        }
+
+        @Override
+        protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
+            return Arrays.asList(
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData("2019-01-01 00:00:00", getPrecision()),
+                            "2019-01-01 00:00:00"),
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData("2019-01-01 00:00:01", getPrecision()),
+                            "2019-01-01 00:00:01"));
         }
     }
 
@@ -70,6 +73,19 @@ public abstract class TimestampSerializerTest extends SerializerTestBase<Timesta
         protected int getPrecision() {
             return 3;
         }
+
+        @Override
+        protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
+            return Arrays.asList(
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.000", getPrecision()),
+                            "2019-01-01 00:00:00.000"),
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.001", getPrecision()),
+                            "2019-01-01 00:00:00.001"));
+        }
     }
 
     static final class TimestampSerializer6Test extends TimestampSerializerTest {
@@ -77,12 +93,38 @@ public abstract class TimestampSerializerTest extends SerializerTestBase<Timesta
         protected int getPrecision() {
             return 6;
         }
+
+        @Override
+        protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
+            return Arrays.asList(
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.000000", getPrecision()),
+                            "2019-01-01 00:00:00.000000"),
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.000001", getPrecision()),
+                            "2019-01-01 00:00:00.000001"));
+        }
     }
 
     static final class TimestampSerializer8Test extends TimestampSerializerTest {
         @Override
         protected int getPrecision() {
             return 8;
+        }
+
+        @Override
+        protected List<Pair<Timestamp, String>> getSerializableToStringTestData() {
+            return Arrays.asList(
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.00000000", getPrecision()),
+                            "2019-01-01 00:00:00.00000000"),
+                    Pair.of(
+                            DateTimeUtils.parseTimestampData(
+                                    "2019-01-01 00:00:00.00000001", getPrecision()),
+                            "2019-01-01 00:00:00.00000001"));
         }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Introduce serializeToString and deserializeFromString for internal data structure, support data structures:

BinaryString, Boolean, Byte, Decimal, Double, Float, Int, Long, Shot, Timestamp

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
