### PR TITLE
[core] FieldIgnoreRetractAgg should implement the reset method by calling the wrapped aggregator

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldIgnoreRetractAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldIgnoreRetractAgg.java
@@ -39,6 +39,11 @@ public class FieldIgnoreRetractAgg extends FieldAggregator {
     }
 
     @Override
+    public void reset() {
+        aggregator.reset();
+    }
+
+    @Override
     public Object retract(Object accumulator, Object retractField) {
         return accumulator;
     }


### PR DESCRIPTION
### Purpose

Currently `FieldIgnoreRetractAgg` forgets to implement the reset method. When using `first_value` aggregate function with `ignore-retract = false`, the aggregated result will be incorrect.

This PR fixes the issue.

### Tests

* `PreAggregationITCase.FirstValueAggregation#testAggregatorResetWhenIgnoringRetract`.

### API and Format

No.

### Documentation

No.
