### PR TITLE
[hotfix] Fix spark test typo and missing test

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTest.scala
@@ -15,22 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark.sql
+package org.apache.paimon.spark.procedure
 
-import org.apache.paimon.spark.PaimonSparkTestBase
-import org.apache.paimon.spark.analysis.NoSuchProcedureException
-
-import org.assertj.core.api.Assertions.assertThatThrownBy
-
-class ProcedureTest extends PaimonSparkTestBase {
-
-  test(s"test call unknown procedure") {
-    spark.sql(s"""
-                 |CREATE TABLE T (id INT, name STRING, dt STRING)
-                 |""".stripMargin)
-
-    assertThatThrownBy(() => spark.sql("CALL unknown_procedure(table => 'test.T')"))
-      .isInstanceOf(classOf[NoSuchProcedureException])
-  }
-
-}
+class CompactProcedureTest extends CompactProcedureTestBase {}

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
@@ -15,19 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark.sql
+package org.apache.paimon.spark.procedure
 
-import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{Attribute, GetStructField, NamedExpression, ScalarSubquery}
-import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
-
-class PaimonOptimzationTest extends PaimonOptimzationTestBase {
-
-  override def extractorExpression(
-      cteIndex: Int,
-      output: Seq[Attribute],
-      fieldIndex: Int): NamedExpression = {
-    GetStructField(ScalarSubquery(CTERelationRef(cteIndex, _resolved = true, output)), fieldIndex)
-      .as("scalarsubquery()")
-  }
-}
+class ProcedureTest extends ProcedureTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
@@ -15,19 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark.sql
+package org.apache.paimon.spark.procedure
 
-import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{Attribute, GetStructField, NamedExpression, ScalarSubquery}
-import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
-
-class PaimonOptimzationTest extends PaimonOptimzationTestBase {
-
-  override def extractorExpression(
-      cteIndex: Int,
-      output: Seq[Attribute],
-      fieldIndex: Int): NamedExpression = {
-    GetStructField(ScalarSubquery(CTERelationRef(cteIndex, _resolved = true, output)), fieldIndex)
-      .as("scalarsubquery()")
-  }
-}
+class ProcedureTest extends ProcedureTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
@@ -17,6 +17,17 @@
  */
 package org.apache.paimon.spark.sql
 
-import org.apache.paimon.spark.procedure.CompactProcedureTestBase
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GetStructField, NamedExpression, ScalarSubquery}
+import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
 
-class CompactProcedureTest extends CompactProcedureTestBase {}
+class PaimonOptimizationTest extends PaimonOptimizationTestBase {
+
+  override def extractorExpression(
+      cteIndex: Int,
+      output: Seq[Attribute],
+      fieldIndex: Int): NamedExpression = {
+    GetStructField(ScalarSubquery(CTERelationRef(cteIndex, _resolved = true, output)), fieldIndex)
+      .as("scalarsubquery()")
+  }
+}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GetStructField, NamedExpression, ScalarSubquery}
+import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
+
+class PaimonOptimizationTest extends PaimonOptimizationTestBase {
+
+  import org.apache.spark.sql.catalyst.dsl.expressions._
+
+  override def extractorExpression(
+      cteIndex: Int,
+      output: Seq[Attribute],
+      fieldIndex: Int): NamedExpression = {
+    GetStructField(ScalarSubquery(CTERelationRef(cteIndex, _resolved = true, output)), fieldIndex)
+      .as("scalarsubquery()")
+  }
+}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTest.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.procedure
+
+class CompactProcedureTest extends CompactProcedureTestBase {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTest.scala
@@ -15,22 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark.sql
+package org.apache.paimon.spark.procedure
 
-import org.apache.paimon.spark.PaimonSparkTestBase
-import org.apache.paimon.spark.analysis.NoSuchProcedureException
-
-import org.assertj.core.api.Assertions.assertThatThrownBy
-
-class ProcedureTest extends PaimonSparkTestBase {
-
-  test(s"test call unknown procedure") {
-    spark.sql(s"""
-                 |CREATE TABLE T (id INT, name STRING, dt STRING)
-                 |""".stripMargin)
-
-    assertThatThrownBy(() => spark.sql("CALL unknown_procedure(table => 'test.T')"))
-      .isInstanceOf(classOf[NoSuchProcedureException])
-  }
-
-}
+class ProcedureTest extends ProcedureTestBase {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTest.scala
@@ -17,12 +17,11 @@
  */
 package org.apache.paimon.spark.sql
 
+import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, GetStructField, NamedExpression, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
 
-class PaimonOptimzationTest extends PaimonOptimzationTestBase {
-
-  import org.apache.spark.sql.catalyst.dsl.expressions._
+class PaimonOptimizationTest extends PaimonOptimizationTestBase {
 
   override def extractorExpression(
       cteIndex: Int,

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonHiveTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonHiveTestBase.scala
@@ -30,7 +30,7 @@ class PaimonHiveTestBase extends PaimonSparkTestBase {
 
   protected lazy val testHiveMetastore: TestHiveMetastore = new TestHiveMetastore
 
-  protected val paimonHiveCatalog: String = "paimon_hive"
+  protected val paimonHiveCatalogName: String = "paimon_hive"
 
   protected val hiveDbName: String = "test_hive"
 
@@ -43,9 +43,9 @@ class PaimonHiveTestBase extends PaimonSparkTestBase {
       .set("spark.sql.warehouse.dir", tempHiveDBDir.getCanonicalPath)
       .set("spark.sql.catalogImplementation", "hive")
       .set("spark.sql.catalog.spark_catalog", classOf[SparkGenericCatalog[_]].getName)
-      .set(s"spark.sql.catalog.$paimonHiveCatalog", classOf[SparkCatalog].getName)
-      .set(s"spark.sql.catalog.$paimonHiveCatalog.metastore", "hive")
-      .set(s"spark.sql.catalog.$paimonHiveCatalog.warehouse", tempHiveDBDir.getCanonicalPath)
+      .set(s"spark.sql.catalog.$paimonHiveCatalogName", classOf[SparkCatalog].getName)
+      .set(s"spark.sql.catalog.$paimonHiveCatalogName.metastore", "hive")
+      .set(s"spark.sql.catalog.$paimonHiveCatalogName.warehouse", tempHiveDBDir.getCanonicalPath)
   }
 
   override protected def beforeAll(): Unit = {
@@ -53,7 +53,6 @@ class PaimonHiveTestBase extends PaimonSparkTestBase {
     super.beforeAll()
     spark.sql(s"USE spark_catalog")
     spark.sql(s"CREATE DATABASE IF NOT EXISTS $hiveDbName")
-    spark.sql(s"USE $hiveDbName")
   }
 
   override protected def afterAll(): Unit = {
@@ -70,5 +69,6 @@ class PaimonHiveTestBase extends PaimonSparkTestBase {
   /** Default is spark_catalog */
   override protected def beforeEach(): Unit = {
     spark.sql(s"USE spark_catalog")
+    spark.sql(s"USE $hiveDbName")
   }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -58,12 +58,12 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession with WithTab
     super.beforeAll()
     spark.sql(s"USE paimon")
     spark.sql(s"CREATE DATABASE IF NOT EXISTS paimon.$dbName0")
-    spark.sql(s"USE paimon.$dbName0")
   }
 
   override protected def afterAll(): Unit = {
     try {
       spark.sql(s"USE paimon")
+      spark.sql(s"DROP TABLE IF EXISTS $dbName0.$tableName0")
       spark.sql("USE default")
       spark.sql(s"DROP DATABASE paimon.$dbName0 CASCADE")
     } finally {
@@ -75,6 +75,7 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession with WithTab
   override protected def beforeEach(): Unit = {
     super.beforeAll()
     spark.sql(s"USE paimon")
+    spark.sql(s"USE paimon.$dbName0")
     spark.sql(s"DROP TABLE IF EXISTS $tableName0")
   }
 
@@ -92,8 +93,8 @@ class PaimonSparkTestBase extends QueryTest with SharedSparkSession with WithTab
     val currentCatalog = spark.sessionState.catalogManager.currentCatalog.name()
     val options = Catalogs.catalogOptions(currentCatalog, spark.sessionState.conf)
     val catalogContext =
-      CatalogContext.create(Options.fromMap(options), spark.sessionState.newHadoopConf());
-    CatalogFactory.createCatalog(catalogContext);
+      CatalogContext.create(Options.fromMap(options), spark.sessionState.newHadoopConf())
+    CatalogFactory.createCatalog(catalogContext)
   }
 
   def loadTable(tableName: String): AbstractFileStoreTable = {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -28,7 +28,7 @@ import org.assertj.core.api.Assertions
 
 import java.util
 
-/** Test sort compact procedure. See [[CompactProcedure]]. */
+/** Test compact procedure. See [[CompactProcedure]]. */
 abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamTest {
 
   import testImplicits._

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.procedure
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.spark.analysis.NoSuchProcedureException
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+
+abstract class ProcedureTestBase extends PaimonSparkTestBase {
+
+  test(s"test call unknown procedure") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, dt STRING)
+                 |""".stripMargin)
+
+    assertThatThrownBy(() => spark.sql("CALL unknown_procedure(table => 'test.T')"))
+      .isInstanceOf(classOf[NoSuchProcedureException])
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assertions
 class DDLWithHiveCatalogTest extends PaimonHiveTestBase {
 
   test("Paimon DDL with hive catalog: create database with location and comment") {
-    Seq("spark_catalog", paimonHiveCatalog).foreach {
+    Seq("spark_catalog", paimonHiveCatalogName).foreach {
       catalogName =>
         spark.sql(s"USE $catalogName")
         withTempDir {
@@ -52,7 +52,7 @@ class DDLWithHiveCatalogTest extends PaimonHiveTestBase {
   }
 
   test("Paimon DDL with hive catalog: create database with props") {
-    Seq("spark_catalog", paimonHiveCatalog).foreach {
+    Seq("spark_catalog", paimonHiveCatalogName).foreach {
       catalogName =>
         spark.sql(s"USE $catalogName")
         withDatabase("paimon_db") {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
@@ -33,7 +33,7 @@ class DeleteFromTableTest extends PaimonSparkTestBase {
     spark.sql("INSERT INTO T VALUES (1, 'a', '11'), (2, 'b', '22')")
 
     assertThatThrownBy(() => spark.sql("DELETE FROM T WHERE name = 'a'"))
-      .isInstanceOf(classOf[UnsupportedOperationException]);
+      .isInstanceOf(classOf[UnsupportedOperationException])
   }
 
   CoreOptions.MergeEngine.values().foreach {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
@@ -25,14 +25,17 @@ import org.apache.spark.sql.catalyst.plans.logical.{CTERelationDef, LogicalPlan,
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.functions._
 
-abstract class PaimonOptimzationTestBase extends PaimonSparkTestBase {
+import scala.collection.immutable
+
+abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase {
 
   import org.apache.spark.sql.catalyst.dsl.expressions._
   import org.apache.spark.sql.catalyst.dsl.plans._
   import testImplicits._
 
   private object Optimize extends RuleExecutor[LogicalPlan] {
-    val batches = Batch("MergePaimonScalarSubqueries", Once, MergePaimonScalarSubqueriers) :: Nil
+    val batches: immutable.Seq[Batch] =
+      Batch("MergePaimonScalarSubqueries", Once, MergePaimonScalarSubqueriers) :: Nil
   }
 
   test("Paimon Optimization: merge scalar subqueries") {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- https://github.com/apache/incubator-paimon/pull/2707 make `CompactProcedureTestBase` abstract, and only test at spark3.2, we need add it to spark3.5 too
- other typo (￣▽￣)...

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
