### PR TITLE
[core] Introduce stats in snapshot

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
@@ -22,7 +22,7 @@ import java.util.OptionalLong;
 
 /** Utils for Optional. * */
 public class OptionalUtils {
-    public static OptionalLong of(Long value) {
+    public static OptionalLong ofNullable(Long value) {
         return value == null ? OptionalLong.empty() : OptionalLong.of(value);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/OptionalUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.OptionalLong;
+
+/** Utils for Optional. * */
+public class OptionalUtils {
+    public static OptionalLong of(Long value) {
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -35,6 +35,8 @@ import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.stats.StatsFile;
+import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.sink.CallbackUtils;
 import org.apache.paimon.table.sink.TagCallback;
@@ -144,6 +146,14 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     }
 
     @Override
+    public StatsFileHandler newStatsFileHandler() {
+        return new StatsFileHandler(
+                snapshotManager(),
+                schemaManager,
+                new StatsFile(fileIO, pathFactory().statsFileFactory()));
+    }
+
+    @Override
     public RowType partitionType() {
         return partitionType;
     }
@@ -176,7 +186,8 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.manifestFullCompactionThresholdSize(),
                 options.manifestMergeMinCount(),
                 partitionType.getFieldCount() > 0 && options.dynamicPartitionOverwrite(),
-                newKeyComparator());
+                newKeyComparator(),
+                newStatsFileHandler());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -31,6 +31,7 @@ import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoCreation;
@@ -68,6 +69,8 @@ public interface FileStore<T> extends Serializable {
     ManifestFile.Factory manifestFileFactory();
 
     IndexFileHandler newIndexFileHandler();
+
+    StatsFileHandler newStatsFileHandler();
 
     FileStoreRead<T> newRead();
 

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -87,7 +87,7 @@ public class Snapshot {
     private static final String FIELD_DELTA_RECORD_COUNT = "deltaRecordCount";
     private static final String FIELD_CHANGELOG_RECORD_COUNT = "changelogRecordCount";
     private static final String FIELD_WATERMARK = "watermark";
-    private static final String FIELD_STATS = "stats";
+    private static final String FIELD_STATISTICS = "statistics";
 
     // version of snapshot
     // null for paimon <= 0.2
@@ -170,12 +170,12 @@ public class Snapshot {
     @Nullable
     private final Long watermark;
 
-    // stats file name for stats of this table
+    // stats file name for statistics of this table
     // null if no stats file
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty(FIELD_STATS)
+    @JsonProperty(FIELD_STATISTICS)
     @Nullable
-    private final String stats;
+    private final String statistics;
 
     public Snapshot(
             long id,
@@ -193,7 +193,7 @@ public class Snapshot {
             @Nullable Long deltaRecordCount,
             @Nullable Long changelogRecordCount,
             @Nullable Long watermark,
-            @Nullable String stats) {
+            @Nullable String statistics) {
         this(
                 CURRENT_VERSION,
                 id,
@@ -211,7 +211,7 @@ public class Snapshot {
                 deltaRecordCount,
                 changelogRecordCount,
                 watermark,
-                stats);
+                statistics);
     }
 
     @JsonCreator
@@ -232,7 +232,7 @@ public class Snapshot {
             @JsonProperty(FIELD_DELTA_RECORD_COUNT) @Nullable Long deltaRecordCount,
             @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) @Nullable Long changelogRecordCount,
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
-            @JsonProperty(FIELD_STATS) @Nullable String stats) {
+            @JsonProperty(FIELD_STATISTICS) @Nullable String statistics) {
         this.version = version;
         this.id = id;
         this.schemaId = schemaId;
@@ -249,7 +249,7 @@ public class Snapshot {
         this.deltaRecordCount = deltaRecordCount;
         this.changelogRecordCount = changelogRecordCount;
         this.watermark = watermark;
-        this.stats = stats;
+        this.statistics = statistics;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -339,10 +339,10 @@ public class Snapshot {
         return watermark;
     }
 
-    @JsonGetter(FIELD_STATS)
+    @JsonGetter(FIELD_STATISTICS)
     @Nullable
-    public String stats() {
-        return stats;
+    public String statistics() {
+        return statistics;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -170,6 +170,8 @@ public class Snapshot {
     @Nullable
     private final Long watermark;
 
+    // stats file name for stats of this table
+    // null if no stats file
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_STATS)
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -87,6 +87,7 @@ public class Snapshot {
     private static final String FIELD_DELTA_RECORD_COUNT = "deltaRecordCount";
     private static final String FIELD_CHANGELOG_RECORD_COUNT = "changelogRecordCount";
     private static final String FIELD_WATERMARK = "watermark";
+    private static final String FIELD_STATS = "stats";
 
     // version of snapshot
     // null for paimon <= 0.2
@@ -169,6 +170,11 @@ public class Snapshot {
     @Nullable
     private final Long watermark;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_STATS)
+    @Nullable
+    private final String stats;
+
     public Snapshot(
             long id,
             long schemaId,
@@ -184,7 +190,8 @@ public class Snapshot {
             @Nullable Long totalRecordCount,
             @Nullable Long deltaRecordCount,
             @Nullable Long changelogRecordCount,
-            @Nullable Long watermark) {
+            @Nullable Long watermark,
+            @Nullable String stats) {
         this(
                 CURRENT_VERSION,
                 id,
@@ -201,7 +208,8 @@ public class Snapshot {
                 totalRecordCount,
                 deltaRecordCount,
                 changelogRecordCount,
-                watermark);
+                watermark,
+                stats);
     }
 
     @JsonCreator
@@ -218,10 +226,11 @@ public class Snapshot {
             @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
             @JsonProperty(FIELD_TIME_MILLIS) long timeMillis,
             @JsonProperty(FIELD_LOG_OFFSETS) Map<Integer, Long> logOffsets,
-            @JsonProperty(FIELD_TOTAL_RECORD_COUNT) Long totalRecordCount,
-            @JsonProperty(FIELD_DELTA_RECORD_COUNT) Long deltaRecordCount,
-            @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) Long changelogRecordCount,
-            @JsonProperty(FIELD_WATERMARK) Long watermark) {
+            @JsonProperty(FIELD_TOTAL_RECORD_COUNT) @Nullable Long totalRecordCount,
+            @JsonProperty(FIELD_DELTA_RECORD_COUNT) @Nullable Long deltaRecordCount,
+            @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) @Nullable Long changelogRecordCount,
+            @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
+            @JsonProperty(FIELD_STATS) @Nullable String stats) {
         this.version = version;
         this.id = id;
         this.schemaId = schemaId;
@@ -238,6 +247,7 @@ public class Snapshot {
         this.deltaRecordCount = deltaRecordCount;
         this.changelogRecordCount = changelogRecordCount;
         this.watermark = watermark;
+        this.stats = stats;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -325,6 +335,12 @@ public class Snapshot {
     @Nullable
     public Long watermark() {
         return watermark;
+    }
+
+    @JsonGetter(FIELD_STATS)
+    @Nullable
+    public String stats() {
+        return stats;
     }
 
     /**
@@ -487,6 +503,9 @@ public class Snapshot {
         COMPACT,
 
         /** Changes that clear up the whole partition and then add new records. */
-        OVERWRITE
+        OVERWRITE,
+
+        /** Collect statistics. */
+        ANALYZE
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -87,10 +87,10 @@ public interface FileStoreCommit {
     FileStoreCommit withMetrics(CommitMetrics metrics);
 
     /**
-     * Write new stats. The {@link Snapshot.CommitKind} of generated snapshot is {@link
+     * Commit new statistics. The {@link Snapshot.CommitKind} of generated snapshot is {@link
      * Snapshot.CommitKind#ANALYZE}.
      */
-    void writeStats(Stats stats, long commitIdentifier);
+    void commitStatistics(Stats stats, long commitIdentifier);
 
     FileStorePathFactory pathFactory();
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -22,6 +22,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.operation.metrics.CommitMetrics;
+import org.apache.paimon.stats.Stats;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.utils.FileStorePathFactory;
 
@@ -84,6 +85,12 @@ public interface FileStoreCommit {
 
     /** With metrics to measure commits. */
     FileStoreCommit withMetrics(CommitMetrics metrics);
+
+    /**
+     * Write new stats. The {@link Snapshot.CommitKind} of generated snapshot is {@link
+     * Snapshot.CommitKind#ANALYZE}.
+     */
+    void writeStats(Stats stats, long commitIdentifier);
 
     FileStorePathFactory pathFactory();
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -40,6 +40,8 @@ import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.stats.Stats;
+import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.RowType;
@@ -116,6 +118,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private CommitMetrics commitMetrics;
 
+    private final StatsFileHandler statsFileHandler;
+
     public FileStoreCommitImpl(
             FileIO fileIO,
             SchemaManager schemaManager,
@@ -132,7 +136,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             MemorySize manifestFullCompactionSize,
             int manifestMergeMinCount,
             boolean dynamicPartitionOverwrite,
-            @Nullable Comparator<InternalRow> keyComparator) {
+            @Nullable Comparator<InternalRow> keyComparator,
+            StatsFileHandler statsFileHandler) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.commitUser = commitUser;
@@ -150,10 +155,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         this.manifestMergeMinCount = manifestMergeMinCount;
         this.dynamicPartitionOverwrite = dynamicPartitionOverwrite;
         this.keyComparator = keyComparator;
-
         this.lock = null;
         this.ignoreEmptyCommit = true;
         this.commitMetrics = null;
+        this.statsFileHandler = statsFileHandler;
     }
 
     @Override
@@ -248,7 +253,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.watermark(),
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.APPEND,
-                                safeLatestSnapshotId);
+                                safeLatestSnapshotId,
+                                null);
                 generatedSnapshot += 1;
             }
 
@@ -276,7 +282,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.watermark(),
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.COMPACT,
-                                safeLatestSnapshotId);
+                                safeLatestSnapshotId,
+                                null);
                 generatedSnapshot += 1;
             }
         } finally {
@@ -421,6 +428,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.watermark(),
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.COMPACT,
+                                null,
                                 null);
                 generatedSnapshot += 1;
             }
@@ -505,6 +513,21 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     @Override
+    public void writeStats(Stats stats, long commitIdentifier) {
+        String statsFileName = statsFileHandler.writeStats(stats);
+        tryCommit(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                commitIdentifier,
+                null,
+                Collections.emptyMap(),
+                Snapshot.CommitKind.ANALYZE,
+                null,
+                statsFileName);
+    }
+
+    @Override
     public FileStorePathFactory pathFactory() {
         return pathFactory;
     }
@@ -573,7 +596,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             @Nullable Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
-            Long safeLatestSnapshotId) {
+            @Nullable Long safeLatestSnapshotId,
+            @Nullable String statsFileName) {
         int cnt = 0;
         while (true) {
             Snapshot latestSnapshot = snapshotManager.latestSnapshot();
@@ -587,7 +611,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     logOffsets,
                     commitKind,
                     latestSnapshot,
-                    safeLatestSnapshotId)) {
+                    safeLatestSnapshotId,
+                    statsFileName)) {
                 break;
             }
         }
@@ -650,6 +675,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     logOffsets,
                     Snapshot.CommitKind.OVERWRITE,
                     latestSnapshot,
+                    null,
                     null)) {
                 break;
             }
@@ -666,8 +692,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             @Nullable Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
-            Snapshot latestSnapshot,
-            Long safeLatestSnapshotId) {
+            @Nullable Snapshot latestSnapshot,
+            @Nullable Long safeLatestSnapshotId,
+            @Nullable String newStatsFileName) {
         long newSnapshotId =
                 latestSnapshot == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshot.id() + 1;
         Path newSnapshotPath = snapshotManager.snapshotPath(newSnapshotId);
@@ -752,11 +779,25 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 newIndexManifest = indexManifest;
             }
 
+            long latestSchemaId = schemaManager.latest().get().id();
+
+            // write new stats or inherit from latest snapshot
+            String statsFileName = null;
+            if (newStatsFileName != null) {
+                statsFileName = newStatsFileName;
+            } else if (latestSnapshot != null && latestSnapshot.stats() != null) {
+                if (latestSnapshot.schemaId() != latestSchemaId) {
+                    LOG.warn("Schema changed, stats will not be inherited");
+                } else {
+                    statsFileName = latestSnapshot.stats();
+                }
+            }
+
             // prepare snapshot file
             newSnapshot =
                     new Snapshot(
                             newSnapshotId,
-                            schemaManager.latest().get().id(),
+                            latestSchemaId,
                             previousChangesListName,
                             newChangesListName,
                             changelogListName,
@@ -769,7 +810,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             totalRecordCount,
                             deltaRecordCount,
                             Snapshot.recordCount(changelogFiles),
-                            currentWatermark);
+                            currentWatermark,
+                            statsFileName);
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
             cleanUpTmpManifests(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -781,7 +781,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             long latestSchemaId = schemaManager.latest().get().id();
 
-            // write new stats or inherit from latest snapshot
+            // write new stats or inherit from the previous snapshot
             String statsFileName = null;
             if (newStatsFileName != null) {
                 statsFileName = newStatsFileName;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -785,11 +785,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String statsFileName = null;
             if (newStatsFileName != null) {
                 statsFileName = newStatsFileName;
-            } else if (latestSnapshot != null && latestSnapshot.stats() != null) {
+            } else if (latestSnapshot != null && latestSnapshot.statistics() != null) {
                 if (latestSnapshot.schemaId() != latestSchemaId) {
                     LOG.warn("Schema changed, stats will not be inherited");
                 } else {
-                    statsFileName = latestSnapshot.stats();
+                    statsFileName = latestSnapshot.statistics();
                 }
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -513,7 +513,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     @Override
-    public void writeStats(Stats stats, long commitIdentifier) {
+    public void commitStatistics(Stats stats, long commitIdentifier) {
         String statsFileName = statsFileHandler.writeStats(stats);
         tryCommit(
                 Collections.emptyList(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -785,11 +785,14 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String statsFileName = null;
             if (newStatsFileName != null) {
                 statsFileName = newStatsFileName;
-            } else if (latestSnapshot != null && latestSnapshot.statistics() != null) {
-                if (latestSnapshot.schemaId() != latestSchemaId) {
-                    LOG.warn("Schema changed, stats will not be inherited");
-                } else {
-                    statsFileName = latestSnapshot.statistics();
+            } else if (latestSnapshot != null) {
+                Optional<Stats> previousStatistic = statsFileHandler.readStats(latestSnapshot);
+                if (previousStatistic.isPresent()) {
+                    if (previousStatistic.get().schemaId() != latestSchemaId) {
+                        LOG.warn("Schema changed, stats will not be inherited");
+                    } else {
+                        statsFileName = latestSnapshot.statistics();
+                    }
                 }
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.OptionalUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/* Col stats */
+public class ColStats {
+
+    private static final String FIELD_DISTINCT_COUNT = "distinctCount";
+    private static final String FIELD_MIN = "min";
+    private static final String FIELD_MAX = "max";
+    private static final String FIELD_NULL_COUNT = "nullCount";
+    private static final String FIELD_AVG_LEN = "avgLen";
+    private static final String FIELD_MAX_LEN = "maxLen";
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_DISTINCT_COUNT)
+    private final @Nullable Long distinctCount;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_MIN)
+    private @Nullable String serializedMin;
+
+    private @Nullable Object min;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_MAX)
+    private @Nullable String serializedMax;
+
+    private @Nullable Object max;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_NULL_COUNT)
+    private final @Nullable Long nullCount;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_AVG_LEN)
+    private final @Nullable Long avgLen;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_MAX_LEN)
+    private final @Nullable Long maxLen;
+
+    @JsonCreator
+    public ColStats(
+            @JsonProperty(FIELD_DISTINCT_COUNT) @Nullable Long distinctCount,
+            @JsonProperty(FIELD_MIN) @Nullable String serializedMin,
+            @JsonProperty(FIELD_MAX) @Nullable String serializedMax,
+            @JsonProperty(FIELD_NULL_COUNT) @Nullable Long nullCount,
+            @JsonProperty(FIELD_AVG_LEN) @Nullable Long avgLen,
+            @JsonProperty(FIELD_MAX_LEN) @Nullable Long maxLen) {
+        this.distinctCount = distinctCount;
+        this.serializedMin = serializedMin;
+        this.serializedMax = serializedMax;
+        this.nullCount = nullCount;
+        this.avgLen = avgLen;
+        this.maxLen = maxLen;
+    }
+
+    public ColStats(
+            @Nullable Long distinctCount,
+            @Nullable Object min,
+            @Nullable Object max,
+            @Nullable Long nullCount,
+            @Nullable Long avgLen,
+            @Nullable Long maxLen) {
+        this.distinctCount = distinctCount;
+        this.min = min;
+        this.max = max;
+        this.nullCount = nullCount;
+        this.avgLen = avgLen;
+        this.maxLen = maxLen;
+    }
+
+    public OptionalLong distinctCount() {
+        return OptionalUtils.of(distinctCount);
+    }
+
+    public Optional<Object> min() {
+        return Optional.ofNullable(min);
+    }
+
+    public Optional<Object> max() {
+        return Optional.ofNullable(max);
+    }
+
+    public OptionalLong NullCount() {
+        return OptionalUtils.of(nullCount);
+    }
+
+    public OptionalLong avgLen() {
+        return OptionalUtils.of(avgLen);
+    }
+
+    public OptionalLong maxLen() {
+        return OptionalUtils.of(maxLen);
+    }
+
+    public void serializeFieldsToString(DataType dataType) {
+        if ((min != null && serializedMin == null) || (max != null && serializedMax == null)) {
+            Serializer<Object> serializer = InternalSerializers.create(dataType);
+            if (min != null && serializedMin == null) {
+                serializedMin = serializer.serializeToString(min);
+            }
+            if (max != null && serializedMax == null) {
+                serializedMax = serializer.serializeToString(max);
+            }
+        }
+    }
+
+    public void deserializeFieldsFromString(DataType dataType) {
+        if ((serializedMin != null && min == null) || (serializedMax != null && max == null)) {
+            Serializer<Object> serializer = InternalSerializers.create(dataType);
+            if (serializedMin != null && min == null) {
+                min = serializer.deserializeFromString(serializedMin);
+            }
+            if (serializedMax != null && max == null) {
+                max = serializer.deserializeFromString(serializedMax);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        ColStats colStats = (ColStats) object;
+        return Objects.equals(distinctCount, colStats.distinctCount)
+                && Objects.equals(serializedMin, colStats.serializedMin)
+                && Objects.equals(min, colStats.min)
+                && Objects.equals(serializedMax, colStats.serializedMax)
+                && Objects.equals(max, colStats.max)
+                && Objects.equals(nullCount, colStats.nullCount)
+                && Objects.equals(avgLen, colStats.avgLen)
+                && Objects.equals(maxLen, colStats.maxLen);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                distinctCount, serializedMin, min, serializedMax, max, nullCount, avgLen, maxLen);
+    }
+
+    @Override
+    public String toString() {
+        return "ColStats{"
+                + "distinctCount="
+                + distinctCount
+                + ", serializedMin='"
+                + serializedMin
+                + '\''
+                + ", serializedMax='"
+                + serializedMax
+                + '\''
+                + ", nullCount="
+                + nullCount
+                + ", avgLen="
+                + avgLen
+                + ", maxLen="
+                + maxLen
+                + '}';
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -139,7 +139,7 @@ public class ColStats<T extends Comparable<T>> {
 
     public void serializeFieldsToString(DataType dataType) {
         if ((min != null && serializedMin == null) || (max != null && serializedMax == null)) {
-            Serializer<Object> serializer = InternalSerializers.create(dataType);
+            Serializer<T> serializer = InternalSerializers.create(dataType);
             if (min != null && serializedMin == null) {
                 serializedMin = serializer.serializeToString(min);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -191,10 +191,10 @@ public class ColStats {
         return "ColStats{"
                 + "distinctCount="
                 + distinctCount
-                + ", serializedMin='"
+                + ", min='"
                 + serializedMin
                 + '\''
-                + ", serializedMax='"
+                + ", max='"
                 + serializedMax
                 + '\''
                 + ", nullCount="

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -21,6 +21,7 @@ package org.apache.paimon.stats;
 import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.data.serializer.Serializer;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.OptionalUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -49,12 +50,16 @@ import java.util.OptionalLong;
  */
 public class ColStats<T> {
 
+    private static final String FIELD_COL_ID = "colId";
     private static final String FIELD_DISTINCT_COUNT = "distinctCount";
     private static final String FIELD_MIN = "min";
     private static final String FIELD_MAX = "max";
     private static final String FIELD_NULL_COUNT = "nullCount";
     private static final String FIELD_AVG_LEN = "avgLen";
     private static final String FIELD_MAX_LEN = "maxLen";
+
+    @JsonProperty(FIELD_COL_ID)
+    private final int colId;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_DISTINCT_COUNT)
@@ -86,12 +91,14 @@ public class ColStats<T> {
 
     @JsonCreator
     public ColStats(
+            @JsonProperty(FIELD_COL_ID) int colId,
             @JsonProperty(FIELD_DISTINCT_COUNT) @Nullable Long distinctCount,
             @JsonProperty(FIELD_MIN) @Nullable String serializedMin,
             @JsonProperty(FIELD_MAX) @Nullable String serializedMax,
             @JsonProperty(FIELD_NULL_COUNT) @Nullable Long nullCount,
             @JsonProperty(FIELD_AVG_LEN) @Nullable Long avgLen,
             @JsonProperty(FIELD_MAX_LEN) @Nullable Long maxLen) {
+        this.colId = colId;
         this.distinctCount = distinctCount;
         this.serializedMin = serializedMin;
         this.serializedMax = serializedMax;
@@ -101,18 +108,24 @@ public class ColStats<T> {
     }
 
     public ColStats(
+            int colId,
             @Nullable Long distinctCount,
             @Nullable Comparable<T> min,
             @Nullable Comparable<T> max,
             @Nullable Long nullCount,
             @Nullable Long avgLen,
             @Nullable Long maxLen) {
+        this.colId = colId;
         this.distinctCount = distinctCount;
         this.min = min;
         this.max = max;
         this.nullCount = nullCount;
         this.avgLen = avgLen;
         this.maxLen = maxLen;
+    }
+
+    public int colId() {
+        return colId;
     }
 
     public OptionalLong distinctCount() {
@@ -166,15 +179,16 @@ public class ColStats<T> {
     }
 
     @Override
-    public boolean equals(Object object) {
-        if (this == object) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (object == null || getClass() != object.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ColStats<?> colStats = (ColStats<?>) object;
-        return Objects.equals(distinctCount, colStats.distinctCount)
+        ColStats<?> colStats = (ColStats<?>) o;
+        return colId == colStats.colId
+                && Objects.equals(distinctCount, colStats.distinctCount)
                 && Objects.equals(serializedMin, colStats.serializedMin)
                 && Objects.equals(min, colStats.min)
                 && Objects.equals(serializedMax, colStats.serializedMax)
@@ -187,26 +201,19 @@ public class ColStats<T> {
     @Override
     public int hashCode() {
         return Objects.hash(
-                distinctCount, serializedMin, min, serializedMax, max, nullCount, avgLen, maxLen);
+                colId,
+                distinctCount,
+                serializedMin,
+                min,
+                serializedMax,
+                max,
+                nullCount,
+                avgLen,
+                maxLen);
     }
 
     @Override
     public String toString() {
-        return "ColStats{"
-                + "distinctCount="
-                + distinctCount
-                + ", min='"
-                + serializedMin
-                + '\''
-                + ", max='"
-                + serializedMax
-                + '\''
-                + ", nullCount="
-                + nullCount
-                + ", avgLen="
-                + avgLen
-                + ", maxLen="
-                + maxLen
-                + '}';
+        return JsonSerdeUtil.toJson(this);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -33,7 +33,18 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-/* Col stats */
+/**
+ * Col stats, supports the following stats.
+ *
+ * <ul>
+ *   <li>distinctCount: the number of distinct values
+ *   <li>min: the minimum value of the column
+ *   <li>max: the maximum value of the column
+ *   <li>nullCount: the number of nulls
+ *   <li>avgLen: average column length
+ *   <li>maxLen: max column length
+ * </ul>
+ */
 public class ColStats {
 
     private static final String FIELD_DISTINCT_COUNT = "distinctCount";
@@ -103,7 +114,7 @@ public class ColStats {
     }
 
     public OptionalLong distinctCount() {
-        return OptionalUtils.of(distinctCount);
+        return OptionalUtils.ofNullable(distinctCount);
     }
 
     public Optional<Object> min() {
@@ -114,16 +125,16 @@ public class ColStats {
         return Optional.ofNullable(max);
     }
 
-    public OptionalLong NullCount() {
-        return OptionalUtils.of(nullCount);
+    public OptionalLong nullCount() {
+        return OptionalUtils.ofNullable(nullCount);
     }
 
     public OptionalLong avgLen() {
-        return OptionalUtils.of(avgLen);
+        return OptionalUtils.ofNullable(avgLen);
     }
 
     public OptionalLong maxLen() {
-        return OptionalUtils.of(maxLen);
+        return OptionalUtils.ofNullable(maxLen);
     }
 
     public void serializeFieldsToString(DataType dataType) {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -44,8 +44,10 @@ import java.util.OptionalLong;
  *   <li>avgLen: average column length
  *   <li>maxLen: max column length
  * </ul>
+ *
+ * @param <T> col internal data type
  */
-public class ColStats<T extends Comparable<T>> {
+public class ColStats<T> {
 
     private static final String FIELD_DISTINCT_COUNT = "distinctCount";
     private static final String FIELD_MIN = "min";
@@ -62,13 +64,13 @@ public class ColStats<T extends Comparable<T>> {
     @JsonProperty(FIELD_MIN)
     private @Nullable String serializedMin;
 
-    private @Nullable T min;
+    private @Nullable Comparable<T> min;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MAX)
     private @Nullable String serializedMax;
 
-    private @Nullable T max;
+    private @Nullable Comparable<T> max;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_NULL_COUNT)
@@ -100,8 +102,8 @@ public class ColStats<T extends Comparable<T>> {
 
     public ColStats(
             @Nullable Long distinctCount,
-            @Nullable T min,
-            @Nullable T max,
+            @Nullable Comparable<T> min,
+            @Nullable Comparable<T> max,
             @Nullable Long nullCount,
             @Nullable Long avgLen,
             @Nullable Long maxLen) {
@@ -117,11 +119,11 @@ public class ColStats<T extends Comparable<T>> {
         return OptionalUtils.ofNullable(distinctCount);
     }
 
-    public Optional<T> min() {
+    public Optional<Comparable<T>> min() {
         return Optional.ofNullable(min);
     }
 
-    public Optional<T> max() {
+    public Optional<Comparable<T>> max() {
         return Optional.ofNullable(max);
     }
 
@@ -137,26 +139,28 @@ public class ColStats<T extends Comparable<T>> {
         return OptionalUtils.ofNullable(maxLen);
     }
 
+    @SuppressWarnings("unchecked")
     public void serializeFieldsToString(DataType dataType) {
         if ((min != null && serializedMin == null) || (max != null && serializedMax == null)) {
             Serializer<T> serializer = InternalSerializers.create(dataType);
             if (min != null && serializedMin == null) {
-                serializedMin = serializer.serializeToString(min);
+                serializedMin = serializer.serializeToString((T) min);
             }
             if (max != null && serializedMax == null) {
-                serializedMax = serializer.serializeToString(max);
+                serializedMax = serializer.serializeToString((T) max);
             }
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void deserializeFieldsFromString(DataType dataType) {
         if ((serializedMin != null && min == null) || (serializedMax != null && max == null)) {
             Serializer<T> serializer = InternalSerializers.create(dataType);
             if (serializedMin != null && min == null) {
-                min = serializer.deserializeFromString(serializedMin);
+                min = (Comparable<T>) serializer.deserializeFromString(serializedMin);
             }
             if (serializedMax != null && max == null) {
-                max = serializer.deserializeFromString(serializedMax);
+                max = (Comparable<T>) serializer.deserializeFromString(serializedMax);
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/ColStats.java
@@ -45,7 +45,7 @@ import java.util.OptionalLong;
  *   <li>maxLen: max column length
  * </ul>
  */
-public class ColStats {
+public class ColStats<T extends Comparable<T>> {
 
     private static final String FIELD_DISTINCT_COUNT = "distinctCount";
     private static final String FIELD_MIN = "min";
@@ -62,13 +62,13 @@ public class ColStats {
     @JsonProperty(FIELD_MIN)
     private @Nullable String serializedMin;
 
-    private @Nullable Object min;
+    private @Nullable T min;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MAX)
     private @Nullable String serializedMax;
 
-    private @Nullable Object max;
+    private @Nullable T max;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_NULL_COUNT)
@@ -100,8 +100,8 @@ public class ColStats {
 
     public ColStats(
             @Nullable Long distinctCount,
-            @Nullable Object min,
-            @Nullable Object max,
+            @Nullable T min,
+            @Nullable T max,
             @Nullable Long nullCount,
             @Nullable Long avgLen,
             @Nullable Long maxLen) {
@@ -117,11 +117,11 @@ public class ColStats {
         return OptionalUtils.ofNullable(distinctCount);
     }
 
-    public Optional<Object> min() {
+    public Optional<T> min() {
         return Optional.ofNullable(min);
     }
 
-    public Optional<Object> max() {
+    public Optional<T> max() {
         return Optional.ofNullable(max);
     }
 
@@ -151,7 +151,7 @@ public class ColStats {
 
     public void deserializeFieldsFromString(DataType dataType) {
         if ((serializedMin != null && min == null) || (serializedMax != null && max == null)) {
-            Serializer<Object> serializer = InternalSerializers.create(dataType);
+            Serializer<T> serializer = InternalSerializers.create(dataType);
             if (serializedMin != null && min == null) {
                 min = serializer.deserializeFromString(serializedMin);
             }
@@ -169,7 +169,7 @@ public class ColStats {
         if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        ColStats colStats = (ColStats) object;
+        ColStats<?> colStats = (ColStats<?>) object;
         return Objects.equals(distinctCount, colStats.distinctCount)
                 && Objects.equals(serializedMin, colStats.serializedMin)
                 && Objects.equals(min, colStats.min)

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -48,14 +48,19 @@ import java.util.OptionalLong;
  */
 public class Stats {
 
-    // SnapshotId that stats belongs to
+    // ID of the snapshot this statistics collected from
     private static final String FIELD_SNAPSHOT_ID = "snapshotId";
+    // Schema ID of the snapshot this statistics collected from
+    private static final String FIELD_SCHEMA_ID = "schemaId";
     private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
     private static final String FIELD_MERGED_RECORD_SIZE = "mergedRecordSize";
     private static final String FIELD_COL_STATS = "colStats";
 
     @JsonProperty(FIELD_SNAPSHOT_ID)
     private final long snapshotId;
+
+    @JsonProperty(FIELD_SCHEMA_ID)
+    private final long schemaId;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MERGED_RECORD_COUNT)
@@ -71,21 +76,27 @@ public class Stats {
     @JsonCreator
     public Stats(
             @JsonProperty(FIELD_SNAPSHOT_ID) long snapshotId,
+            @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
             @JsonProperty(FIELD_COL_STATS) Map<String, ColStats<?>> colStats) {
         this.snapshotId = snapshotId;
+        this.schemaId = schemaId;
         this.mergedRecordCount = mergedRecordCount;
         this.mergedRecordSize = mergedRecordSize;
         this.colStats = colStats;
     }
 
-    public Stats(Long snapshotId, Long mergedRecordCount, Long mergedRecordSize) {
-        this(snapshotId, mergedRecordCount, mergedRecordSize, Collections.emptyMap());
+    public Stats(long snapshotId, long schemaId, Long mergedRecordCount, Long mergedRecordSize) {
+        this(snapshotId, schemaId, mergedRecordCount, mergedRecordSize, Collections.emptyMap());
     }
 
     public long snapshotId() {
         return snapshotId;
+    }
+
+    public long schemaId() {
+        return schemaId;
     }
 
     public OptionalLong mergedRecordCount() {
@@ -164,15 +175,16 @@ public class Stats {
     }
 
     @Override
-    public boolean equals(Object object) {
-        if (this == object) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (object == null || getClass() != object.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Stats stats = (Stats) object;
-        return Objects.equals(snapshotId, stats.snapshotId)
+        Stats stats = (Stats) o;
+        return snapshotId == stats.snapshotId
+                && schemaId == stats.schemaId
                 && Objects.equals(mergedRecordCount, stats.mergedRecordCount)
                 && Objects.equals(mergedRecordSize, stats.mergedRecordSize)
                 && Objects.equals(colStats, stats.colStats);
@@ -180,20 +192,11 @@ public class Stats {
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotId, mergedRecordCount, mergedRecordSize, colStats);
+        return Objects.hash(snapshotId, schemaId, mergedRecordCount, mergedRecordSize, colStats);
     }
 
     @Override
     public String toString() {
-        return "Stats{"
-                + "snapshotId="
-                + snapshotId
-                + ", mergedRecordCount="
-                + mergedRecordCount
-                + ", mergedRecordSize="
-                + mergedRecordSize
-                + ", colStats="
-                + colStats
-                + '}';
+        return JsonSerdeUtil.toJson(this);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -69,7 +69,7 @@ public class Stats {
 
     @JsonCreator
     public Stats(
-            @JsonProperty(FIELD_SNAPSHOT_ID) Long snapshotId,
+            @JsonProperty(FIELD_SNAPSHOT_ID) long snapshotId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
             @JsonProperty(FIELD_COL_STATS) Map<String, ColStats<?>> colStats) {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.OptionalUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/** Stats. */
+public class Stats {
+
+    private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
+    private static final String FIELD_MERGED_RECORD_SIZE = "mergedRecordSize";
+    private static final String FIELD_COL_STATS = "colStats";
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_MERGED_RECORD_COUNT)
+    @Nullable
+    private final Long mergedRecordCount;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_MERGED_RECORD_SIZE)
+    @Nullable
+    private final Long mergedRecordSize;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_COL_STATS)
+    @Nullable
+    private final Map<String, ColStats> colStats;
+
+    @JsonCreator
+    public Stats(
+            @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
+            @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
+            @JsonProperty(FIELD_COL_STATS) @Nullable Map<String, ColStats> colStats) {
+        this.mergedRecordCount = mergedRecordCount;
+        this.mergedRecordSize = mergedRecordSize;
+        this.colStats = colStats;
+    }
+
+    public OptionalLong mergedRecordCount() {
+        return OptionalUtils.of(mergedRecordCount);
+    }
+
+    public OptionalLong mergedRecordSize() {
+        return OptionalUtils.of(mergedRecordSize);
+    }
+
+    public Optional<Map<String, ColStats>> colStats() {
+        return Optional.ofNullable(colStats);
+    }
+
+    public void serializeFieldsToString(TableSchema schema) {
+        try {
+            if (colStats != null) {
+                for (Map.Entry<String, ColStats> entry : colStats.entrySet()) {
+                    String colName = entry.getKey();
+                    ColStats colStats = entry.getValue();
+                    DataType type =
+                            schema.fields().stream()
+                                    .filter(field -> field.name().equals(colName))
+                                    .findFirst()
+                                    .get()
+                                    .type();
+                    colStats.serializeFieldsToString(type);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to serialize fields to string", e);
+        }
+    }
+
+    public void deserializeFieldsFromString(TableSchema schema) {
+        try {
+            if (colStats != null) {
+                for (Map.Entry<String, ColStats> entry : colStats.entrySet()) {
+                    String colName = entry.getKey();
+                    ColStats colStats = entry.getValue();
+                    DataType type =
+                            schema.fields().stream()
+                                    .filter(field -> field.name().equals(colName))
+                                    .findFirst()
+                                    .get()
+                                    .type();
+                    colStats.deserializeFieldsFromString(type);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to deserialize fields from string", e);
+        }
+    }
+
+    public String toJson() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    public static Stats fromJson(String json) {
+        return JsonSerdeUtil.fromJson(json, Stats.class);
+    }
+
+    public static Stats fromPath(FileIO fileIO, Path path) {
+        try {
+            String json = fileIO.readFileUtf8(path);
+            return Stats.fromJson(json);
+        } catch (IOException e) {
+            throw new RuntimeException("Fails to read snapshot from path " + path, e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Stats stats = (Stats) object;
+        return Objects.equals(mergedRecordCount, stats.mergedRecordCount)
+                && Objects.equals(mergedRecordSize, stats.mergedRecordSize)
+                && Objects.equals(colStats, stats.colStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mergedRecordCount, mergedRecordSize, colStats);
+    }
+
+    @Override
+    public String toString() {
+        return "Stats{"
+                + "mergedRecordCount="
+                + mergedRecordCount
+                + ", mergedRecordSize="
+                + mergedRecordSize
+                + ", colStats="
+                + colStats
+                + '}';
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -48,9 +48,13 @@ import java.util.OptionalLong;
  */
 public class Stats {
 
+    private static final String FIELD_SNAPSHOT_ID = "snapshotId";
     private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
     private static final String FIELD_MERGED_RECORD_SIZE = "mergedRecordSize";
     private static final String FIELD_COL_STATS = "colStats";
+
+    @JsonProperty(FIELD_SNAPSHOT_ID)
+    private final Long snapshotId;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MERGED_RECORD_COUNT)
@@ -66,12 +70,25 @@ public class Stats {
 
     @JsonCreator
     public Stats(
+            @JsonProperty(FIELD_SNAPSHOT_ID) Long snapshotId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
             @JsonProperty(FIELD_COL_STATS) @Nullable Map<String, ColStats> colStats) {
+        this.snapshotId = snapshotId;
         this.mergedRecordCount = mergedRecordCount;
         this.mergedRecordSize = mergedRecordSize;
         this.colStats = colStats;
+    }
+
+    public Stats(
+            @Nullable Long mergedRecordCount,
+            @Nullable Long mergedRecordSize,
+            @Nullable Map<String, ColStats> colStats) {
+        this(null, mergedRecordCount, mergedRecordSize, colStats);
+    }
+
+    public long snapshotId() {
+        return snapshotId;
     }
 
     public OptionalLong mergedRecordCount() {
@@ -84,6 +101,11 @@ public class Stats {
 
     public Optional<Map<String, ColStats>> colStats() {
         return Optional.ofNullable(colStats);
+    }
+
+    public static Stats withNewSnapshotId(Stats stats, long snapshotId) {
+        return new Stats(
+                snapshotId, stats.mergedRecordCount, stats.mergedRecordSize, stats.colStats);
     }
 
     public void serializeFieldsToString(TableSchema schema) {
@@ -152,20 +174,23 @@ public class Stats {
             return false;
         }
         Stats stats = (Stats) object;
-        return Objects.equals(mergedRecordCount, stats.mergedRecordCount)
+        return Objects.equals(snapshotId, stats.snapshotId)
+                && Objects.equals(mergedRecordCount, stats.mergedRecordCount)
                 && Objects.equals(mergedRecordSize, stats.mergedRecordSize)
                 && Objects.equals(colStats, stats.colStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mergedRecordCount, mergedRecordSize, colStats);
+        return Objects.hash(snapshotId, mergedRecordCount, mergedRecordSize, colStats);
     }
 
     @Override
     public String toString() {
         return "Stats{"
-                + "mergedRecordCount="
+                + "snapshotId="
+                + snapshotId
+                + ", mergedRecordCount="
                 + mergedRecordCount
                 + ", mergedRecordSize="
                 + mergedRecordSize

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -54,7 +54,7 @@ public class Stats {
     private static final String FIELD_COL_STATS = "colStats";
 
     @JsonProperty(FIELD_SNAPSHOT_ID)
-    private final Long snapshotId;
+    private final long snapshotId;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MERGED_RECORD_COUNT)
@@ -80,13 +80,6 @@ public class Stats {
         this.colStats = colStats;
     }
 
-    public Stats(
-            @Nullable Long mergedRecordCount,
-            @Nullable Long mergedRecordSize,
-            @Nullable Map<String, ColStats> colStats) {
-        this(null, mergedRecordCount, mergedRecordSize, colStats);
-    }
-
     public long snapshotId() {
         return snapshotId;
     }
@@ -101,11 +94,6 @@ public class Stats {
 
     public Optional<Map<String, ColStats>> colStats() {
         return Optional.ofNullable(colStats);
-    }
-
-    public static Stats withNewSnapshotId(Stats stats, long snapshotId) {
-        return new Stats(
-                snapshotId, stats.mergedRecordCount, stats.mergedRecordSize, stats.colStats);
     }
 
     public void serializeFieldsToString(TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -32,9 +32,9 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.OptionalLong;
 
 /**
@@ -64,20 +64,23 @@ public class Stats {
     @JsonProperty(FIELD_MERGED_RECORD_SIZE)
     private final @Nullable Long mergedRecordSize;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_COL_STATS)
-    private final @Nullable Map<String, ColStats> colStats;
+    private final Map<String, ColStats> colStats;
 
     @JsonCreator
     public Stats(
             @JsonProperty(FIELD_SNAPSHOT_ID) Long snapshotId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
-            @JsonProperty(FIELD_COL_STATS) @Nullable Map<String, ColStats> colStats) {
+            @JsonProperty(FIELD_COL_STATS) Map<String, ColStats> colStats) {
         this.snapshotId = snapshotId;
         this.mergedRecordCount = mergedRecordCount;
         this.mergedRecordSize = mergedRecordSize;
         this.colStats = colStats;
+    }
+
+    public Stats(Long snapshotId, Long mergedRecordCount, Long mergedRecordSize) {
+        this(snapshotId, mergedRecordCount, mergedRecordSize, Collections.emptyMap());
     }
 
     public long snapshotId() {
@@ -92,8 +95,8 @@ public class Stats {
         return OptionalUtils.ofNullable(mergedRecordSize);
     }
 
-    public Optional<Map<String, ColStats>> colStats() {
-        return Optional.ofNullable(colStats);
+    public Map<String, ColStats> colStats() {
+        return colStats;
     }
 
     public void serializeFieldsToString(TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -65,14 +65,14 @@ public class Stats {
     private final @Nullable Long mergedRecordSize;
 
     @JsonProperty(FIELD_COL_STATS)
-    private final Map<String, ColStats> colStats;
+    private final Map<String, ColStats<?>> colStats;
 
     @JsonCreator
     public Stats(
             @JsonProperty(FIELD_SNAPSHOT_ID) Long snapshotId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
-            @JsonProperty(FIELD_COL_STATS) Map<String, ColStats> colStats) {
+            @JsonProperty(FIELD_COL_STATS) Map<String, ColStats<?>> colStats) {
         this.snapshotId = snapshotId;
         this.mergedRecordCount = mergedRecordCount;
         this.mergedRecordSize = mergedRecordSize;
@@ -95,16 +95,16 @@ public class Stats {
         return OptionalUtils.ofNullable(mergedRecordSize);
     }
 
-    public Map<String, ColStats> colStats() {
+    public Map<String, ColStats<?>> colStats() {
         return colStats;
     }
 
     public void serializeFieldsToString(TableSchema schema) {
         try {
             if (colStats != null) {
-                for (Map.Entry<String, ColStats> entry : colStats.entrySet()) {
+                for (Map.Entry<String, ColStats<?>> entry : colStats.entrySet()) {
                     String colName = entry.getKey();
-                    ColStats colStats = entry.getValue();
+                    ColStats<?> colStats = entry.getValue();
                     DataType type =
                             schema.fields().stream()
                                     .filter(field -> field.name().equals(colName))
@@ -122,9 +122,9 @@ public class Stats {
     public void deserializeFieldsFromString(TableSchema schema) {
         try {
             if (colStats != null) {
-                for (Map.Entry<String, ColStats> entry : colStats.entrySet()) {
+                for (Map.Entry<String, ColStats<?>> entry : colStats.entrySet()) {
                     String colName = entry.getKey();
-                    ColStats colStats = entry.getValue();
+                    ColStats<?> colStats = entry.getValue();
                     DataType type =
                             schema.fields().stream()
                                     .filter(field -> field.name().equals(colName))

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -48,6 +48,7 @@ import java.util.OptionalLong;
  */
 public class Stats {
 
+    // SnapshotId that stats belongs to
     private static final String FIELD_SNAPSHOT_ID = "snapshotId";
     private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
     private static final String FIELD_MERGED_RECORD_SIZE = "mergedRecordSize";
@@ -109,7 +110,10 @@ public class Stats {
                             schema.fields().stream()
                                     .filter(field -> field.name().equals(colName))
                                     .findFirst()
-                                    .get()
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "Unable to obtain the latest schema"))
                                     .type();
                     colStats.serializeFieldsToString(type);
                 }
@@ -129,7 +133,10 @@ public class Stats {
                             schema.fields().stream()
                                     .filter(field -> field.name().equals(colName))
                                     .findFirst()
-                                    .get()
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "Unable to obtain the latest schema"))
                                     .type();
                     colStats.deserializeFieldsFromString(type);
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Stats.java
@@ -37,7 +37,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-/** Stats. */
+/**
+ * Global stats, supports the following stats.
+ *
+ * <ul>
+ *   <li>mergedRecordCount: the total number of records after merge
+ *   <li>mergedRecordSize: the size of the mergedRecordCount in bytes
+ *   <li>colStats: column stats map
+ * </ul>
+ */
 public class Stats {
 
     private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
@@ -46,18 +54,15 @@ public class Stats {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MERGED_RECORD_COUNT)
-    @Nullable
-    private final Long mergedRecordCount;
+    private final @Nullable Long mergedRecordCount;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_MERGED_RECORD_SIZE)
-    @Nullable
-    private final Long mergedRecordSize;
+    private final @Nullable Long mergedRecordSize;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(FIELD_COL_STATS)
-    @Nullable
-    private final Map<String, ColStats> colStats;
+    private final @Nullable Map<String, ColStats> colStats;
 
     @JsonCreator
     public Stats(
@@ -70,11 +75,11 @@ public class Stats {
     }
 
     public OptionalLong mergedRecordCount() {
-        return OptionalUtils.of(mergedRecordCount);
+        return OptionalUtils.ofNullable(mergedRecordCount);
     }
 
     public OptionalLong mergedRecordSize() {
-        return OptionalUtils.of(mergedRecordSize);
+        return OptionalUtils.ofNullable(mergedRecordSize);
     }
 
     public Optional<Map<String, ColStats>> colStats() {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
@@ -46,9 +46,9 @@ public class StatsFile {
     }
 
     /**
-     * Write stats to stats file.
+     * Write stats to a stats file.
      *
-     * @return stats file name
+     * @return the written file name
      */
     public String write(Stats stats) {
         Path path = pathFactory.newPath();

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.PathFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/** Stats file contains stats. */
+public class StatsFile {
+
+    private final FileIO fileIO;
+    private final PathFactory pathFactory;
+
+    public StatsFile(FileIO fileIO, PathFactory pathFactory) {
+        this.fileIO = fileIO;
+        this.pathFactory = pathFactory;
+    }
+
+    /**
+     * Read stats from stat file name.
+     *
+     * @return stats
+     */
+    public Stats read(String fileName) {
+        return Stats.fromPath(fileIO, pathFactory.toPath(fileName));
+    }
+
+    /**
+     * Write stats to stats file.
+     *
+     * @return stats file name
+     */
+    public String write(Stats stats) {
+        Path path = pathFactory.newPath();
+
+        try {
+            fileIO.writeFileUtf8(path, stats.toJson());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write stats file: " + path, e);
+        }
+        return path.getName();
+    }
+
+    public void delete(String fileName) {
+        fileIO.deleteQuietly(pathFactory.toPath(fileName));
+    }
+
+    public boolean exists(String fileName) {
+        try {
+            return fileIO.exists(pathFactory.toPath(fileName));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -48,7 +48,9 @@ public class StatsFileHandler {
                 schemaManager
                         .latest()
                         .orElseThrow(
-                                () -> new IllegalStateException("Latest schema cannot be found")));
+                                () ->
+                                        new IllegalStateException(
+                                                "Unable to obtain the latest schema")));
         return statsFile.write(stats);
     }
 
@@ -60,7 +62,7 @@ public class StatsFileHandler {
     public Optional<Stats> readStats() {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         if (latestSnapshotId == null) {
-            throw new IllegalStateException("Latest snapshot cannot be found");
+            throw new IllegalStateException("Unable to obtain the latest schema");
         }
         return readStats(latestSnapshotId);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -24,7 +24,7 @@ import org.apache.paimon.utils.SnapshotManager;
 
 import java.util.Optional;
 
-/** Handle stats files. */
+/** Handler of StatsFile. */
 public class StatsFileHandler {
 
     private final SnapshotManager snapshotManager;
@@ -39,21 +39,26 @@ public class StatsFileHandler {
     }
 
     /**
-     * Write stats to stats file.
+     * Write stats to a stats file.
      *
-     * @return stats file name
+     * @return the written file name
      */
     public String writeStats(Stats stats) {
         stats.serializeFieldsToString(schemaManager.latest().get());
         return statsFile.write(stats);
     }
 
+    /**
+     * Read stats of the latest snapshot.
+     *
+     * @return stats
+     */
     public Optional<Stats> readStats() {
         return readStats(snapshotManager.latestSnapshotId());
     }
 
     /**
-     * Read stats for the specified snapshotId.
+     * Read stats of the specified snapshot.
      *
      * @return stats
      */
@@ -65,6 +70,14 @@ public class StatsFileHandler {
             Stats stats = statsFile.read(snapshot.stats());
             stats.deserializeFieldsFromString(schemaManager.schema(snapshot.schemaId()));
             return Optional.of(stats);
+        }
+    }
+
+    /** Delete stats of the specified snapshot. */
+    public void deleteStats(long snapshotId) {
+        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
+        if (snapshot.stats() != null) {
+            statsFile.delete(snapshot.stats());
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.utils.SnapshotManager;
+
+import java.util.Optional;
+
+/** Handle stats files. */
+public class StatsFileHandler {
+
+    private final SnapshotManager snapshotManager;
+    private final SchemaManager schemaManager;
+    private final StatsFile statsFile;
+
+    public StatsFileHandler(
+            SnapshotManager snapshotManager, SchemaManager schemaManager, StatsFile statsFile) {
+        this.snapshotManager = snapshotManager;
+        this.schemaManager = schemaManager;
+        this.statsFile = statsFile;
+    }
+
+    /**
+     * Write stats to stats file.
+     *
+     * @return stats file name
+     */
+    public String writeStats(Stats stats) {
+        stats.serializeFieldsToString(schemaManager.latest().get());
+        return statsFile.write(stats);
+    }
+
+    public Optional<Stats> readStats() {
+        return readStats(snapshotManager.latestSnapshotId());
+    }
+
+    /**
+     * Read stats for the specified snapshotId.
+     *
+     * @return stats
+     */
+    public Optional<Stats> readStats(long snapshotId) {
+        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
+        if (snapshot.stats() == null) {
+            return Optional.empty();
+        } else {
+            Stats stats = statsFile.read(snapshot.stats());
+            stats.deserializeFieldsFromString(schemaManager.schema(snapshot.schemaId()));
+            return Optional.of(stats);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -44,11 +44,6 @@ public class StatsFileHandler {
      * @return the written file name
      */
     public String writeStats(Stats stats) {
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            throw new IllegalStateException("Latest snapshot cannot be found");
-        }
-        stats = Stats.withNewSnapshotId(stats, latestSnapshotId);
         stats.serializeFieldsToString(
                 schemaManager
                         .latest()

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -44,13 +44,7 @@ public class StatsFileHandler {
      * @return the written file name
      */
     public String writeStats(Stats stats) {
-        stats.serializeFieldsToString(
-                schemaManager
-                        .latest()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Unable to obtain the latest schema")));
+        stats.serializeFieldsToString(schemaManager.schema(stats.schemaId()));
         return statsFile.write(stats);
     }
 
@@ -73,12 +67,15 @@ public class StatsFileHandler {
      * @return stats
      */
     public Optional<Stats> readStats(long snapshotId) {
-        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
+        return readStats(snapshotManager.snapshot(snapshotId));
+    }
+
+    public Optional<Stats> readStats(Snapshot snapshot) {
         if (snapshot.statistics() == null) {
             return Optional.empty();
         } else {
             Stats stats = statsFile.read(snapshot.statistics());
-            stats.deserializeFieldsFromString(schemaManager.schema(snapshot.schemaId()));
+            stats.deserializeFieldsFromString(schemaManager.schema(stats.schemaId()));
             return Optional.of(stats);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -215,12 +215,16 @@ public class FileStorePathFactory {
             @Override
             public Path newPath() {
                 return new Path(
-                        root + "/stats/stats-" + uuid + "-" + statsFileCount.getAndIncrement());
+                        root
+                                + "/statistics/stats-"
+                                + uuid
+                                + "-"
+                                + statsFileCount.getAndIncrement());
             }
 
             @Override
             public Path toPath(String fileName) {
-                return new Path(root + "/stats/" + fileName);
+                return new Path(root + "/statistics/" + fileName);
             }
         };
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -56,6 +56,7 @@ public class FileStorePathFactory {
     private final AtomicInteger manifestListCount;
     private final AtomicInteger indexManifestCount;
     private final AtomicInteger indexFileCount;
+    private final AtomicInteger statsFileCount;
 
     public FileStorePathFactory(Path root) {
         this(
@@ -78,6 +79,7 @@ public class FileStorePathFactory {
         this.manifestListCount = new AtomicInteger(0);
         this.indexManifestCount = new AtomicInteger(0);
         this.indexFileCount = new AtomicInteger(0);
+        this.statsFileCount = new AtomicInteger(0);
     }
 
     public Path root() {
@@ -204,6 +206,21 @@ public class FileStorePathFactory {
             @Override
             public Path toPath(String fileName) {
                 return new Path(root + "/index/" + fileName);
+            }
+        };
+    }
+
+    public PathFactory statsFileFactory() {
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return new Path(
+                        root + "/stats/stats-" + uuid + "-" + statsFileCount.getAndIncrement());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(root + "/stats/" + fileName);
             }
         };
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -722,6 +722,7 @@ public class FileDeletionTest {
                         Collections.emptyMap(),
                         Snapshot.CommitKind.APPEND,
                         store.snapshotManager().latestSnapshot(),
+                        null,
                         null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -794,13 +794,13 @@ public class FileStoreCommitTest {
         fileStoreCommit.writeStats(fakeStats, Long.MAX_VALUE);
         Optional<Stats> readStats = statsFileHandler.readStats();
         assertThat(readStats).isPresent();
-        assertThat(readStats.get()).isEqualTo(fakeStats);
+        assertThat(readStats.get()).isEqualTo(Stats.withNewSnapshotId(fakeStats, 1));
 
         // New snapshot will inherit last snapshot's stats
         store.commitData(generateDataList(10), gen::getPartition, kv -> 0, Collections.emptyMap());
         readStats = statsFileHandler.readStats();
         assertThat(readStats).isPresent();
-        assertThat(readStats.get()).isEqualTo(fakeStats);
+        assertThat(readStats.get()).isEqualTo(Stats.withNewSnapshotId(fakeStats, 1));
 
         // When table schema is modified, new snapshot will not inherit last snapshot's stats
         ArrayList<DataField> newFields =
@@ -818,7 +818,7 @@ public class FileStoreCommitTest {
         fileStoreCommit.writeStats(fakeStats, Long.MAX_VALUE);
         readStats = statsFileHandler.readStats();
         assertThat(readStats).isPresent();
-        assertThat(readStats.get()).isEqualTo(fakeStats);
+        assertThat(readStats.get()).isEqualTo(Stats.withNewSnapshotId(fakeStats, 4));
     }
 
     private TestFileStore createStore(boolean failing) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -788,8 +788,8 @@ public class FileStoreCommitTest {
         store.commitData(generateDataList(10), gen::getPartition, kv -> 0, Collections.emptyMap());
 
         // Analyze and check
-        HashMap<String, ColStats> fakeColStatsMap = new HashMap<>();
-        fakeColStatsMap.put("orderId", new ColStats(10L, 1L, 10L, 0L, 8L, 8L));
+        HashMap<String, ColStats<?>> fakeColStatsMap = new HashMap<>();
+        fakeColStatsMap.put("orderId", new ColStats<>(10L, 1L, 10L, 0L, 8L, 8L));
         Stats fakeStats =
                 new Stats(store.snapshotManager().latestSnapshotId(), 10L, 1000L, fakeColStatsMap);
         fileStoreCommit.commitStatistics(fakeStats, Long.MAX_VALUE);
@@ -814,7 +814,7 @@ public class FileStoreCommitTest {
 
         // Then we need to analyze again
         fakeColStatsMap = new HashMap<>();
-        fakeColStatsMap.put("orderId", new ColStats(30L, 1L, 30L, 0L, 8L, 8L));
+        fakeColStatsMap.put("orderId", new ColStats<>(30L, 1L, 30L, 0L, 8L, 8L));
         fakeStats =
                 new Stats(store.snapshotManager().latestSnapshotId(), 30L, 3000L, fakeColStatsMap);
         fileStoreCommit.commitStatistics(fakeStats, Long.MAX_VALUE);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -812,11 +812,18 @@ public class FileStoreCommitTest {
         readStats = statsFileHandler.readStats();
         assertThat(readStats).isEmpty();
 
-        // We need to analyze again
+        // Then we need to analyze again
         fakeColStatsMap = new HashMap<>();
         fakeColStatsMap.put("orderId", new ColStats(30L, 1L, 30L, 0L, 8L, 8L));
         fakeStats =
                 new Stats(store.snapshotManager().latestSnapshotId(), 30L, 3000L, fakeColStatsMap);
+        fileStoreCommit.commitStatistics(fakeStats, Long.MAX_VALUE);
+        readStats = statsFileHandler.readStats();
+        assertThat(readStats).isPresent();
+        assertThat(readStats.get()).isEqualTo(fakeStats);
+
+        // Analyze without col stats and check
+        fakeStats = new Stats(store.snapshotManager().latestSnapshotId(), 30L, 3000L);
         fileStoreCommit.commitStatistics(fakeStats, Long.MAX_VALUE);
         readStats = statsFileHandler.readStats();
         assertThat(readStats).isPresent();

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
@@ -55,7 +55,7 @@ public class StatsFileTest {
         StatsFile file = new StatsFile(LocalFileIO.create(), pathFactory);
         HashMap<String, ColStats> colStatsMap = new HashMap<>();
         colStatsMap.put("orderId", new ColStats(10L, "111", "222", 0L, 8L, 8L));
-        Stats stats = new Stats(10L, 1000L, colStatsMap);
+        Stats stats = new Stats(1L, 10L, 1000L, colStatsMap);
         String fileName = file.write(stats);
 
         assertThat(file.exists(fileName)).isTrue();

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
@@ -53,8 +53,8 @@ public class StatsFileTest {
                 };
 
         StatsFile file = new StatsFile(LocalFileIO.create(), pathFactory);
-        HashMap<String, ColStats> colStatsMap = new HashMap<>();
-        colStatsMap.put("orderId", new ColStats(10L, "111", "222", 0L, 8L, 8L));
+        HashMap<String, ColStats<?>> colStatsMap = new HashMap<>();
+        colStatsMap.put("orderId", new ColStats<>(10L, "111", "222", 0L, 8L, 8L));
         Stats stats = new Stats(1L, 10L, 1000L, colStatsMap);
         String fileName = file.write(stats);
 

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
@@ -54,8 +54,8 @@ public class StatsFileTest {
 
         StatsFile file = new StatsFile(LocalFileIO.create(), pathFactory);
         HashMap<String, ColStats<?>> colStatsMap = new HashMap<>();
-        colStatsMap.put("orderId", new ColStats<>(10L, "111", "222", 0L, 8L, 8L));
-        Stats stats = new Stats(1L, 10L, 1000L, colStatsMap);
+        colStatsMap.put("orderId", new ColStats<>(0, 10L, "111", "222", 0L, 8L, 8L));
+        Stats stats = new Stats(1L, 0L, 10L, 1000L, colStatsMap);
         String fileName = file.write(stats);
 
         assertThat(file.exists(fileName)).isTrue();

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatsFileTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.PathFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link StatsFile}. */
+public class StatsFileTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    public void test() throws IOException {
+        Path dir = new Path(tempPath.toUri());
+        PathFactory pathFactory =
+                new PathFactory() {
+                    @Override
+                    public Path newPath() {
+                        return new Path(dir, UUID.randomUUID().toString());
+                    }
+
+                    @Override
+                    public Path toPath(String fileName) {
+                        return new Path(dir, fileName);
+                    }
+                };
+
+        StatsFile file = new StatsFile(LocalFileIO.create(), pathFactory);
+        HashMap<String, ColStats> colStatsMap = new HashMap<>();
+        colStatsMap.put("orderId", new ColStats(10L, "111", "222", 0L, 8L, 8L));
+        Stats stats = new Stats(10L, 1000L, colStatsMap);
+        String fileName = file.write(stats);
+
+        assertThat(file.exists(fileName)).isTrue();
+
+        assertThat(file.read(fileName)).isEqualTo(stats);
+
+        file.delete(fileName);
+
+        assertThat(file.exists(fileName)).isFalse();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -73,6 +73,7 @@ public class SnapshotManagerTest {
                             null,
                             null,
                             null,
+                            null,
                             null);
             localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
@@ -106,6 +107,7 @@ public class SnapshotManagerTest {
                             0L,
                             Snapshot.CommitKind.APPEND,
                             i * 1000,
+                            null,
                             null,
                             null,
                             null,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

First step of [PIP-14: Paimon statistics](https://cwiki.apache.org/confluence/display/PAIMON/PIP-14%3A+Paimon+statistics)

snapshot-x
```json
{
  "version" : 3,
  "id" : 2,
  "schemaId" : 3,
  "baseManifestList" : "manifest-list-485c5847-cb20-4324-b2ea-fd73959c5857-0",
  "deltaManifestList" : "manifest-list-485c5847-cb20-4324-b2ea-fd73959c5857-1",
  "changelogManifestList" : null,
  "commitUser" : "e30257ac-a617-4571-a57b-60c3dd608754",
  "commitIdentifier" : 9223372036854775807,
  "commitKind" : "ANALYZE",
  "timeMillis" : 1704944283486,
  "logOffsets" : { },
  "totalRecordCount" : 6,
  "deltaRecordCount" : 0,
  "changelogRecordCount" : 0,
  "watermark" : null,
  "statistics" : "stats-87effd5d-48fd-4aab-81fe-4222b847d247-0"
}
```
statistics/stats-87effd5d-48fd-4aab-81fe-4222b847d247-0
```json
{
  "snapshotId": 2,
  "mergedRecordCount" : 10,
  "mergedRecordSize" : 1000,
  "colStats" : {
    "orderId" : {
      "distinctCount" : 10,
      "min" : "1",
      "max" : "10",
      "nullCount" : 0,
      "avgLen" : 8,
      "maxLen" : 8
    }
  }
}
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

write
```
FileStoreCommitImpl commit = store.newCommit();
commit.writeStats(stats, Long.MAX_VALUE);
```

read
```
StatsFileHandler statsFileHandler = store.newStatsFileHandler();
Optional<Stats> stats = statsFileHandler.readStats();
```

### Next

Future work

- expire of stats
- read stats with system table
- spark analyze
