### PR TITLE
[flink] StaticFileStoreSplitEnumerator should ignore ReaderConsumeProgressEvent

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
@@ -118,6 +118,12 @@ public class StaticFileStoreSplitEnumerator
 
     @Override
     public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+        if (sourceEvent instanceof ReaderConsumeProgressEvent) {
+            // batch reading doesn't handle consumer
+            // avoid meaningless error logs
+            return;
+        }
+
         if (sourceEvent.getClass().getSimpleName().equals("DynamicFilteringEvent")) {
             checkNotNull(
                     dynamicPartitionFilteringInfo,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2647 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
