### PR TITLE
[core] Fix the issue in `sequence.auto-padding` where `second-to-micro` and `millis-to-micro` are not meeting the requirements.

### DIFF
--- a/docs/content/concepts/primary-key-table/sequence-rowkind.md
+++ b/docs/content/concepts/primary-key-table/sequence-rowkind.md
@@ -61,12 +61,7 @@ option to automatically pad the sequence field for you.
    (the time that the change was made in the database) in Mysql Binlog. It is recommended to use the automatic
    padding for row kind flag, which will automatically distinguish between -U (-D) and +U (+I).
 
-2. Insufficient precision: If the provided `sequence.field` doesn't meet the precision, like a rough second or
-   millisecond, you can set `sequence.auto-padding` to `second-to-micro` or `millis-to-micro` so that the precision
-   of sequence number will be made up to microsecond by system.
-
-3. Composite pattern: for example, "second-to-micro,row-kind-flag", first, add the micro to the second, and then
-   pad the row kind flag.
+(Note: If the provided `sequence.field` doesn't meet the precision, like a rough second or millisecond, system will combine `sequence.field` with an internal incrementing sequence number to ensure that even if the same `sequence.field` appears, the built-in incrementing sequence number can distinguish between different records.)
 
 ## Row Kind Field
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -531,7 +531,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>sequence.auto-padding</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specify the way of padding precision, if the provided sequence field is used to indicate "time" but doesn't meet the precise.<ul><li>You can specific:</li><li>1. "row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li><li>2. "second-to-micro": Pads the sequence field that indicates time with precision of seconds to micro-second.</li><li>3. "millis-to-micro": Pads the sequence field that indicates time with precision of milli-second to micro-second.</li><li>4. Composite pattern: for example, "second-to-micro,row-kind-flag".</li></ul></td>
+            <td>Specify the way of padding precision.<ul><li>You can specific:</li><li>1. "row-kind-flag": Pads a bit flag to indicate whether it is retract (0) or add (1) message.</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence.field</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2099,13 +2099,7 @@ public class CoreOptions implements Serializable {
     public enum SequenceAutoPadding implements DescribedEnum {
         ROW_KIND_FLAG(
                 "row-kind-flag",
-                "Pads a bit flag to indicate whether it is retract (0) or add (1) message."),
-        SECOND_TO_MICRO(
-                "second-to-micro",
-                "Pads the sequence field that indicates time with precision of seconds to micro-second."),
-        MILLIS_TO_MICRO(
-                "millis-to-micro",
-                "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
+                "Pads a bit flag to indicate whether it is retract (0) or add (1) message.");
 
         private final String value;
         private final String description;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -492,18 +492,11 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             Description.builder()
-                                    .text(
-                                            "Specify the way of padding precision, if the provided sequence field is used to indicate \"time\" but doesn't meet the precise.")
+                                    .text("Specify the way of padding precision.")
                                     .list(
                                             text("You can specific:"),
                                             text(
-                                                    "1. \"row-kind-flag\": Pads a bit flag to indicate whether it is retract (0) or add (1) message."),
-                                            text(
-                                                    "2. \"second-to-micro\": Pads the sequence field that indicates time with precision of seconds to micro-second."),
-                                            text(
-                                                    "3. \"millis-to-micro\": Pads the sequence field that indicates time with precision of milli-second to micro-second."),
-                                            text(
-                                                    "4. Composite pattern: for example, \"second-to-micro,row-kind-flag\"."))
+                                                    "1. \"row-kind-flag\": Pads a bit flag to indicate whether it is retract (0) or add (1) message."))
                                     .build());
 
     public static final ConfigOption<StartupMode> SCAN_MODE =

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -27,6 +27,7 @@ import org.apache.paimon.index.IndexMaintainer;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
+import org.apache.paimon.mergetree.compact.ReorderFunctionFactory;
 import org.apache.paimon.operation.KeyValueFileStoreRead;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreWrite;
@@ -69,6 +70,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final Supplier<RecordEqualiser> valueEqualiserSupplier;
     private final MergeFunctionFactory<KeyValue> mfFactory;
     private final String tableName;
+    private final ReorderFunctionFactory<KeyValue> rfFactory;
 
     public KeyValueFileStore(
             FileIO fileIO,
@@ -83,7 +85,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             KeyValueFieldsExtractor keyValueFieldsExtractor,
             MergeFunctionFactory<KeyValue> mfFactory,
             String tableName,
-            CatalogEnvironment catalogEnvironment) {
+            CatalogEnvironment catalogEnvironment,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         super(fileIO, schemaManager, schemaId, options, partitionType, catalogEnvironment);
         this.crossPartitionUpdate = crossPartitionUpdate;
         this.bucketKeyType = bucketKeyType;
@@ -94,6 +97,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
         this.valueEqualiserSupplier = new ValueEqualiserSupplier(valueType);
         this.tableName = tableName;
+        this.rfFactory = rfFactory;
     }
 
     @Override
@@ -124,7 +128,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 valueType,
                 newKeyComparator(),
                 mfFactory,
-                newReaderFactoryBuilder());
+                newReaderFactoryBuilder(),
+                rfFactory);
     }
 
     public KeyValueFileReaderFactory.Builder newReaderFactoryBuilder() {
@@ -168,7 +173,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 indexFactory,
                 options,
                 keyValueFieldsExtractor,
-                tableName);
+                tableName,
+                rfFactory);
     }
 
     private Map<String, FileStorePathFactory> format2PathFactory() {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
@@ -74,10 +74,10 @@ public class KeyValueSerializer extends ObjectSerializer<KeyValue> {
 
     @Override
     public KeyValue fromRow(InternalRow row) {
-        reusedKey.replace(row);
-        reusedValue.replace(row);
         long sequenceNumber = row.getLong(keyArity);
         RowKind valueKind = RowKind.fromByteValue(row.getByte(keyArity + 1));
+        reusedKey.replace(row);
+        reusedValue.replace(row).replace(valueKind);
         reusedKv.replace(reusedKey, sequenceNumber, valueKind, reusedValue);
         return reusedKv;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
@@ -74,10 +74,10 @@ public class KeyValueSerializer extends ObjectSerializer<KeyValue> {
 
     @Override
     public KeyValue fromRow(InternalRow row) {
+        reusedKey.replace(row);
+        reusedValue.replace(row);
         long sequenceNumber = row.getLong(keyArity);
         RowKind valueKind = RowKind.fromByteValue(row.getByte(keyArity + 1));
-        reusedKey.replace(row);
-        reusedValue.replace(row).replace(valueKind);
         reusedKv.replace(reusedKey, sequenceNumber, valueKind, reusedValue);
         return reusedKv;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
@@ -316,12 +316,14 @@ public class MergeSorter {
 
             int keyArity = keyType.getFieldCount();
             int valueArity = valueType.getFieldCount();
+
+            RowKind rowKind = RowKind.fromByteValue(row.getByte(keyArity + 1));
             return new KeyValue()
                     .replace(
                             new OffsetRow(keyArity, 0).replace(row),
                             row.getLong(keyArity),
-                            RowKind.fromByteValue(row.getByte(keyArity + 1)),
-                            new OffsetRow(valueArity, keyArity + 3).replace(row))
+                            rowKind,
+                            new OffsetRow(valueArity, keyArity + 3).replace(row).replace(rowKind))
                     .setLevel(row.getInt(keyArity + 2));
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
@@ -316,14 +316,12 @@ public class MergeSorter {
 
             int keyArity = keyType.getFieldCount();
             int valueArity = valueType.getFieldCount();
-
-            RowKind rowKind = RowKind.fromByteValue(row.getByte(keyArity + 1));
             return new KeyValue()
                     .replace(
                             new OffsetRow(keyArity, 0).replace(row),
                             row.getLong(keyArity),
-                            rowKind,
-                            new OffsetRow(valueArity, keyArity + 3).replace(row).replace(rowKind))
+                            RowKind.fromByteValue(row.getByte(keyArity + 1)),
+                            new OffsetRow(valueArity, keyArity + 3).replace(row))
                     .setLevel(row.getInt(keyArity + 2));
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/WriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/WriteBuffer.java
@@ -21,6 +21,7 @@ package org.apache.paimon.mergetree;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.mergetree.compact.MergeFunction;
+import org.apache.paimon.mergetree.compact.ReorderFunction;
 import org.apache.paimon.types.RowKind;
 
 import javax.annotation.Nullable;
@@ -57,12 +58,14 @@ public interface WriteBuffer {
      *
      * @param rawConsumer consumer to consume records without merging.
      * @param mergedConsumer consumer to consume records after merging.
+     * @param reorderFunction reorder records before merging and consumption.
      */
     void forEach(
             Comparator<InternalRow> keyComparator,
             MergeFunction<KeyValue> mergeFunction,
             @Nullable KvConsumer rawConsumer,
-            KvConsumer mergedConsumer)
+            KvConsumer mergedConsumer,
+            @Nullable ReorderFunction<KeyValue> reorderFunction)
             throws IOException;
 
     /** Removes all records from this table. The table will be empty after this call returns. */

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -57,8 +57,9 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
             MergeFunctionFactory<KeyValue> mfFactory,
             MergeSorter mergeSorter,
             RecordEqualiser valueEqualiser,
-            boolean changelogRowDeduplicate) {
-        super(readerFactory, writerFactory, keyComparator, mfFactory, mergeSorter);
+            boolean changelogRowDeduplicate,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
+        super(readerFactory, writerFactory, keyComparator, mfFactory, mergeSorter, rfFactory);
         this.maxLevel = maxLevel;
         this.mergeEngine = mergeEngine;
         this.valueEqualiser = valueEqualiser;
@@ -120,7 +121,8 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                                     readerFactory,
                                     keyComparator,
                                     createMergeWrapper(outputLevel),
-                                    mergeSorter));
+                                    mergeSorter,
+                                    rfFactory.create()));
         }
 
         RecordReaderIterator<ChangelogResult> iterator = null;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeTreeCompactRewriter.java
@@ -59,7 +59,8 @@ public class FirstRowMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter
             MergeFunctionFactory<KeyValue> mfFactory,
             MergeSorter mergeSorter,
             RecordEqualiser valueEqualiser,
-            boolean changelogRowDeduplicate) {
+            boolean changelogRowDeduplicate,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         super(
                 maxLevel,
                 mergeEngine,
@@ -69,7 +70,8 @@ public class FirstRowMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter
                 mfFactory,
                 mergeSorter,
                 valueEqualiser,
-                changelogRowDeduplicate);
+                changelogRowDeduplicate,
+                rfFactory);
         this.containsLevels = containsLevels;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -48,7 +48,8 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
             MergeFunctionFactory<KeyValue> mfFactory,
             MergeSorter mergeSorter,
             RecordEqualiser valueComparator,
-            boolean changelogRowDeduplicate) {
+            boolean changelogRowDeduplicate,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         super(
                 maxLevel,
                 mergeEngine,
@@ -58,7 +59,8 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
                 mfFactory,
                 mergeSorter,
                 valueComparator,
-                changelogRowDeduplicate);
+                changelogRowDeduplicate,
+                rfFactory);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -56,7 +56,8 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
             MergeFunctionFactory<KeyValue> mfFactory,
             MergeSorter mergeSorter,
             RecordEqualiser valueEqualiser,
-            boolean changelogRowDeduplicate) {
+            boolean changelogRowDeduplicate,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         super(
                 maxLevel,
                 mergeEngine,
@@ -66,7 +67,8 @@ public class LookupMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
                 mfFactory,
                 mergeSorter,
                 valueEqualiser,
-                changelogRowDeduplicate);
+                changelogRowDeduplicate,
+                rfFactory);
         this.lookupLevels = lookupLevels;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -42,18 +42,21 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
     protected final Comparator<InternalRow> keyComparator;
     protected final MergeFunctionFactory<KeyValue> mfFactory;
     protected final MergeSorter mergeSorter;
+    protected final ReorderFunctionFactory<KeyValue> rfFactory;
 
     public MergeTreeCompactRewriter(
             KeyValueFileReaderFactory readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
-            MergeSorter mergeSorter) {
+            MergeSorter mergeSorter,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         this.readerFactory = readerFactory;
         this.writerFactory = writerFactory;
         this.keyComparator = keyComparator;
         this.mfFactory = mfFactory;
         this.mergeSorter = mergeSorter;
+        this.rfFactory = rfFactory;
     }
 
     @Override
@@ -73,7 +76,8 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
                         readerFactory,
                         keyComparator,
                         mfFactory.create(),
-                        mergeSorter);
+                        mergeSorter,
+                        rfFactory.create());
         writer.write(new RecordReaderIterator<>(sectionsReader));
         writer.close();
         return new CompactResult(extractFilesFromSections(sections), writer.result());

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -144,7 +144,7 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                     row.setField(i, field);
                 }
             } else {
-                Long currentSeq = sequenceGen.generateNullable(kv.value());
+                Long currentSeq = sequenceGen.generateNullable(kv.value(), kv.valueKind());
                 if (currentSeq != null) {
                     Long previousSeq = sequenceGen.generateNullable(row);
                     if (previousSeq == null || currentSeq >= previousSeq) {
@@ -162,7 +162,7 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
         for (int i = 0; i < getters.length; i++) {
             SequenceGenerator sequenceGen = fieldSequences.get(i);
             if (sequenceGen != null) {
-                Long currentSeq = sequenceGen.generateNullable(kv.value());
+                Long currentSeq = sequenceGen.generateNullable(kv.value(), kv.valueKind());
                 if (currentSeq != null) {
                     Long previousSeq = sequenceGen.generateNullable(row);
                     FieldAggregator aggregator = fieldAggregators.get(i);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReorderFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReorderFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+
+import java.util.List;
+
+/**
+ * Reorder function to reorder multiple {@link KeyValue}s.
+ *
+ * @param <T> result type
+ */
+public interface ReorderFunction<T> {
+
+    /** Reset the reorder function to its default state. */
+    void reset();
+
+    /** Add the given {@link KeyValue} to the reorder function. */
+    void add(KeyValue kv);
+
+    /** Get current reorder values. */
+    List<T> getResult();
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReorderFunctionFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReorderFunctionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/** Factory to create {@link ReorderFunction}. */
+@FunctionalInterface
+public interface ReorderFunctionFactory<T> extends Serializable {
+
+    default ReorderFunction<T> create() {
+        return create(null);
+    }
+
+    ReorderFunction<T> create(@Nullable int[][] projection);
+
+    default MergeFunctionFactory.AdjustedProjection adjustProjection(@Nullable int[][] projection) {
+        return new MergeFunctionFactory.AdjustedProjection(projection, null);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunction.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.table.sink.SequenceGenerator;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Projection;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Combine the Sequence Field defined in the Schema with the auto-incremented Sequence Number in
+ * KeyValue, and reorder KeyValue with the same primary key.
+ */
+public class SequenceFieldReorderFunction implements ReorderFunction<KeyValue> {
+
+    private final InternalRowSerializer keySerializer;
+    private final InternalRowSerializer valueSerializer;
+    private final SequenceGenerator sequenceGenerator;
+    private final List<KeyValue> kvList;
+    private final List<SequenceValue> svList;
+
+    private Long lastActualSequence;
+    private boolean allSameActualSequence;
+
+    public SequenceFieldReorderFunction(
+            SequenceGenerator sequenceGenerator, RowType keyType, RowType valueType) {
+        this.sequenceGenerator = sequenceGenerator;
+        this.keySerializer = new InternalRowSerializer(keyType);
+        this.valueSerializer = new InternalRowSerializer(valueType);
+        this.kvList = new LinkedList<>();
+        this.svList = new ArrayList<>();
+        this.allSameActualSequence = true;
+    }
+
+    @Override
+    public void reset() {
+        kvList.clear();
+        svList.clear();
+    }
+
+    @Override
+    public void add(KeyValue kv) {
+        long autoSequence = kv.sequenceNumber();
+        KeyValue copy =
+                new KeyValue().replace(keySerializer.copy(kv.key()), autoSequence, null, null);
+        Long actualSequence = sequenceGenerator.generateNullable(kv.value());
+        if (actualSequence != null) {
+            // add for sorting.
+            svList.add(
+                    new SequenceValue(
+                            autoSequence,
+                            actualSequence,
+                            kv.valueKind(),
+                            valueSerializer.copy(kv.value()),
+                            kv.level()));
+            if (lastActualSequence == null) {
+                lastActualSequence = actualSequence;
+            } else if (actualSequence.compareTo(lastActualSequence) != 0) {
+                allSameActualSequence = false;
+            }
+        } else {
+            // when the sequence field is null, it will retain the order in which it flows in.
+            copy.replaceValueKind(kv.valueKind())
+                    .replaceValue(valueSerializer.copy(kv.value()))
+                    .setLevel(kv.level());
+        }
+        // add all.
+        kvList.add(copy);
+    }
+
+    /**
+     * Return the reordered KeyValues.
+     *
+     * <pre>
+     * example format:
+     * valueKind,sequence,key,value(sequence field)
+     * add:                     return:
+     * INSERT,22,1,58           INSERT,22,1,7
+     * DELETE,23,1,58           INSERT,23,1,31
+     * INSERT,24,1,31           DELETE,24,1,31
+     * DELETE,25,1,31           INSERT,25,1,40
+     * INSERT,26,1,76           INSERT,26,1,58
+     * INSERT,27,1,7            DELETE,27,1,58
+     * INSERT,28,1,null         INSERT,28,1,null
+     * INSERT,29,1,40           INSERT,29,1,76
+     * </pre>
+     */
+    @Override
+    public List<KeyValue> getResult() {
+        if (!allSameActualSequence && svList.size() > 1) {
+            svList.sort(
+                    Comparator.comparingLong(SequenceValue::getActualSequence)
+                            .thenComparingLong(SequenceValue::getAutoSequence));
+        }
+
+        int index = 0;
+        for (KeyValue kv : kvList) {
+            if (kv.value() == null) {
+                SequenceValue sv = svList.get(index++);
+                kv.replaceValueKind(sv.getValueKind())
+                        .replaceValue(sv.getValue())
+                        .setLevel(sv.getLevel());
+            }
+        }
+        return kvList;
+    }
+
+    public static ReorderFunctionFactory<KeyValue> factory(
+            RowType keyType, RowType valueType, CoreOptions options) {
+        return new Factory(keyType, valueType, options);
+    }
+
+    private static class Factory implements ReorderFunctionFactory<KeyValue> {
+
+        private static final long serialVersionUID = 1L;
+        private final RowType keyType;
+        private final RowType valueType;
+        @Nullable private final SequenceGenerator sequenceGenerator;
+        private final CoreOptions options;
+
+        public Factory(RowType keyType, RowType valueType, CoreOptions options) {
+            this.keyType = keyType;
+            this.valueType = valueType;
+            this.options = options;
+            this.sequenceGenerator = SequenceGenerator.create(valueType, options);
+        }
+
+        @Override
+        public ReorderFunction<KeyValue> create(@Nullable int[][] projection) {
+            if (sequenceGenerator != null) {
+                if (projection != null) {
+                    int[] projects = Projection.of(projection).toTopLevelIndexes();
+                    for (int i = 0; i < projects.length; i++) {
+                        if (projects[i] == sequenceGenerator.index()) {
+                            return new SequenceFieldReorderFunction(
+                                    new SequenceGenerator(i, sequenceGenerator.fieldType()),
+                                    keyType,
+                                    Projection.of(projection).project(valueType));
+                        }
+                    }
+                } else {
+                    return new SequenceFieldReorderFunction(sequenceGenerator, keyType, valueType);
+                }
+            }
+
+            return null;
+        }
+
+        @Override
+        public MergeFunctionFactory.AdjustedProjection adjustProjection(
+                @Nullable int[][] projection) {
+            if (sequenceGenerator == null) {
+                return new MergeFunctionFactory.AdjustedProjection(projection, null);
+            }
+
+            if (projection == null) {
+                return new MergeFunctionFactory.AdjustedProjection(null, null);
+            }
+            int[] topProjects = Projection.of(projection).toTopLevelIndexes();
+            Set<Integer> indexSet = Arrays.stream(topProjects).boxed().collect(Collectors.toSet());
+
+            int[] allProjects =
+                    Stream.concat(
+                                    Arrays.stream(topProjects).boxed(),
+                                    indexSet.contains(sequenceGenerator.index())
+                                            ? Stream.empty()
+                                            : Stream.of(sequenceGenerator.index()))
+                            .mapToInt(Integer::intValue)
+                            .toArray();
+            int[][] pushdown = Projection.of(allProjects).toNestedIndexes();
+            int[][] outer =
+                    Projection.of(IntStream.range(0, topProjects.length).toArray())
+                            .toNestedIndexes();
+            return new MergeFunctionFactory.AdjustedProjection(pushdown, outer);
+        }
+    }
+
+    private static class SequenceValue {
+
+        private final Long autoSequence;
+        private final Long actualSequence;
+        private final RowKind valueKind;
+        private final InternalRow value;
+        private final int level;
+
+        public SequenceValue(
+                Long autoSequence,
+                Long actualSequence,
+                RowKind valueKind,
+                InternalRow value,
+                int level) {
+            this.autoSequence = autoSequence;
+            this.actualSequence = actualSequence;
+            this.valueKind = valueKind;
+            this.value = value;
+            this.level = level;
+        }
+
+        public Long getAutoSequence() {
+            return autoSequence;
+        }
+
+        public Long getActualSequence() {
+            return actualSequence;
+        }
+
+        public RowKind getValueKind() {
+            return valueKind;
+        }
+
+        public InternalRow getValue() {
+            return value;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunction.java
@@ -75,7 +75,7 @@ public class SequenceFieldReorderFunction implements ReorderFunction<KeyValue> {
         long autoSequence = kv.sequenceNumber();
         KeyValue copy =
                 new KeyValue().replace(keySerializer.copy(kv.key()), autoSequence, null, null);
-        Long actualSequence = sequenceGenerator.generateNullable(kv.value());
+        Long actualSequence = sequenceGenerator.generateNullable(kv.value(), kv.valueKind());
         if (actualSequence != null) {
             // add for sorting.
             svList.add(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -23,6 +23,8 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
 
+import javax.annotation.Nullable;
+
 import java.util.Comparator;
 import java.util.List;
 
@@ -39,14 +41,15 @@ public interface SortMergeReader<T> extends RecordReader<T> {
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,
-            SortEngine sortEngine) {
+            SortEngine sortEngine,
+            @Nullable ReorderFunction<KeyValue> reorderFunction) {
         switch (sortEngine) {
             case MIN_HEAP:
                 return new SortMergeReaderWithMinHeap<>(
-                        readers, userKeyComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, mergeFunctionWrapper, reorderFunction);
             case LOSER_TREE:
                 return new SortMergeReaderWithLoserTree<>(
-                        readers, userKeyComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, mergeFunctionWrapper, reorderFunction);
             default:
                 throw new UnsupportedOperationException("Unsupported sort engine: " + sortEngine);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
+import org.apache.paimon.mergetree.compact.ReorderFunctionFactory;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.RowKind;
 
@@ -44,14 +45,16 @@ public class DiffReader {
             RecordReader<KeyValue> afterReader,
             Comparator<InternalRow> keyComparator,
             MergeSorter sorter,
-            boolean keepDelete)
+            boolean keepDelete,
+            ReorderFunctionFactory<KeyValue> rfFactory)
             throws IOException {
         return sorter.mergeSort(
                 Arrays.asList(
                         () -> wrapLevelToReader(beforeReader, BEFORE_LEVEL),
                         () -> wrapLevelToReader(afterReader, AFTER_LEVEL)),
                 keyComparator,
-                new DiffMerger(keepDelete));
+                new DiffMerger(keepDelete),
+                rfFactory.create());
     }
 
     private static RecordReader<KeyValue> wrapLevelToReader(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -69,7 +69,7 @@ public class SnapshotDeletion extends FileDeletionBase {
         // try read manifests
         List<String> manifestFileNames =
                 readManifestFileNames(tryReadManifestList(snapshot.deltaManifestList()));
-        List<ManifestEntry> manifestEntries = new ArrayList<>();
+        List<ManifestEntry> manifestEntries;
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete = new HashMap<>();
         for (String manifest : manifestFileNames) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
@@ -24,6 +24,8 @@ import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.mergetree.compact.FirstRowMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
+import org.apache.paimon.mergetree.compact.ReorderFunctionFactory;
+import org.apache.paimon.mergetree.compact.SequenceFieldReorderFunction;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
@@ -79,6 +81,11 @@ public class PrimaryKeyTableUtils {
             default:
                 throw new UnsupportedOperationException("Unsupported merge engine: " + mergeEngine);
         }
+    }
+
+    public static ReorderFunctionFactory<KeyValue> createReorderFunctionFactory(
+            RowType keyType, RowType valueType, CoreOptions options) {
+        return SequenceFieldReorderFunction.factory(keyType, valueType, options);
     }
 
     /** Primary key fields extractor. */

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/RowKindGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/RowKindGenerator.java
@@ -20,7 +20,6 @@ package org.apache.paimon.table.sink;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
@@ -57,9 +56,9 @@ public class RowKindGenerator {
     }
 
     @Nullable
-    public static RowKindGenerator create(TableSchema schema, CoreOptions options) {
+    public static RowKindGenerator create(RowType logicalRowType, CoreOptions options) {
         return options.rowkindField()
-                .map(field -> new RowKindGenerator(field, schema.logicalRowType()))
+                .map(field -> new RowKindGenerator(field, logicalRowType))
                 .orElse(null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/SequenceGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/SequenceGenerator.java
@@ -103,18 +103,27 @@ public class SequenceGenerator {
 
     @Nullable
     public Long generateNullable(InternalRow row) {
+        return generateNullable(row, row.getRowKind());
+    }
+
+    @Nullable
+    public Long generateNullable(InternalRow row, RowKind rowKind) {
         Long sequence = generator.generateNullable(row, index);
-        return sequence != null ? withPaddings(row, sequence) : null;
+        return sequence != null ? withPaddings(sequence, rowKind) : null;
     }
 
     public long generate(InternalRow row) {
-        return withPaddings(row, generator.generate(row, index));
+        return generate(row, row.getRowKind());
     }
 
-    private long withPaddings(InternalRow row, long sequence) {
+    public long generate(InternalRow row, RowKind rowKind) {
+        return withPaddings(generator.generate(row, index), rowKind);
+    }
+
+    private long withPaddings(long sequence, RowKind rowKind) {
         for (SequenceAutoPadding padding : paddings) {
             if (padding == SequenceAutoPadding.ROW_KIND_FLAG) {
-                sequence = addRowKindFlag(sequence, row.getRowKind());
+                sequence = addRowKindFlag(sequence, rowKind);
             } else {
                 throw new UnsupportedOperationException("Unknown sequence padding mode " + padding);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -133,14 +133,6 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
         return record;
     }
 
-    @VisibleForTesting
-    public T writeAndReturnData(InternalRow row) throws Exception {
-        SinkRecord record = toSinkRecord(row);
-        T data = recordExtractor.extract(record);
-        write.write(record.partition(), record.bucket(), data);
-        return data;
-    }
-
     private SinkRecord toSinkRecord(InternalRow row) {
         keyAndBucketExtractor.setRecord(row);
         return new SinkRecord(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
@@ -45,11 +45,6 @@ public class OffsetRow implements InternalRow {
         return this;
     }
 
-    public OffsetRow replace(RowKind rowKind) {
-        setRowKind(rowKind);
-        return this;
-    }
-
     @Override
     public int getFieldCount() {
         return arity;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
@@ -45,6 +45,11 @@ public class OffsetRow implements InternalRow {
         return this;
     }
 
+    public OffsetRow replace(RowKind rowKind) {
+        setRowKind(rowKind);
+        return this;
+    }
+
     @Override
     public int getFieldCount() {
         return arity;

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -33,6 +33,7 @@ import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryOwner;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
+import org.apache.paimon.mergetree.compact.ReorderFunctionFactory;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreCommitImpl;
@@ -103,7 +104,8 @@ public class TestFileStore extends KeyValueFileStore {
             RowType keyType,
             RowType valueType,
             KeyValueFieldsExtractor keyValueFieldsExtractor,
-            MergeFunctionFactory<KeyValue> mfFactory) {
+            MergeFunctionFactory<KeyValue> mfFactory,
+            ReorderFunctionFactory<KeyValue> rfFactory) {
         super(
                 FileIOFinder.find(new Path(root)),
                 new SchemaManager(FileIOFinder.find(new Path(root)), options.path()),
@@ -117,7 +119,8 @@ public class TestFileStore extends KeyValueFileStore {
                 keyValueFieldsExtractor,
                 mfFactory,
                 (new Path(root)).getName(),
-                new CatalogEnvironment(Lock.emptyFactory(), null, null));
+                new CatalogEnvironment(Lock.emptyFactory(), null, null),
+                rfFactory);
         this.root = root;
         this.fileIO = FileIOFinder.find(new Path(root));
         this.keySerializer = new InternalRowSerializer(keyType);
@@ -563,6 +566,7 @@ public class TestFileStore extends KeyValueFileStore {
         private final RowType valueType;
         private final KeyValueFieldsExtractor keyValueFieldsExtractor;
         private final MergeFunctionFactory<KeyValue> mfFactory;
+        private final ReorderFunctionFactory<KeyValue> rfFactory;
 
         private CoreOptions.ChangelogProducer changelogProducer;
 
@@ -574,7 +578,8 @@ public class TestFileStore extends KeyValueFileStore {
                 RowType keyType,
                 RowType valueType,
                 KeyValueFieldsExtractor keyValueFieldsExtractor,
-                MergeFunctionFactory<KeyValue> mfFactory) {
+                MergeFunctionFactory<KeyValue> mfFactory,
+                ReorderFunctionFactory<KeyValue> rfFactory) {
             this.format = format;
             this.root = root;
             this.numBuckets = numBuckets;
@@ -583,6 +588,7 @@ public class TestFileStore extends KeyValueFileStore {
             this.valueType = valueType;
             this.keyValueFieldsExtractor = keyValueFieldsExtractor;
             this.mfFactory = mfFactory;
+            this.rfFactory = rfFactory;
 
             this.changelogProducer = CoreOptions.ChangelogProducer.NONE;
         }
@@ -620,7 +626,8 @@ public class TestFileStore extends KeyValueFileStore {
                     keyType,
                     valueType,
                     keyValueFieldsExtractor,
-                    mfFactory);
+                    mfFactory,
+                    rfFactory);
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
@@ -139,7 +139,7 @@ public class MergeSorterTest {
                     }
                 };
         List<KeyValue> all = new ArrayList<>();
-        sorter.mergeSort(readers, Comparator.comparingInt(o -> o.getInt(0)), collectFunc)
+        sorter.mergeSort(readers, Comparator.comparingInt(o -> o.getInt(0)), collectFunc, null)
                 .forEachRemaining(all::addAll);
 
         assertThat(toString(all)).containsExactlyElementsOf(toString(expectedKvs));

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -154,19 +154,13 @@ public abstract class MergeTreeTestBase {
                             @Override
                             public List<DataField> keyFields(TableSchema schema) {
                                 return Collections.singletonList(
-                                        new DataField(
-                                                0,
-                                                "k",
-                                                new org.apache.paimon.types.IntType(false)));
+                                        new DataField(0, "k", new IntType(false)));
                             }
 
                             @Override
                             public List<DataField> valueFields(TableSchema schema) {
                                 return Collections.singletonList(
-                                        new DataField(
-                                                0,
-                                                "v",
-                                                new org.apache.paimon.types.IntType(false)));
+                                        new DataField(0, "v", new IntType(false)));
                             }
                         },
                         new CoreOptions(new HashMap<>()));
@@ -426,6 +420,7 @@ public abstract class MergeTreeTestBase {
                         options.commitForceCompact(),
                         ChangelogProducer.NONE,
                         null,
+                        null,
                         null);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
@@ -555,7 +550,8 @@ public abstract class MergeTreeTestBase {
                         readerFactory,
                         comparator,
                         DeduplicateMergeFunction.factory().create(),
-                        new MergeSorter(options, null, null, null));
+                        new MergeSorter(options, null, null, null),
+                        null);
         List<TestRecord> records = new ArrayList<>();
         try (RecordReaderIterator<KeyValue> iterator = new RecordReaderIterator<>(reader)) {
             while (iterator.hasNext()) {
@@ -601,7 +597,8 @@ public abstract class MergeTreeTestBase {
                             compactReaderFactory,
                             comparator,
                             DeduplicateMergeFunction.factory().create(),
-                            new MergeSorter(options, null, null, null));
+                            new MergeSorter(options, null, null, null),
+                            null);
             writer.write(new RecordReaderIterator<>(sectionsReader));
             writer.close();
             return new CompactResult(extractFilesFromSections(sections), writer.result());

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
@@ -85,6 +85,7 @@ public abstract class CombiningRecordReaderTestBase {
                 getExpected(
                                 readersData.stream()
                                         .flatMap(Collection::stream)
+                                        .sorted()
                                         .collect(Collectors.toList()))
                         .iterator();
         List<TestReusingRecordReader> readers = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CombiningRecordReaderTestBase.java
@@ -85,7 +85,6 @@ public abstract class CombiningRecordReaderTestBase {
                 getExpected(
                                 readersData.stream()
                                         .flatMap(Collection::stream)
-                                        .sorted()
                                         .collect(Collectors.toList()))
                         .iterator();
         List<TestReusingRecordReader> readers = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
@@ -23,7 +23,6 @@ import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.ReusingTestData;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -33,9 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MergeFunctionTestUtils {
 
     public static List<ReusingTestData> getExpectedForDeduplicate(List<ReusingTestData> input) {
-        input = new ArrayList<>(input);
-        Collections.sort(input);
-
         List<ReusingTestData> expected = new ArrayList<>();
         for (int i = 0; i < input.size(); i++) {
             ReusingTestData data = input.get(i);
@@ -47,9 +43,6 @@ public class MergeFunctionTestUtils {
     }
 
     public static List<ReusingTestData> getExpectedForPartialUpdate(List<ReusingTestData> input) {
-        input = new ArrayList<>(input);
-        Collections.sort(input);
-
         LinkedHashMap<Integer, List<ReusingTestData>> groups = new LinkedHashMap<>();
         for (ReusingTestData d : input) {
             groups.computeIfAbsent(d.key, k -> new ArrayList<>()).add(d);
@@ -71,9 +64,6 @@ public class MergeFunctionTestUtils {
     }
 
     public static List<ReusingTestData> getExpectedForAggSum(List<ReusingTestData> input) {
-        input = new ArrayList<>(input);
-        Collections.sort(input);
-
         LinkedHashMap<Integer, List<ReusingTestData>> groups = new LinkedHashMap<>();
         for (ReusingTestData d : input) {
             groups.computeIfAbsent(d.key, k -> new ArrayList<>()).add(d);
@@ -98,9 +88,6 @@ public class MergeFunctionTestUtils {
     }
 
     public static List<ReusingTestData> getExpectedForFirstRow(List<ReusingTestData> input) {
-        input = new ArrayList<>(input);
-        Collections.sort(input);
-
         List<ReusingTestData> expected = new ArrayList<>();
         for (int i = 0; i < input.size(); i++) {
             if (i == 0 || input.get(i).key != input.get(i - 1).key) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SequenceFieldReorderFunctionTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SequenceFieldReorderFunction}. */
+public class SequenceFieldReorderFunctionTest {
+
+    private long sequence = 0;
+    private ReorderFunction<KeyValue> reorderFunction;
+    private RowType keyType;
+    private RowType valueType;
+    private CoreOptions options;
+
+    @BeforeEach
+    public void createReorderFunction() {
+        Options conf = new Options();
+        conf.set(CoreOptions.SEQUENCE_FIELD, "c");
+        options = new CoreOptions(conf);
+
+        keyType = RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"PK_a"});
+        valueType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.INT(),
+                            DataTypes.INT(),
+                            DataTypes.INT(),
+                            DataTypes.INT(),
+                            DataTypes.INT()
+                        },
+                        new String[] {"a", "b", "c", "d", "e"});
+    }
+
+    @Test
+    public void testAddAndResult() {
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options).create();
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.DELETE, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 76, 100, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 7, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, null, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 40, 21, 1);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(valueType),
+                createKeyValue(RowKind.INSERT, 1, 1, 7, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 40, 21, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.DELETE, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, null, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 76, 100, 1));
+    }
+
+    @Test
+    public void testSeqFieldSameValue() {
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options).create();
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, 1, 10, 1);
+        add(reorderFunction, RowKind.DELETE, 1, 1, 1, 10, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 1, 100, 1);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(valueType),
+                createKeyValue(RowKind.INSERT, 1, 1, 1, 10, 1),
+                createKeyValue(RowKind.DELETE, 1, 1, 1, 10, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 1, 100, 1));
+    }
+
+    @Test
+    public void testSeqFieldNullValue() {
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options).create();
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, null, 10, 1);
+        add(reorderFunction, RowKind.DELETE, 1, 1, null, 10, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, null, 100, 1);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(valueType),
+                createKeyValue(RowKind.INSERT, 1, 1, null, 10, 1),
+                createKeyValue(RowKind.DELETE, 1, 1, null, 10, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, null, 100, 1));
+    }
+
+    @Test
+    public void testAdjustProjectionRepeatProject() {
+        int[][] projection = new int[][] {{1}, {1}, {3}};
+        MergeFunctionFactory.AdjustedProjection adjustProjection =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .adjustProjection(projection);
+
+        validate(adjustProjection, new int[] {1, 1, 3, 2}, new int[] {0, 1, 2});
+
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .create(adjustProjection.pushdownProjection);
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, 10, 58);
+        add(reorderFunction, RowKind.DELETE, 1, 1, 10, 58);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 100, 76);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 1, 7);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 1, null);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 21, 40);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(Projection.of(projection).project(valueType)),
+                createKeyValue(RowKind.INSERT, 1, 1, 1, 7),
+                createKeyValue(RowKind.INSERT, 1, 1, 21, 40),
+                createKeyValue(RowKind.INSERT, 1, 1, 10, 58),
+                createKeyValue(RowKind.DELETE, 1, 1, 10, 58),
+                createKeyValue(RowKind.INSERT, 1, 1, 1, null),
+                createKeyValue(RowKind.INSERT, 1, 1, 100, 76));
+    }
+
+    @Test
+    public void testAdjustProjectionSequenceFieldsProject() {
+        int[][] projection = new int[][] {{1}, {3}, {2}};
+        MergeFunctionFactory.AdjustedProjection adjustProjection =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .adjustProjection(projection);
+
+        validate(adjustProjection, new int[] {1, 3, 2}, new int[] {0, 1, 2});
+
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .create(adjustProjection.pushdownProjection);
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 10, 58);
+        add(reorderFunction, RowKind.DELETE, 1, 10, 58);
+        add(reorderFunction, RowKind.INSERT, 1, 100, 76);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 7);
+        add(reorderFunction, RowKind.INSERT, 1, 1, null);
+        add(reorderFunction, RowKind.INSERT, 1, 21, 40);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(Projection.of(projection).project(valueType)),
+                createKeyValue(RowKind.INSERT, 1, 1, 7),
+                createKeyValue(RowKind.INSERT, 1, 21, 40),
+                createKeyValue(RowKind.INSERT, 1, 10, 58),
+                createKeyValue(RowKind.DELETE, 1, 10, 58),
+                createKeyValue(RowKind.INSERT, 1, 1, null),
+                createKeyValue(RowKind.INSERT, 1, 100, 76));
+    }
+
+    @Test
+    public void testAdjustProjectionAllFieldsProject() {
+        int[][] projection = new int[][] {{0}, {1}, {2}, {3}, {4}};
+        MergeFunctionFactory.AdjustedProjection adjustProjection =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .adjustProjection(projection);
+
+        validate(adjustProjection, new int[] {0, 1, 2, 3, 4}, new int[] {0, 1, 2, 3, 4});
+
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .create(adjustProjection.pushdownProjection);
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.DELETE, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 76, 100, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 7, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, null, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 40, 21, 1);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(Projection.of(projection).project(valueType)),
+                createKeyValue(RowKind.INSERT, 1, 1, 7, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 40, 21, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.DELETE, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, null, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 76, 100, 1));
+    }
+
+    @Test
+    public void testAdjustProjectionNonProject() {
+        MergeFunctionFactory.AdjustedProjection adjustProjection =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .adjustProjection(null);
+
+        validate(adjustProjection, null, null);
+
+        reorderFunction =
+                SequenceFieldReorderFunction.factory(keyType, valueType, options)
+                        .create(adjustProjection.pushdownProjection);
+        reorderFunction.reset();
+        add(reorderFunction, RowKind.INSERT, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.DELETE, 1, 1, 58, 10, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 76, 100, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 7, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, null, 1, 1);
+        add(reorderFunction, RowKind.INSERT, 1, 1, 40, 21, 1);
+        validate(
+                reorderFunction,
+                createInternalRowSerializer(valueType),
+                createKeyValue(RowKind.INSERT, 1, 1, 7, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 40, 21, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.DELETE, 1, 1, 58, 10, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, null, 1, 1),
+                createKeyValue(RowKind.INSERT, 1, 1, 76, 100, 1));
+    }
+
+    private void validate(
+            ReorderFunction<KeyValue> reorderFunction,
+            InternalRowSerializer serializer,
+            KeyValue... keyValues) {
+        List<KeyValue> list = Arrays.asList(keyValues);
+        for (int i = 0; i < list.size(); i++) {
+            assert equals(reorderFunction.getResult().get(i), list.get(i), serializer);
+        }
+    }
+
+    private void validate(
+            MergeFunctionFactory.AdjustedProjection projection, int[] pushdown, int[] outer) {
+        if (projection.pushdownProjection == null) {
+            assertThat(pushdown).isNull();
+        } else {
+            assertThat(pushdown)
+                    .containsExactly(
+                            Projection.of(projection.pushdownProjection).toTopLevelIndexes());
+        }
+
+        if (projection.outerProjection == null) {
+            assertThat(outer).isNull();
+        } else {
+            assertThat(outer)
+                    .containsExactly(Projection.of(projection.outerProjection).toTopLevelIndexes());
+        }
+    }
+
+    private boolean equals(KeyValue kv1, KeyValue kv2, InternalRowSerializer serializer) {
+        return kv1.valueKind() == kv2.valueKind()
+                && serializer
+                        .toBinaryRow(kv1.value())
+                        .copy()
+                        .equals(serializer.toBinaryRow(kv2.value()).copy());
+    }
+
+    private KeyValue createKeyValue(RowKind rowKind, Integer... value) {
+        return new KeyValue().replaceValueKind(rowKind).replaceValue(GenericRow.of(value));
+    }
+
+    private void add(ReorderFunction<KeyValue> reorderFunction, RowKind rowKind, Integer... value) {
+        reorderFunction.add(
+                new KeyValue()
+                        .replace(GenericRow.of(1), sequence++, rowKind, GenericRow.of(value)));
+    }
+
+    private InternalRowSerializer createInternalRowSerializer(RowType rowType) {
+        return new InternalRowSerializer(rowType);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -49,7 +49,8 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
                 new ArrayList<>(readers),
                 KEY_COMPARATOR,
                 new ReducerMergeFunctionWrapper(createMergeFunction()),
-                sortEngine);
+                sortEngine,
+                null);
     }
 
     @ParameterizedTest

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Tests for {@link SortMergeReader}. */
@@ -103,6 +104,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
 
         @Override
         protected List<ReusingTestData> getExpected(List<ReusingTestData> input) {
+            Collections.sort(input);
             return MergeFunctionTestUtils.getExpectedForDeduplicate(input);
         }
 
@@ -122,6 +124,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
 
         @Override
         protected List<ReusingTestData> getExpected(List<ReusingTestData> input) {
+            Collections.sort(input);
             return MergeFunctionTestUtils.getExpectedForFirstRow(input);
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -680,7 +680,8 @@ public class FileDeletionTest {
                         TestKeyValueGenerator.KEY_TYPE,
                         rowType,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory())
+                        DeduplicateMergeFunction.factory(),
+                        p -> null)
                 .changelogProducer(changelogProducer)
                 .build();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -873,7 +873,8 @@ public class FileStoreCommitTest {
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory())
+                        DeduplicateMergeFunction.factory(),
+                        p -> null)
                 .changelogProducer(changelogProducer)
                 .build();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreExpireTestBase.java
@@ -86,7 +86,8 @@ public abstract class FileStoreExpireTestBase {
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory())
+                        DeduplicateMergeFunction.factory(),
+                        p -> null)
                 .changelogProducer(changelogProducer)
                 .build();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreReadTest.java
@@ -127,10 +127,7 @@ public class KeyValueFileStoreReadTest {
                             @Override
                             public List<DataField> valueFields(TableSchema schema) {
                                 return Collections.singletonList(
-                                        new DataField(
-                                                0,
-                                                "count",
-                                                new org.apache.paimon.types.BigIntType()));
+                                        new DataField(0, "count", new BigIntType()));
                             }
                         },
                         TestValueCountMergeFunction.factory());
@@ -289,7 +286,8 @@ public class KeyValueFileStoreReadTest {
                         keyType,
                         valueType,
                         extractor,
-                        mfFactory)
+                        mfFactory,
+                        p -> null)
                 .build();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -76,7 +76,8 @@ public class KeyValueFileStoreScanTest {
                                 TestKeyValueGenerator.KEY_TYPE,
                                 TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                                 TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                                DeduplicateMergeFunction.factory())
+                                DeduplicateMergeFunction.factory(),
+                                p -> null)
                         .build();
         snapshotManager = store.snapshotManager();
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -294,12 +294,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 binaryRow(1),
                                 0,
                                 rowData ->
-                                        (rowData.getRowKind() == RowKind.INSERT
-                                                                || rowData.getRowKind()
-                                                                        == RowKind.UPDATE_AFTER
-                                                        ? "+"
-                                                        : "-")
-                                                + rowData.getInt(0)
+                                        rowData.getInt(0)
                                                 + "|"
                                                 + rowData.getInt(1)
                                                 + "|"
@@ -308,7 +303,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                                                 + (!rowData.isNullAt(3) ? rowData.getInt(3) : null)
                                                 + "|"
                                                 + rowData.getString(4)))
-                .isEqualTo(Arrays.asList("+1|10|102|null|a3", "+1|11|100|1685530986|a4"));
+                .isEqualTo(Arrays.asList("1|10|102|null|a3", "1|11|100|1685530986|a4"));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/SequenceGeneratorTest.java
@@ -34,14 +34,10 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import static org.apache.paimon.CoreOptions.SequenceAutoPadding.MILLIS_TO_MICRO;
 import static org.apache.paimon.CoreOptions.SequenceAutoPadding.ROW_KIND_FLAG;
-import static org.apache.paimon.CoreOptions.SequenceAutoPadding.SECOND_TO_MICRO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -169,58 +165,6 @@ public class SequenceGeneratorTest {
     }
 
     @Test
-    public void testGenerateWithPadding() {
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_id")))
-                .isEqualTo(1);
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("pt")))
-                .isEqualTo(1);
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_intsecond")))
-                .isEqualTo(1685548953);
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_tinyint")))
-                .isEqualTo(2);
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_smallint")))
-                .isEqualTo(3);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigint")))
-                .isEqualTo(4000000000000L);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_bigintmillis")))
-                .isEqualTo(1685548953000L);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_float")))
-                .isEqualTo(2);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_double")))
-                .isEqualTo(3);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_string")))
-                .isEqualTo(1);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_date")))
-                .isEqualTo(375);
-        assertThat(getSecondFromGeneratedWithPadding(generateWithPaddingOnSecond("_timestamp0")))
-                .isEqualTo(1685548953L);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_timestamp3")))
-                .isEqualTo(1685548953123L);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_timestamp6")))
-                .isEqualTo(1685548953123L);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_char")))
-                .isEqualTo(3);
-        assertThat(getMillisFromGeneratedWithPadding(generateWithPaddingOnMillis("_varchar")))
-                .isEqualTo(4);
-        assertThat(
-                        getSecondFromGeneratedWithPadding(
-                                generateWithPaddingOnSecond("_localtimestamp")))
-                .isEqualTo(1685548953L);
-        assertThat(
-                        getMillisFromGeneratedWithPadding(
-                                generateWithPaddingOnMillis("_localtimestamp")))
-                .isEqualTo(1685548953123L);
-        assertUnsupportedDatatype("_boolean");
-        assertUnsupportedDatatype("_binary");
-        assertUnsupportedDatatype("_varbinary");
-        assertUnsupportedDatatype("_bytes");
-        assertUnsupportedDatatype("_time");
-        assertUnsupportedDatatype("_map");
-        assertUnsupportedDatatype("_array");
-        assertUnsupportedDatatype("_multiset");
-    }
-
-    @Test
     public void testGenerateWithPaddingRowKind() {
         assertThat(generateWithPaddingOnRowKind(1L, RowKind.INSERT)).isEqualTo(3);
         assertThat(generateWithPaddingOnRowKind(1L, RowKind.UPDATE_AFTER)).isEqualTo(3);
@@ -231,11 +175,6 @@ public class SequenceGeneratorTest {
                 Timestamp.fromLocalDateTime(LocalDateTime.parse("5000-01-01T00:00:00")).toMicros();
         assertThat(generateWithPaddingOnRowKind(maxMicros, RowKind.INSERT))
                 .isEqualTo(191235168000000001L);
-
-        assertThat(generateWithPaddingOnMicrosAndRowKind(1L, RowKind.INSERT))
-                .isBetween(2001L, 3999L);
-        assertThat(generateWithPaddingOnMicrosAndRowKind(1L, RowKind.UPDATE_BEFORE))
-                .isBetween(2000L, 3998L);
     }
 
     private SequenceGenerator getGenerator(String field) {
@@ -252,29 +191,8 @@ public class SequenceGeneratorTest {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    private long generateWithPaddingOnSecond(String field) {
-        return getGenerator(field, Collections.singletonList(SECOND_TO_MICRO)).generate(row);
-    }
-
-    private long getSecondFromGeneratedWithPadding(long generated) {
-        return TimeUnit.SECONDS.convert(generated, TimeUnit.MICROSECONDS);
-    }
-
-    private long generateWithPaddingOnMillis(String field) {
-        return getGenerator(field, Collections.singletonList(MILLIS_TO_MICRO)).generate(row);
-    }
-
     private long generateWithPaddingOnRowKind(long sequence, RowKind rowKind) {
         return getGenerator("_bigint", Collections.singletonList(ROW_KIND_FLAG))
                 .generate(GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence));
-    }
-
-    private long generateWithPaddingOnMicrosAndRowKind(long sequence, RowKind rowKind) {
-        return getGenerator("_bigint", Arrays.asList(MILLIS_TO_MICRO, ROW_KIND_FLAG))
-                .generate(GenericRow.ofKind(rowKind, 0, 0, 0, 0, 0, 0, sequence));
-    }
-
-    private long getMillisFromGeneratedWithPadding(long generated) {
-        return TimeUnit.MILLISECONDS.convert(generated, TimeUnit.MICROSECONDS);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
@@ -173,8 +173,8 @@ public class FilesTableTest extends TableTestBase {
             DataFileMeta file = fileEntry.file();
             String minKey = String.valueOf(file.minKey().getInt(0));
             String maxKey = String.valueOf(file.maxKey().getInt(0));
-            String minSequenceNumber = String.valueOf(file.minSequenceNumber());
-            String maxSequenceNumber = String.valueOf(file.maxSequenceNumber());
+            int minValue = file.valueStats().minValues().getInt(2);
+            int maxValue = file.valueStats().maxValues().getInt(2);
             expectedRow.add(
                     GenericRow.of(
                             BinaryString.fromString(Arrays.toString(new String[] {partition})),
@@ -192,11 +192,11 @@ public class FilesTableTest extends TableTestBase {
                             BinaryString.fromString(
                                     String.format(
                                             "{col1=%s, pk=%s, pt=%s}",
-                                            minSequenceNumber, minKey, partition)),
+                                            minValue, minKey, partition)),
                             BinaryString.fromString(
                                     String.format(
                                             "{col1=%s, pk=%s, pt=%s}",
-                                            maxSequenceNumber, maxKey, partition)),
+                                            maxValue, maxKey, partition)),
                             file.minSequenceNumber(),
                             file.maxSequenceNumber(),
                             file.creationTime()));

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ReusingTestData.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ReusingTestData implements Comparable<ReusingTestData> {
 
-    public final int key;
-    public final long sequenceNumber;
-    public final RowKind valueKind;
-    public final long value;
+    public int key;
+    public long sequenceNumber;
+    public RowKind valueKind;
+    public long value;
 
     public ReusingTestData(int key, long sequenceNumber, RowKind valueKind, long value) {
         this.key = key;
@@ -57,6 +57,20 @@ public class ReusingTestData implements Comparable<ReusingTestData> {
         Preconditions.checkArgument(
                 result != 0 || this == that,
                 "Found two CompactTestData with the same sequenceNumber. This is invalid.");
+        return result;
+    }
+
+    public int compareByFieldAndSequence(ReusingTestData that) {
+        if (key != that.key) {
+            return Integer.compare(key, that.key);
+        }
+        int result = Long.compare(value, that.value);
+        if (result == 0) {
+            result = Long.compare(sequenceNumber, that.sequenceNumber);
+        }
+        Preconditions.checkArgument(
+                result != 0 || this == that,
+                "Found two CompactTestData with the same value and sequenceNumber. This is invalid.");
         return result;
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -194,15 +194,22 @@ public class LookupTableTest extends TableTestBase {
         assertRow(result.get(0), 1, 22, 222);
 
         // refresh with old sequence
-        table.refresh(singletonList((sequence(row(1, 33, 333), 0L))).iterator(), true);
-        result = table.get(row(1));
+        table.refresh(singletonList((sequence(row(2, 11, 111), 0L))).iterator(), true);
+        result = table.get(row(2));
         assertThat(result).hasSize(1);
-        assertRow(result.get(0), 1, 22, 222);
+        assertRow(result.get(0), 2, 22, 222);
+
+        // test refresh with same sequence
+        table.refresh(singletonList((sequence(row(2, 22, 2222), 1L))).iterator(), true);
+        result = table.get(row(2));
+        assertThat(result).hasSize(1);
+        assertRow(result.get(0), 2, 22, 2222);
 
         // test refresh delete data with old sequence
         table.refresh(
-                singletonList(sequence(row(RowKind.DELETE, 1, 11, 111), -1L)).iterator(), true);
-        assertThat(table.get(row(1))).hasSize(1);
+                singletonList(sequence(row(RowKind.DELETE, 1, 11, 111), 2L)).iterator(), true);
+        result = table.get(row(1));
+        assertThat(result).hasSize(1);
         assertRow(result.get(0), 1, 22, 222);
     }
 
@@ -351,7 +358,7 @@ public class LookupTableTest extends TableTestBase {
 
         // refresh with old value
         table.refresh(
-                singletonList((InternalRow) joined.replace(row(1, 22, 333), GenericRow.of(0L)))
+                singletonList((InternalRow) joined.replace(row(1, 11, 333), GenericRow.of(2L)))
                         .iterator(),
                 true);
         result = table.get(row(22));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -129,7 +129,8 @@ public class TestChangelogDataReadWrite {
                         ignore -> avro,
                         pathFactory,
                         EXTRACTOR,
-                        new CoreOptions(new HashMap<>()));
+                        new CoreOptions(new HashMap<>()),
+                        p -> null);
         return new KeyValueTableRead(read, null) {
 
             @Override
@@ -185,7 +186,8 @@ public class TestChangelogDataReadWrite {
                                 null,
                                 options,
                                 EXTRACTOR,
-                                tablePath.getName())
+                                tablePath.getName(),
+                                p -> null)
                         .createWriterContainer(partition, bucket, true)
                         .writer;
         ((MemoryOwner) writer)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2041

<!-- What is the purpose of the change -->
By adding `ReorderFunction`(impl: `SequenceFieldReorderFunction`), it performs reordering based on `sequence.field` and the internal incrementing sequence number before data merging. This truly achieves the functionality users desire with custom `sequence.field`.

PS: Perhaps, in the end, achieving optimal performance could involve modifying the underlying storage format, as outlined in https://github.com/facebook/rocksdb/wiki/User-defined-Timestamp.
### Tests

<!-- List UT and IT cases to verify this change -->
`SequenceFieldReorderFunctionTest`
`SortBufferWriteBufferTestBase`
`PrimaryKeyFileStoreTableTest`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
