### PR TITLE
[core] Make PrimaryKeyFileStoreTable and AppendOnlyFileStoreTable package private

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -47,7 +47,7 @@ import java.io.IOException;
 import java.util.function.BiConsumer;
 
 /** {@link FileStoreTable} for append table. */
-public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
+class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     private static final long serialVersionUID = 1L;
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -56,7 +56,7 @@ import static org.apache.paimon.predicate.PredicateBuilder.pickTransformFieldMap
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
 
 /** {@link FileStoreTable} for primary key table. */
-public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
+class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
 
     private static final long serialVersionUID = 1L;
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionCoordinatorTest.java
@@ -26,7 +26,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.types.DataTypes;
 
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AppendOnlyTableCompactionCoordinatorTest {
 
     @TempDir Path tempDir;
-    private AppendOnlyFileStoreTable appendOnlyFileStoreTable;
+    private FileStoreTable appendOnlyFileStoreTable;
     private AppendOnlyTableCompactionCoordinator compactionCoordinator;
     private BinaryRow partition;
 
@@ -159,11 +159,8 @@ public class AppendOnlyTableCompactionCoordinatorTest {
         TableSchema tableSchema = schemaManager.createTable(schema());
 
         appendOnlyFileStoreTable =
-                (AppendOnlyFileStoreTable)
-                        FileStoreTableFactory.create(
-                                fileIO,
-                                new org.apache.paimon.fs.Path(tempDir.toString()),
-                                tableSchema);
+                FileStoreTableFactory.create(
+                        fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
         compactionCoordinator = new AppendOnlyTableCompactionCoordinator(appendOnlyFileStoreTable);
         partition = BinaryRow.EMPTY_ROW;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionITTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionITTest.java
@@ -28,7 +28,7 @@ import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AppendOnlyTableCompactionITTest {
 
     @TempDir private Path tempDir;
-    private AppendOnlyFileStoreTable appendOnlyFileStoreTable;
+    private FileStoreTable appendOnlyFileStoreTable;
     private SnapshotManager snapshotManager;
     private AppendOnlyTableCompactionCoordinator compactionCoordinator;
     private AppendOnlyFileStoreWrite write;
@@ -188,12 +188,9 @@ public class AppendOnlyTableCompactionITTest {
         TableSchema tableSchema = schemaManager.createTable(schema());
         snapshotManager = new SnapshotManager(fileIO, path);
         appendOnlyFileStoreTable =
-                (AppendOnlyFileStoreTable)
-                        FileStoreTableFactory.create(
-                                fileIO,
-                                new org.apache.paimon.fs.Path(tempDir.toString()),
-                                tableSchema);
+                FileStoreTableFactory.create(
+                        fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
         compactionCoordinator = new AppendOnlyTableCompactionCoordinator(appendOnlyFileStoreTable);
-        write = appendOnlyFileStoreTable.store().newWrite(commitUser);
+        write = (AppendOnlyFileStoreWrite) appendOnlyFileStoreTable.store().newWrite(commitUser);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
@@ -31,7 +31,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.schema.Schema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataTypes;
@@ -50,9 +50,9 @@ public class AppendOnlyFileStoreWriteTest {
 
     @Test
     public void testWritesInBatch() throws Exception {
-        AppendOnlyFileStoreTable table = createFileStoreTable();
+        FileStoreTable table = createFileStoreTable();
 
-        AppendOnlyFileStoreWrite write = table.store().newWrite("ss");
+        AppendOnlyFileStoreWrite write = (AppendOnlyFileStoreWrite) table.store().newWrite("ss");
         write.withExecutionMode(false);
 
         write.write(partition(0), 0, GenericRow.of(0, 0, 0));
@@ -101,7 +101,7 @@ public class AppendOnlyFileStoreWriteTest {
         Assertions.assertThat(records).isEqualTo(11);
     }
 
-    protected AppendOnlyFileStoreTable createFileStoreTable() throws Exception {
+    protected FileStoreTable createFileStoreTable() throws Exception {
         Catalog catalog = new FileSystemCatalog(LocalFileIO.create(), new Path(tempDir.toString()));
         Schema schema =
                 Schema.newBuilder()
@@ -114,7 +114,7 @@ public class AppendOnlyFileStoreWriteTest {
         Identifier identifier = Identifier.create("default", "test");
         catalog.createDatabase("default", false);
         catalog.createTable(identifier, schema, false);
-        return (AppendOnlyFileStoreTable) catalog.getTable(identifier);
+        return (FileStoreTable) catalog.getTable(identifier);
     }
 
     private BinaryRow partition(int i) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -185,8 +185,8 @@ public abstract class TableTestBase {
         return messages;
     }
 
-    public Table getTableDefault() throws Exception {
-        return catalog.getTable(identifier());
+    public FileStoreTable getTableDefault() throws Exception {
+        return (FileStoreTable) catalog.getTable(identifier());
     }
 
     private List<CommitMessage> writeOnce(Table table, int time, int size) throws Exception {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -23,7 +23,6 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.schema.SchemaManager;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
@@ -135,7 +134,6 @@ public class CdcSinkBuilder<T> {
 
     private DataStreamSink<?> buildForUnawareBucket(DataStream<CdcRecord> parsed) {
         FileStoreTable dataTable = (FileStoreTable) table;
-        return new CdcUnawareBucketSink((AppendOnlyFileStoreTable) dataTable, parallelism)
-                .sinkFrom(parsed);
+        return new CdcUnawareBucketSink(dataTable, parallelism).sinkFrom(parsed);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
@@ -21,14 +21,14 @@ package org.apache.paimon.flink.sink.cdc;
 import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.UnawareBucketSink;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
 /** CDC Sink for unaware bucket table. */
 public class CdcUnawareBucketSink extends UnawareBucketSink<CdcRecord> {
 
-    public CdcUnawareBucketSink(AppendOnlyFileStoreTable table, Integer parallelism) {
+    public CdcUnawareBucketSink(FileStoreTable table, Integer parallelism) {
         super(table, null, null, parallelism, false);
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -27,7 +27,6 @@ import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.Preconditions;
@@ -171,7 +170,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     }
 
     private void buildForUnawareBucket(FileStoreTable table, DataStream<CdcRecord> parsed) {
-        new CdcUnawareBucketSink((AppendOnlyFileStoreTable) table, parallelism).sinkFrom(parsed);
+        new CdcUnawareBucketSink(table, parallelism).sinkFrom(parsed);
     }
 
     private void buildDividedCdcSink() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -23,7 +23,6 @@ import org.apache.paimon.flink.compact.UnawareBucketCompactionTopoBuilder;
 import org.apache.paimon.flink.sink.CompactorSinkBuilder;
 import org.apache.paimon.flink.source.CompactorSourceBuilder;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -83,8 +82,7 @@ public class CompactAction extends TableActionBase {
         switch (fileStoreTable.bucketMode()) {
             case UNAWARE:
                 {
-                    buildForUnawareBucketCompaction(
-                            env, (AppendOnlyFileStoreTable) table, isStreaming);
+                    buildForUnawareBucketCompaction(env, fileStoreTable, isStreaming);
                     break;
                 }
             case FIXED:
@@ -109,7 +107,7 @@ public class CompactAction extends TableActionBase {
     }
 
     private void buildForUnawareBucketCompaction(
-            StreamExecutionEnvironment env, AppendOnlyFileStoreTable table, boolean isStreaming) {
+            StreamExecutionEnvironment env, FileStoreTable table, boolean isStreaming) {
         UnawareBucketCompactionTopoBuilder unawareBucketCompactionTopoBuilder =
                 new UnawareBucketCompactionTopoBuilder(env, identifier.getFullName(), table);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
@@ -25,7 +25,7 @@ import org.apache.paimon.flink.sink.UnawareBucketCompactionSink;
 import org.apache.paimon.flink.source.BucketUnawareCompactSource;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.PredicateBuilder;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
@@ -51,14 +51,12 @@ public class UnawareBucketCompactionTopoBuilder {
 
     private final transient StreamExecutionEnvironment env;
     private final String tableIdentifier;
-    private final AppendOnlyFileStoreTable table;
+    private final FileStoreTable table;
     @Nullable private List<Map<String, String>> specifiedPartitions = null;
     private boolean isContinuous = false;
 
     public UnawareBucketCompactionTopoBuilder(
-            StreamExecutionEnvironment env,
-            String tableIdentifier,
-            AppendOnlyFileStoreTable table) {
+            StreamExecutionEnvironment env, String tableIdentifier, FileStoreTable table) {
         this.env = env;
         this.tableIdentifier = tableIdentifier;
         this.table = table;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperator.java
@@ -23,7 +23,7 @@ import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.flink.source.BucketUnawareCompactSource;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.utils.ExecutorThreadFactory;
@@ -53,15 +53,14 @@ public class AppendOnlyTableCompactionWorkerOperator
     private static final Logger LOG =
             LoggerFactory.getLogger(AppendOnlyTableCompactionWorkerOperator.class);
 
-    private final AppendOnlyFileStoreTable table;
+    private final FileStoreTable table;
     private final String commitUser;
 
     private transient AppendOnlyFileStoreWrite write;
     private transient ExecutorService lazyCompactExecutor;
     private transient Queue<Future<CommitMessage>> result;
 
-    public AppendOnlyTableCompactionWorkerOperator(
-            AppendOnlyFileStoreTable table, String commitUser) {
+    public AppendOnlyTableCompactionWorkerOperator(FileStoreTable table, String commitUser) {
         super(Options.fromMap(table.options()));
         this.table = table;
         this.commitUser = commitUser;
@@ -75,7 +74,7 @@ public class AppendOnlyTableCompactionWorkerOperator
     @Override
     public void open() throws Exception {
         LOG.debug("Opened a append-only table compaction worker.");
-        this.write = table.store().newWrite(commitUser);
+        this.write = (AppendOnlyFileStoreWrite) table.store().newWrite(commitUser);
         this.result = new LinkedList<>();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.sink.index.GlobalDynamicBucketSink;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 
@@ -142,14 +141,10 @@ public class FlinkSinkBuilder {
 
     private DataStreamSink<?> buildUnawareBucketSink(DataStream<InternalRow> input) {
         checkArgument(
-                table instanceof AppendOnlyFileStoreTable,
+                table.primaryKeys().isEmpty(),
                 "Unaware bucket mode only works with append-only table for now.");
         return new RowUnawareBucketSink(
-                        (AppendOnlyFileStoreTable) table,
-                        overwritePartition,
-                        logSinkFunction,
-                        parallelism,
-                        boundedInput)
+                        table, overwritePartition, logSinkFunction, parallelism, boundedInput)
                 .sinkFrom(input);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
@@ -26,9 +26,7 @@ import org.apache.paimon.flink.PaimonDataStreamSinkProvider;
 import org.apache.paimon.flink.log.LogSinkProvider;
 import org.apache.paimon.flink.log.LogStoreTableFactory;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.PrimaryKeyFileStoreTable;
 import org.apache.paimon.table.Table;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -75,11 +73,11 @@ public abstract class FlinkTableSinkBase
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-        if (table instanceof AppendOnlyFileStoreTable) {
+        if (table.primaryKeys().isEmpty()) {
             // Don't check this, for example, only inserts are available from the database, but the
             // plan phase contains all changelogs
             return requestedMode;
-        } else if (table instanceof PrimaryKeyFileStoreTable) {
+        } else {
             Options options = Options.fromMap(table.options());
             if (options.get(CHANGELOG_PRODUCER) == ChangelogProducer.INPUT) {
                 return requestedMode;
@@ -101,9 +99,6 @@ public abstract class FlinkTableSinkBase
                 }
             }
             return builder.build();
-        } else {
-            throw new UnsupportedOperationException(
-                    "Unknown FileStoreTable subclass " + table.getClass().getName());
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
@@ -29,7 +29,7 @@ import java.util.Map;
 public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
 
     public RowUnawareBucketSink(
-            AppendOnlyFileStoreTable table,
+            FileStoreTable table,
             Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
             Integer parallelism,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
@@ -28,9 +28,7 @@ import org.apache.paimon.predicate.AllPrimaryKeyEqualVisitor;
 import org.apache.paimon.predicate.OnlyPartitionKeyEqualVisitor;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.PrimaryKeyFileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableUtils;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -93,7 +91,7 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
         // unsupported. Similarly, it is not allowed to update the primary key column when updating
         // the column of PrimaryKeyFileStoreTable, because the old data cannot be handled
         // correctly.
-        if (table instanceof PrimaryKeyFileStoreTable) {
+        if (table.primaryKeys().size() > 0) {
             Options options = Options.fromMap(table.options());
             Set<String> primaryKeys = new HashSet<>(table.primaryKeys());
             updatedColumns.forEach(
@@ -126,15 +124,10 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
                             MERGE_ENGINE.key(),
                             MergeEngine.DEDUPLICATE,
                             MergeEngine.PARTIAL_UPDATE));
-        } else if (table instanceof AppendOnlyFileStoreTable) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "%s can not support update, because there is no primary key.",
-                            table.getClass().getName()));
         } else {
             throw new UnsupportedOperationException(
                     String.format(
-                            "%s can not support update, because it is an unknown subclass of FileStoreTable.",
+                            "%s can not support update, because there is no primary key.",
                             table.getClass().getName()));
         }
     }
@@ -184,7 +177,7 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
     }
 
     private void validateDeletable() {
-        if (table instanceof PrimaryKeyFileStoreTable) {
+        if (table.primaryKeys().size() > 0) {
             Options options = Options.fromMap(table.options());
             if (options.get(MERGE_ENGINE) == MergeEngine.DEDUPLICATE) {
                 return;
@@ -193,15 +186,10 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
                     String.format(
                             "merge engine '%s' can not support delete, currently only %s can support delete.",
                             options.get(MERGE_ENGINE), MergeEngine.DEDUPLICATE));
-        } else if (table instanceof AppendOnlyFileStoreTable) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "table '%s' can not support delete, because there is no primary key.",
-                            table.getClass().getName()));
         } else {
             throw new UnsupportedOperationException(
                     String.format(
-                            "%s can not support delete, because it is an unknown subclass of FileStoreTable.",
+                            "table '%s' can not support delete, because there is no primary key.",
                             table.getClass().getName()));
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -20,7 +20,7 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.manifest.ManifestCommittable;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -29,15 +29,15 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 /** Compaction Sink for unaware-bucket table. */
 public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionTask> {
 
-    private final AppendOnlyFileStoreTable table;
+    private final FileStoreTable table;
 
-    public UnawareBucketCompactionSink(AppendOnlyFileStoreTable table) {
+    public UnawareBucketCompactionSink(FileStoreTable table) {
         super(table, true);
         this.table = table;
     }
 
     public static DataStreamSink<?> sink(
-            AppendOnlyFileStoreTable table, DataStream<AppendOnlyCompactionTask> input) {
+            FileStoreTable table, DataStream<AppendOnlyCompactionTask> input) {
         return new UnawareBucketCompactionSink(table).sinkFrom(input);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.flink.compact.UnawareBucketCompactionTopoBuilder;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -37,14 +37,14 @@ import java.util.Map;
  */
 public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
 
-    protected final AppendOnlyFileStoreTable table;
+    protected final FileStoreTable table;
     protected final LogSinkFunction logSinkFunction;
 
     @Nullable protected final Integer parallelism;
     protected final boolean boundedInput;
 
     public UnawareBucketSink(
-            AppendOnlyFileStoreTable table,
+            FileStoreTable table,
             @Nullable Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
             @Nullable Integer parallelism,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BucketUnawareCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BucketUnawareCompactSource.java
@@ -22,7 +22,7 @@ import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.append.AppendOnlyTableCompactionCoordinator;
 import org.apache.paimon.flink.sink.CompactionTaskTypeInfo;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.EndOfScanException;
 
 import org.apache.flink.api.connector.source.Boundedness;
@@ -52,7 +52,7 @@ public class BucketUnawareCompactSource extends RichSourceFunction<AppendOnlyCom
     private static final Logger LOG = LoggerFactory.getLogger(BucketUnawareCompactSource.class);
     private static final String COMPACTION_COORDINATOR_NAME = "Compaction Coordinator";
 
-    private final AppendOnlyFileStoreTable table;
+    private final FileStoreTable table;
     private final boolean streaming;
     private final long scanInterval;
     private final Predicate filter;
@@ -61,7 +61,7 @@ public class BucketUnawareCompactSource extends RichSourceFunction<AppendOnlyCom
     private volatile boolean isRunning = true;
 
     public BucketUnawareCompactSource(
-            AppendOnlyFileStoreTable table,
+            FileStoreTable table,
             boolean isStreaming,
             long scanInterval,
             @Nullable Predicate filter) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -31,8 +31,6 @@ import org.apache.paimon.flink.lookup.FileStoreLookupFunction;
 import org.apache.paimon.flink.lookup.LookupRuntimeProviderFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
-import org.apache.paimon.table.PrimaryKeyFileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Projection;
@@ -145,9 +143,9 @@ public class DataTableSource extends FlinkTableSource {
             return ChangelogMode.insertOnly();
         }
 
-        if (table instanceof AppendOnlyFileStoreTable) {
+        if (table.primaryKeys().isEmpty()) {
             return ChangelogMode.insertOnly();
-        } else if (table instanceof PrimaryKeyFileStoreTable) {
+        } else {
             Options options = Options.fromMap(table.options());
 
             if (new CoreOptions(options).mergeEngine() == CoreOptions.MergeEngine.FIRST_ROW) {
@@ -169,11 +167,6 @@ public class DataTableSource extends FlinkTableSource {
                             && options.get(LOG_CHANGELOG_MODE) == LogChangelogMode.ALL
                     ? ChangelogMode.all()
                     : ChangelogMode.upsert();
-        } else {
-            throw new UnsupportedOperationException(
-                    "Unsupported Table subclass "
-                            + table.getClass().getName()
-                            + " for streaming mode.");
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
@@ -24,11 +24,11 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.PrimaryKeyFileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -41,6 +41,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -57,23 +58,18 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
         PredicateBuilder predicateBuilder = new PredicateBuilder(getTable().rowType());
         Predicate predicate = predicateBuilder.between(1, 100L, 200L);
 
-        List<ManifestEntry> files = ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilter =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
 
         zorder(Arrays.asList("f2", "f1"));
 
-        List<ManifestEntry> filesZorder =
-                ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> filesZorder = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilterZorder =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
@@ -91,23 +87,18 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
 
         // order f2,f1 will make predicate of f1 perform worse.
         order(Arrays.asList("f2", "f1"));
-        List<ManifestEntry> files = ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilter =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
 
         zorder(Arrays.asList("f2", "f1"));
 
-        List<ManifestEntry> filesZorder =
-                ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> filesZorder = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilterZorder =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
@@ -128,23 +119,18 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
                         BinaryString.fromString("000000000" + 100),
                         BinaryString.fromString("000000000" + 200));
 
-        List<ManifestEntry> files = ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilter =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
 
-        zorder(Arrays.asList("f4"));
+        zorder(Collections.singletonList("f4"));
 
-        List<ManifestEntry> filesZorder =
-                ((FileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> filesZorder = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilterZorder =
-                ((PrimaryKeyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((KeyValueFileStoreScan) getTable().store().newScan())
                         .withValueFilter(predicate)
                         .plan()
                         .files();
@@ -238,8 +224,8 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
         catalog.createTable(identifier(), schema(), true);
     }
 
-    private Table getTable() throws Exception {
-        return catalog.getTable(identifier());
+    private FileStoreTable getTable() throws Exception {
+        return (FileStoreTable) catalog.getTable(identifier());
     }
 
     private Identifier identifier() {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -26,10 +26,11 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -92,8 +93,7 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         Assertions.assertThatCode(() -> order(Arrays.asList("f1", "f2")))
                 .doesNotThrowAnyException();
 
-        List<ManifestEntry> files =
-                ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
 
         ManifestEntry entry = files.get(0);
         DataSplit dataSplit =
@@ -118,7 +118,7 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         Assertions.assertThatCode(() -> order(Arrays.asList("f2", "f1")))
                 .doesNotThrowAnyException();
 
-        files = ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        files = getTable().store().newScan().plan().files();
 
         entry = files.get(0);
         dataSplit =
@@ -161,12 +161,9 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         PredicateBuilder predicateBuilder = new PredicateBuilder(getTable().rowType());
         Predicate predicate = predicateBuilder.between(1, 100, 200);
 
-        List<ManifestEntry> files =
-                ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilter =
-                ((AppendOnlyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((AppendOnlyFileStoreScan) getTable().store().newScan())
                         .withFilter(predicate)
                         .plan()
                         .files();
@@ -175,11 +172,9 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
 
         zorder(Arrays.asList("f2", "f1"));
 
-        files = ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        files = getTable().store().newScan().plan().files();
         filesFilter =
-                ((AppendOnlyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((AppendOnlyFileStoreScan) getTable().store().newScan())
                         .withFilter(predicate)
                         .plan()
                         .files();
@@ -194,23 +189,17 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         PredicateBuilder predicateBuilder = new PredicateBuilder(getTable().rowType());
         Predicate predicate = predicateBuilder.between(1, 10, 20);
 
-        List<ManifestEntry> filesZorder =
-                ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> filesZorder = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilterZorder =
-                ((AppendOnlyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((AppendOnlyFileStoreScan) getTable().store().newScan())
                         .withFilter(predicate)
                         .plan()
                         .files();
 
         order(Arrays.asList("f2", "f1"));
-        List<ManifestEntry> filesOrder =
-                ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> filesOrder = getTable().store().newScan().plan().files();
         List<ManifestEntry> filesFilterOrder =
-                ((AppendOnlyFileStoreTable) getTable())
-                        .store()
-                        .newScan()
+                ((AppendOnlyFileStoreScan) getTable().store().newScan())
                         .withFilter(predicate)
                         .plan()
                         .files();
@@ -246,15 +235,14 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         prepareSameData(200);
         Assertions.assertThatCode(() -> order(Collections.singletonList("f1")))
                 .doesNotThrowAnyException();
-        List<ManifestEntry> files =
-                ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        List<ManifestEntry> files = getTable().store().newScan().plan().files();
         Assertions.assertThat(files.size()).isEqualTo(3);
 
         dropTable();
         prepareSameData(200);
         Assertions.assertThatCode(() -> zorder(Arrays.asList("f1", "f2")))
                 .doesNotThrowAnyException();
-        files = ((AppendOnlyFileStoreTable) getTable()).store().newScan().plan().files();
+        files = getTable().store().newScan().plan().files();
         Assertions.assertThat(files.size()).isEqualTo(3);
     }
 
@@ -370,8 +358,8 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         return messages;
     }
 
-    private Table getTable() throws Exception {
-        return catalog.getTable(identifier());
+    private FileStoreTable getTable() throws Exception {
+        return (FileStoreTable) catalog.getTable(identifier());
     }
 
     private static List<CommitMessage> writeOnce(Table table, int p, int size) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyTableCompactionWorkerOperatorTest.java
@@ -27,7 +27,6 @@ import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.schema.Schema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
@@ -50,8 +49,7 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
     public void testAsyncCompactionWorks() throws Exception {
         createTableDefault();
         AppendOnlyTableCompactionWorkerOperator workerOperator =
-                new AppendOnlyTableCompactionWorkerOperator(
-                        (AppendOnlyFileStoreTable) getTableDefault(), "user");
+                new AppendOnlyTableCompactionWorkerOperator(getTableDefault(), "user");
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 20);
@@ -103,8 +101,7 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
     public void testAsyncCompactionFileDeletedWhenShutdown() throws Exception {
         createTableDefault();
         AppendOnlyTableCompactionWorkerOperator workerOperator =
-                new AppendOnlyTableCompactionWorkerOperator(
-                        (AppendOnlyFileStoreTable) getTableDefault(), "user");
+                new AppendOnlyTableCompactionWorkerOperator(getTableDefault(), "user");
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 40);
@@ -125,7 +122,7 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
 
         LocalFileIO localFileIO = LocalFileIO.create();
         DataFilePathFactory dataFilePathFactory =
-                ((AppendOnlyFileStoreTable) getTableDefault())
+                getTableDefault()
                         .store()
                         .pathFactory()
                         .createDataFilePathFactory(BinaryRow.EMPTY_ROW, 0);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/AppendOnlyTableStatisticsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/AppendOnlyTableStatisticsTest.java
@@ -23,11 +23,10 @@ import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 
-/** Statistics tests for {@link AppendOnlyFileStoreTable}. */
+/** Statistics tests for append only tables. */
 public class AppendOnlyTableStatisticsTest extends FileStoreTableStatisticsTestBase {
     @Override
     protected FileStoreTable createStoreTable() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
@@ -27,15 +27,14 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
-import org.apache.paimon.table.PrimaryKeyFileStoreTable;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/** Statistics tests for {@link PrimaryKeyFileStoreTable}. */
+/** Statistics tests for table with primary keys. */
 public class PrimaryKeyTableStatisticsTest extends FileStoreTableStatisticsTestBase {
 
-    /** {@link PrimaryKeyFileStoreTable} does not support filter value. */
+    /** Primary key tables does not support filter value. */
     @Test
     public void testTableFilterValueStatistics() throws Exception {
         FileStoreTable table = writeData();

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -30,7 +30,6 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.migrate.FileMetaUtils;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.schema.Schema;
-import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.BatchTableCommit;
@@ -187,7 +186,7 @@ public class HiveMigrator implements Migrator {
     }
 
     private void checkPaimonTable(FileStoreTable paimonTable) {
-        if (!(paimonTable instanceof AppendOnlyFileStoreTable)) {
+        if (paimonTable.primaryKeys().size() > 0) {
             throw new IllegalArgumentException(
                     "Hive migrator only support append only table target table");
         }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -17,8 +17,7 @@
  */
 package org.apache.paimon.spark
 
-import org.apache.paimon.table.{AppendOnlyFileStoreTable, Table}
-import org.apache.paimon.table.source.ReadBuilder
+import org.apache.paimon.table.Table
 
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit
 
@@ -27,7 +26,7 @@ class PaimonScanBuilder(table: Table)
   with SupportsPushDownLimit {
 
   override def pushLimit(limit: Int): Boolean = {
-    if (table.isInstanceOf[AppendOnlyFileStoreTable]) {
+    if (table.primaryKeys().isEmpty) {
       pushDownLimit = Some(limit)
     }
     // just make a best effort to push down limit


### PR DESCRIPTION
### Purpose

This PR makes `PrimaryKeyFileStoreTable` and `AppendOnlyFileStoreTable` package private classes. Developers should use `FileStoreTable` interface instead and check if the table has primary keys.

### Tests

This PR is a refactor without tests.

### API and Format

No.

### Documentation

No.
