### PR TITLE
[hive] Fix paimon table comment cannot be synchronized to hive metastore

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -95,7 +95,7 @@ public class HiveCatalog extends AbstractCatalog {
     private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
     // Reserved properties
-    public static final String DB_COMMENT_PROP = "comment";
+    public static final String COMMENT_PROP = "comment";
     public static final String TABLE_TYPE_PROP = "table_type";
     public static final String PAIMON_TABLE_TYPE_VALUE = "paimon";
 
@@ -242,7 +242,7 @@ public class HiveCatalog extends AbstractCatalog {
         Map<String, String> parameter = new HashMap<>();
         properties.forEach(
                 (key, value) -> {
-                    if (key.equals(DB_COMMENT_PROP)) {
+                    if (key.equals(COMMENT_PROP)) {
                         database.setDescription(value);
                     } else if (key.equals(DB_LOCATION_PROP)) {
                         database.setLocationUri(value);
@@ -270,7 +270,7 @@ public class HiveCatalog extends AbstractCatalog {
             properties.put(DB_LOCATION_PROP, database.getLocationUri());
         }
         if (database.getDescription() != null) {
-            properties.put(DB_COMMENT_PROP, database.getDescription());
+            properties.put(COMMENT_PROP, database.getDescription());
         }
         return properties;
     }
@@ -556,6 +556,9 @@ public class HiveCatalog extends AbstractCatalog {
                             .collect(Collectors.toList()));
         }
         table.setSd(sd);
+        if (schema.comment() != null) {
+            table.getParameters().put(COMMENT_PROP, schema.comment());
+        }
 
         // update location
         locationHelper.specifyTableLocation(table, getDataTableLocation(identifier).toString());

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -194,7 +194,7 @@ public class HiveCatalogTest extends CatalogTestBase {
                             Collections.emptyList(),
                             Collections.emptyList(),
                             options,
-                            "");
+                            "this is a hive table");
 
             catalog.createTable(
                     Identifier.create(databaseName, tableName),
@@ -210,6 +210,7 @@ public class HiveCatalogTest extends CatalogTestBase {
             // Verify the transformed parameters
             assertThat(tableProperties).containsEntry("table.owner", "Jon");
             assertThat(tableProperties).containsEntry("storage.format", "ORC");
+            assertThat(tableProperties).containsEntry("comment", "this is a hive table");
             assertThat(tableProperties)
                     .containsEntry(
                             TABLE_TYPE_PROP, PAIMON_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT));


### PR DESCRIPTION

### Purpose
Fix paimon table comment cannot be synchronized to hive metastore

### Tests
HiveCatalogTest.testAddHiveTableParameters

assertThat(tableProperties).containsEntry("comment", "this is a hive table");
### API and Format

### Documentation
