### PR TITLE
[hotfix] The new column exception shows the specific column name in the cdc database synchronization action.

### DIFF
--- a/docs/content/program-api/java-api.md
+++ b/docs/content/program-api/java-api.md
@@ -310,7 +310,7 @@ public class RenameTable {
 
 You can use the catalog to alter a table, but you need to pay attention to the following points.
 
-- Add column cannot specify NOT NULL.
+- Column %s cannot specify NOT NULL in the %s table.
 - Cannot update partition column type in the table.
 - Cannot change nullability of primary key.
 - If the type of the column is nested row type, update the column type is not supported.

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -189,7 +189,9 @@ public class SchemaManager implements Serializable {
                     }
                     Preconditions.checkArgument(
                             addColumn.dataType().isNullable(),
-                            "ADD COLUMN cannot specify NOT NULL.");
+                            "Column %s cannot specify NOT NULL in the %s table.",
+                            addColumn.fieldName(),
+                            fromPath(tableRoot.toString(), true).getFullName());
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =
                             ReassignFieldId.reassign(addColumn.dataType(), highestFieldId);

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -264,7 +264,10 @@ public class SchemaEvolutionTest {
                                                         null,
                                                         null))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("ADD COLUMN cannot specify NOT NULL.");
+                .hasMessage(
+                        String.format(
+                                "Column %s cannot specify NOT NULL in the %s table.",
+                                "f4", identifier.getFullName()));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -221,8 +221,9 @@ public class CdcActionCommonUtils {
             for (String key : specifiedPrimaryKeys) {
                 checkArgument(
                         sourceColumns.contains(key),
-                        "Specified primary key '%s' does not exist in source tables or computed columns.",
-                        key);
+                        "Specified primary key '%s' does not exist in source tables or computed columns %s.",
+                        key,
+                        sourceColumns);
             }
             builder.primaryKey(listCaseConvert(specifiedPrimaryKeys, caseSensitive));
         } else if (!sourceSchema.primaryKeys().isEmpty()) {

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -667,7 +667,7 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Specified primary key 'pk' does not exist in source tables or computed columns."));
+                                "Specified primary key 'pk' does not exist in source tables or computed columns [pt, _id, v1]."));
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -101,7 +101,7 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "ADD COLUMN cannot specify NOT NULL."));
+                                "Column d cannot specify NOT NULL in the default.testAddNotNullColumn table."));
     }
 
     @Test


### PR DESCRIPTION
…

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The new column exception shows the specific column name in the cdc database synchronization action.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
