### PR TITLE
[core]: fix flaky test `testSavepointTag`.

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoCreationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 
 import static org.apache.paimon.CoreOptions.SINK_WATERMARK_TIME_ZONE;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
@@ -239,7 +240,8 @@ public class TagAutoCreationTest extends PrimaryKeyTableTestBase {
 
         // test newCommit create
         commit.commit(new ManifestCommittable(1, utcMills("2023-07-18T14:00:00")));
-        assertThat(tagManager.tags().values()).contains("2023-07-18 11", "2023-07-18 13");
+        assertThat(tagManager.tags(name -> !Objects.equals("savepoint-11", name)).values())
+                .contains("2023-07-18 11", "2023-07-18 13");
 
         // test expire old tag
         commit.commit(new ManifestCommittable(2, utcMills("2023-07-18T15:00:00")));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
`testSavepointTag` is flaky,  this test will fail on CentOS. 
The reason is that when using  `tagManager.tags()`in L243 to get tags, the result order of `listVersionedFileStatus` is undetermined, depending on different operating systems.  
When running this test on CentOS, the result of `listVersionedFileStatus` is `tag-2023-07-18 11  tag-2023-07-18 13  tag-savepoint-11`. Because `tag-2023-07-18 11`  and `tag-savepoint-11` belongs to the same snapshot, the later `tag-savepoint-11` tag will overwride the previous `tag-2023-07-18 11` tag. The result of `tagManager.tags()` will be {<s1, tag-savepoint-11>, <s2, tag-2023-07-18 13>} and thus won't pass the validation.

This fix filters out the savepoint tag when getting tags to fix the issue.

<!-- Linking this pull request to the isssue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
