### PR TITLE
[core] Fix bug: zindexer should deal well with column `null` value.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
@@ -390,6 +390,7 @@ public class ZIndexer implements Serializable {
         }
     }
 
+    /** Process function interface. */
     public interface ZProcessFunction
             extends BiFunction<InternalRow, ByteBuffer, byte[]>, Serializable {}
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

If a column is null, ZIndexer will throws an exception. It shouldn't get the null row:

```sql
                -- it is not correct to get the string before check if it is null.
                BinaryString binaryString = row.getString(fieldIndex);

                return row.isNullAt(fieldIndex)
                        ? NULL_BYTES
                        : ZOrderByteUtils.byteTruncateOrFill(
                                        MemorySegmentUtils.getBytes(
                                                binaryString.getSegments(),
                                                binaryString.getOffset(),
                                                Math.min(
                                                        varTypeSize,
                                                        binaryString.getSizeInBytes())),
                                        varTypeSize,
                                        reuse)
                                .array();
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
