### PR TITLE
[spark] Integrate statistics into spark scan

### DIFF
--- a/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -27,5 +27,6 @@ case class PaimonScan(
     table: Table,
     requiredSchema: StructType,
     filters: Array[Predicate],
+    reservedFilters: Array[Filter],
     pushDownLimit: Option[Int])
-  extends PaimonBaseScan(table, requiredSchema, filters, pushDownLimit)
+  extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)

--- a/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
+++ b/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
@@ -15,25 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark
+package org.apache.paimon.spark.statistics
 
-import java.util.Optional
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.connector.read.Statistics
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
-import scala.language.implicitConversions
-
-object PaimonImplicits {
-  implicit def toScalaOption[T](o: Optional[T]): Option[T] = {
-    if (o.isPresent) {
-      Some(o.get)
-    } else {
-      None
-    }
-  }
-
-  implicit def toJavaOptional[T, U](o: Option[T]): Optional[U] = {
-    o match {
-      case Some(t) => Optional.ofNullable(t.asInstanceOf[U])
-      case _ => Optional.empty[U]
-    }
+trait StatisticsHelper extends StatisticsHelperBase {
+  protected def toV1Stats(v2Stats: Statistics, attrs: Seq[Attribute]): logical.Statistics = {
+    DataSourceV2Relation.transformV2Stats(v2Stats, None, conf.defaultSizeInBytes)
   }
 }

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
@@ -15,25 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark
+package org.apache.paimon.spark.statistics
 
-import java.util.Optional
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.connector.read.Statistics
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
-import scala.language.implicitConversions
-
-object PaimonImplicits {
-  implicit def toScalaOption[T](o: Optional[T]): Option[T] = {
-    if (o.isPresent) {
-      Some(o.get)
-    } else {
-      None
-    }
-  }
-
-  implicit def toJavaOptional[T, U](o: Option[T]): Optional[U] = {
-    o match {
-      case Some(t) => Optional.ofNullable(t.asInstanceOf[U])
-      case _ => Optional.empty[U]
-    }
+trait StatisticsHelper extends StatisticsHelperBase {
+  protected def toV1Stats(v2Stats: Statistics, attrs: Seq[Attribute]): logical.Statistics = {
+    DataSourceV2Relation.transformV2Stats(v2Stats, None, conf.defaultSizeInBytes)
   }
 }

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
@@ -15,25 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark
+package org.apache.paimon.spark.statistics
 
-import java.util.Optional
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.connector.read.Statistics
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
-import scala.language.implicitConversions
-
-object PaimonImplicits {
-  implicit def toScalaOption[T](o: Optional[T]): Option[T] = {
-    if (o.isPresent) {
-      Some(o.get)
-    } else {
-      None
-    }
-  }
-
-  implicit def toJavaOptional[T, U](o: Option[T]): Optional[U] = {
-    o match {
-      case Some(t) => Optional.ofNullable(t.asInstanceOf[U])
-      case _ => Optional.empty[U]
-    }
+trait StatisticsHelper extends StatisticsHelperBase {
+  protected def toV1Stats(v2Stats: Statistics, attrs: Seq[Attribute]): logical.Statistics = {
+    DataSourceV2Relation.transformV2Stats(v2Stats, None, conf.defaultSizeInBytes)
   }
 }

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -17,4 +17,46 @@
  */
 package org.apache.paimon.spark.sql
 
-class AnalyzeTableTest extends AnalyzeTableTestBase {}
+import org.junit.jupiter.api.Assertions
+
+class AnalyzeTableTest extends AnalyzeTableTestBase {
+
+  test("Paimon analyze: spark use col stats") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a', 1, 1)")
+    spark.sql(s"INSERT INTO T VALUES ('2', 'aaa', 1, 2)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    val stats = getScanStatistic("SELECT * FROM T")
+    Assertions.assertEquals(2L, stats.rowCount.get.longValue())
+    // spark 33' v2 table not support col stats
+    Assertions.assertEquals(0, stats.attributeStats.size)
+  }
+
+  test("Paimon analyze: partition filter push down hit") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, pt INT)
+                 |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='2')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', 1), (2, 'b', 1), (3, 'c', 2), (4, 'd', 3)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    // partition push down hit
+    var sql = "SELECT * FROM T WHERE pt < 1"
+    // spark 33' v2 table not support col stats
+    Assertions.assertEquals(4L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+
+    // partition push down not hit
+    sql = "SELECT * FROM T WHERE id < 1"
+    Assertions.assertEquals(4L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+  }
+}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -17,4 +17,45 @@
  */
 package org.apache.paimon.spark.sql
 
-class AnalyzeTableTest extends AnalyzeTableTestBase {}
+import org.junit.jupiter.api.Assertions
+
+class AnalyzeTableTest extends AnalyzeTableTestBase {
+
+  test("Paimon analyze: spark use col stats") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a', 1, 1)")
+    spark.sql(s"INSERT INTO T VALUES ('2', 'aaa', 1, 2)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    val stats = getScanStatistic("SELECT * FROM T")
+    Assertions.assertEquals(2L, stats.rowCount.get.longValue())
+    Assertions.assertEquals(4, stats.attributeStats.size)
+  }
+
+  test("Paimon analyze: partition filter push down hit") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, pt INT)
+                 |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='2')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', 1), (2, 'b', 1), (3, 'c', 2), (4, 'd', 3)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    // paimon will reserve partition filter and not return it to spark, we need to ensure stats are filtered correctly.
+    // partition push down hit
+    var sql = "SELECT * FROM T WHERE pt < 1"
+    Assertions.assertEquals(0L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+
+    // partition push down not hit
+    sql = "SELECT * FROM T WHERE id < 1"
+    Assertions.assertEquals(4L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+  }
+}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -17,4 +17,45 @@
  */
 package org.apache.paimon.spark.sql
 
-class AnalyzeTableTest extends AnalyzeTableTestBase {}
+import org.junit.jupiter.api.Assertions
+
+class AnalyzeTableTest extends AnalyzeTableTestBase {
+
+  test("Paimon analyze: spark use col stats") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a', 1, 1)")
+    spark.sql(s"INSERT INTO T VALUES ('2', 'aaa', 1, 2)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    val stats = getScanStatistic("SELECT * FROM T")
+    Assertions.assertEquals(2L, stats.rowCount.get.longValue())
+    Assertions.assertEquals(4, stats.attributeStats.size)
+  }
+
+  test("Paimon analyze: partition filter push down hit") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, pt INT)
+                 |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='2')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    spark.sql("INSERT INTO T VALUES (1, 'a', 1), (2, 'b', 1), (3, 'c', 2), (4, 'd', 3)")
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    // paimon will reserve partition filter and not return it to spark, we need to ensure stats are filtered correctly.
+    // partition push down hit
+    var sql = "SELECT * FROM T WHERE pt < 1"
+    Assertions.assertEquals(0L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+
+    // partition push down not hit
+    sql = "SELECT * FROM T WHERE id < 1"
+    Assertions.assertEquals(4L, getScanStatistic(sql).rowCount.get.longValue())
+    checkAnswer(spark.sql(sql), Nil)
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -32,8 +32,9 @@ case class PaimonScan(
     table: Table,
     requiredSchema: StructType,
     filters: Array[Predicate],
+    reservedFilters: Array[Filter],
     pushDownLimit: Option[Int])
-  extends PaimonBaseScan(table, requiredSchema, filters, pushDownLimit)
+  extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering {
 
   override def filterAttributes(): Array[NamedReference] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelper.scala
@@ -15,25 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.paimon.spark
+package org.apache.paimon.spark.statistics
 
-import java.util.Optional
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.connector.read.Statistics
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
-import scala.language.implicitConversions
-
-object PaimonImplicits {
-  implicit def toScalaOption[T](o: Optional[T]): Option[T] = {
-    if (o.isPresent) {
-      Some(o.get)
-    } else {
-      None
-    }
-  }
-
-  implicit def toJavaOptional[T, U](o: Option[T]): Optional[U] = {
-    o match {
-      case Some(t) => Optional.ofNullable(t.asInstanceOf[U])
-      case _ => Optional.empty[U]
-    }
+trait StatisticsHelper extends StatisticsHelperBase {
+  protected def toV1Stats(v2Stats: Statistics, attrs: Seq[Attribute]): logical.Statistics = {
+    DataSourceV2Relation.transformV2Stats(v2Stats, None, conf.defaultSizeInBytes, attrs)
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelperBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/statistics/StatisticsHelperBase.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.paimon.spark.statistics
+
+import org.apache.paimon.spark.PaimonColumnStats
+
+import org.apache.spark.sql.Utils
+import org.apache.spark.sql.catalyst.{SQLConfHelper, StructFilters}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Expression}
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.FilterEstimation
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.read.Statistics
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics
+import org.apache.spark.sql.sources.{And, Filter}
+import org.apache.spark.sql.types.{StructField, StructType}
+
+import java.util.OptionalLong
+
+trait StatisticsHelperBase extends SQLConfHelper {
+
+  val requiredSchema: StructType
+
+  def filterStatistics(v2Stats: Statistics, filters: Array[Filter]): Statistics = {
+    val attrs: Seq[AttributeReference] =
+      requiredSchema.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+    val condition = filterToCondition(filters, attrs)
+
+    if (condition.isDefined && v2Stats.numRows().isPresent) {
+      val filteredStats = FilterEstimation(
+        logical.Filter(condition.get, FakePlanWithStats(toV1Stats(v2Stats, attrs)))).estimate.get
+      toV2Stats(filteredStats)
+    } else {
+      v2Stats
+    }
+  }
+
+  private def filterToCondition(
+      filters: Array[Filter],
+      attrs: Seq[Attribute]): Option[Expression] = {
+    StructFilters.filterToExpression(filters.reduce(And), toRef).map {
+      expression =>
+        expression.transform {
+          case ref: BoundReference => attrs.find(_.name == requiredSchema(ref.ordinal).name).get
+        }
+    }
+  }
+
+  private def toRef(attr: String): Option[BoundReference] = {
+    val index = requiredSchema.fieldIndex(attr)
+    val field = requiredSchema(index)
+    Option.apply(BoundReference(index, field.dataType, field.nullable))
+  }
+
+  protected def toV1Stats(v2Stats: Statistics, attrs: Seq[Attribute]): logical.Statistics
+
+  private def toV2Stats(v1Stats: logical.Statistics): Statistics = {
+    new Statistics() {
+      override def sizeInBytes(): OptionalLong = if (v1Stats.sizeInBytes != null)
+        OptionalLong.of(v1Stats.sizeInBytes.longValue())
+      else OptionalLong.empty()
+
+      override def numRows(): OptionalLong = if (v1Stats.rowCount.isDefined)
+        OptionalLong.of(v1Stats.rowCount.get.longValue())
+      else OptionalLong.empty()
+
+      override def columnStats(): java.util.Map[NamedReference, ColumnStatistics] = {
+        val columnStatsMap = new java.util.HashMap[NamedReference, ColumnStatistics]()
+        v1Stats.attributeStats.foreach {
+          case (attr, v1ColStats) =>
+            columnStatsMap.put(
+              Utils.fieldReference(attr.name),
+              PaimonColumnStats(v1ColStats)
+            )
+        }
+        columnStatsMap
+      }
+    }
+  }
+}
+
+case class FakePlanWithStats(v1Stats: logical.Statistics) extends LogicalPlan {
+  override def output: Seq[Attribute] = Seq.empty
+  override def children: Seq[LogicalPlan] = Seq.empty
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = throw new UnsupportedOperationException
+  override def stats: logical.Statistics = v1Stats
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Integrate statistics into spark scan

### Tests

Test this on 1T tpc-ds, overall performance improved by 15%, some case:

q19 cost from 175s -> 11s
q64 cost from 84s -> 56s
q72 can't run  ->  32s

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
