### PR TITLE
[format]Fix orc and parquet writer about timestamp not contains [local timezone] and [is_adjust_to_utc]

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
@@ -74,8 +74,9 @@ public class OrcSplitReaderUtil {
             case DATE:
                 return TypeDescription.createDate();
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return TypeDescription.createTimestamp();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return TypeDescription.createTimestampInstant();
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 return TypeDescription.createList(toOrcType(arrayType.getElementType()));

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -115,11 +115,11 @@ public class ParquetSchemaConverter {
             case TIMESTAMP_WITHOUT_TIME_ZONE:
                 TimestampType timestampType = (TimestampType) type;
                 return createTimestampWithLogicalType(
-                        name, timestampType.getPrecision(), repetition);
+                        name, timestampType.getPrecision(), repetition, false);
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 LocalZonedTimestampType localZonedTimestampType = (LocalZonedTimestampType) type;
                 return createTimestampWithLogicalType(
-                        name, localZonedTimestampType.getPrecision(), repetition);
+                        name, localZonedTimestampType.getPrecision(), repetition, true);
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 return ConversionPatterns.listOfElements(
@@ -151,13 +151,15 @@ public class ParquetSchemaConverter {
     }
 
     private static Type createTimestampWithLogicalType(
-            String name, int precision, Type.Repetition repetition) {
+            String name, int precision, Type.Repetition repetition, boolean isAdjustToUTC) {
         if (precision <= 3) {
-            return Types.primitive(INT64, repetition).as(OriginalType.TIMESTAMP_MILLIS).named(name);
+            return Types.primitive(INT64, repetition)
+                    .as(LogicalTypeAnnotation.timestampType(isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MILLIS)).named(name);
         } else if (precision > 6) {
             return Types.primitive(PrimitiveType.PrimitiveTypeName.INT96, repetition).named(name);
         } else {
-            return Types.primitive(INT64, repetition).as(OriginalType.TIMESTAMP_MICROS).named(name);
+            return Types.primitive(INT64, repetition)
+                    .as(LogicalTypeAnnotation.timestampType(isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MICROS)).named(name);
         }
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -154,12 +154,18 @@ public class ParquetSchemaConverter {
             String name, int precision, Type.Repetition repetition, boolean isAdjustToUTC) {
         if (precision <= 3) {
             return Types.primitive(INT64, repetition)
-                    .as(LogicalTypeAnnotation.timestampType(isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MILLIS)).named(name);
+                    .as(
+                            LogicalTypeAnnotation.timestampType(
+                                    isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MILLIS))
+                    .named(name);
         } else if (precision > 6) {
             return Types.primitive(PrimitiveType.PrimitiveTypeName.INT96, repetition).named(name);
         } else {
             return Types.primitive(INT64, repetition)
-                    .as(LogicalTypeAnnotation.timestampType(isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MICROS)).named(name);
+                    .as(
+                            LogicalTypeAnnotation.timestampType(
+                                    isAdjustToUTC, LogicalTypeAnnotation.TimeUnit.MICROS))
+                    .named(name);
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Now, paimon timestamp type lost some metadata
orc file Type meta not contains timestamp with local zone, just timestamp type
parquet file file schema meta not contains adjust to UTC   
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
