### PR TITLE
[core][spark] Support create database with location, comment, props using hive catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -71,6 +71,10 @@ public interface Catalog extends AutoCloseable {
      */
     boolean databaseExists(String databaseName);
 
+    /**
+     * Create a database, see {@link Catalog#createDatabase(String name, boolean ignoreIfExists, Map
+     * properties)}
+     */
     default void createDatabase(String name, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException {
         createDatabase(name, ignoreIfExists, Collections.emptyMap());

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -81,7 +81,33 @@ public interface Catalog extends AutoCloseable {
      * @throws DatabaseAlreadyExistException if the given database already exists and ignoreIfExists
      *     is false
      */
-    void createDatabase(String name, boolean ignoreIfExists) throws DatabaseAlreadyExistException;
+    default void createDatabase(String name, boolean ignoreIfExists)
+            throws DatabaseAlreadyExistException {
+        createDatabase(name, ignoreIfExists, Collections.emptyMap());
+    }
+
+    /**
+     * Create a database with properties.
+     *
+     * @param name Name of the database to be created
+     * @param ignoreIfExists Flag to specify behavior when a database with the given name already
+     *     exists: if set to false, throw a DatabaseAlreadyExistException, if set to true, do
+     *     nothing.
+     * @param properties properties to be associated with the database
+     * @throws DatabaseAlreadyExistException if the given database already exists and ignoreIfExists
+     *     is false
+     */
+    void createDatabase(String name, boolean ignoreIfExists, Map<String, String> properties)
+            throws DatabaseAlreadyExistException;
+
+    /**
+     * Load database properties.
+     *
+     * @param name Database name
+     * @return The requested database's properties
+     * @throws DatabaseNotExistException if the requested database does not exist
+     */
+    Map<String, String> loadDatabaseProperties(String name) throws DatabaseNotExistException;
 
     /**
      * Drop a database.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -71,16 +71,6 @@ public interface Catalog extends AutoCloseable {
      */
     boolean databaseExists(String databaseName);
 
-    /**
-     * Create a database.
-     *
-     * @param name Name of the database to be created
-     * @param ignoreIfExists Flag to specify behavior when a database with the given name already
-     *     exists: if set to false, throw a DatabaseAlreadyExistException, if set to true, do
-     *     nothing.
-     * @throws DatabaseAlreadyExistException if the given database already exists and ignoreIfExists
-     *     is false
-     */
     default void createDatabase(String name, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException {
         createDatabase(name, ignoreIfExists, Collections.emptyMap());

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -73,7 +73,7 @@ public interface Catalog extends AutoCloseable {
 
     /**
      * Create a database, see {@link Catalog#createDatabase(String name, boolean ignoreIfExists, Map
-     * properties)}
+     * properties)}.
      */
     default void createDatabase(String name, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -191,6 +191,7 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException, CatalogException {
+        // todo: flink hive catalog support create db with props
         if (database != null) {
             if (database.getProperties().size() > 0) {
                 throw new UnsupportedOperationException(

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -94,11 +94,13 @@ import static org.apache.paimon.utils.StringUtils.isNullOrWhitespaceOnly;
 public class HiveCatalog extends AbstractCatalog {
     private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
-    // we don't include paimon-hive-connector as dependencies because it depends on
-    // hive-exec
+    // Reserved properties
+    public static final String DB_COMMENT_PROP = "comment";
     public static final String TABLE_TYPE_PROP = "table_type";
     public static final String PAIMON_TABLE_TYPE_VALUE = "paimon";
 
+    // we don't include paimon-hive-connector as dependencies because it depends on
+    // hive-exec
     private static final String INPUT_FORMAT_CLASS_NAME =
             "org.apache.paimon.hive.mapred.PaimonInputFormat";
     private static final String OUTPUT_FORMAT_CLASS_NAME =
@@ -219,18 +221,58 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    protected void createDatabaseImpl(String name) {
+    protected void createDatabaseImpl(String name, Map<String, String> properties) {
         try {
-            Path databasePath = newDatabasePath(name);
+            Database database = convertToHiveDatabase(name, properties);
+            Path databasePath =
+                    database.getLocationUri() == null
+                            ? newDatabasePath(name)
+                            : new Path(database.getLocationUri());
             locationHelper.createPathIfRequired(databasePath, fileIO);
-
-            Database database = new Database();
-            database.setName(name);
             locationHelper.specifyDatabaseLocation(databasePath, database);
             client.createDatabase(database);
         } catch (TException | IOException e) {
             throw new RuntimeException("Failed to create database " + name, e);
         }
+    }
+
+    private Database convertToHiveDatabase(String name, Map<String, String> properties) {
+        Database database = new Database();
+        database.setName(name);
+        Map<String, String> parameter = new HashMap<>();
+        properties.forEach(
+                (key, value) -> {
+                    if (key.equals(DB_COMMENT_PROP)) {
+                        database.setDescription(value);
+                    } else if (key.equals(DB_LOCATION_PROP)) {
+                        database.setLocationUri(value);
+                    } else if (value != null) {
+                        parameter.put(key, value);
+                    }
+                });
+        database.setParameters(parameter);
+        return database;
+    }
+
+    @Override
+    public Map<String, String> loadDatabasePropertiesImpl(String name) {
+        try {
+            return convertToProperties(client.getDatabase(name));
+        } catch (TException e) {
+            throw new RuntimeException(
+                    String.format("Failed to get database %s properties", name), e);
+        }
+    }
+
+    private Map<String, String> convertToProperties(Database database) {
+        Map<String, String> properties = new HashMap<>(database.getParameters());
+        if (database.getLocationUri() != null) {
+            properties.put(DB_LOCATION_PROP, database.getLocationUri());
+        }
+        if (database.getDescription() != null) {
+            properties.put(DB_COMMENT_PROP, database.getDescription());
+        }
+        return properties;
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -105,7 +105,7 @@ public class SparkCatalog extends SparkBaseCatalog {
                 "Namespace %s is not valid",
                 Arrays.toString(namespace));
         try {
-            catalog.createDatabase(namespace[0], false);
+            catalog.createDatabase(namespace[0], false, metadata);
         } catch (Catalog.DatabaseAlreadyExistException e) {
             throw new NamespaceAlreadyExistsException(namespace);
         }
@@ -142,10 +142,12 @@ public class SparkCatalog extends SparkBaseCatalog {
                 isValidateNamespace(namespace),
                 "Namespace %s is not valid",
                 Arrays.toString(namespace));
-        if (catalog.databaseExists(namespace[0])) {
-            return Collections.emptyMap();
+        String dataBaseName = namespace[0];
+        try {
+            return catalog.loadDatabaseProperties(dataBaseName);
+        } catch (Catalog.DatabaseNotExistException e) {
+            throw new NoSuchNamespaceException(namespace);
         }
-        throw new NoSuchNamespaceException(namespace);
     }
 
     /**

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -46,6 +46,7 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession with WithTab
 
   protected val tableName0: String = "T"
 
+  /** Add paimon ([[SparkCatalog]] in fileSystem) catalog */
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
@@ -70,6 +71,7 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession with WithTab
     }
   }
 
+  /** Default is paimon catalog */
   override protected def beforeEach(): Unit = {
     super.beforeAll()
     spark.sql(s"USE paimon")

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -25,7 +25,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
 
   import testImplicits._
 
-  test("Paimon: Create Table As Select") {
+  test("Paimon DDL: Create Table As Select") {
     withTable("source", "t1", "t2") {
       Seq((1L, "x1", "2023"), (2L, "x2", "2023"))
         .toDF("a", "b", "pt")
@@ -58,4 +58,16 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Paimon DDL: create database with location with filesystem catalog") {
+    withTempDir {
+      dBLocation =>
+        withDatabase("paimon_db") {
+          val error = intercept[Exception] {
+            spark.sql(s"CREATE DATABASE paimon_db LOCATION '${dBLocation.getCanonicalPath}'")
+          }.getMessage
+          assert(
+            error.contains("Cannot specify location for a database when using fileSystem catalog."))
+        }
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonHiveTestBase
+
+import org.junit.jupiter.api.Assertions
+
+class DDLWithHiveCatalogTest extends PaimonHiveTestBase {
+
+  test("Paimon DDL with hive catalog: create database with location and comment") {
+    Seq("spark_catalog", paimonHiveCatalog).foreach {
+      catalogName =>
+        spark.sql(s"USE $catalogName")
+        withTempDir {
+          dBLocation =>
+            withDatabase("paimon_db") {
+              val comment = "this is a test comment"
+              spark.sql(
+                s"CREATE DATABASE paimon_db LOCATION '${dBLocation.getCanonicalPath}' COMMENT '$comment'")
+              Assertions.assertEquals(getDatabaseLocation("paimon_db"), dBLocation.getCanonicalPath)
+              Assertions.assertEquals(getDatabaseComment("paimon_db"), comment)
+
+              withTable("paimon_db.paimon_tbl") {
+                spark.sql(s"""
+                             |CREATE TABLE paimon_db.paimon_tbl (id STRING, name STRING, pt STRING)
+                             |USING PAIMON
+                             |TBLPROPERTIES ('primary-key' = 'id')
+                             |""".stripMargin)
+                Assertions.assertEquals(
+                  getTableLocation("paimon_db.paimon_tbl"),
+                  s"${dBLocation.getCanonicalPath}/paimon_tbl")
+              }
+            }
+        }
+    }
+  }
+
+  test("Paimon DDL with hive catalog: create database with props") {
+    Seq("spark_catalog", paimonHiveCatalog).foreach {
+      catalogName =>
+        spark.sql(s"USE $catalogName")
+        withDatabase("paimon_db") {
+          spark.sql(s"CREATE DATABASE paimon_db WITH DBPROPERTIES ('k1' = 'v1', 'k2' = 'v2')")
+          val props = getDatabaseProps("paimon_db")
+          Assertions.assertEquals(props("k1"), "v1")
+          Assertions.assertEquals(props("k2"), "v2")
+        }
+    }
+  }
+
+  def getDatabaseLocation(dbName: String): String = {
+    spark
+      .sql(s"DESC DATABASE $dbName")
+      .filter("info_name == 'Location'")
+      .head()
+      .getAs[String]("info_value")
+      .split(":")(1)
+  }
+
+  def getDatabaseComment(dbName: String): String = {
+    spark
+      .sql(s"DESC DATABASE $dbName")
+      .filter("info_name == 'Comment'")
+      .head()
+      .getAs[String]("info_value")
+  }
+
+  def getDatabaseProps(dbName: String): Map[String, String] = {
+    val dbPropsStr = spark
+      .sql(s"DESC DATABASE EXTENDED $dbName")
+      .filter("info_name == 'Properties'")
+      .head()
+      .getAs[String]("info_value")
+    val pattern = "\\(([^,]+),([^)]+)\\)".r
+    pattern
+      .findAllIn(dbPropsStr.drop(1).dropRight(1))
+      .matchData
+      .map {
+        m =>
+          val key = m.group(1).trim
+          val value = m.group(2).trim
+          (key, value)
+      }
+      .toMap
+  }
+
+  def getTableLocation(tblName: String): String = {
+    val tablePropsStr = spark
+      .sql(s"DESC TABLE EXTENDED $tblName")
+      .filter("col_name == 'Table Properties'")
+      .head()
+      .getAs[String]("data_type")
+    val tableProps = tablePropsStr
+      .substring(1, tablePropsStr.length - 1)
+      .split(",")
+      .map(_.split("="))
+      .map { case Array(key, value) => (key, value) }
+      .toMap
+    tableProps("path").split(":")(1)
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: one step of #2619

support  create database with location, comment, props

```sql
CREATE DATABASE db LOCATION 'x' COMMENT 'x' WITH DBPROPERTIES ('k1' = 'v1', 'k2' = 'v2')
```

Note:

- for hive catalog: store all props(location, comment, other props) to hms
- for filesystem catalog: when props is not empty, do nothings but give a warn `Currently filesystem catalog can't store database properties, discard properties: {}`, because filesystem catalog can't store meta.  Besides, because db's location in filesystem catalog is stable, **when create db location 'xxx' with filesystem catalog, an exception is thrown**: `Cannot specify location for a database when using fileSystem catalog`


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
