### PR TITLE
[core] Introduce Context for LookupStoreFactory to avoid writing metadata

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/LookupBloomFilterBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/LookupBloomFilterBenchmark.java
@@ -137,7 +137,6 @@ public class LookupBloomFilterBenchmark {
         for (byte[] input : inputs) {
             writer.put(input, value);
         }
-        writer.close();
-        return factory.createReader(file);
+        return factory.createReader(file, writer.close());
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStoreFactory.java
@@ -42,7 +42,7 @@ public interface LookupStoreFactory {
     LookupStoreWriter createWriter(File file, @Nullable BloomFilter.Builder bloomFilter)
             throws IOException;
 
-    LookupStoreReader createReader(File file) throws IOException;
+    LookupStoreReader createReader(File file, Context context) throws IOException;
 
     static Function<Long, BloomFilter.Builder> bfGenerator(Options options) {
         Function<Long, BloomFilter.Builder> bfGenerator = rowCount -> null;
@@ -58,4 +58,7 @@ public interface LookupStoreFactory {
         }
         return bfGenerator;
     }
+
+    /** Context between writer and reader. */
+    interface Context {}
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStoreWriter.java
@@ -18,12 +18,15 @@
 
 package org.apache.paimon.lookup;
 
-import java.io.Closeable;
+import org.apache.paimon.lookup.LookupStoreFactory.Context;
+
 import java.io.IOException;
 
 /** Writer to prepare binary file. */
-public interface LookupStoreWriter extends Closeable {
+public interface LookupStoreWriter {
 
     /** Put key value to store. */
     void put(byte[] key, byte[] value) throws IOException;
+
+    Context close() throws IOException;
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashContext.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lookup.hash;
+
+import org.apache.paimon.lookup.LookupStoreFactory.Context;
+
+/** Context for {@link HashLookupStoreFactory}. */
+public class HashContext implements Context {
+
+    // is bloom filter enabled
+    final boolean bloomFilterEnabled;
+    // expected entries for bloom filter
+    final long bloomFilterExpectedEntries;
+    // bytes for bloom filter
+    final int bloomFilterBytes;
+
+    // Key count for each key length
+    final int[] keyCounts;
+    // Slot size for each key length
+    final int[] slotSizes;
+    // Number of slots for each key length
+    final int[] slots;
+    // Offset of the index for different key length
+    final int[] indexOffsets;
+    // Offset of the data for different key length
+    final long[] dataOffsets;
+
+    public HashContext(
+            boolean bloomFilterEnabled,
+            long bloomFilterExpectedEntries,
+            int bloomFilterBytes,
+            int[] keyCounts,
+            int[] slotSizes,
+            int[] slots,
+            int[] indexOffsets,
+            long[] dataOffsets) {
+        this.bloomFilterEnabled = bloomFilterEnabled;
+        this.bloomFilterExpectedEntries = bloomFilterExpectedEntries;
+        this.bloomFilterBytes = bloomFilterBytes;
+        this.keyCounts = keyCounts;
+        this.slotSizes = slotSizes;
+        this.slots = slots;
+        this.indexOffsets = indexOffsets;
+        this.dataOffsets = dataOffsets;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
@@ -41,8 +41,8 @@ public class HashLookupStoreFactory implements LookupStoreFactory {
     }
 
     @Override
-    public HashLookupStoreReader createReader(File file) throws IOException {
-        return new HashLookupStoreReader(cacheManager, cachePageSize, file);
+    public HashLookupStoreReader createReader(File file, Context context) throws IOException {
+        return new HashLookupStoreReader(file, (HashContext) context, cacheManager, cachePageSize);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
@@ -30,16 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.BufferedInputStream;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -64,111 +58,41 @@ public class HashLookupStoreReader
     private FileBasedRandomInputView inputView;
     // Buffers
     private final byte[] slotBuffer;
+
     @Nullable private FileBasedBloomFilter bloomFilter;
 
-    HashLookupStoreReader(CacheManager cacheManager, int cachePageSize, File file)
+    HashLookupStoreReader(
+            File file, HashContext context, CacheManager cacheManager, int cachePageSize)
             throws IOException {
         // File path
         if (!file.exists()) {
             throw new FileNotFoundException("File " + file.getAbsolutePath() + " not found");
         }
+
+        keyCounts = context.keyCounts;
+        slots = context.slots;
+        slotSizes = context.slotSizes;
+        int maxSlotSize = 0;
+        for (int slotSize : slotSizes) {
+            maxSlotSize = Math.max(maxSlotSize, slotSize);
+        }
+        slotBuffer = new byte[maxSlotSize];
+        indexOffsets = context.indexOffsets;
+        dataOffsets = context.dataOffsets;
+
         LOG.info("Opening file {}", file.getName());
         // Create Mapped file in read-only mode
         inputView = new FileBasedRandomInputView(file, cacheManager, cachePageSize);
 
-        // Open file and read metadata
-        long createdAt;
-        FileInputStream inputStream = new FileInputStream(file);
-        DataInputStream dataInputStream = new DataInputStream(new BufferedInputStream(inputStream));
-        // Offset of the index in the channel
-        int keyCount;
-        int indexOffset;
-        long dataOffset;
-        boolean bloomFilterEnabled;
-        try {
-            // Time
-            createdAt = dataInputStream.readLong();
-
-            // Metadata counters
-            keyCount = dataInputStream.readInt();
-            // Number of different key length
-            int keyLengthCount = dataInputStream.readInt();
-            // Max key length
-            int maxKeyLength = dataInputStream.readInt();
-            // BloomFilter
-            bloomFilterEnabled = dataInputStream.readBoolean();
-            if (bloomFilterEnabled) {
-                long recordCount = dataInputStream.readLong();
-                int bfBytes = dataInputStream.readInt();
-                // Bloom filter buffer start index
-                int bfStartIndex = dataInputStream.readInt();
-                // Skip bloom filter buffers
-                dataInputStream.skipBytes(bfBytes);
-                bloomFilter =
-                        new FileBasedBloomFilter(
-                                inputView.file(), cacheManager, recordCount, bfStartIndex, bfBytes);
-            }
-
-            // Read offset counts and keys
-            indexOffsets = new int[maxKeyLength + 1];
-            dataOffsets = new long[maxKeyLength + 1];
-            keyCounts = new int[maxKeyLength + 1];
-            slots = new int[maxKeyLength + 1];
-            slotSizes = new int[maxKeyLength + 1];
-
-            int maxSlotSize = 0;
-            for (int i = 0; i < keyLengthCount; i++) {
-                int keyLength = dataInputStream.readInt();
-
-                keyCounts[keyLength] = dataInputStream.readInt();
-                slots[keyLength] = dataInputStream.readInt();
-                slotSizes[keyLength] = dataInputStream.readInt();
-                indexOffsets[keyLength] = dataInputStream.readInt();
-                dataOffsets[keyLength] = dataInputStream.readLong();
-
-                maxSlotSize = Math.max(maxSlotSize, slotSizes[keyLength]);
-            }
-
-            slotBuffer = new byte[maxSlotSize];
-
-            // Read index offset to resign indexOffsets
-            indexOffset = dataInputStream.readInt();
-            for (int i = 0; i < indexOffsets.length; i++) {
-                indexOffsets[i] = indexOffset + indexOffsets[i];
-            }
-            // Read data offset to resign dataOffsets
-            dataOffset = dataInputStream.readLong();
-            for (int i = 0; i < dataOffsets.length; i++) {
-                dataOffsets[i] = dataOffset + dataOffsets[i];
-            }
-        } finally {
-            // Close metadata
-            dataInputStream.close();
-            inputStream.close();
+        if (context.bloomFilterEnabled) {
+            bloomFilter =
+                    new FileBasedBloomFilter(
+                            inputView.file(),
+                            cacheManager,
+                            context.bloomFilterExpectedEntries,
+                            0,
+                            context.bloomFilterBytes);
         }
-
-        // logging
-        DecimalFormat integerFormat = new DecimalFormat("#,##0.00");
-        StringBuilder statMsg = new StringBuilder("Storage metadata\n");
-        statMsg.append("  Created at: ").append(formatCreatedAt(createdAt)).append("\n");
-        statMsg.append("  Key count: ").append(keyCount).append("\n");
-        statMsg.append("  Bloom filter: ").append(bloomFilterEnabled).append("\n");
-        for (int i = 0; i < keyCounts.length; i++) {
-            if (keyCounts[i] > 0) {
-                statMsg.append("  Key count for key length ")
-                        .append(i)
-                        .append(": ")
-                        .append(keyCounts[i])
-                        .append("\n");
-            }
-        }
-        statMsg.append("  Index size: ")
-                .append(integerFormat.format((dataOffset - indexOffset) / (1024.0 * 1024.0)))
-                .append(" Mb\n");
-        statMsg.append("  Data size: ")
-                .append(integerFormat.format((file.length() - dataOffset) / (1024.0 * 1024.0)))
-                .append(" Mb\n");
-        LOG.info(statMsg.toString());
     }
 
     @Override
@@ -224,13 +148,6 @@ public class HashLookupStoreReader
         byte[] res = new byte[size];
         inputView.readFully(res);
         return res;
-    }
-
-    private String formatCreatedAt(long createdAt) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd G 'at' HH:mm:ss z");
-        Calendar cl = Calendar.getInstance();
-        cl.setTimeInMillis(createdAt);
-        return sdf.format(cl.getTime());
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BloomFilter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BloomFilter.java
@@ -125,13 +125,13 @@ public class BloomFilter {
 
         private final MemorySegment buffer;
         private final BloomFilter filter;
-        private final long numRecords;
+        private final long expectedEntries;
 
-        Builder(MemorySegment buffer, long numRecords) {
+        Builder(MemorySegment buffer, long expectedEntries) {
             this.buffer = buffer;
-            this.filter = new BloomFilter(numRecords, buffer.size());
+            this.filter = new BloomFilter(expectedEntries, buffer.size());
             filter.setMemorySegment(buffer, 0);
-            this.numRecords = numRecords;
+            this.expectedEntries = expectedEntries;
         }
 
         public boolean testHash(int hash) {
@@ -146,8 +146,8 @@ public class BloomFilter {
             return buffer;
         }
 
-        public long getNumRecords() {
-            return numRecords;
+        public long expectedEntries() {
+            return expectedEntries;
         }
 
         @VisibleForTesting

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FileBasedBloomFilter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FileBasedBloomFilter.java
@@ -43,13 +43,13 @@ public class FileBasedBloomFilter {
     public FileBasedBloomFilter(
             RandomAccessFile file,
             CacheManager cacheManager,
-            long numRecords,
+            long expectedEntries,
             long readOffset,
             int readLength) {
         this.file = file;
         this.cacheManager = cacheManager;
-        checkArgument(numRecords >= 0);
-        this.filter = new BloomFilter(numRecords, readLength);
+        checkArgument(expectedEntries >= 0);
+        this.filter = new BloomFilter(expectedEntries, readLength);
         this.readOffset = readOffset;
         this.readLength = readLength;
         this.accessCount = 0;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The previous approach made the file structure too complex, which is not conducive to adding file compression in the future.

We can interact solely through memory.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
