### PR TITLE
[Minor] Remove duplicate code from FileFormat#fromIdentifier.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -81,18 +81,13 @@ public abstract class FileFormat {
 
     /** Create a {@link FileFormat} from format identifier and format options. */
     public static FileFormat fromIdentifier(String identifier, FormatContext context) {
-        Optional<FileFormat> format =
-                fromIdentifier(identifier, context, FileFormat.class.getClassLoader());
-        return format.orElseGet(
-                () ->
-                        fromIdentifier(identifier, context, FileFormat.class.getClassLoader())
-                                .orElseThrow(
-                                        () ->
-                                                new RuntimeException(
-                                                        String.format(
-                                                                "Could not find any factories that implement '%s' in the classpath.",
-                                                                FileFormatFactory.class
-                                                                        .getName()))));
+        return fromIdentifier(identifier, context, FileFormat.class.getClassLoader())
+                .orElseThrow(
+                        () ->
+                                new RuntimeException(
+                                        String.format(
+                                                "Could not find a FileFormatFactory implementation class for %s format",
+                                                identifier)));
     }
 
     private static Optional<FileFormat> fromIdentifier(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

After this [fix](https://github.com/apache/incubator-paimon/commit/83049b7bd4dd772e8ecef974e42f7ad6f0ad0969), loading the FileFormatFactory class became duplicated in `FileFormat#fromIdentifier`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
