### PR TITLE
[flink] Add random suffix for lots of data sort to avoid data skew

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -570,6 +570,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>If the maximum number of sort readers exceeds this value, a spill will be attempted. This prevents too many readers from consuming too much memory and causing OOM.</td>
         </tr>
         <tr>
+            <td><h5>sort.random-bytes-suffix</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The random bytes added behind sort columns to avoid data skew</td>
+        </tr>
+        <tr>
             <td><h5>source.split.open-file-cost</h5></td>
             <td style="word-wrap: break-word;">4 mb</td>
             <td>MemorySize</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1016,6 +1016,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "The bytes of types (CHAR, VARCHAR, BINARY, VARBINARY) devote to the zorder sort.");
 
+    public static final ConfigOption<Integer> SORT_RANDOM_BYTES_SUFFIX =
+            key("sort.random-bytes-suffix")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "The random bytes added behind sort columns to avoid data skew");
+
     public static final ConfigOption<MemorySize> FILE_READER_ASYNC_THRESHOLD =
             key("file-reader-async-threshold")
                     .memoryType()
@@ -1543,6 +1550,10 @@ public class CoreOptions implements Serializable {
 
     public int varTypeSize() {
         return options.get(ZORDER_VAR_LENGTH_CONTRIBUTION);
+    }
+
+    public int sortRandomBytesSuffix() {
+        return options.get(SORT_RANDOM_BYTES_SUFFIX);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/RandomBytesSuffixGenerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/RandomBytesSuffixGenerator.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sorter;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/** Generate random suffix to avoid data skew. */
+public class RandomBytesSuffixGenerator {
+
+    private static final String FIELD_NAME = "_RANDOM_SUFFIX_";
+
+    private final int byteSize;
+    private final Random random;
+
+    public RandomBytesSuffixGenerator(int byteSize) {
+        if (byteSize < 0) {
+            throw new IllegalArgumentException(
+                    "byte size should be greater than or equal to zero.");
+        }
+        this.byteSize = byteSize;
+        this.random = new Random();
+    }
+
+    public InternalRow addRandomSuffix(InternalRow input) {
+        if (byteSize > 0) {
+            GenericRow bytesRow = new GenericRow(1);
+            byte[] randomBytes = new byte[byteSize];
+            random.nextBytes(randomBytes);
+            bytesRow.setField(0, randomBytes);
+
+            return new JoinedRow(input.getRowKind(), input, bytesRow);
+        }
+        return input;
+    }
+
+    public byte[] addRandomSuffix(byte[] input) {
+        if (byteSize > 0) {
+            byte[] out = new byte[input.length + byteSize];
+            byte[] randomBytes = new byte[byteSize];
+            random.nextBytes(randomBytes);
+            System.arraycopy(input, 0, out, 0, input.length);
+            System.arraycopy(randomBytes, 0, out, input.length, randomBytes.length);
+            return out;
+        }
+        return input;
+    }
+
+    public static RandomBytesSuffixGenerator create(int byteSize) {
+        return new RandomBytesSuffixGenerator(byteSize);
+    }
+
+    public static RowType combine(RowType input, int byteSize) {
+        if (byteSize > 0) {
+            List<DataField> newFields = new ArrayList<>(input.getFields());
+            newFields.add(new DataField(newFields.size(), FIELD_NAME, DataTypes.BINARY(byteSize)));
+            return new RowType(newFields);
+        }
+        return input;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -180,11 +180,12 @@ public class SortUtils {
     }
 
     /** Abstract key from a row data. */
-    interface KeyAbstract<KEY> extends Serializable {
+    public interface KeyAbstract<KEY> extends Serializable {
         default void open() {}
 
         KEY apply(RowData value);
     }
 
-    interface ShuffleKeyConvertor<KEY> extends Function<KEY, InternalRow>, Serializable {}
+    /** Convert KEY to InternalRow. */
+    public interface ShuffleKeyConvertor<KEY> extends Function<KEY, InternalRow>, Serializable {}
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Run sort compact action in flink job may cause a data skew with lots of hot data.

This pull request is mainly to resolved this problem, if you config `sort.random-bytes-suffix` = <number>, <number> greater than zero, then we will add a <number>-size long random bytes behind the selected sort columns.

We can avoid hot data all goes to one task by random suffix.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
