### PR TITLE
[cdc] the newly added table cannot obtain the metadata column in the database cdc action.

### DIFF
--- a/docs/layouts/shortcodes/generated/postgres_sync_table.html
+++ b/docs/layouts/shortcodes/generated/postgres_sync_table.html
@@ -60,7 +60,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--metadata_column</h5></td>
-        <td>--metadata_column is used to specify which metadata columns to include in the output schema of the connector. Metadata columns provide additional information related to the source data, for example: --metadata_column table_name --metadata_column database_name --metadata_column schema_name --metadata_column op_ts. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/postgres-cdc.html#available-metadata">document</a> for a complete list of available metadata.</td>
+        <td>--metadata_column is used to specify which metadata columns to include in the output schema of the connector. Metadata columns provide additional information related to the source data, for example: --metadata_column table_name,database_name,schema_name,op_ts. See its <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/postgres-cdc.html#available-metadata">document</a> for a complete list of available metadata.</td>
     </tr>
     <tr>
         <td><h5>--postgres_conf</h5></td>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -117,7 +117,8 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
 
     @Override
     protected EventParser.Factory<RichCdcMultiplexRecord> buildEventParserFactory() {
-        NewTableSchemaBuilder schemaBuilder = new NewTableSchemaBuilder(tableConfig, caseSensitive);
+        NewTableSchemaBuilder schemaBuilder =
+                new NewTableSchemaBuilder(tableConfig, caseSensitive, metadataConverters);
         Pattern includingPattern = Pattern.compile(includingTables);
         Pattern excludingPattern =
                 excludingTables == null ? null : Pattern.compile(excludingTables);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -1314,6 +1314,18 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                     table,
                     rowType,
                     Collections.singletonList("k"));
+
+            // test new added table
+            statement.execute("USE " + "metadata");
+            statement.executeUpdate("CREATE TABLE t3 (k INT, v1 VARCHAR(10), PRIMARY KEY (k))");
+            statement.executeUpdate("INSERT INTO t3 VALUES (1, 'Hi')");
+            waitingTables("t3");
+            table = getFileStoreTable("t3");
+            waitForResult(
+                    Collections.singletonList("+I[1, Hi, t3, metadata]"),
+                    table,
+                    rowType,
+                    Collections.singletonList("k"));
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -1315,17 +1315,19 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                     rowType,
                     Collections.singletonList("k"));
 
-            // test new added table
-            statement.execute("USE " + "metadata");
-            statement.executeUpdate("CREATE TABLE t3 (k INT, v1 VARCHAR(10), PRIMARY KEY (k))");
-            statement.executeUpdate("INSERT INTO t3 VALUES (1, 'Hi')");
-            waitingTables("t3");
-            table = getFileStoreTable("t3");
-            waitForResult(
-                    Collections.singletonList("+I[1, Hi, t3, metadata]"),
-                    table,
-                    rowType,
-                    Collections.singletonList("k"));
+            // test newly created table
+            if (mode == COMBINED) {
+                statement.execute("USE " + "metadata");
+                statement.executeUpdate("CREATE TABLE t3 (k INT, v1 VARCHAR(10), PRIMARY KEY (k))");
+                statement.executeUpdate("INSERT INTO t3 VALUES (1, 'Hi')");
+                waitingTables("t3");
+                table = getFileStoreTable("t3");
+                waitForResult(
+                        Collections.singletonList("+I[1, Hi, t3, metadata]"),
+                        table,
+                        rowType,
+                        Collections.singletonList("k"));
+            }
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -508,7 +508,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Specified primary key 'pk' does not exist in source tables or computed columns."));
+                                "Specified primary key 'pk' does not exist in source tables or computed columns [pt, _id, v1]."));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1.the newly added table cannot obtain the metadata column in the database cdc action.
2. resolve pg cdc ut exception.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

https://github.com/zhuangchong/flink-table-store/blob/74f6c61bdc7f68a1460d031bbc83e71552b42dc2/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java#L1318-L1329

```java
            // test new added table
            statement.execute("USE " + "metadata");
            statement.executeUpdate("CREATE TABLE t3 (k INT, v1 VARCHAR(10), PRIMARY KEY (k))");
            statement.executeUpdate("INSERT INTO t3 VALUES (1, 'Hi')");
            waitingTables("t3");
            table = getFileStoreTable("t3");
            waitForResult(
                    Collections.singletonList("+I[1, Hi, t3, metadata]"),
                    table,
                    rowType,
                    Collections.singletonList("k"));
        }
```

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
