### PR TITLE
[flink] Fix that sink.parallelism doesn't work in compact_database action divided mode

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,11 +141,11 @@ public class CompactDatabaseAction extends ActionBase {
                                                 table.getClass().getName()));
                                 continue;
                             }
+                            Map<String, String> dynamicOptions =
+                                    new HashMap<>(tableOptions.toMap());
+                            dynamicOptions.put(CoreOptions.WRITE_ONLY.key(), "false");
                             FileStoreTable fileStoreTable =
-                                    (FileStoreTable)
-                                            table.copy(
-                                                    Collections.singletonMap(
-                                                            CoreOptions.WRITE_ONLY.key(), "false"));
+                                    (FileStoreTable) table.copy(dynamicOptions);
                             tableMap.put(fullTableName, fileStoreTable);
                         } else {
                             LOG.debug("The table {} is excluded.", fullTableName);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In divided mode, the dynamic conf isn't applied.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
