### PR TITLE
[core] Introduce 'scan.version' to refactor spark time travel

### DIFF
--- a/docs/content/how-to/querying-tables.md
+++ b/docs/content/how-to/querying-tables.md
@@ -87,6 +87,12 @@ SELECT * FROM t TIMESTAMP AS OF 1678883047;
 SELECT * FROM t VERSION AS OF 'my-tag';
 ```
 
+{{< hint warning >}}
+If tag's name is a number and equals to a snapshot id, the VERSION AS OF syntax will consider tag first. For example, if 
+you have a tag named '1' based on snapshot 2, the statement `SELECT * FROM t VERSION AS OF '1'` actually queries snapshot 2 
+instead of snapshot 1.
+{{< /hint >}}
+
 {{< /tab >}}
 
 {{< tab "Spark3-DF" >}}

--- a/docs/content/maintenance/manage-tags.md
+++ b/docs/content/maintenance/manage-tags.md
@@ -92,7 +92,7 @@ See [Query Tables]({{< ref "how-to/querying-tables" >}}) to see more query for e
 
 ## Create Tags
 
-You can create a tag with given name (cannot be number) and snapshot ID.
+You can create a tag with given name and snapshot ID.
 
 {{< tabs "create-tag" >}}
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -529,6 +529,15 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Optional tag name used in case of \"from-snapshot\" scan mode.");
 
+    @ExcludeFromDocumentation("Internal use only")
+    public static final ConfigOption<String> SCAN_VERSION =
+            key("scan.version")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify the time travel version string used in 'VERSION AS OF' syntax. "
+                                    + "We will use tag when both tag and snapshot of that version exist.");
+
     public static final ConfigOption<Long> SCAN_BOUNDED_WATERMARK =
             key("scan.bounded.watermark")
                     .longType()
@@ -1334,7 +1343,8 @@ public class CoreOptions implements Serializable {
             if (options.getOptional(SCAN_TIMESTAMP_MILLIS).isPresent()) {
                 return StartupMode.FROM_TIMESTAMP;
             } else if (options.getOptional(SCAN_SNAPSHOT_ID).isPresent()
-                    || options.getOptional(SCAN_TAG_NAME).isPresent()) {
+                    || options.getOptional(SCAN_TAG_NAME).isPresent()
+                    || options.getOptional(SCAN_VERSION).isPresent()) {
                 return StartupMode.FROM_SNAPSHOT;
             } else if (options.getOptional(SCAN_FILE_CREATION_TIME_MILLIS).isPresent()) {
                 return StartupMode.FROM_FILE_CREATION_TIME;
@@ -1369,6 +1379,10 @@ public class CoreOptions implements Serializable {
 
     public String scanTagName() {
         return options.get(SCAN_TAG_NAME);
+    }
+
+    public String scanVersion() {
+        return options.get(SCAN_VERSION);
     }
 
     public Pair<String, String> incrementalBetween() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -337,6 +337,8 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
         if (tagManager.tagExists(version)) {
             return travelToSnapshot(tagManager.taggedSnapshot(version), options);
         } else if (version.chars().allMatch(Character::isDigit)) {
+            options.remove(CoreOptions.SCAN_TAG_NAME.key());
+            options.set(CoreOptions.SCAN_SNAPSHOT_ID.key(), version);
             return travelToSnapshot(Long.parseLong(version), options);
         }
         return Optional.empty();

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -223,12 +223,9 @@ public class SparkCatalog extends SparkBaseCatalog {
      */
     public SparkTable loadTable(Identifier ident, String version) throws NoSuchTableException {
         Table table = loadPaimonTable(ident);
-        Options dynamicOptions = new Options();
-
         LOG.info("Time travel to version '{}'.", version);
-        dynamicOptions.set(CoreOptions.SCAN_VERSION, version);
-
-        return new SparkTable(table.copy(dynamicOptions.toMap()));
+        return new SparkTable(
+                table.copy(Collections.singletonMap(CoreOptions.SCAN_VERSION.key(), version)));
     }
 
     /**

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -225,8 +225,8 @@ public class SparkCatalog extends SparkBaseCatalog {
         Table table = loadPaimonTable(ident);
         Options dynamicOptions = new Options();
 
-        LOG.info("Time travel to version '{}' (tag first).", version);
-        dynamicOptions.set(CoreOptions.SCAN_TAG_NAME, version);
+        LOG.info("Time travel to version '{}'.", version);
+        dynamicOptions.set(CoreOptions.SCAN_VERSION, version);
 
         return new SparkTable(table.copy(dynamicOptions.toMap()));
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -225,14 +225,8 @@ public class SparkCatalog extends SparkBaseCatalog {
         Table table = loadPaimonTable(ident);
         Options dynamicOptions = new Options();
 
-        if (version.chars().allMatch(Character::isDigit)) {
-            long snapshotId = Long.parseUnsignedLong(version);
-            LOG.info("Time travel to snapshot '{}'.", snapshotId);
-            dynamicOptions.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshotId);
-        } else {
-            LOG.info("Time travel to tag '{}'.", version);
-            dynamicOptions.set(CoreOptions.SCAN_TAG_NAME, version);
-        }
+        LOG.info("Time travel to version '{}' (tag first).", version);
+        dynamicOptions.set(CoreOptions.SCAN_TAG_NAME, version);
 
         return new SparkTable(table.copy(dynamicOptions.toMap()));
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTimeTravelITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTimeTravelITCase.java
@@ -235,7 +235,8 @@ public class SparkTimeTravelITCase extends SparkReadTestBase {
                         () -> spark.sql("SELECT * FROM t VERSION AS OF 'unknown'").collectAsList())
                 .satisfies(
                         AssertionUtils.anyCauseMatches(
-                                IllegalArgumentException.class, "Tag 'unknown' doesn't exist."));
+                                RuntimeException.class,
+                                "Cannot find a time travel version for unknown"));
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTimeTravelITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTimeTravelITCase.java
@@ -274,4 +274,28 @@ public class SparkTimeTravelITCase extends SparkReadTestBase {
         assertThat(spark.sql("SELECT * FROM t VERSION AS OF 'tag2'").collectAsList().toString())
                 .isEqualTo("[[1,Hello], [2,Paimon], [3,Test], [4,Case]]");
     }
+
+    @Test
+    public void testTravelToTagWithDigitalName() throws Exception {
+        spark.sql("CREATE TABLE t (k INT, v STRING)");
+
+        // snapshot 1
+        writeTable(
+                "t",
+                GenericRow.of(1, BinaryString.fromString("Hello")),
+                GenericRow.of(2, BinaryString.fromString("Paimon")));
+
+        // snapshot 2
+        writeTable(
+                "t",
+                GenericRow.of(3, BinaryString.fromString("Test")),
+                GenericRow.of(4, BinaryString.fromString("Case")));
+
+        FileStoreTable table = getTable("t");
+        table.createTag("1", 2);
+
+        // time travel to tag '1'
+        assertThat(spark.sql("SELECT * FROM t VERSION AS OF '1'").collectAsList().toString())
+                .isEqualTo("[[1,Hello], [2,Paimon], [3,Test], [4,Case]]");
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
After #2566, a tag name can be a number, so spark time travel to a number version string may be confused (the version string is a tag or a snapshot ?)
This PR fix it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
