### PR TITLE
[flink] Fix the problem that flink job for reading paimon won't recov…

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -25,6 +25,7 @@ import org.apache.paimon.flink.source.assigners.SplitAssigner;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
@@ -210,6 +211,8 @@ public class ContinuousFileSplitEnumerator
                 LOG.debug("Catching EndOfStreamException, the stream is finished.");
                 finished = true;
                 assignSplits();
+            } else if (error instanceof OutOfRangeException) {
+                throw (RuntimeException) error;
             } else {
                 LOG.error("Failed to enumerate files", error);
             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -212,7 +212,7 @@ public class ContinuousFileSplitEnumerator
                 assignSplits();
             } else {
                 LOG.error("Failed to enumerate files", error);
-                throw (RuntimeException) error;
+                throw new RuntimeException(error);
             }
             return;
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -25,7 +25,6 @@ import org.apache.paimon.flink.source.assigners.SplitAssigner;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
-import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
@@ -211,10 +210,9 @@ public class ContinuousFileSplitEnumerator
                 LOG.debug("Catching EndOfStreamException, the stream is finished.");
                 finished = true;
                 assignSplits();
-            } else if (error instanceof OutOfRangeException) {
-                throw (RuntimeException) error;
             } else {
                 LOG.error("Failed to enumerate files", error);
+                throw (RuntimeException) error;
             }
             return;
         }


### PR DESCRIPTION
…er when catching snapshot OutOfRangeException

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2761

<!-- What is the purpose of the change -->
Throw a runtime exception in flink job to try to failover, when reading paimon found a OutOfRangeException

### Tests

<!-- List UT and IT cases to verify this change -->
None

### API and Format

<!-- Does this change affect API or storage format -->
None
### Documentation

<!-- Does this change introduce a new feature -->
None
