### PR TITLE
[cdc] KafkaLogSourceProvider preferentially uses the user-configured group-id.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogSourceProvider.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogSourceProvider.java
@@ -103,9 +103,9 @@ public class KafkaLogSourceProvider implements LogSourceProvider {
         return KafkaSource.<RowData>builder()
                 .setTopics(topic)
                 .setStartingOffsets(toOffsetsInitializer(bucketOffsets))
-                .setProperties(properties)
                 .setDeserializer(createDeserializationSchema())
                 .setGroupId(UUID.randomUUID().toString())
+                .setProperties(properties)
                 .build();
     }
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2688 

<!-- What is the purpose of the change -->
The user-configured `group-id` should be used with higher priority.

### Tests

<!-- List UT and IT cases to verify this change -->
No
### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No