### PR TITLE
[core] Let CacheManager page unaware

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -45,6 +45,12 @@ under the License.
             <td>Specify the paimon distribution policy. Data is assigned to each bucket according to the hash value of bucket-key.<br />If you specify multiple fields, delimiter is ','.<br />If not specified, the primary key will be used; if there is no primary key, the full row will be used.</td>
         </tr>
         <tr>
+            <td><h5>cache-page-size</h5></td>
+            <td style="word-wrap: break-word;">16 kb</td>
+            <td>MemorySize</td>
+            <td>Memory page size for caching.</td>
+        </tr>
+        <tr>
             <td><h5>changelog-producer</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
@@ -606,12 +612,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Whether to create tag automatically. And how to generate tags.<br /><br />Possible values:<ul><li>"none": No automatically created tags.</li><li>"process-time": Based on the time of the machine, create TAG once the processing time passes period time plus delay.</li><li>"watermark": Based on the watermark of the input, create TAG once the watermark passes period time plus delay.</li><li>"batch": In the batch processing scenario, the tag corresponding to the current snapshot is generated after the task is completed.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>tag.period-formatter</h5></td>
-            <td style="word-wrap: break-word;">with_dashes</td>
-            <td><p>Enum</p></td>
-            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>tag.callback.#.param</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
@@ -640,6 +640,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The maximum number of tags to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>tag.period-formatter</h5></td>
+            <td style="word-wrap: break-word;">with_dashes</td>
+            <td><p>Enum</p></td>
+            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li></ul></td>
         </tr>
         <tr>
             <td><h5>target-file-size</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -356,6 +356,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MemorySize.parse("64 kb"))
                     .withDescription("Memory page size.");
 
+    public static final ConfigOption<MemorySize> CACHE_PAGE_SIZE =
+            key("cache-page-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("16 kb"))
+                    .withDescription("Memory page size for caching.");
+
     public static final ConfigOption<MemorySize> TARGET_FILE_SIZE =
             key("target-file-size")
                     .memoryType()
@@ -1259,6 +1265,14 @@ public class CoreOptions implements Serializable {
 
     public int pageSize() {
         return (int) options.get(PAGE_SIZE).getBytes();
+    }
+
+    public int cachePageSize() {
+        return (int) options.get(CACHE_PAGE_SIZE).getBytes();
+    }
+
+    public MemorySize lookupCacheMaxMemory() {
+        return options.get(LOOKUP_CACHE_MAX_MEMORY_SIZE);
     }
 
     public long targetFileSize() {

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheManager.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheManager.java
@@ -30,16 +30,14 @@ import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExe
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 /** Cache manager to cache bytes to paged {@link MemorySegment}s. */
 public class CacheManager {
 
-    private final int pageSize;
     private final Cache<CacheKey, CacheValue> cache;
 
-    public CacheManager(int pageSize, MemorySize maxMemorySize) {
-        this.pageSize = pageSize;
+    public CacheManager(MemorySize maxMemorySize) {
         this.cache =
                 Caffeine.newBuilder()
                         .weigher(this::weigh)
@@ -54,20 +52,16 @@ public class CacheManager {
         return cache;
     }
 
-    public int pageSize() {
-        return pageSize;
-    }
-
     public MemorySegment getPage(
             RandomAccessFile file,
-            long fileLength,
-            int pageNumber,
-            Consumer<Integer> cleanCallback) {
-        CacheKey key = new CacheKey(file, pageNumber);
+            long readOffset,
+            int readLength,
+            BiConsumer<Long, Integer> cleanCallback) {
+        CacheKey key = new CacheKey(file, readOffset, readLength);
         CacheValue value = cache.getIfPresent(key);
         while (value == null || value.isClosed) {
             try {
-                value = createValue(key, fileLength, cleanCallback);
+                value = new CacheValue(key.read(), cleanCallback);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -76,8 +70,8 @@ public class CacheManager {
         return value.segment;
     }
 
-    public void invalidPage(RandomAccessFile file, int pageNumber) {
-        cache.invalidate(new CacheKey(file, pageNumber));
+    public void invalidPage(RandomAccessFile file, long readOffset, int readLength) {
+        cache.invalidate(new CacheKey(file, readOffset, readLength));
     }
 
     private int weigh(CacheKey cacheKey, CacheValue cacheValue) {
@@ -86,29 +80,24 @@ public class CacheManager {
 
     private void onRemoval(CacheKey key, CacheValue value, RemovalCause cause) {
         value.isClosed = true;
-        value.cleanCallback.accept(key.pageNumber);
-    }
-
-    private CacheValue createValue(CacheKey key, long fileLength, Consumer<Integer> cleanCallback)
-            throws IOException {
-        return new CacheValue(key.read(fileLength, pageSize), cleanCallback);
+        value.cleanCallback.accept(key.offset, key.length);
     }
 
     private static class CacheKey {
 
         private final RandomAccessFile file;
-        private final int pageNumber;
+        private final long offset;
+        private final int length;
 
-        private CacheKey(RandomAccessFile file, int pageNumber) {
+        private CacheKey(RandomAccessFile file, long offset, int length) {
             this.file = file;
-            this.pageNumber = pageNumber;
+            this.offset = offset;
+            this.length = length;
         }
 
-        private MemorySegment read(long fileLength, int pageSize) throws IOException {
-            long pageAddress = (long) pageNumber * pageSize;
-            int len = (int) Math.min(pageSize, fileLength - pageAddress);
-            byte[] bytes = new byte[len];
-            file.seek(pageAddress);
+        private MemorySegment read() throws IOException {
+            byte[] bytes = new byte[length];
+            file.seek(offset);
             file.readFully(bytes);
             return MemorySegment.wrap(bytes);
         }
@@ -122,23 +111,25 @@ public class CacheManager {
                 return false;
             }
             CacheKey cacheKey = (CacheKey) o;
-            return pageNumber == cacheKey.pageNumber && Objects.equals(file, cacheKey.file);
+            return Objects.equals(file, cacheKey.file)
+                    && offset == cacheKey.offset
+                    && length == cacheKey.length;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(file, pageNumber);
+            return Objects.hash(file, offset, length);
         }
     }
 
     private static class CacheValue {
 
         private final MemorySegment segment;
-        private final Consumer<Integer> cleanCallback;
+        private final BiConsumer<Long, Integer> cleanCallback;
 
         private boolean isClosed = false;
 
-        private CacheValue(MemorySegment segment, Consumer<Integer> cleanCallback) {
+        private CacheValue(MemorySegment segment, BiConsumer<Long, Integer> cleanCallback) {
             this.segment = segment;
             this.cleanCallback = cleanCallback;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
@@ -28,10 +28,12 @@ import java.io.IOException;
 public class HashLookupStoreFactory implements LookupStoreFactory {
 
     private final CacheManager cacheManager;
+    private final int cachePageSize;
     private final double loadFactor;
 
-    public HashLookupStoreFactory(CacheManager cacheManager, double loadFactor) {
+    public HashLookupStoreFactory(CacheManager cacheManager, int cachePageSize, double loadFactor) {
         this.cacheManager = cacheManager;
+        this.cachePageSize = cachePageSize;
         this.loadFactor = loadFactor;
     }
 
@@ -42,6 +44,6 @@ public class HashLookupStoreFactory implements LookupStoreFactory {
 
     @Override
     public HashLookupStoreReader createReader(File file) throws IOException {
-        return new HashLookupStoreReader(cacheManager, file);
+        return new HashLookupStoreReader(cacheManager, cachePageSize, file);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
@@ -62,7 +62,8 @@ public class HashLookupStoreReader
     // Buffers
     private final byte[] slotBuffer;
 
-    HashLookupStoreReader(CacheManager cacheManager, File file) throws IOException {
+    HashLookupStoreReader(CacheManager cacheManager, int cachePageSize, File file)
+            throws IOException {
         // File path
         if (!file.exists()) {
             throw new FileNotFoundException("File " + file.getAbsolutePath() + " not found");
@@ -127,7 +128,7 @@ public class HashLookupStoreReader
         }
 
         // Create Mapped file in read-only mode
-        inputView = new CachedRandomInputView(file, cacheManager);
+        inputView = new CachedRandomInputView(file, cacheManager, cachePageSize);
 
         // logging
         DecimalFormat integerFormat = new DecimalFormat("#,##0.00");

--- a/paimon-common/src/test/java/org/apache/paimon/io/cache/CachedRandomInputViewTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/cache/CachedRandomInputViewTest.java
@@ -65,8 +65,8 @@ public class CachedRandomInputViewTest {
         }
 
         File file = writeFile(bytes);
-        CacheManager cacheManager = new CacheManager(1024, MemorySize.ofKibiBytes(128));
-        CachedRandomInputView view = new CachedRandomInputView(file, cacheManager);
+        CacheManager cacheManager = new CacheManager(MemorySize.ofKibiBytes(128));
+        CachedRandomInputView view = new CachedRandomInputView(file, cacheManager, 1024);
 
         // read first one
         // this assertThatCode check the ConcurrentModificationException is not threw.

--- a/paimon-common/src/test/java/org/apache/paimon/lookup/hash/HashLookupStoreFactoryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/lookup/hash/HashLookupStoreFactoryTest.java
@@ -62,7 +62,7 @@ public class HashLookupStoreFactoryTest {
     public void setUp() throws IOException {
         this.factory =
                 new HashLookupStoreFactory(
-                        new CacheManager(1024, MemorySize.ofMebiBytes(1)), 0.75d);
+                        new CacheManager(MemorySize.ofMebiBytes(1)), 1024, 0.75d);
         this.file = new File(tempDir.toFile(), UUID.randomUUID().toString());
         if (!file.createNewFile()) {
             throw new IOException("Can not create file: " + file);
@@ -178,9 +178,8 @@ public class HashLookupStoreFactoryTest {
         // Read
         factory =
                 new HashLookupStoreFactory(
-                        new CacheManager(
-                                MathUtils.roundDownToPowerOf2(byteSize - 100),
-                                MemorySize.ofMebiBytes(1)),
+                        new CacheManager(MemorySize.ofMebiBytes(1)),
+                        MathUtils.roundDownToPowerOf2(byteSize - 100),
                         0.75d);
         HashLookupStoreReader reader = factory.createReader(file);
         for (int i = 0; i < keys.length; i++) {
@@ -209,9 +208,8 @@ public class HashLookupStoreFactoryTest {
         // Read
         factory =
                 new HashLookupStoreFactory(
-                        new CacheManager(
-                                MathUtils.roundDownToPowerOf2(byteSize + sizeSize + 3),
-                                MemorySize.ofMebiBytes(1)),
+                        new CacheManager(MemorySize.ofMebiBytes(1)),
+                        MathUtils.roundDownToPowerOf2(byteSize + sizeSize + 3),
                         0.75d);
         HashLookupStoreReader reader = factory.createReader(file);
         for (int i = 0; i < keys.length; i++) {
@@ -279,7 +277,7 @@ public class HashLookupStoreFactoryTest {
         writeStore(file, keys, values);
 
         // Read
-        factory = new HashLookupStoreFactory(new CacheManager(1024, new MemorySize(8096)), 0.75d);
+        factory = new HashLookupStoreFactory(new CacheManager(new MemorySize(8096)), 1024, 0.75d);
         HashLookupStoreReader reader = factory.createReader(file);
         for (int i = 0; i < keys.length; i++) {
             assertThat(reader.lookup(toBytes(keys[i]))).isEqualTo(toBytes(values[i]));

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -276,6 +276,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 () -> ioManager.createChannel().getPathFile(),
                 new HashLookupStoreFactory(
                         cacheManager,
+                        options.cachePageSize(),
                         options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR)),
                 options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_FILE_RETENTION),
                 options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE));
@@ -297,6 +298,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 () -> ioManager.createChannel().getPathFile(),
                 new HashLookupStoreFactory(
                         cacheManager,
+                        options.cachePageSize(),
                         options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR)),
                 options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_FILE_RETENTION),
                 options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE));

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -40,8 +40,6 @@ import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.apache.paimon.CoreOptions.LOOKUP_CACHE_MAX_MEMORY_SIZE;
-
 /**
  * Base {@link FileStoreWrite} implementation which supports using shared memory and preempting
  * memory from other writers.
@@ -74,10 +72,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                 pathFactory,
                 options.writeMaxWritersToSpill());
         this.options = options;
-        this.cacheManager =
-                new CacheManager(
-                        options.pageSize(),
-                        options.toConfiguration().get(LOOKUP_CACHE_MAX_MEMORY_SIZE));
+        this.cacheManager = new CacheManager(options.lookupCacheMaxMemory());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.apache.paimon.CoreOptions.LOOKUP_CACHE_MAX_MEMORY_SIZE;
 import static org.apache.paimon.CoreOptions.MergeEngine.DEDUPLICATE;
 
 /** Implementation for {@link TableQuery} for caching data and file in local. */
@@ -82,9 +81,8 @@ public class LocalTableQuery implements TableQuery {
         this.keyComparatorSupplier = new KeyComparatorSupplier(readerFactoryBuilder.keyType());
         this.hashLookupStoreFactory =
                 new HashLookupStoreFactory(
-                        new CacheManager(
-                                options.pageSize(),
-                                options.toConfiguration().get(LOOKUP_CACHE_MAX_MEMORY_SIZE)),
+                        new CacheManager(options.lookupCacheMaxMemory()),
+                        options.cachePageSize(),
                         options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR));
 
         if (options.changelogProducer() == CoreOptions.ChangelogProducer.LOOKUP) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
@@ -185,7 +185,7 @@ public class ContainsLevelsTest {
                                 .createRecordReader(
                                         0, file.fileName(), file.fileSize(), file.level()),
                 () -> new File(tempDir.toFile(), LOOKUP_FILE_PREFIX + UUID.randomUUID()),
-                new HashLookupStoreFactory(new CacheManager(2048, MemorySize.ofMebiBytes(1)), 0.75),
+                new HashLookupStoreFactory(new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75),
                 Duration.ofHours(1),
                 maxDiskSize);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -225,7 +225,7 @@ public class LookupLevelsTest {
                                 .createRecordReader(
                                         0, file.fileName(), file.fileSize(), file.level()),
                 () -> new File(tempDir.toFile(), LOOKUP_FILE_PREFIX + UUID.randomUUID()),
-                new HashLookupStoreFactory(new CacheManager(2048, MemorySize.ofMebiBytes(1)), 0.75),
+                new HashLookupStoreFactory(new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75),
                 Duration.ofHours(1),
                 maxDiskSize);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- The Cache system should be page independent and can use a custom pageSize.
- Introduce a new Page size for cache, can be smaller.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

cache-page-size default 16 KB

### Documentation

<!-- Does this change introduce a new feature -->
