### PR TITLE
[core] Delete useless schema when expire snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -185,6 +185,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.snapshotNumRetainMin(),
                 options.snapshotNumRetainMax(),
                 options.snapshotTimeRetain().toMillis(),
+                schemaManager,
                 snapshotManager(),
                 newSnapshotDeletion(),
                 newTagManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -88,6 +88,17 @@ public class SchemaManager implements Serializable {
         return this;
     }
 
+    /** @return earliest schema. */
+    public Optional<TableSchema> earliest() {
+        try {
+            return listVersionedFiles(fileIO, schemaDirectory(), SCHEMA_PREFIX)
+                    .reduce(Math::min)
+                    .map(this::schema);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     /** @return latest schema. */
     public Optional<TableSchema> latest() {
         try {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -95,6 +95,10 @@ public class SnapshotManager implements Serializable {
         }
     }
 
+    public void deleteSnapshot(long snapshotId) {
+        fileIO.deleteQuietly(snapshotPath(snapshotId));
+    }
+
     public @Nullable Snapshot latestSnapshot() {
         Long snapshotId = latestSnapshotId();
         return snapshotId == null ? null : snapshot(snapshotId);

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -148,6 +148,7 @@ public class TestFileStore extends KeyValueFileStore {
                 numRetainedMin,
                 numRetainedMax,
                 millisRetained,
+                schemaManager,
                 snapshotManager(),
                 newSnapshotDeletion(),
                 new TagManager(fileIO, options.path()),

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
@@ -51,13 +51,14 @@ public abstract class FileStoreExpireTestBase {
     @TempDir java.nio.file.Path tempDir;
     protected TestFileStore store;
     protected SnapshotManager snapshotManager;
+    protected SchemaManager schemaManager;
 
     @BeforeEach
     public void beforeEach() throws Exception {
         gen = new TestKeyValueGenerator();
         store = createStore();
         snapshotManager = store.snapshotManager();
-        SchemaManager schemaManager = new SchemaManager(fileIO, new Path(tempDir.toUri()));
+        schemaManager = new SchemaManager(fileIO, new Path(tempDir.toUri()));
         schemaManager.createTable(
                 new Schema(
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE.getFields(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
@@ -65,22 +65,22 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
         long indexFileSize = indexFileSize();
         long indexManifestSize = indexManifestSize();
 
-        expire.expireUntil(1, 2);
+        expire.expireBetween(1, 2);
         checkIndexFiles(2);
         assertThat(indexFileSize()).isEqualTo(indexFileSize - 1);
         assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 1);
 
-        expire.expireUntil(2, 3);
+        expire.expireBetween(2, 3);
         checkIndexFiles(3);
         assertThat(indexFileSize()).isEqualTo(indexFileSize - 1);
         assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 1);
 
-        expire.expireUntil(3, 5);
+        expire.expireBetween(3, 5);
         checkIndexFiles(5);
         assertThat(indexFileSize()).isEqualTo(indexFileSize - 2);
         assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 2);
 
-        expire.expireUntil(5, 7);
+        expire.expireBetween(5, 7);
         checkIndexFiles(7);
         assertThat(indexFileSize()).isEqualTo(3);
         assertThat(indexManifestSize()).isEqualTo(1);
@@ -97,12 +97,12 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
         long indexFileSize = indexFileSize();
         long indexManifestSize = indexManifestSize();
 
-        expire.expireUntil(1, 5);
+        expire.expireBetween(1, 5);
         checkIndexFiles(5);
         assertThat(indexFileSize()).isEqualTo(indexFileSize - 1);
         assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 1);
 
-        expire.expireUntil(5, 7);
+        expire.expireBetween(5, 7);
         checkIndexFiles(7);
         assertThat(indexFileSize()).isEqualTo(5);
         assertThat(indexManifestSize()).isEqualTo(3);
@@ -131,7 +131,7 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
 
         // test delete tag after expiring snapshots
         table.createTag("tag3", 3);
-        expire.expireUntil(1, 7);
+        expire.expireBetween(1, 7);
         table.deleteTag("tag3");
 
         TagManager tagManager = new TagManager(LocalFileIO.create(), table.path);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

When a schema is not referenced by any snapshot or tag, we can safely delete it

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
