### PR TITLE
[hive] alter paimon table options cannot be synchronized to hive par

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -438,6 +438,7 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             // sync to hive hms
             Table table = client.getTable(identifier.getDatabaseName(), identifier.getObjectName());
+            updateHmsTablePars(table, schema);
             updateHmsTable(table, identifier, schema);
             client.alter_table(
                     identifier.getDatabaseName(), identifier.getObjectName(), table, true);
@@ -563,6 +564,10 @@ public class HiveCatalog extends AbstractCatalog {
 
         // update location
         locationHelper.specifyTableLocation(table, getDataTableLocation(identifier).toString());
+    }
+
+    private void updateHmsTablePars(Table table, TableSchema schema) {
+        table.getParameters().putAll(convertToPropertiesPrefixKey(schema.options(), HIVE_PREFIX));
     }
 
     @VisibleForTesting


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix alter paimon table options cannot be synchronized to hive parameters.

### Tests
org.apache.paimon.hive.HiveCatalogTest.testAlterHiveTableParameters()

### API and Format


### Documentation

<!-- Does this change introduce a new feature -->
