### PR TITLE
[core] If writers size greater than 5, enable buffer and spill for append-only writers in batch mode

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -660,16 +660,16 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Cache size for reading manifest files for write initialization.</td>
         </tr>
         <tr>
-            <td><h5>write-number-max</h5></td>
-            <td style="word-wrap: break-word;">5</td>
-            <td>Integer</td>
-            <td>This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.</td>
-        </tr>
-        <tr>
             <td><h5>write-only</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
+        </tr>
+        <tr>
+            <td><h5>writer-number-max-force-buffer</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>When in batch append inserting, if the writer number is greater than this option, we open the buffer cache and spill function to avoid out-of-memory. </td>
         </tr>
         <tr>
             <td><h5>zorder.var-length-contribution</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -660,6 +660,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Cache size for reading manifest files for write initialization.</td>
         </tr>
         <tr>
+            <td><h5>write-number-max</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.</td>
+        </tr>
+        <tr>
             <td><h5>write-only</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -660,16 +660,16 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Cache size for reading manifest files for write initialization.</td>
         </tr>
         <tr>
+            <td><h5>write-max-writers-to-spill</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>When in batch append inserting, if the writer number is greater than this option, we open the buffer cache and spill function to avoid out-of-memory. </td>
+        </tr>
+        <tr>
             <td><h5>write-only</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
-        </tr>
-        <tr>
-            <td><h5>writer-number-max-force-buffer</h5></td>
-            <td style="word-wrap: break-word;">5</td>
-            <td>Integer</td>
-            <td>When in batch append inserting, if the writer number is greater than this option, we open the buffer cache and spill function to avoid out-of-memory. </td>
         </tr>
         <tr>
             <td><h5>zorder.var-length-contribution</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -327,8 +327,8 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
 
-    public static final ConfigOption<Integer> WRITER_NUMBER_MAX_FORCE_BUFFER =
-            key("writer-number-max-force-buffer")
+    public static final ConfigOption<Integer> WRITE_MAX_WRITERS_TO_SPILL =
+            key("write-max-writers-to-spill")
                     .intType()
                     .defaultValue(5)
                     .withDescription(
@@ -1214,8 +1214,8 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_FOR_APPEND);
     }
 
-    public int writeNumberMaxForceBuffer() {
-        return options.get(WRITER_NUMBER_MAX_FORCE_BUFFER);
+    public int writeMaxWritersToSpill() {
+        return options.get(WRITE_MAX_WRITERS_TO_SPILL);
     }
 
     public long sortSpillBufferSize() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -327,6 +327,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
 
+    public static final ConfigOption<Integer> WRITE_NUMBER_MAX =
+            key("write-number-max")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
+
     public static final ConfigOption<MemorySize> WRITE_MANIFEST_CACHE =
             key("write-manifest-cache")
                     .memoryType()
@@ -1205,6 +1212,10 @@ public class CoreOptions implements Serializable {
 
     public boolean useWriteBufferForAppend() {
         return options.get(WRITE_BUFFER_FOR_APPEND);
+    }
+
+    public int writeNumberMax() {
+        return options.get(WRITE_NUMBER_MAX);
     }
 
     public long sortSpillBufferSize() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -332,7 +332,7 @@ public class CoreOptions implements Serializable {
                     .intType()
                     .defaultValue(5)
                     .withDescription(
-                            "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
+                            "When in batch append inserting, if the writer number is greater than this option, we open the buffer cache and spill function to avoid out-of-memory. ");
 
     public static final ConfigOption<MemorySize> WRITE_MANIFEST_CACHE =
             key("write-manifest-cache")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -327,8 +327,8 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "This option only works for append-only table. Whether the write use write buffer to avoid out-of-memory error.");
 
-    public static final ConfigOption<Integer> WRITE_NUMBER_MAX =
-            key("write-number-max")
+    public static final ConfigOption<Integer> WRITER_NUMBER_MAX_FORCE_BUFFER =
+            key("writer-number-max-force-buffer")
                     .intType()
                     .defaultValue(5)
                     .withDescription(
@@ -1214,8 +1214,8 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_FOR_APPEND);
     }
 
-    public int writeNumberMax() {
-        return options.get(WRITE_NUMBER_MAX);
+    public int writeNumberMaxForceBuffer() {
+        return options.get(WRITER_NUMBER_MAX_FORCE_BUFFER);
     }
 
     public long sortSpillBufferSize() {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -276,7 +276,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
     }
 
     @VisibleForTesting
-    RowBuffer getWriteBuffer() {
+    public RowBuffer getWriteBuffer() {
         if (sinkWriter instanceof BufferedSinkWriter) {
             return ((BufferedSinkWriter) sinkWriter).writeBuffer;
         } else {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -66,6 +66,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     private final String commitUser;
     protected final SnapshotManager snapshotManager;
     private final FileStoreScan scan;
+    private final int writerNumberMax;
     @Nullable private final IndexMaintainer.Factory<T> indexFactory;
 
     @Nullable protected IOManager ioManager;
@@ -87,7 +88,8 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             FileStoreScan scan,
             @Nullable IndexMaintainer.Factory<T> indexFactory,
             String tableName,
-            FileStorePathFactory pathFactory) {
+            FileStorePathFactory pathFactory,
+            int writerNumberMax) {
         this.commitUser = commitUser;
         this.snapshotManager = snapshotManager;
         this.scan = scan;
@@ -96,6 +98,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         this.writers = new HashMap<>();
         this.tableName = tableName;
         this.pathFactory = pathFactory;
+        this.writerNumberMax = writerNumberMax;
     }
 
     @Override
@@ -327,11 +330,23 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 bucket, k -> createWriterContainer(partition.copy(), bucket, ignorePreviousFiles));
     }
 
+    private long writeSize() {
+        return writers.values().stream().mapToLong(e -> e.values().size()).sum();
+    }
+
     @VisibleForTesting
     public WriterContainer<T> createWriterContainer(
             BinaryRow partition, int bucket, boolean ignorePreviousFiles) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating writer for partition {}, bucket {}", partition, bucket);
+        }
+
+        if (!isStreamingMode && writeSize() > writerNumberMax) {
+            try {
+                forceBufferSpill();
+            } catch (Exception e) {
+                throw new RuntimeException("Error happens while force buffer spill", e);
+            }
         }
 
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
@@ -421,6 +436,9 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             List<DataFileMeta> restoreFiles,
             @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor);
+
+    // force buffer spill to avoid out of memory in batch mode
+    protected void forceBufferSpill() throws Exception {}
 
     /**
      * {@link RecordWriter} with the snapshot id it is created upon and the identifier of its last

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -65,7 +65,14 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
             @Nullable IndexMaintainer.Factory<T> indexFactory,
             String tableName,
             FileStorePathFactory pathFactory) {
-        super(commitUser, snapshotManager, scan, indexFactory, tableName, pathFactory);
+        super(
+                commitUser,
+                snapshotManager,
+                scan,
+                indexFactory,
+                tableName,
+                pathFactory,
+                options.writeNumberMax());
         this.options = options;
         this.cacheManager =
                 new CacheManager(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -72,7 +72,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                 indexFactory,
                 tableName,
                 pathFactory,
-                options.writeNumberMaxForceBuffer());
+                options.writeMaxWritersToSpill());
         this.options = options;
         this.cacheManager =
                 new CacheManager(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -72,7 +72,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                 indexFactory,
                 tableName,
                 pathFactory,
-                options.writeNumberMax());
+                options.writeNumberMaxForceBuffer());
         this.options = options;
         this.cacheManager =
                 new CacheManager(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.append.AppendOnlyWriter;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.ExternalBuffer;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.types.DataTypes;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.List;
+import java.util.Map;
+
+/** Tests for {@link AppendOnlyFileStoreWrite}. */
+public class AppendOnlyFileStoreWriteTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testWritesInBatch() throws Exception {
+        AppendOnlyFileStoreTable table = createFileStoreTable();
+
+        AppendOnlyFileStoreWrite write = table.store().newWrite("ss");
+        write.withExecutionMode(false);
+
+        write.write(partition(0), 0, GenericRow.of(0, 0, 0));
+        write.write(partition(1), 1, GenericRow.of(1, 1, 0));
+        write.write(partition(2), 2, GenericRow.of(2, 2, 0));
+        write.write(partition(3), 3, GenericRow.of(3, 3, 0));
+        write.write(partition(4), 4, GenericRow.of(4, 4, 0));
+
+        for (Map<Integer, AbstractFileStoreWrite.WriterContainer<InternalRow>> bucketWriters :
+                write.writers().values()) {
+            for (AbstractFileStoreWrite.WriterContainer<InternalRow> writerContainer :
+                    bucketWriters.values()) {
+                Assertions.assertThat(((AppendOnlyWriter) writerContainer.writer).getWriteBuffer())
+                        .isEqualTo(null);
+            }
+        }
+
+        write.write(partition(5), 5, GenericRow.of(5, 5, 0));
+        for (Map<Integer, AbstractFileStoreWrite.WriterContainer<InternalRow>> bucketWriters :
+                write.writers().values()) {
+            for (AbstractFileStoreWrite.WriterContainer<InternalRow> writerContainer :
+                    bucketWriters.values()) {
+                Assertions.assertThat(((AppendOnlyWriter) writerContainer.writer).getWriteBuffer())
+                        .isInstanceOf(ExternalBuffer.class);
+            }
+        }
+
+        write.write(partition(6), 6, GenericRow.of(6, 6, 0));
+        write.write(partition(0), 0, GenericRow.of(0, 0, 0));
+        write.write(partition(1), 1, GenericRow.of(1, 1, 0));
+        write.write(partition(2), 2, GenericRow.of(2, 2, 0));
+        write.write(partition(3), 3, GenericRow.of(3, 3, 0));
+        List<CommitMessage> commit = write.prepareCommit(true, Long.MAX_VALUE);
+
+        Assertions.assertThat(commit.size()).isEqualTo(7);
+
+        long records =
+                commit.stream()
+                        .map(s -> (CommitMessageImpl) s)
+                        .mapToLong(
+                                s ->
+                                        s.newFilesIncrement().newFiles().stream()
+                                                .mapToLong(DataFileMeta::rowCount)
+                                                .sum())
+                        .sum();
+        Assertions.assertThat(records).isEqualTo(11);
+    }
+
+    protected AppendOnlyFileStoreTable createFileStoreTable() throws Exception {
+        Catalog catalog = new FileSystemCatalog(LocalFileIO.create(), new Path(tempDir.toString()));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.INT())
+                        .column("f1", DataTypes.INT())
+                        .column("f2", DataTypes.INT())
+                        .partitionKeys("f0")
+                        .option("bucket", "100")
+                        .build();
+        Identifier identifier = Identifier.create("default", "test");
+        catalog.createDatabase("default", false);
+        catalog.createTable(identifier, schema, false);
+        return (AppendOnlyFileStoreTable) catalog.getTable(identifier);
+    }
+
+    private BinaryRow partition(int i) {
+        BinaryRow binaryRow = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        writer.writeInt(0, i);
+        writer.complete();
+        return binaryRow;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -425,6 +426,14 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                     .forEachRemaining(r -> result.add(r.getInt(1)));
             assertThat(result).containsExactlyElementsOf(expected);
         }
+    }
+
+    @Test
+    public void testWriteInBatch() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        AppendOnlyFileStoreWrite write = ((AppendOnlyFileStoreTable) table).store().newWrite("");
+        write.withExecutionMode(false);
     }
 
     private void writeData() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -426,14 +425,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                     .forEachRemaining(r -> result.add(r.getInt(1)));
             assertThat(result).containsExactlyElementsOf(expected);
         }
-    }
-
-    @Test
-    public void testWriteInBatch() throws Exception {
-        FileStoreTable table = createFileStoreTable();
-
-        AppendOnlyFileStoreWrite write = ((AppendOnlyFileStoreTable) table).store().newWrite("");
-        write.withExecutionMode(false);
     }
 
     private void writeData() throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In batch write to append-only table mode, if the partition-bucket writers number is greater than 5, we forcedly to enable write-buffer-for-append and write-buffer-spillable to avoid out of memory error.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
