### PR TITLE
[flink] Add validation for parallelism of the SortOperator.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -94,6 +94,11 @@ public class SortUtils {
                 sinkParallelismValue == null
                         ? inputStream.getParallelism()
                         : Integer.parseInt(sinkParallelismValue);
+        if (sinkParallelism == -1) {
+            throw new UnsupportedOperationException(
+                    "The adaptive batch scheduler is not supported. Please set the sink parallelism using the key: "
+                            + FlinkConnectorOptions.SINK_PARALLELISM.key());
+        }
         final int sampleSize = sinkParallelism * 1000;
         final int rangeNum = sinkParallelism * 10;
 
@@ -155,7 +160,8 @@ public class SortUtils {
                                 longRowType,
                                 options.writeBufferSize(),
                                 options.pageSize(),
-                                options.localSortMaxNumFileHandles()))
+                                options.localSortMaxNumFileHandles(),
+                                sinkParallelism))
                 .setParallelism(sinkParallelism)
                 // remove the key column from every row
                 .map(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sorter/SortOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sorter/SortOperatorTest.java
@@ -61,7 +61,8 @@ public class SortOperatorTest {
                         rowType,
                         MemorySize.parse("10 mb").getBytes(),
                         (int) MemorySize.parse("16 kb").getBytes(),
-                        128) {};
+                        128,
+                        1) {};
 
         OneInputStreamOperatorTestHarness harness = createTestHarness(sortOperator);
         harness.open();
@@ -88,7 +89,7 @@ public class SortOperatorTest {
     }
 
     @Test
-    public void testCloseSortOprator() throws Exception {
+    public void testCloseSortOperator() throws Exception {
         RowType keyRowType =
                 new RowType(
                         Collections.singletonList(
@@ -107,7 +108,8 @@ public class SortOperatorTest {
                         rowType,
                         MemorySize.parse("10 mb").getBytes(),
                         (int) MemorySize.parse("16 kb").getBytes(),
-                        128) {};
+                        128,
+                        1) {};
         OneInputStreamOperatorTestHarness harness = createTestHarness(sortOperator);
         harness.open();
         File[] files = harness.getEnvironment().getIOManager().getSpillingDirectories();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add validation for parallelism of the SortOperator to avoid potential issues with skewed range partitioning.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
