### PR TITLE
[hive] Support HiveCatalog for Hive 3.x and certain metastore client classes with constructors only for 2.x

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
@@ -93,6 +93,33 @@ public class RetryingMetaStoreClientFactory {
                                                     new ConcurrentHashMap<>(),
                                                     clientClassName,
                                                     true))
+                    // for hive 3.x,
+                    // and some metastore client classes providing constructors only for 2.x
+                    .put(
+                            new Class<?>[] {
+                                Configuration.class,
+                                Class[].class,
+                                Object[].class,
+                                ConcurrentHashMap.class,
+                                String.class
+                            },
+                            (getProxyMethod, hiveConf, clientClassName) ->
+                                    (IMetaStoreClient)
+                                            getProxyMethod.invoke(
+                                                    null,
+                                                    hiveConf,
+                                                    new Class[] {
+                                                        HiveConf.class,
+                                                        HiveMetaHookLoader.class,
+                                                        Boolean.class
+                                                    },
+                                                    new Object[] {
+                                                        hiveConf,
+                                                        (HiveMetaHookLoader) (tbl -> null),
+                                                        true
+                                                    },
+                                                    new ConcurrentHashMap<>(),
+                                                    clientClassName))
                     .build();
 
     // If clientClassName is HiveMetaStoreClient,


### PR DESCRIPTION
### Purpose

Some metastore client classes (for example, aliyun DLF) only provides constructor for Hive 2.x (with arguments `HiveConf, HiveMetaHookLoader, Boolean`). However metastore protocols are compatible between Hive 2.x and 3.x so these metastore client classes can also support Hive 3.x, just that Hive 3.x requires the constructor arguments to be `Configuration, HiveMetaHookLoader, Boolean` by default.

This PR explicitly specify constructor arguments in `RetryingMetaStoreClientFactory` to support such scenario.

### Tests

This PR is tested by hand.

### API and Format

No.

### Documentation

No.
