### PR TITLE
[core] Integrate compression to Hash Lookup

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -46,7 +46,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>cache-page-size</h5></td>
-            <td style="word-wrap: break-word;">16 kb</td>
+            <td style="word-wrap: break-word;">64 kb</td>
             <td>MemorySize</td>
             <td>Memory page size for caching.</td>
         </tr>
@@ -272,6 +272,12 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
             <td>Max memory size for lookup cache.</td>
+        </tr>
+        <tr>
+            <td><h5>lookup.cache-spill-compression</h5></td>
+            <td style="word-wrap: break-word;">"lz4"</td>
+            <td>String</td>
+            <td>Spill compression for lookup cache, currently none, lz4, lzo and zstd are supported.</td>
         </tr>
         <tr>
             <td><h5>lookup.cache.bloom.filter.enabled</h5></td>

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/LookupBloomFilterBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/LookupBloomFilterBenchmark.java
@@ -130,7 +130,7 @@ public class LookupBloomFilterBenchmark {
         Arrays.fill(value, (byte) 1);
         HashLookupStoreFactory factory =
                 new HashLookupStoreFactory(
-                        new CacheManager(MemorySize.ofMebiBytes(10)), 16 * 1024, 0.75);
+                        new CacheManager(MemorySize.ofMebiBytes(10)), 16 * 1024, 0.75, "none");
 
         File file = new File(tempDir.toFile(), UUID.randomUUID().toString());
         HashLookupStoreWriter writer = factory.createWriter(file, filter);

--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -296,6 +296,11 @@ under the License.
                                     <pattern>it.unimi.dsi.fastutil</pattern>
                                     <shadedPattern>org.apache.paimon.shade.it.unimi.dsi.fastutil</shadedPattern>
                                 </relocation>
+                                <!-- Same to paimon-format. -->
+                                <relocation>
+                                    <pattern>io.airlift</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.io.airlift</shadedPattern>
+                                </relocation>
                             </relocations>
                             <minimizeJar>true</minimizeJar>
                         </configuration>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -366,7 +366,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<MemorySize> CACHE_PAGE_SIZE =
             key("cache-page-size")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("16 kb"))
+                    .defaultValue(MemorySize.parse("64 kb"))
                     .withDescription("Memory page size for caching.");
 
     public static final ConfigOption<MemorySize> TARGET_FILE_SIZE =
@@ -728,6 +728,13 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MemorySize.MAX_VALUE)
                     .withDescription(
                             "Max disk size for lookup cache, you can use this option to limit the use of local disks.");
+
+    public static final ConfigOption<String> LOOKUP_CACHE_SPILL_COMPRESSION =
+            key("lookup.cache-spill-compression")
+                    .stringType()
+                    .defaultValue("lz4")
+                    .withDescription(
+                            "Spill compression for lookup cache, currently none, lz4, lzo and zstd are supported.");
 
     public static final ConfigOption<MemorySize> LOOKUP_CACHE_MAX_MEMORY_SIZE =
             key("lookup.cache-max-memory-size")

--- a/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
@@ -23,6 +23,8 @@ import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.zstd.ZstdCompressor;
 import io.airlift.compress.zstd.ZstdDecompressor;
 
+import javax.annotation.Nullable;
+
 /**
  * Each compression codec has an implementation of {@link BlockCompressionFactory} to create
  * compressors and decompressors.
@@ -34,7 +36,12 @@ public interface BlockCompressionFactory {
     BlockDecompressor getDecompressor();
 
     /** Creates {@link BlockCompressionFactory} according to the configuration. */
-    static BlockCompressionFactory create(String compression) {
+    @Nullable
+    static BlockCompressionFactory create(@Nullable String compression) {
+        if (compression == null) {
+            return null;
+        }
+
         switch (compression.toUpperCase()) {
             case "LZ4":
                 return new Lz4BlockCompressionFactory();

--- a/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
@@ -37,12 +37,10 @@ public interface BlockCompressionFactory {
 
     /** Creates {@link BlockCompressionFactory} according to the configuration. */
     @Nullable
-    static BlockCompressionFactory create(@Nullable String compression) {
-        if (compression == null) {
-            return null;
-        }
-
+    static BlockCompressionFactory create(String compression) {
         switch (compression.toUpperCase()) {
+            case "NONE":
+                return null;
             case "LZ4":
                 return new Lz4BlockCompressionFactory();
             case "LZO":

--- a/paimon-common/src/main/java/org/apache/paimon/io/CompressedPageFileInput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/CompressedPageFileInput.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockDecompressor;
+import org.apache.paimon.utils.MathUtils;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/** A class to wrap compressed {@link RandomAccessFile}. */
+public class CompressedPageFileInput implements PageFileInput {
+
+    private final RandomAccessFile file;
+    private final int pageSize;
+    private final long uncompressBytes;
+    private final long[] pagePositions;
+
+    private final BlockDecompressor decompressor;
+    private final byte[] uncompressedBuffer;
+    private final byte[] compressedBuffer;
+
+    private final int pageSizeBits;
+    private final int pageSizeMask;
+
+    public CompressedPageFileInput(
+            RandomAccessFile file,
+            int pageSize,
+            BlockCompressionFactory compressionFactory,
+            long uncompressBytes,
+            long[] pagePositions) {
+        this.file = file;
+        this.pageSize = pageSize;
+        this.uncompressBytes = uncompressBytes;
+        this.pagePositions = pagePositions;
+
+        this.uncompressedBuffer = new byte[pageSize];
+        this.decompressor = compressionFactory.getDecompressor();
+        this.compressedBuffer =
+                new byte[compressionFactory.getCompressor().getMaxCompressedSize(pageSize)];
+
+        this.pageSizeBits = MathUtils.log2strict(pageSize);
+        this.pageSizeMask = pageSize - 1;
+    }
+
+    @Override
+    public RandomAccessFile file() {
+        return file;
+    }
+
+    @Override
+    public long uncompressBytes() {
+        return uncompressBytes;
+    }
+
+    @Override
+    public int pageSize() {
+        return pageSize;
+    }
+
+    @Override
+    public byte[] readPage(int pageIndex) throws IOException {
+        long position = pagePositions[pageIndex];
+        file.seek(position);
+        int compressLength = file.readInt();
+        file.readFully(compressedBuffer, 0, compressLength);
+
+        int uncompressedLength =
+                decompressor.decompress(compressedBuffer, 0, compressLength, uncompressedBuffer, 0);
+
+        byte[] result = new byte[uncompressedLength];
+        System.arraycopy(uncompressedBuffer, 0, result, 0, uncompressedLength);
+        return result;
+    }
+
+    @Override
+    public byte[] readPosition(long position, int length) throws IOException {
+        int offset = (int) (position & this.pageSizeMask);
+        int pageIndex = (int) (position >>> this.pageSizeBits);
+
+        byte[] result = new byte[length];
+        int n = 0;
+        do {
+            byte[] page = readPage(pageIndex);
+            int currentLength = Math.min(page.length - offset, length - n);
+            System.arraycopy(page, offset, result, n, currentLength);
+            offset = 0;
+            n += currentLength;
+            pageIndex++;
+        } while (n < length);
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.file.close();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/CompressedPageFileOutput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/CompressedPageFileOutput.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockCompressor;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A class to output bytes with compression. */
+public class CompressedPageFileOutput implements PageFileOutput {
+
+    private final FileOutputStream out;
+    private final byte[] page;
+    private final BlockCompressor compressor;
+    private final byte[] compressedPage;
+    private final List<Long> pages;
+
+    private long uncompressBytes;
+    private long position;
+    private int count;
+
+    public CompressedPageFileOutput(
+            File file, int pageSize, BlockCompressionFactory compressionFactory)
+            throws FileNotFoundException {
+        this.out = new FileOutputStream(file);
+        this.page = new byte[pageSize];
+        this.compressor = compressionFactory.getCompressor();
+        this.compressedPage = new byte[compressor.getMaxCompressedSize(pageSize)];
+        this.pages = new ArrayList<>();
+
+        this.uncompressBytes = 0;
+        this.position = 0;
+        this.count = 0;
+    }
+
+    private void flushBuffer() throws IOException {
+        if (count > 0) {
+            pages.add(position);
+            int len = compressor.compress(page, 0, count, compressedPage, 0);
+            // write length
+            out.write((len >>> 24) & 0xFF);
+            out.write((len >>> 16) & 0xFF);
+            out.write((len >>> 8) & 0xFF);
+            out.write(len & 0xFF);
+            // write page
+            out.write(compressedPage, 0, len);
+            count = 0;
+            position += (len + 4);
+        }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        uncompressBytes += len;
+
+        while (len > 0) {
+            if (count >= page.length) {
+                flushBuffer();
+            }
+            int toWrite = Math.min(len, page.length - count);
+            System.arraycopy(b, off, page, count, toWrite);
+            off += toWrite;
+            len -= toWrite;
+            count += toWrite;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try (OutputStream ignored = out) {
+            flushBuffer();
+        }
+    }
+
+    public long uncompressBytes() {
+        return uncompressBytes;
+    }
+
+    public long[] pages() {
+        long[] pages = new long[this.pages.size()];
+        for (int i = 0; i < pages.length; i++) {
+            pages[i] = this.pages.get(i);
+        }
+        return pages;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/PageFileInput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/PageFileInput.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/** An interface to read pages from file. */
+public interface PageFileInput extends Closeable {
+
+    RandomAccessFile file();
+
+    long uncompressBytes();
+
+    int pageSize();
+
+    byte[] readPage(int pageIndex) throws IOException;
+
+    byte[] readPosition(long position, int length) throws IOException;
+
+    static PageFileInput create(File file, int pageSize) throws IOException {
+        RandomAccessFile accessFile = new RandomAccessFile(file, "r");
+        return new UncompressedPageFileInput(accessFile, pageSize);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/PageFileInput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/PageFileInput.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.io;
 
+import org.apache.paimon.compression.BlockCompressionFactory;
+
+import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -36,8 +40,23 @@ public interface PageFileInput extends Closeable {
 
     byte[] readPosition(long position, int length) throws IOException;
 
-    static PageFileInput create(File file, int pageSize) throws IOException {
+    static PageFileInput create(
+            File file,
+            int pageSize,
+            @Nullable BlockCompressionFactory compressionFactory,
+            long uncompressBytes,
+            @Nullable long[] compressPagePositions)
+            throws IOException {
         RandomAccessFile accessFile = new RandomAccessFile(file, "r");
-        return new UncompressedPageFileInput(accessFile, pageSize);
+        if (compressionFactory == null) {
+            return new UncompressedPageFileInput(accessFile, pageSize);
+        } else {
+            return new CompressedPageFileInput(
+                    accessFile,
+                    pageSize,
+                    compressionFactory,
+                    uncompressBytes,
+                    compressPagePositions);
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/io/PageFileOutput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/PageFileOutput.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+/** An interface to write bytes with pages into file. */
+public interface PageFileOutput extends Closeable {
+
+    void write(byte[] bytes, int off, int len) throws IOException;
+
+    static PageFileOutput create(File file) throws IOException {
+        return new UncompressedPageFileOutput(file);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/PageFileOutput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/PageFileOutput.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.io;
 
+import org.apache.paimon.compression.BlockCompressionFactory;
+
+import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +31,12 @@ public interface PageFileOutput extends Closeable {
 
     void write(byte[] bytes, int off, int len) throws IOException;
 
-    static PageFileOutput create(File file) throws IOException {
-        return new UncompressedPageFileOutput(file);
+    static PageFileOutput create(
+            File file, int pageSize, @Nullable BlockCompressionFactory compressionFactory)
+            throws IOException {
+        if (compressionFactory == null) {
+            return new UncompressedPageFileOutput(file);
+        }
+        return new CompressedPageFileOutput(file, pageSize, compressionFactory);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/io/UncompressedPageFileInput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/UncompressedPageFileInput.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.utils.MathUtils;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/** A class to wrap uncompressed {@link RandomAccessFile}. */
+public class UncompressedPageFileInput implements PageFileInput {
+
+    private final RandomAccessFile file;
+    private final long fileLength;
+    private final int pageSize;
+    private final int pageSizeBits;
+
+    public UncompressedPageFileInput(RandomAccessFile file, int pageSize) throws IOException {
+        this.file = file;
+        this.fileLength = file.length();
+        this.pageSize = pageSize;
+        this.pageSizeBits = MathUtils.log2strict(pageSize);
+    }
+
+    @Override
+    public RandomAccessFile file() {
+        return file;
+    }
+
+    @Override
+    public long uncompressBytes() {
+        return fileLength;
+    }
+
+    @Override
+    public int pageSize() {
+        return pageSize;
+    }
+
+    @Override
+    public byte[] readPage(int pageIndex) throws IOException {
+        long position = (long) pageIndex << pageSizeBits;
+        file.seek(position);
+
+        int length = (int) Math.min(pageSize, fileLength - position);
+        byte[] result = new byte[length];
+        file.readFully(result);
+        return result;
+    }
+
+    @Override
+    public byte[] readPosition(long position, int length) throws IOException {
+        file.seek(position);
+        byte[] result = new byte[length];
+        file.readFully(result);
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.file.close();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/UncompressedPageFileOutput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/UncompressedPageFileOutput.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/** A class to wrap uncompressed {@link FileOutputStream}. */
+public class UncompressedPageFileOutput implements PageFileOutput {
+
+    private final FileOutputStream out;
+
+    public UncompressedPageFileOutput(File file) throws FileNotFoundException {
+        this.out = new FileOutputStream(file);
+    }
+
+    @Override
+    public void write(byte[] bytes, int off, int len) throws IOException {
+        this.out.write(bytes, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.out.close();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheCallback.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheCallback.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io.cache;
+
+/** Callback for cache removal. */
+public interface CacheCallback {
+
+    void onRemoval(CacheKey key);
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheKey.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheKey.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io.cache;
+
+import java.io.RandomAccessFile;
+import java.util.Objects;
+
+/** Key for cache manager. */
+public interface CacheKey {
+
+    static CacheKey forPosition(RandomAccessFile file, long position, int length) {
+        return new PositionCacheKey(file, position, length);
+    }
+
+    static CacheKey forPageIndex(RandomAccessFile file, int pageSize, int pageIndex) {
+        return new PageIndexCacheKey(file, pageSize, pageIndex);
+    }
+
+    /** Key for file position and length. */
+    class PositionCacheKey implements CacheKey {
+
+        private final RandomAccessFile file;
+        private final long position;
+        private final int length;
+
+        private PositionCacheKey(RandomAccessFile file, long position, int length) {
+            this.file = file;
+            this.position = position;
+            this.length = length;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PositionCacheKey that = (PositionCacheKey) o;
+            return position == that.position
+                    && length == that.length
+                    && Objects.equals(file, that.file);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(file, position, length);
+        }
+    }
+
+    /** Key for file page index. */
+    class PageIndexCacheKey implements CacheKey {
+
+        private final RandomAccessFile file;
+        private final int pageSize;
+        private final int pageIndex;
+
+        private PageIndexCacheKey(RandomAccessFile file, int pageSize, int pageIndex) {
+            this.file = file;
+            this.pageSize = pageSize;
+            this.pageIndex = pageIndex;
+        }
+
+        public int pageIndex() {
+            return pageIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PageIndexCacheKey that = (PageIndexCacheKey) o;
+            return pageSize == that.pageSize
+                    && pageIndex == that.pageIndex
+                    && Objects.equals(file, that.file);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(file, pageSize, pageIndex);
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheReader.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io.cache;
+
+import java.io.IOException;
+
+/** Reader to read byte[]. */
+public interface CacheReader {
+
+    byte[] read(CacheKey key) throws IOException;
+}

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashContext.java
@@ -41,6 +41,9 @@ public class HashContext implements Context {
     // Offset of the data for different key length
     final long[] dataOffsets;
 
+    final long uncompressBytes;
+    final long[] compressPages;
+
     public HashContext(
             boolean bloomFilterEnabled,
             long bloomFilterExpectedEntries,
@@ -49,7 +52,9 @@ public class HashContext implements Context {
             int[] slotSizes,
             int[] slots,
             int[] indexOffsets,
-            long[] dataOffsets) {
+            long[] dataOffsets,
+            long uncompressBytes,
+            long[] compressPages) {
         this.bloomFilterEnabled = bloomFilterEnabled;
         this.bloomFilterExpectedEntries = bloomFilterExpectedEntries;
         this.bloomFilterBytes = bloomFilterBytes;
@@ -58,5 +63,21 @@ public class HashContext implements Context {
         this.slots = slots;
         this.indexOffsets = indexOffsets;
         this.dataOffsets = dataOffsets;
+        this.uncompressBytes = uncompressBytes;
+        this.compressPages = compressPages;
+    }
+
+    public HashContext copy(long uncompressBytes, long[] compressPages) {
+        return new HashContext(
+                bloomFilterEnabled,
+                bloomFilterExpectedEntries,
+                bloomFilterBytes,
+                keyCounts,
+                slotSizes,
+                slots,
+                indexOffsets,
+                dataOffsets,
+                uncompressBytes,
+                compressPages);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.lookup.hash;
 
+import org.apache.paimon.compression.BlockCompressionFactory;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.lookup.LookupStoreFactory;
 import org.apache.paimon.utils.BloomFilter;
@@ -33,21 +34,26 @@ public class HashLookupStoreFactory implements LookupStoreFactory {
     private final CacheManager cacheManager;
     private final int cachePageSize;
     private final double loadFactor;
+    @Nullable private final BlockCompressionFactory compressionFactory;
 
-    public HashLookupStoreFactory(CacheManager cacheManager, int cachePageSize, double loadFactor) {
+    public HashLookupStoreFactory(
+            CacheManager cacheManager, int cachePageSize, double loadFactor, String compression) {
         this.cacheManager = cacheManager;
         this.cachePageSize = cachePageSize;
         this.loadFactor = loadFactor;
+        this.compressionFactory = BlockCompressionFactory.create(compression);
     }
 
     @Override
     public HashLookupStoreReader createReader(File file, Context context) throws IOException {
-        return new HashLookupStoreReader(file, (HashContext) context, cacheManager, cachePageSize);
+        return new HashLookupStoreReader(
+                file, (HashContext) context, cacheManager, cachePageSize, compressionFactory);
     }
 
     @Override
     public HashLookupStoreWriter createWriter(File file, @Nullable BloomFilter.Builder bloomFilter)
             throws IOException {
-        return new HashLookupStoreWriter(loadFactor, file, bloomFilter);
+        return new HashLookupStoreWriter(
+                loadFactor, file, bloomFilter, compressionFactory, cachePageSize);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.lookup.hash;
 
+import org.apache.paimon.compression.BlockCompressionFactory;
 import org.apache.paimon.io.PageFileInput;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.io.cache.FileBasedRandomInputView;
@@ -63,7 +64,11 @@ public class HashLookupStoreReader
     @Nullable private FileBasedBloomFilter bloomFilter;
 
     HashLookupStoreReader(
-            File file, HashContext context, CacheManager cacheManager, int cachePageSize)
+            File file,
+            HashContext context,
+            CacheManager cacheManager,
+            int cachePageSize,
+            @Nullable BlockCompressionFactory compressionFactory)
             throws IOException {
         // File path
         if (!file.exists()) {
@@ -83,7 +88,13 @@ public class HashLookupStoreReader
 
         LOG.info("Opening file {}", file.getName());
 
-        PageFileInput fileInput = PageFileInput.create(file, cachePageSize);
+        PageFileInput fileInput =
+                PageFileInput.create(
+                        file,
+                        cachePageSize,
+                        compressionFactory,
+                        context.uncompressBytes,
+                        context.compressPages);
         inputView = new FileBasedRandomInputView(fileInput, cacheManager);
 
         if (context.bloomFilterEnabled) {

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.lookup.hash;
 
+import org.apache.paimon.io.PageFileInput;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.io.cache.FileBasedRandomInputView;
 import org.apache.paimon.lookup.LookupStoreReader;
@@ -81,13 +82,14 @@ public class HashLookupStoreReader
         dataOffsets = context.dataOffsets;
 
         LOG.info("Opening file {}", file.getName());
-        // Create Mapped file in read-only mode
-        inputView = new FileBasedRandomInputView(file, cacheManager, cachePageSize);
+
+        PageFileInput fileInput = PageFileInput.create(file, cachePageSize);
+        inputView = new FileBasedRandomInputView(fileInput, cacheManager);
 
         if (context.bloomFilterEnabled) {
             bloomFilter =
                     new FileBasedBloomFilter(
-                            inputView.file(),
+                            fileInput,
                             cacheManager,
                             context.bloomFilterExpectedEntries,
                             0,

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
@@ -494,14 +494,4 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
         }
         return dos;
     }
-
-    private int getNumKeyCount() {
-        int res = 0;
-        for (int count : keyCounts) {
-            if (count != 0) {
-                res++;
-            }
-        }
-        return res;
-    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.lookup.hash;
 
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.io.CompressedPageFileOutput;
 import org.apache.paimon.io.PageFileOutput;
 import org.apache.paimon.lookup.LookupStoreFactory.Context;
 import org.apache.paimon.lookup.LookupStoreWriter;
@@ -81,10 +83,20 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
 
     @Nullable private final BloomFilter.Builder bloomFilter;
 
-    HashLookupStoreWriter(double loadFactor, File file, @Nullable BloomFilter.Builder bloomFilter)
+    @Nullable private final BlockCompressionFactory compressionFactory;
+    private final int compressPageSize;
+
+    HashLookupStoreWriter(
+            double loadFactor,
+            File file,
+            @Nullable BloomFilter.Builder bloomFilter,
+            @Nullable BlockCompressionFactory compressionFactory,
+            int compressPageSize)
             throws IOException {
         this.loadFactor = loadFactor;
         this.outputFile = file;
+        this.compressionFactory = compressionFactory;
+        this.compressPageSize = compressPageSize;
         if (loadFactor <= 0.0 || loadFactor >= 1.0) {
             throw new IllegalArgumentException(
                     "Illegal load factor = " + loadFactor + ", should be between 0.0 and 1.0.");
@@ -187,7 +199,9 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
                         new int[keyCounts.length],
                         new int[keyCounts.length],
                         new int[keyCounts.length],
-                        new long[keyCounts.length]);
+                        new long[keyCounts.length],
+                        0,
+                        null);
 
         long indexesLength = bloomFilterBytes;
         long datasLength = 0;
@@ -223,7 +237,9 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
             context.dataOffsets[i] = indexesLength + context.dataOffsets[i];
         }
 
-        try (PageFileOutput output = PageFileOutput.create(outputFile)) {
+        PageFileOutput output =
+                PageFileOutput.create(outputFile, compressPageSize, compressionFactory);
+        try {
             // Write bloom filter file
             if (bloomFilter != null) {
                 File bloomFilterFile = new File(tempFolder, "bloomfilter.dat");
@@ -257,11 +273,17 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
             mergeFiles(filesToMerge, output);
         } finally {
             cleanup(filesToMerge);
+            output.close();
         }
 
         LOG.info(
                 "Compressed Total store size: {} Mb",
                 new DecimalFormat("#,##0.0").format(outputFile.length() / (1024 * 1024)));
+
+        if (output instanceof CompressedPageFileOutput) {
+            CompressedPageFileOutput compressedOutput = (CompressedPageFileOutput) output;
+            context = context.copy(compressedOutput.uncompressBytes(), compressedOutput.pages());
+        }
         return context;
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/io/CompressedInputOutputTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/CompressedInputOutputTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.compression.Lz4BlockCompressionFactory;
+import org.apache.paimon.utils.MathUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link CompressedPageFileOutput} and {@link CompressedPageFileInput}. */
+public class CompressedInputOutputTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    public void testRandom() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            innerTestRandom();
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void innerTestRandom() throws IOException {
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        byte[] bytes = new byte[rnd.nextInt(1_000) + 1];
+        rnd.nextBytes(bytes);
+        int pageSize = MathUtils.roundDownToPowerOf2(rnd.nextInt(2_000) + 2);
+
+        // prepare compressed file
+        File compressed = new File(tempDir.toFile(), "compressed");
+        compressed.delete();
+        Lz4BlockCompressionFactory compressionFactory = new Lz4BlockCompressionFactory();
+        CompressedPageFileOutput output1 =
+                new CompressedPageFileOutput(compressed, pageSize, compressionFactory);
+        long uncompressBytes;
+        long[] pagePositions;
+        try {
+            output1.write(bytes, 0, bytes.length);
+        } finally {
+            output1.close();
+            uncompressBytes = output1.uncompressBytes();
+            pagePositions = output1.pages();
+        }
+        CompressedPageFileInput input1 =
+                new CompressedPageFileInput(
+                        new RandomAccessFile(compressed, "r"),
+                        pageSize,
+                        compressionFactory,
+                        uncompressBytes,
+                        pagePositions);
+
+        // prepare uncompressed file
+        File uncompressed = new File(tempDir.toFile(), "uncompressed");
+        uncompressed.delete();
+        try (UncompressedPageFileOutput output2 = new UncompressedPageFileOutput(uncompressed)) {
+            output2.write(bytes, 0, bytes.length);
+        }
+        UncompressedPageFileInput input2 =
+                new UncompressedPageFileInput(new RandomAccessFile(uncompressed, "r"), pageSize);
+
+        // test uncompressBytes
+        assertThat(input1.uncompressBytes()).isEqualTo(input2.uncompressBytes());
+
+        // test readPage
+        for (int i = 0; i < pagePositions.length; i++) {
+            assertThat(input1.readPage(i)).isEqualTo(input2.readPage(i));
+        }
+
+        // test readPosition
+        for (int i = 0; i < 10; i++) {
+            long position;
+            int length;
+            if (uncompressBytes == 1) {
+                position = 0;
+                length = 1;
+            } else {
+                position = rnd.nextLong(uncompressBytes - 1);
+                length = rnd.nextInt((int) (uncompressBytes - position)) + 1;
+            }
+            assertThat(input1.readPosition(position, length))
+                    .isEqualTo(input2.readPosition(position, length));
+        }
+
+        input1.close();
+        input2.close();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/io/cache/FileBasedRandomInputViewTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/cache/FileBasedRandomInputViewTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.io.cache;
 
+import org.apache.paimon.io.PageFileInput;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.options.MemorySize;
 
@@ -66,7 +67,8 @@ public class FileBasedRandomInputViewTest {
 
         File file = writeFile(bytes);
         CacheManager cacheManager = new CacheManager(MemorySize.ofKibiBytes(128));
-        FileBasedRandomInputView view = new FileBasedRandomInputView(file, cacheManager, 1024);
+        FileBasedRandomInputView view =
+                new FileBasedRandomInputView(PageFileInput.create(file, 1024), cacheManager);
 
         // read first one
         // this assertThatCode check the ConcurrentModificationException is not threw.

--- a/paimon-common/src/test/java/org/apache/paimon/io/cache/FileBasedRandomInputViewTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/cache/FileBasedRandomInputViewTest.java
@@ -68,7 +68,8 @@ public class FileBasedRandomInputViewTest {
         File file = writeFile(bytes);
         CacheManager cacheManager = new CacheManager(MemorySize.ofKibiBytes(128));
         FileBasedRandomInputView view =
-                new FileBasedRandomInputView(PageFileInput.create(file, 1024), cacheManager);
+                new FileBasedRandomInputView(
+                        PageFileInput.create(file, 1024, null, 0, null), cacheManager);
 
         // read first one
         // this assertThatCode check the ConcurrentModificationException is not threw.

--- a/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.io.PageFileInput;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.options.MemorySize;
@@ -30,7 +31,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -53,7 +53,7 @@ public class FileBasedBloomFilterTest {
         CacheManager cacheManager = new CacheManager(MemorySize.ofMebiBytes(1));
         FileBasedBloomFilter filter =
                 new FileBasedBloomFilter(
-                        new RandomAccessFile(file, "r"), cacheManager, 100, 0, 1000);
+                        PageFileInput.create(file, 1000), cacheManager, 100, 0, 1000);
 
         Arrays.stream(inputs)
                 .forEach(i -> Assertions.assertThat(filter.testHash(Integer.hashCode(i))).isTrue());

--- a/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
@@ -53,7 +53,11 @@ public class FileBasedBloomFilterTest {
         CacheManager cacheManager = new CacheManager(MemorySize.ofMebiBytes(1));
         FileBasedBloomFilter filter =
                 new FileBasedBloomFilter(
-                        PageFileInput.create(file, 1000), cacheManager, 100, 0, 1000);
+                        PageFileInput.create(file, 1024, null, 0, null),
+                        cacheManager,
+                        100,
+                        0,
+                        1000);
 
         Arrays.stream(inputs)
                 .forEach(i -> Assertions.assertThat(filter.testHash(Integer.hashCode(i))).isTrue());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -288,7 +288,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 new HashLookupStoreFactory(
                         cacheManager,
                         this.options.cachePageSize(),
-                        options.get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR)),
+                        options.get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR),
+                        options.get(CoreOptions.LOOKUP_CACHE_SPILL_COMPRESSION)),
                 options.get(CoreOptions.LOOKUP_CACHE_FILE_RETENTION),
                 options.get(CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE),
                 bfGenerator(options));
@@ -312,7 +313,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 new HashLookupStoreFactory(
                         cacheManager,
                         this.options.cachePageSize(),
-                        options.get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR)),
+                        options.get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR),
+                        options.get(CoreOptions.LOOKUP_CACHE_SPILL_COMPRESSION)),
                 options.get(CoreOptions.LOOKUP_CACHE_FILE_RETENTION),
                 options.get(CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE),
                 bfGenerator(options));

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -85,7 +85,8 @@ public class LocalTableQuery implements TableQuery {
                 new HashLookupStoreFactory(
                         new CacheManager(options.lookupCacheMaxMemory()),
                         options.cachePageSize(),
-                        options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR));
+                        options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR),
+                        options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_SPILL_COMPRESSION));
 
         if (options.changelogProducer() == CoreOptions.ChangelogProducer.LOOKUP) {
             startLevel = 1;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
@@ -186,7 +186,8 @@ public class ContainsLevelsTest {
                                 .createRecordReader(
                                         0, file.fileName(), file.fileSize(), file.level()),
                 () -> new File(tempDir.toFile(), LOOKUP_FILE_PREFIX + UUID.randomUUID()),
-                new HashLookupStoreFactory(new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75),
+                new HashLookupStoreFactory(
+                        new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75, "none"),
                 Duration.ofHours(1),
                 maxDiskSize,
                 rowCount -> BloomFilter.builder(rowCount, 0.01));

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -226,7 +226,8 @@ public class LookupLevelsTest {
                                 .createRecordReader(
                                         0, file.fileName(), file.fileSize(), file.level()),
                 () -> new File(tempDir.toFile(), LOOKUP_FILE_PREFIX + UUID.randomUUID()),
-                new HashLookupStoreFactory(new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75),
+                new HashLookupStoreFactory(
+                        new CacheManager(MemorySize.ofMebiBytes(1)), 2048, 0.75, "none"),
                 Duration.ofHours(1),
                 maxDiskSize,
                 rowCount -> BloomFilter.builder(rowCount, 0.05));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, Hash Lookup does not have any compression, which may result in high local disk usage and high disk IO. This PR introduces compression and is configurable.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

1. Page 16KB -> 64KB, for compression.
2. Default compression: lz4.

### Documentation

<!-- Does this change introduce a new feature -->
