### PR TITLE
[spark] Fix filter push down failed while triggers a sort compact job

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -320,7 +320,13 @@ public class CompactProcedure extends BaseProcedure {
                 .map(
                         a ->
                                 a.entrySet().stream()
-                                        .map(entry -> entry.getKey() + "=" + entry.getValue())
+                                        .map(
+                                                entry ->
+                                                        entry.getKey()
+                                                                + "="
+                                                                + "'"
+                                                                + entry.getValue()
+                                                                + "'")
                                         .reduce((s0, s1) -> s0 + " AND " + s1))
                 .filter(Optional::isPresent)
                 .map(Optional::get)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

We can spell date=2023-01-01 in row.where(). We need to add "'", convert to date='2023-01-01'.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
