### PR TITLE
[core] Fix deserialization of sequenceNumber in lookup

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
@@ -72,6 +72,7 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
     // Max offset length
     private int[] maxOffsetLengths;
     // Number of keys
+    private int keyCount;
     private int[] keyCounts;
     // Number of values
     private int valueCount;
@@ -148,6 +149,7 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
             valueCount++;
         }
 
+        keyCount++;
         keyCounts[keyLength]++;
         if (bloomFilter != null) {
             bloomFilter.addHash(MurmurHashUtils.hashBytes(key));
@@ -169,7 +171,7 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
         }
 
         // Stats
-        LOG.info("Number of keys: {}", getNumKeyCount());
+        LOG.info("Number of keys: {}", keyCount);
         LOG.info("Number of values: {}", valueCount);
 
         // Prepare files to merge

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreWriter.java
@@ -72,7 +72,6 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
     // Max offset length
     private int[] maxOffsetLengths;
     // Number of keys
-    private int keyCount;
     private int[] keyCounts;
     // Number of values
     private int valueCount;
@@ -149,7 +148,6 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
             valueCount++;
         }
 
-        keyCount++;
         keyCounts[keyLength]++;
         if (bloomFilter != null) {
             bloomFilter.addHash(MurmurHashUtils.hashBytes(key));
@@ -171,7 +169,7 @@ public class HashLookupStoreWriter implements LookupStoreWriter {
         }
 
         // Stats
-        LOG.info("Number of keys: {}", keyCount);
+        LOG.info("Number of keys: {}", getNumKeyCount());
         LOG.info("Number of values: {}", valueCount);
 
         // Prepare files to merge

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupUtils.java
@@ -81,7 +81,7 @@ public class LookupUtils {
             SortedRun level,
             BiFunctionWithIOE<InternalRow, DataFileMeta, T> lookup)
             throws IOException {
-        if (!level.nonEmpty()) {
+        if (level.isEmpty()) {
             return null;
         }
         List<DataFileMeta> files = level.files();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortedRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortedRun.java
@@ -72,8 +72,12 @@ public class SortedRun {
         return files;
     }
 
+    public boolean isEmpty() {
+        return files.isEmpty();
+    }
+
     public boolean nonEmpty() {
-        return !files.isEmpty();
+        return !isEmpty();
     }
 
     public long totalSize() {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -86,29 +86,29 @@ public class LookupLevelsTest {
                 new Levels(
                         comparator,
                         Arrays.asList(
-                                newFile(1, kv(1, 11), kv(3, 33), kv(5, 5)),
-                                newFile(2, kv(2, 22), kv(5, 55))),
+                                newFile(1, kv(1, 11, 1), kv(3, 33, 2), kv(5, 5, 3)),
+                                newFile(2, kv(2, 22, 4), kv(5, 55, 5))),
                         3);
         LookupLevels lookupLevels = createLookupLevels(levels, MemorySize.ofMebiBytes(10));
 
         // only in level 1
         KeyValue kv = lookupLevels.lookup(row(1), 1);
         assertThat(kv).isNotNull();
-        assertThat(kv.sequenceNumber()).isEqualTo(UNKNOWN_SEQUENCE);
+        assertThat(kv.sequenceNumber()).isEqualTo(1);
         assertThat(kv.level()).isEqualTo(1);
         assertThat(kv.value().getInt(1)).isEqualTo(11);
 
         // only in level 2
         kv = lookupLevels.lookup(row(2), 1);
         assertThat(kv).isNotNull();
-        assertThat(kv.sequenceNumber()).isEqualTo(UNKNOWN_SEQUENCE);
+        assertThat(kv.sequenceNumber()).isEqualTo(4);
         assertThat(kv.level()).isEqualTo(2);
         assertThat(kv.value().getInt(1)).isEqualTo(22);
 
         // both in level 1 and level 2
         kv = lookupLevels.lookup(row(5), 1);
         assertThat(kv).isNotNull();
-        assertThat(kv.sequenceNumber()).isEqualTo(UNKNOWN_SEQUENCE);
+        assertThat(kv.sequenceNumber()).isEqualTo(3);
         assertThat(kv.level()).isEqualTo(1);
         assertThat(kv.value().getInt(1)).isEqualTo(5);
 
@@ -233,8 +233,12 @@ public class LookupLevelsTest {
     }
 
     private KeyValue kv(int key, int value) {
+        return kv(key, value, UNKNOWN_SEQUENCE);
+    }
+
+    private KeyValue kv(int key, int value, long seqNumber) {
         return new KeyValue()
-                .replace(GenericRow.of(key), RowKind.INSERT, GenericRow.of(key, value));
+                .replace(GenericRow.of(key), seqNumber, RowKind.INSERT, GenericRow.of(key, value));
     }
 
     private DataFileMeta newFile(int level, KeyValue... records) throws IOException {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When lookup, we use `DataOutputSerializer` to serialize sequenceNumber by `writeLong`,  which is BigEndian default, so when read, we need use `getLongBigEndian`



### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
