### PR TITLE
[cdc] Fixed constant value of org.apache.kafka prefix being shaded.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -334,6 +334,10 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.kafka</pattern>
                                     <shadedPattern>org.apache.flink.kafka.shaded.org.apache.kafka</shadedPattern>
+                                    <!-- TODO Constants will be shaded. see https://issues.apache.org/jira/browse/MSHADE-156 -->
+                                    <excludes>
+                                        <exclude>org.apache.kafka.connect.data.Decimal</exclude>
+                                    </excludes>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -334,10 +334,6 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.kafka</pattern>
                                     <shadedPattern>org.apache.flink.kafka.shaded.org.apache.kafka</shadedPattern>
-                                    <!-- TODO Constants will be shaded. see https://issues.apache.org/jira/browse/MSHADE-156 -->
-                                    <excludes>
-                                        <exclude>org.apache.kafka.connect.data.Decimal</exclude>
-                                    </excludes>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
@@ -36,7 +36,6 @@ import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
 import io.debezium.time.Timestamp;
 import io.debezium.time.ZonedTimestamp;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 
 import javax.annotation.Nullable;
@@ -55,6 +54,8 @@ import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_
  * MySqlRecordParser. Need refactor.
  */
 public class DebeziumSchemaUtils {
+
+    public static final String DECIMAL_LOGICAL_NAME = "org.apache.kafka.connect.data.Decimal";
 
     /** Transform raw string value according to schema. */
     public static String transformRawValue(
@@ -85,7 +86,7 @@ public class DebeziumSchemaUtils {
         } else if (("bytes".equals(debeziumType) && className == null)) {
             // MySQL binary, varbinary, blob
             transformed = new String(Base64.getDecoder().decode(rawValue));
-        } else if ("bytes".equals(debeziumType) && Decimal.LOGICAL_NAME.equals(className)) {
+        } else if ("bytes".equals(debeziumType) && DECIMAL_LOGICAL_NAME.equals(className)) {
             // MySQL numeric, fixed, decimal
             try {
                 new BigDecimal(rawValue);
@@ -176,7 +177,7 @@ public class DebeziumSchemaUtils {
                 case Bits.LOGICAL_NAME:
                     int length = Integer.parseInt(parameters.get("length"));
                     return DataTypes.BINARY((length + 7) / 8);
-                case Decimal.LOGICAL_NAME:
+                case DECIMAL_LOGICAL_NAME:
                     String precision = parameters.get("connect.decimal.precision");
                     if (precision == null) {
                         return DataTypes.DECIMAL(20, 0);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
@@ -79,7 +79,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCase
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_NULLABLE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
-import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.DECIMAL_LOGICAL_NAME;
+import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.decimalLogicalName;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
 
 /**
@@ -276,7 +276,7 @@ public class MySqlRecordParser implements FlatMapFunction<String, RichCdcMultipl
             } else if (("bytes".equals(mySqlType) && className == null)) {
                 // MySQL binary, varbinary, blob
                 newValue = new String(Base64.getDecoder().decode(oldValue));
-            } else if ("bytes".equals(mySqlType) && DECIMAL_LOGICAL_NAME.equals(className)) {
+            } else if ("bytes".equals(mySqlType) && decimalLogicalName().equals(className)) {
                 // MySQL numeric, fixed, decimal
                 try {
                     new BigDecimal(oldValue);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
@@ -51,7 +51,6 @@ import io.debezium.time.ZonedTimestamp;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +79,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCase
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_NULLABLE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
+import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.DECIMAL_LOGICAL_NAME;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
 
 /**
@@ -276,7 +276,7 @@ public class MySqlRecordParser implements FlatMapFunction<String, RichCdcMultipl
             } else if (("bytes".equals(mySqlType) && className == null)) {
                 // MySQL binary, varbinary, blob
                 newValue = new String(Base64.getDecoder().decode(oldValue));
-            } else if ("bytes".equals(mySqlType) && Decimal.LOGICAL_NAME.equals(className)) {
+            } else if ("bytes".equals(mySqlType) && DECIMAL_LOGICAL_NAME.equals(className)) {
                 // MySQL numeric, fixed, decimal
                 try {
                     new BigDecimal(oldValue);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -74,7 +74,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCase
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_NULLABLE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
-import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.DECIMAL_LOGICAL_NAME;
+import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.decimalLogicalName;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
 
 /**
@@ -206,7 +206,7 @@ public class PostgresRecordParser implements FlatMapFunction<String, RichCdcMult
             case "string":
                 return DataTypes.STRING();
             case "bytes":
-                if (DECIMAL_LOGICAL_NAME.equals(field.name())) {
+                if (decimalLogicalName().equals(field.name())) {
                     int precision = field.parameters().get("connect.decimal.precision").asInt();
                     int scale = field.parameters().get("scale").asInt();
                     return DataTypes.DECIMAL(precision, scale);
@@ -299,7 +299,7 @@ public class PostgresRecordParser implements FlatMapFunction<String, RichCdcMult
             } else if (("bytes".equals(postgresSqlType) && className == null)) {
                 // binary, varbinary
                 newValue = new String(Base64.getDecoder().decode(oldValue));
-            } else if ("bytes".equals(postgresSqlType) && DECIMAL_LOGICAL_NAME.equals(className)) {
+            } else if ("bytes".equals(postgresSqlType) && decimalLogicalName().equals(className)) {
                 // numeric, decimal
                 try {
                     new BigDecimal(oldValue);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -48,7 +48,6 @@ import io.debezium.time.ZonedTimestamp;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +74,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCase
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_NULLABLE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
+import static org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils.DECIMAL_LOGICAL_NAME;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
 
 /**
@@ -206,7 +206,7 @@ public class PostgresRecordParser implements FlatMapFunction<String, RichCdcMult
             case "string":
                 return DataTypes.STRING();
             case "bytes":
-                if (Decimal.LOGICAL_NAME.equals(field.name())) {
+                if (DECIMAL_LOGICAL_NAME.equals(field.name())) {
                     int precision = field.parameters().get("connect.decimal.precision").asInt();
                     int scale = field.parameters().get("scale").asInt();
                     return DataTypes.DECIMAL(precision, scale);
@@ -299,7 +299,7 @@ public class PostgresRecordParser implements FlatMapFunction<String, RichCdcMult
             } else if (("bytes".equals(postgresSqlType) && className == null)) {
                 // binary, varbinary
                 newValue = new String(Base64.getDecoder().decode(oldValue));
-            } else if ("bytes".equals(postgresSqlType) && Decimal.LOGICAL_NAME.equals(className)) {
+            } else if ("bytes".equals(postgresSqlType) && DECIMAL_LOGICAL_NAME.equals(className)) {
                 // numeric, decimal
                 try {
                     new BigDecimal(oldValue);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

After the MySqlRecordParser.class in paimon-flink-1.18-0.6.0-incubating.jar is decompiled, the string `org.apache.kafka.connect.data.Decimal` is shaded to `org.apache.flink.kafka.shaded .org.apache.kafka.connect.data.Decimal`

![image](https://github.com/apache/incubator-paimon/assets/37063904/f8c40dc3-2ff5-451e-bea1-6d3c93a570b5)

After this PR:

MySqlRecordParser.class decompilation:
<img width="1231" alt="image" src="https://github.com/apache/incubator-paimon/assets/37063904/f6ebc046-b0a3-4006-80c1-e5498e760136">


DebeziumSchemaUtils.class decompilation:
<img width="787" alt="image" src="https://github.com/apache/incubator-paimon/assets/37063904/528e3996-4fcc-4c24-a35b-78129c3b39f9">


KafkaSinkFunction.class decompilation:
![image](https://github.com/apache/incubator-paimon/assets/37063904/e13287aa-5141-4cc0-9fd7-8d32296f1d6a)



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
