### PR TITLE
[core] Support skip rewrite when upgrade in ChangelogMergeTreeRewriter

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
@@ -95,6 +95,10 @@ public class KeyValue {
         return valueKind;
     }
 
+    public boolean isAdd() {
+        return valueKind.isAdd();
+    }
+
     public InternalRow value() {
         return value;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -169,7 +169,7 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                     outputLevel,
                     Collections.singletonList(
                             Collections.singletonList(SortedRun.fromSingle(file))),
-                    !canSkipRewriteCompactFile(outputLevel));
+                    !rewriteCompactFileForUpgrade(outputLevel));
         } else {
             return super.upgrade(outputLevel, file);
         }
@@ -183,7 +183,7 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
      *   <li>outputLevel == maxLevel, no previous records
      * </ul>
      */
-    private boolean canSkipRewriteCompactFile(int outputLevel) {
+    private boolean rewriteCompactFileForUpgrade(int outputLevel) {
         return mergeEngine == CoreOptions.MergeEngine.DEDUPLICATE || outputLevel == maxLevel;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -183,7 +183,7 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
      *   <li>outputLevel == maxLevel, no previous records
      * </ul>
      */
-    protected boolean canSkipRewriteCompactFile(int outputLevel) {
+    private boolean canSkipRewriteCompactFile(int outputLevel) {
         return mergeEngine == CoreOptions.MergeEngine.DEDUPLICATE || outputLevel == maxLevel;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.compact.CompactResult;
@@ -35,14 +36,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
-/** A {@link MergeTreeCompactRewriter} which produces changelog files for the compaction. */
+/**
+ * A {@link MergeTreeCompactRewriter} which produces changelog files while performing compaction.
+ */
 public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewriter {
 
+    protected final int maxLevel;
+    protected final CoreOptions.MergeEngine mergeEngine;
     protected final RecordEqualiser valueEqualiser;
     protected final boolean changelogRowDeduplicate;
 
     public ChangelogMergeTreeRewriter(
+            int maxLevel,
+            CoreOptions.MergeEngine mergeEngine,
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
@@ -51,6 +59,8 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             RecordEqualiser valueEqualiser,
             boolean changelogRowDeduplicate) {
         super(readerFactory, writerFactory, keyComparator, mfFactory, mergeSorter);
+        this.maxLevel = maxLevel;
+        this.mergeEngine = mergeEngine;
         this.valueEqualiser = valueEqualiser;
         this.changelogRowDeduplicate = changelogRowDeduplicate;
     }
@@ -83,14 +93,20 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
     public CompactResult rewrite(
             int outputLevel, boolean dropDelete, List<List<SortedRun>> sections) throws Exception {
         if (rewriteChangelog(outputLevel, dropDelete, sections)) {
-            return rewriteChangelogCompaction(outputLevel, sections);
+            return rewriteChangelogCompaction(outputLevel, sections, true);
         } else {
             return rewriteCompaction(outputLevel, dropDelete, sections);
         }
     }
 
+    /**
+     * Rewrite and produce changelog at the same time.
+     *
+     * @param rewriteCompactFile whether to rewrite compact file
+     */
     private CompactResult rewriteChangelogCompaction(
-            int outputLevel, List<List<SortedRun>> sections) throws Exception {
+            int outputLevel, List<List<SortedRun>> sections, boolean rewriteCompactFile)
+            throws Exception {
         List<ConcatRecordReader.ReaderSupplier<ChangelogResult>> sectionReaders = new ArrayList<>();
         for (List<SortedRun> section : sections) {
             sectionReaders.add(
@@ -109,12 +125,14 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
 
         try {
             iterator = new RecordReaderIterator<>(ConcatRecordReader.create(sectionReaders));
-            compactFileWriter = writerFactory.createRollingMergeTreeFileWriter(outputLevel);
+            if (rewriteCompactFile) {
+                compactFileWriter = writerFactory.createRollingMergeTreeFileWriter(outputLevel);
+            }
             changelogFileWriter = writerFactory.createRollingChangelogFileWriter(outputLevel);
 
             while (iterator.hasNext()) {
                 ChangelogResult result = iterator.next();
-                if (result.result() != null) {
+                if (rewriteCompactFile && result.result() != null) {
                     compactFileWriter.write(result.result());
                 }
                 for (KeyValue kv : result.changelogs()) {
@@ -133,10 +151,15 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             }
         }
 
-        return new CompactResult(
-                extractFilesFromSections(sections),
-                compactFileWriter.result(),
-                changelogFileWriter.result());
+        List<DataFileMeta> before = extractFilesFromSections(sections);
+        List<DataFileMeta> after =
+                rewriteCompactFile
+                        ? compactFileWriter.result()
+                        : before.stream()
+                                .map(x -> x.upgrade(outputLevel))
+                                .collect(Collectors.toList());
+
+        return new CompactResult(before, after, changelogFileWriter.result());
     }
 
     @Override
@@ -145,9 +168,22 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             return rewriteChangelogCompaction(
                     outputLevel,
                     Collections.singletonList(
-                            Collections.singletonList(SortedRun.fromSingle(file))));
+                            Collections.singletonList(SortedRun.fromSingle(file))),
+                    !canSkipRewriteCompactFile(outputLevel));
         } else {
             return super.upgrade(outputLevel, file);
         }
+    }
+
+    /**
+     * For upgrade, there are two scenarios can skip rewrite compact file.
+     *
+     * <ul>
+     *   <li>mergeEngine == DEDUPLICATE, no need to consider previous records
+     *   <li>outputLevel == maxLevel, no previous records
+     * </ul>
+     */
+    protected boolean canSkipRewriteCompactFile(int outputLevel) {
+        return mergeEngine == CoreOptions.MergeEngine.DEDUPLICATE || outputLevel == maxLevel;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/CompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/CompactRewriter.java
@@ -25,11 +25,32 @@ import org.apache.paimon.mergetree.SortedRun;
 import java.io.Closeable;
 import java.util.List;
 
-/** Rewrite sections to the files. */
+/** Rewrite sections to new level. */
 public interface CompactRewriter extends Closeable {
 
+    /**
+     * Rewrite sections to new level.
+     *
+     * @param outputLevel new level
+     * @param dropDelete whether to drop the deletion, see {@link
+     *     MergeTreeCompactManager#triggerCompaction}
+     * @param sections list of sections (section is a list of {@link SortedRun}s, and key intervals
+     *     between sections do not overlap)
+     * @return compaction result
+     * @throws Exception exception
+     */
     CompactResult rewrite(int outputLevel, boolean dropDelete, List<List<SortedRun>> sections)
             throws Exception;
 
+    /**
+     * Upgrade file to new level, usually file data is not rewritten, only the metadata is updated.
+     * But in some certain scenarios, we must rewrite file too, e.g. {@link
+     * ChangelogMergeTreeRewriter}
+     *
+     * @param outputLevel new level
+     * @param file file to be updated
+     * @return compaction result
+     * @throws Exception exception
+     */
     CompactResult upgrade(int outputLevel, DataFileMeta file) throws Exception;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.codegen.RecordEqualiser;
@@ -46,6 +47,8 @@ public class FirstRowMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter
     private final ContainsLevels containsLevels;
 
     public FirstRowMergeTreeCompactRewriter(
+            int maxLevel,
+            CoreOptions.MergeEngine mergeEngine,
             ContainsLevels containsLevels,
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
@@ -55,6 +58,8 @@ public class FirstRowMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter
             RecordEqualiser valueEqualiser,
             boolean changelogRowDeduplicate) {
         super(
+                maxLevel,
+                mergeEngine,
                 readerFactory,
                 writerFactory,
                 keyComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeFunctionWrapper.java
@@ -100,11 +100,11 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
         if (isInitialized) {
             KeyValue merged = mergeFunction.getResult();
             if (topLevelKv == null) {
-                if (merged != null && isAdd(merged)) {
+                if (merged != null && merged.isAdd()) {
                     reusedResult.addChangelog(replace(reusedAfter, RowKind.INSERT, merged));
                 }
             } else {
-                if (merged == null || !isAdd(merged)) {
+                if (merged == null || !merged.isAdd()) {
                     reusedResult.addChangelog(replace(reusedBefore, RowKind.DELETE, topLevelKv));
                 } else if (!changelogRowDeduplicate
                         || !valueEqualiser.equals(topLevelKv.value(), merged.value())) {
@@ -115,7 +115,7 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
             }
             return reusedResult.setResultIfNotRetract(merged);
         } else {
-            if (topLevelKv == null && isAdd(initialKv)) {
+            if (topLevelKv == null && initialKv.isAdd()) {
                 reusedResult.addChangelog(replace(reusedAfter, RowKind.INSERT, initialKv));
             }
             // either topLevelKv is not null, but there is only one kv,
@@ -128,9 +128,5 @@ public class FullChangelogMergeFunctionWrapper implements MergeFunctionWrapper<C
 
     private KeyValue replace(KeyValue reused, RowKind valueKind, KeyValue from) {
         return reused.replace(from.key(), from.sequenceNumber(), valueKind, from.value());
-    }
-
-    private boolean isAdd(KeyValue kv) {
-        return kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -36,8 +36,6 @@ import java.util.List;
 /** A {@link MergeTreeCompactRewriter} which produces changelog files for each full compaction. */
 public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
 
-    private final int maxLevel;
-
     public FullChangelogMergeTreeCompactRewriter(
             int maxLevel,
             CoreOptions.MergeEngine mergeEngine,
@@ -58,7 +56,6 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
                 mergeSorter,
                 valueComparator,
                 changelogRowDeduplicate);
-        this.maxLevel = maxLevel;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
@@ -39,6 +40,7 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
 
     public FullChangelogMergeTreeCompactRewriter(
             int maxLevel,
+            CoreOptions.MergeEngine mergeEngine,
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
@@ -47,6 +49,8 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
             RecordEqualiser valueComparator,
             boolean changelogRowDeduplicate) {
         super(
+                maxLevel,
+                mergeEngine,
                 readerFactory,
                 writerFactory,
                 keyComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -100,7 +100,6 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
 
         // 2. With level 0, with the latest high level, return changelog
         if (highLevel != null) {
-            // For first row, we should just return old value. And produce no changelog.
             setChangelog(highLevel, result);
             return reusedResult.setResult(result);
         }
@@ -121,12 +120,12 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
     }
 
     private void setChangelog(KeyValue before, KeyValue after) {
-        if (before == null || !isAdd(before)) {
-            if (isAdd(after)) {
+        if (before == null || !before.isAdd()) {
+            if (after.isAdd()) {
                 reusedResult.addChangelog(replaceAfter(RowKind.INSERT, after));
             }
         } else {
-            if (!isAdd(after)) {
+            if (!after.isAdd()) {
                 reusedResult.addChangelog(replaceBefore(RowKind.DELETE, before));
             } else if (!changelogRowDeduplicate
                     || !valueEqualiser.equals(before.value(), after.value())) {
@@ -147,9 +146,5 @@ public class LookupChangelogMergeFunctionWrapper implements MergeFunctionWrapper
 
     private KeyValue replace(KeyValue reused, RowKind valueKind, KeyValue from) {
         return reused.replace(from.key(), from.sequenceNumber(), valueKind, from.value());
-    }
-
-    private boolean isAdd(KeyValue kv) {
-        return kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
@@ -42,6 +43,8 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
     private final LookupLevels lookupLevels;
 
     public LookupMergeTreeCompactRewriter(
+            int maxLevel,
+            CoreOptions.MergeEngine mergeEngine,
             LookupLevels lookupLevels,
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
@@ -51,6 +54,8 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
             RecordEqualiser valueEqualiser,
             boolean changelogRowDeduplicate) {
         super(
+                maxLevel,
+                mergeEngine,
                 readerFactory,
                 writerFactory,
                 keyComparator,

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/LookupCompactionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/LookupCompactionTest.scala
@@ -30,7 +30,7 @@ class LookupCompactionTest extends PaimonSparkTestBase {
     CoreOptions.MergeEngine.values().foreach {
       mergeEngine =>
         withTable("T") {
-          val extraOptions = if ("aggregation".equals(mergeEngine.toString)) {
+          val extraOptions = if (mergeEngine == CoreOptions.MergeEngine.AGGREGATE) {
             s", 'fields.count.aggregate-function' = 'sum'"
           } else {
             ""

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/LookupCompactionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/LookupCompactionTest.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.fs.{FileStatus, Path}
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.junit.jupiter.api.Assertions
+
+class LookupCompactionTest extends PaimonSparkTestBase {
+
+  test("Paimon lookup compaction: number of data file written") {
+    CoreOptions.MergeEngine.values().foreach {
+      mergeEngine =>
+        withTable("T") {
+          spark.sql(
+            s"""
+               |CREATE TABLE T (id INT, name STRING, count INT)
+               |TBLPROPERTIES ('primary-key' = 'id', 'merge-engine' = '$mergeEngine', 'changelog-producer' = 'lookup')
+               |""".stripMargin)
+
+          val table = loadTable("T")
+          val tabLocation = table.location()
+          val fileIO = table.fileIO()
+
+          // First insert, file is upgraded to the max level when compaction, no need rewrite
+          spark.sql("INSERT INTO T VALUES (1, 'aaaaaaaaaaa', 1), (2, 'b', 2)")
+          var files = fileIO.listStatus(new Path(tabLocation, "bucket-0"))
+          Assertions.assertEquals(1, dataFileCount(files))
+
+          spark.sql("INSERT INTO T VALUES (3, 'b', 3)")
+          files = fileIO.listStatus(new Path(tabLocation, "bucket-0"))
+          // Second insert, file is upgraded to other lower level when compaction, only DEDUPLICATE can skip rewrite
+          if (mergeEngine == CoreOptions.MergeEngine.DEDUPLICATE) {
+            Assertions.assertEquals(2, dataFileCount(files))
+          } else {
+            println(mergeEngine)
+            Assertions.assertEquals(3, dataFileCount(files))
+          }
+        }
+    }
+  }
+
+  private def dataFileCount(files: Array[FileStatus]): Int = {
+    files.count(f => f.getPath.getName.startsWith("data"))
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support skip rewrite when upgrade in ChangelogMergeTreeRewriter, e.g.

```sql
CREATE TABLE IF NOT EXISTS T ("a INT, b INT, c STRING, PRIMARY KEY (a) NOT ENFORCED)
WITH ('merge-engine'='deduplicate', 'file.format'='avro', 'changelog-producer' = 'lookup');

INSERT INTO T VALUES (1, 1, '1')
```

before: rewrite a new file, even we just insert one record
```
bucket-0
├── changelog-a17ac0b1-85b8-4086-a79d-bcfb674ef628-1.avro
├── data-a17ac0b1-85b8-4086-a79d-bcfb674ef628-0.avro
└── data-d12c0084-4da4-4f7c-b57b-abecd360a13b-0.avro
```

after: just upgrade, no new file
```
bucket-0
├── changelog-cf80d9df-ed66-464f-a37e-06e14e3811e4-0.avro
└── data-8b9c5336-f96f-4b10-bd55-d1f83c45f982-0.avro
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
