### PR TITLE
[cdc] Fix that MySqlSyncTableActionFactory handles METADATA_COLUMN in different way with MySqlSyncDatabaseActionFactory

### DIFF
--- a/docs/layouts/shortcodes/generated/mysql_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_table.html
@@ -67,7 +67,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--metadata_column</h5></td>
-        <td>--metadata_column is used to specify which metadata columns to include in the output schema of the connector. Metadata columns provide additional information related to the source data, for example: --metadata_column table_name --metadata_column database_name --metadata_column op_ts. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#available-metadata">document</a> for a complete list of available metadata.</td>
+        <td>--metadata_column is used to specify which metadata columns to include in the output schema of the connector. Metadata columns provide additional information related to the source data, for example: --metadata_column table_name,database_name,op_ts. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mysql-cdc.html#available-metadata">document</a> for a complete list of available metadata.</td>
     </tr>
     <tr>
         <td><h5>--mysql_conf</h5></td>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
@@ -77,10 +77,6 @@ public abstract class SyncTableActionFactoryBase implements ActionFactory {
         }
 
         if (params.has(METADATA_COLUMN)) {
-            action.withMetadataColumns(Arrays.asList(params.get(METADATA_COLUMN).split(",")));
-        }
-
-        if (params.has(METADATA_COLUMN)) {
             List<String> metadataColumns =
                     new ArrayList<>(params.getMultiParameter(METADATA_COLUMN));
             if (metadataColumns.size() == 1) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
@@ -25,6 +25,8 @@ import org.apache.paimon.flink.action.MultipleParameterToolAdapter;
 import org.apache.flink.api.java.tuple.Tuple3;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -75,7 +77,18 @@ public abstract class SyncTableActionFactoryBase implements ActionFactory {
         }
 
         if (params.has(METADATA_COLUMN)) {
-            action.withMetadataColumns(new ArrayList<>(params.getMultiParameter(METADATA_COLUMN)));
+            action.withMetadataColumns(Arrays.asList(params.get(METADATA_COLUMN).split(",")));
+        }
+
+        if (params.has(METADATA_COLUMN)) {
+            List<String> metadataColumns =
+                    new ArrayList<>(params.getMultiParameter(METADATA_COLUMN));
+            if (metadataColumns.size() == 1) {
+                action.withMetadataColumns(Arrays.asList(metadataColumns.get(0).split(",")));
+            } else {
+                action.withMetadataColumns(
+                        new ArrayList<>(params.getMultiParameter(METADATA_COLUMN)));
+            }
         }
 
         if (params.has(TYPE_MAPPING)) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This is confused.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
