### PR TITLE
[doc] Use underscore instead of hyphen for rollback_to in doc.

### DIFF
--- a/docs/content/maintenance/manage-snapshots.md
+++ b/docs/content/maintenance/manage-snapshots.md
@@ -239,7 +239,7 @@ Run the following command:
 ```bash
 <FLINK_HOME>/bin/flink run \
     /path/to/paimon-flink-action-{{< version >}}.jar \
-    rollback-to \
+    rollback_to \
     --warehouse <warehouse-path> \
     --database <database-name> \ 
     --table <table-name> \

--- a/docs/content/maintenance/manage-tags.md
+++ b/docs/content/maintenance/manage-tags.md
@@ -211,7 +211,7 @@ Run the following command:
 ```bash
 <FLINK_HOME>/bin/flink run \
     /path/to/paimon-flink-action-{{< version >}}.jar \
-    rollback-to \
+    rollback_to \
     --warehouse <warehouse-path> \
     --database <database-name> \ 
     --table <table-name> \


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change -->
[doc] Use underscore instead of hyphen for rollback_to in doc.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
