### PR TITLE
[hive] Fix hive to be compatible with uppercase fields when using predicates to query paimon external tables.

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.predicate.PredicateBuilder.convertJavaObject;
 
-/** Converts {@link SearchArgument} to {@link Predicate} with best effort. */
+/** Converts {@link SearchArgument} to {@link Predicate} with the best effort. */
 public class SearchArgumentToPredicateConverter {
 
     private static final Logger LOG =
@@ -55,20 +55,26 @@ public class SearchArgumentToPredicateConverter {
     private final PredicateBuilder builder;
 
     public SearchArgumentToPredicateConverter(
-            SearchArgument sarg,
+            SearchArgument searchArgument,
             List<String> columnNames,
             List<DataType> columnTypes,
             @Nullable Set<String> readColumnNames) {
-        this.root = sarg.getExpression();
-        this.leaves = sarg.getLeaves();
-        this.columnNames = columnNames;
+        this.root = searchArgument.getExpression();
+        this.leaves = searchArgument.getLeaves();
+        this.columnNames =
+                columnNames.stream().map(String::toLowerCase).collect(Collectors.toList());
         this.columnTypes = columnTypes;
+        if (readColumnNames != null) {
+            readColumnNames =
+                    readColumnNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
+        }
         this.readColumnNames = readColumnNames;
+
         this.builder =
                 new PredicateBuilder(
                         RowType.of(
-                                columnTypes.toArray(new DataType[0]),
-                                columnNames.toArray(new String[0])));
+                                this.columnTypes.toArray(new DataType[0]),
+                                this.columnNames.toArray(new String[0])));
     }
 
     public Optional<Predicate> convert() {

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveUtils.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveUtils.java
@@ -57,8 +57,8 @@ public class HiveUtils {
 
     public static Optional<Predicate> createPredicate(
             TableSchema tableSchema, JobConf jobConf, boolean limitToReadColumnNames) {
-        SearchArgument sarg = ConvertAstToSearchArg.createFromConf(jobConf);
-        if (sarg == null) {
+        SearchArgument searchArgument = ConvertAstToSearchArg.createFromConf(jobConf);
+        if (searchArgument == null) {
             return Optional.empty();
         }
         Set<String> readColumnNames = null;
@@ -75,11 +75,11 @@ public class HiveUtils {
             if (readColumnNames == null) {
                 readColumnNames = new HashSet<>(tableSchema.fieldNames());
             }
-            readColumnNames.remove(tagToPartField);
+            readColumnNames.remove(tagToPartField.toLowerCase());
         }
         SearchArgumentToPredicateConverter converter =
                 new SearchArgumentToPredicateConverter(
-                        sarg,
+                        searchArgument,
                         tableSchema.fieldNames(),
                         tableSchema.logicalRowType().getFieldTypes(),
                         readColumnNames);

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveUtils.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveUtils.java
@@ -75,7 +75,7 @@ public class HiveUtils {
             if (readColumnNames == null) {
                 readColumnNames = new HashSet<>(tableSchema.fieldNames());
             }
-            readColumnNames.remove(tagToPartField.toLowerCase());
+            readColumnNames.remove(tagToPartField);
         }
         SearchArgumentToPredicateConverter converter =
                 new SearchArgumentToPredicateConverter(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveReadITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveReadITCase.java
@@ -94,7 +94,9 @@ public class HiveReadITCase extends HiveTestBase {
 
         result = hiveShell.executeQuery("SELECT * FROM " + tableName + " WHERE col2 = 'Hello'");
         assertThat(result).containsExactly("1\tHello");
-        result = hiveShell.executeQuery("SELECT * FROM " + tableName + " WHERE Col2 in ('Hello', 'Paimon')");
+        result =
+                hiveShell.executeQuery(
+                        "SELECT * FROM " + tableName + " WHERE Col2 in ('Hello', 'Paimon')");
         assertThat(result).containsExactly("1\tHello", "2\tPaimon");
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveReadITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveReadITCase.java
@@ -91,5 +91,10 @@ public class HiveReadITCase extends HiveTestBase {
         assertThat(result).containsExactly("Hello", "Paimon");
         result = hiveShell.executeQuery("SELECT Col2 FROM " + tableName);
         assertThat(result).containsExactly("Hello", "Paimon");
+
+        result = hiveShell.executeQuery("SELECT * FROM " + tableName + " WHERE col2 = 'Hello'");
+        assertThat(result).containsExactly("1\tHello");
+        result = hiveShell.executeQuery("SELECT * FROM " + tableName + " WHERE Col2 in ('Hello', 'Paimon')");
+        assertThat(result).containsExactly("1\tHello", "2\tPaimon");
     }
 }


### PR DESCRIPTION
…

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Related issue: #2634

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
