### PR TITLE
[flink] Refactor FlinkSink to clarify the relationships between different bucket-mode tables and sinks

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcFixedBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcFixedBucketSink.java
@@ -16,35 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.sink;
+package org.apache.paimon.flink.sink.cdc;
 
-import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.FlinkSink;
+import org.apache.paimon.flink.sink.FlinkWriteSink;
+import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
-import javax.annotation.Nullable;
-
-import java.util.Map;
-
-/** {@link FlinkSink} for writing records into paimon. */
-public class FileStoreSink extends FlinkWriteSink<InternalRow> {
+/**
+ * A {@link FlinkSink} for fixed-bucket table which accepts {@link CdcRecord} and waits for a schema
+ * change if necessary.
+ */
+public class CdcFixedBucketSink extends FlinkWriteSink<CdcRecord> {
 
     private static final long serialVersionUID = 1L;
 
-    @Nullable private final LogSinkFunction logSinkFunction;
-
-    public FileStoreSink(
-            FileStoreTable table,
-            @Nullable Map<String, String> overwritePartition,
-            @Nullable LogSinkFunction logSinkFunction) {
-        super(table, overwritePartition);
-        this.logSinkFunction = logSinkFunction;
+    public CdcFixedBucketSink(FileStoreTable table) {
+        super(table, null);
     }
 
     @Override
-    protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
+    protected OneInputStreamOperator<CdcRecord, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
+        return new CdcRecordStoreWriteOperator(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -128,6 +128,6 @@ public class CdcSinkBuilder<T> {
         FileStoreTable dataTable = (FileStoreTable) table;
         DataStream<CdcRecord> partitioned =
                 partition(parsed, new CdcRecordChannelComputer(dataTable.schema()), parallelism);
-        return new FlinkCdcSink(dataTable).sinkFrom(partitioned);
+        return new CdcFixedBucketSink(dataTable).sinkFrom(partitioned);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -22,6 +22,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.MultiTablesSinkMode;
+import org.apache.paimon.flink.sink.FlinkWriteSink;
 import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
@@ -43,8 +44,8 @@ import static org.apache.paimon.flink.action.MultiTablesSinkMode.COMBINED;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
 
 /**
- * Builder for {@link FlinkCdcSink} when syncing the whole database into one Paimon database. Each
- * database table will be written into a separate Paimon table.
+ * Builder for CDC {@link FlinkWriteSink} when syncing the whole database into one Paimon database.
+ * Each database table will be written into a separate Paimon table.
  *
  * <p>This builder will create a separate sink for each Paimon sink table. Thus this implementation
  * is not very efficient in resource saving.
@@ -167,7 +168,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     private void buildForFixedBucket(FileStoreTable table, DataStream<CdcRecord> parsed) {
         DataStream<CdcRecord> partitioned =
                 partition(parsed, new CdcRecordChannelComputer(table.schema()), parallelism);
-        new FlinkCdcSink(table).sinkFrom(partitioned);
+        new CdcFixedBucketSink(table).sinkFrom(partitioned);
     }
 
     private void buildDividedCdcSink() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FixedBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FixedBucketSink.java
@@ -16,30 +16,35 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.sink.cdc;
+package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.flink.sink.Committable;
-import org.apache.paimon.flink.sink.FlinkSink;
-import org.apache.paimon.flink.sink.FlinkWriteSink;
-import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
-/**
- * A {@link FlinkSink} which accepts {@link CdcRecord} and waits for a schema change if necessary.
- */
-public class FlinkCdcSink extends FlinkWriteSink<CdcRecord> {
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/** {@link FlinkSink} for writing records into fixed bucket Paimon table. */
+public class FixedBucketSink extends FlinkWriteSink<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
-    public FlinkCdcSink(FileStoreTable table) {
-        super(table, null);
+    @Nullable private final LogSinkFunction logSinkFunction;
+
+    public FixedBucketSink(
+            FileStoreTable table,
+            @Nullable Map<String, String> overwritePartition,
+            @Nullable LogSinkFunction logSinkFunction) {
+        super(table, overwritePartition);
+        this.logSinkFunction = logSinkFunction;
     }
 
     @Override
-    protected OneInputStreamOperator<CdcRecord, Committable> createWriteOperator(
+    protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new CdcRecordStoreWriteOperator(table, writeProvider, commitUser);
+        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -181,7 +181,7 @@ public abstract class FlinkSink<T> implements Serializable {
     }
 
     public SingleOutputStreamOperator<Committable> doWrite(
-            DataStream<T> input, String commitUser, Integer parallelism) {
+            DataStream<T> input, String commitUser, @Nullable Integer parallelism) {
         StreamExecutionEnvironment env = input.getExecutionEnvironment();
         boolean isStreaming =
                 StreamExecutionEnvironmentUtils.getConfiguration(env)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -149,8 +149,7 @@ public abstract class FlinkSink<T> implements Serializable {
         assertNoSinkMaterializer(input);
 
         // do the actually writing action, no snapshot generated in this stage
-        SingleOutputStreamOperator<Committable> written =
-                doWrite(input, initialCommitUser, input.getParallelism());
+        DataStream<Committable> written = doWrite(input, initialCommitUser, input.getParallelism());
 
         // commit the committable to generate a new snapshot
         return doCommit(written, initialCommitUser);
@@ -180,7 +179,7 @@ public abstract class FlinkSink<T> implements Serializable {
         }
     }
 
-    public SingleOutputStreamOperator<Committable> doWrite(
+    public DataStream<Committable> doWrite(
             DataStream<T> input, String commitUser, @Nullable Integer parallelism) {
         StreamExecutionEnvironment env = input.getExecutionEnvironment();
         boolean isStreaming =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Builder for {@link FileStoreSink}. */
+/** Builder for {@link FlinkSink}. */
 public class FlinkSinkBuilder {
 
     private final FileStoreTable table;
@@ -136,7 +136,7 @@ public class FlinkSinkBuilder {
                         input,
                         new RowDataChannelComputer(table.schema(), logSinkFunction != null),
                         parallelism);
-        FileStoreSink sink = new FileStoreSink(table, overwritePartition, logSinkFunction);
+        FixedBucketSink sink = new FixedBucketSink(table, overwritePartition, logSinkFunction);
         return sink.sinkFrom(partitioned);
     }
 
@@ -144,7 +144,7 @@ public class FlinkSinkBuilder {
         checkArgument(
                 table instanceof AppendOnlyFileStoreTable,
                 "Unaware bucket mode only works with append-only table for now.");
-        return new UnawareBucketWriteSink(
+        return new RowUnawareBucketSink(
                         (AppendOnlyFileStoreTable) table,
                         overwritePartition,
                         logSinkFunction,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.table.AppendOnlyFileStoreTable;
+
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+
+import java.util.Map;
+
+/** An {@link UnawareBucketSink} which handles {@link InternalRow}. */
+public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
+
+    public RowUnawareBucketSink(
+            AppendOnlyFileStoreTable table,
+            Map<String, String> overwritePartitions,
+            LogSinkFunction logSinkFunction,
+            Integer parallelism,
+            boolean boundedInput) {
+        super(table, overwritePartitions, logSinkFunction, parallelism, boundedInput);
+    }
+
+    @Override
+    protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
+            StoreSinkWrite.Provider writeProvider, String commitUser) {
+        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -18,48 +18,52 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.compact.UnawareBucketCompactionTopoBuilder;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+import javax.annotation.Nullable;
 
 import java.util.Map;
 
 /**
- * Build topology for unaware bucket table sink.
+ * Sink for unaware-bucket table.
  *
  * <p>Note: in unaware-bucket mode, we don't shuffle by bucket in inserting. We can assign
  * compaction to the inserting jobs aside.
  */
-public class UnawareBucketWriteSink extends FileStoreSink {
+public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
 
-    private final boolean enableCompaction;
-    private final AppendOnlyFileStoreTable table;
-    private final Integer parallelism;
+    protected final AppendOnlyFileStoreTable table;
+    protected final LogSinkFunction logSinkFunction;
+
+    @Nullable private final Integer parallelism;
     private final boolean boundedInput;
 
-    public UnawareBucketWriteSink(
+    public UnawareBucketSink(
             AppendOnlyFileStoreTable table,
-            Map<String, String> overwritePartitions,
+            @Nullable Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
-            Integer parallelism,
+            @Nullable Integer parallelism,
             boolean boundedInput) {
-        super(table, overwritePartitions, logSinkFunction);
+        super(table, overwritePartitions);
         this.table = table;
-        this.enableCompaction = !table.coreOptions().writeOnly();
+        this.logSinkFunction = logSinkFunction;
         this.parallelism = parallelism;
         this.boundedInput = boundedInput;
     }
 
     @Override
-    public DataStreamSink<?> sinkFrom(DataStream<InternalRow> input, String initialCommitUser) {
-        // do the actually writing action, no snapshot generated in this stage
-        DataStream<Committable> written = doWrite(input, initialCommitUser, parallelism);
+    public SingleOutputStreamOperator<Committable> doWrite(
+            DataStream<T> input, String initialCommitUser, @Nullable Integer parallelism) {
+        SingleOutputStreamOperator<Committable> written =
+                super.doWrite(input, initialCommitUser, this.parallelism);
 
+        boolean enableCompaction = !table.coreOptions().writeOnly();
         boolean isStreamingMode =
                 input.getExecutionEnvironment()
                                 .getConfiguration()
@@ -72,10 +76,11 @@ public class UnawareBucketWriteSink extends FileStoreSink {
                     new UnawareBucketCompactionTopoBuilder(
                             input.getExecutionEnvironment(), table.name(), table);
             builder.withContinuousMode(true);
-            written = written.union(builder.fetchUncommitted(initialCommitUser));
+            written =
+                    (SingleOutputStreamOperator<Committable>)
+                            written.union(builder.fetchUncommitted(initialCommitUser));
         }
 
-        // commit the committable to generate a new snapshot
-        return doCommit(written, initialCommitUser);
+        return written;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileStoreITCase.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.flink.sink.FileStoreSink;
+import org.apache.paimon.flink.sink.FixedBucketSink;
 import org.apache.paimon.flink.sink.FlinkSinkBuilder;
 import org.apache.paimon.flink.source.ContinuousFileStoreSource;
 import org.apache.paimon.flink.source.FlinkSourceBuilder;
@@ -85,7 +85,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * ITCase for {@link StaticFileStoreSource}, {@link ContinuousFileStoreSource} and {@link
- * FileStoreSink}.
+ * FixedBucketSink}.
  */
 @ExtendWith(ParameterizedTestExtension.class)
 public class FileStoreITCase extends AbstractTestBase {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -231,7 +231,7 @@ public class FlinkSinkTest {
         DataStreamSource<InternalRow> source =
                 streamExecutionEnvironment.fromCollection(
                         Collections.singletonList(GenericRow.of(1, 1)));
-        FlinkSink<InternalRow> flinkSink = new FileStoreSink(fileStoreTable, null, null);
+        FlinkSink<InternalRow> flinkSink = new FixedBucketSink(fileStoreTable, null, null);
         SingleOutputStreamOperator<Committable> written = flinkSink.doWrite(source, "123", 1);
         RowDataStoreWriteOperator operator =
                 ((RowDataStoreWriteOperator)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -48,8 +48,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.state.StateInitializationContextImpl;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
-import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
@@ -232,7 +232,7 @@ public class FlinkSinkTest {
                 streamExecutionEnvironment.fromCollection(
                         Collections.singletonList(GenericRow.of(1, 1)));
         FlinkSink<InternalRow> flinkSink = new FixedBucketSink(fileStoreTable, null, null);
-        SingleOutputStreamOperator<Committable> written = flinkSink.doWrite(source, "123", 1);
+        DataStream<Committable> written = flinkSink.doWrite(source, "123", 1);
         RowDataStoreWriteOperator operator =
                 ((RowDataStoreWriteOperator)
                         ((SimpleOperatorFactory)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/SinkSavepointITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/SinkSavepointITCase.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** IT cases for {@link FileStoreSink} when writing file store and with savepoints. */
+/** IT cases for {@link FlinkSink} when writing file store and with savepoints. */
 public class SinkSavepointITCase extends AbstractTestBase {
 
     private String path;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In addition, #2630 can extend cdc unaware-bucket sink more easy.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
