### PR TITLE
[core] Agg 'collect' and 'merge_map' support retract

### DIFF
--- a/docs/content/concepts/primary-key-table/merge-engine.md
+++ b/docs/content/concepts/primary-key-table/merge-engine.md
@@ -295,14 +295,28 @@ Current supported aggregate functions and data types are:
 * `merge_map`:
   The merge_map function merge input maps. It only supports MAP type.
 
-Only `sum`, `product` and `count` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
-If you allow some functions to ignore retraction messages, you can configure:
-`'fields.${field_name}.ignore-retract'='true'`.
-
 {{< hint info >}}
 For streaming queries, `aggregation` merge engine must be used together with `lookup` or `full-compaction`
 [changelog producer]({{< ref "concepts/primary-key-table/changelog-producer" >}}). ('input' changelog producer is also supported, but only returns input records.)
 {{< /hint >}}
+
+### Retract
+
+Only `sum`, `product`, `count`, `collect` and `merge_map` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
+If you allow some functions to ignore retraction messages, you can configure:
+`'fields.${field_name}.ignore-retract'='true'`.
+
+NOTE: The `collect` and `merge_map` make a best-effort attempt to handle retraction messages, but the results are not 
+guaranteed to be accurate. The following behaviors may occur when processing retraction messages:
+
+1. It might fail to handle retraction messages if records are disordered. For example, the table uses `collect`, and the 
+upstreams send `+I['A', 'B']` and `-U['A']` respectively. If the table receives `-U['A']` first, it can do nothing; then it receives
+`+I['A', 'B']`, the merge result will be `+I['A', 'B']` instead of `+I['B']`.
+
+2. The retract field from one input stream will retract the result merged from multiple upstreams. For example, the table 
+uses `merge_map`, and one upstream send `+I[1->A]`, another upstream send `+I[1->B]`, `-D[1->B]` later. The table will merge
+two insert values to `+I[1->B]`, and then the `-D[1->B]` will retract the result, so the final merge result is empty map 
+instead of `+I[1->A]`
 
 ## First Row
 

--- a/docs/content/concepts/primary-key-table/merge-engine.md
+++ b/docs/content/concepts/primary-key-table/merge-engine.md
@@ -313,10 +313,10 @@ guaranteed to be accurate. The following behaviors may occur when processing ret
 upstreams send `+I['A', 'B']` and `-U['A']` respectively. If the table receives `-U['A']` first, it can do nothing; then it receives
 `+I['A', 'B']`, the merge result will be `+I['A', 'B']` instead of `+I['B']`.
 
-2. The retract field from one input stream will retract the result merged from multiple upstreams. For example, the table 
-uses `merge_map`, and one upstream send `+I[1->A]`, another upstream send `+I[1->B]`, `-D[1->B]` later. The table will merge
-two insert values to `+I[1->B]`, and then the `-D[1->B]` will retract the result, so the final merge result is empty map 
-instead of `+I[1->A]`
+2. The retract message from one upstream will retract the result merged from multiple upstreams. For example, the table 
+uses `merge_map`, and one upstream sends `+I[1->A]`, another upstream sends `+I[1->B]`, `-D[1->B]` later. The table will 
+merge two insert values to `+I[1->B]` first, and then the `-D[1->B]` will retract the whole result, so the final result 
+is an empty map instead of `+I[1->A]`
 
 ## First Row
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1162,6 +1162,15 @@ public class CoreOptions implements Serializable {
                 .collect(Collectors.toMap(e -> Integer.valueOf(e.getKey()), Map.Entry::getValue));
     }
 
+    public boolean definedAggFunc() {
+        for (String key : options.toMap().keySet()) {
+            if (key.startsWith(FIELDS_PREFIX) && key.endsWith(AGG_FUNCTION)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public String fieldAggFunc(String fieldName) {
         return options.get(
                 key(FIELDS_PREFIX + "." + fieldName + "." + AGG_FUNCTION)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
@@ -83,7 +83,8 @@ public abstract class FlinkTableSinkBase
                 return requestedMode;
             }
 
-            if (options.get(MERGE_ENGINE) == MergeEngine.AGGREGATE) {
+            MergeEngine mergeEngine = options.get(MERGE_ENGINE);
+            if (mergeEngine == MergeEngine.AGGREGATE || mergeEngine == MergeEngine.PARTIAL_UPDATE) {
                 return requestedMode;
             }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.CoreOptions.LogChangelogMode;
 import org.apache.paimon.CoreOptions.MergeEngine;
@@ -83,8 +84,12 @@ public abstract class FlinkTableSinkBase
                 return requestedMode;
             }
 
-            MergeEngine mergeEngine = options.get(MERGE_ENGINE);
-            if (mergeEngine == MergeEngine.AGGREGATE || mergeEngine == MergeEngine.PARTIAL_UPDATE) {
+            if (options.get(MERGE_ENGINE) == MergeEngine.AGGREGATE) {
+                return requestedMode;
+            }
+
+            if (options.get(MERGE_ENGINE) == MergeEngine.PARTIAL_UPDATE
+                    && new CoreOptions(options).definedAggFunc()) {
                 return requestedMode;
             }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The retract isn't correct when:
1. If the retract field arrives but accumulator doesn't, won't retract;
2. The retract field from one input stream will retract the result merged from multiple input streams.
for example, using merge_map, acc (1, A) + input (1, B) will get (1, B), and if retract (1, A) later, the result (1, B) will be deleted from result map.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
