### PR TITLE
[hotfix] Add incrementSafely in MathUtils

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1347,7 +1347,9 @@ public class CoreOptions implements Serializable {
         // By default, this ensures that the compaction does not fall to level 0, but at least to
         // level 1
         Integer numLevels = options.get(NUM_LEVELS);
-        numLevels = numLevels == null ? numSortedRunCompactionTrigger() + 1 : numLevels;
+        if (numLevels == null) {
+            numLevels = MathUtils.incrementSafely(numSortedRunCompactionTrigger());
+        }
         return numLevels;
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -30,6 +30,7 @@ import org.apache.paimon.options.OptionsUtils;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
+import org.apache.paimon.utils.MathUtils;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.StringUtils;
 
@@ -1251,8 +1252,7 @@ public class CoreOptions implements Serializable {
     public int sortSpillThreshold() {
         Integer maxSortedRunNum = options.get(SORT_SPILL_THRESHOLD);
         if (maxSortedRunNum == null) {
-            int stopNum = numSortedRunStopTrigger();
-            maxSortedRunNum = Math.max(stopNum, stopNum + 1);
+            maxSortedRunNum = MathUtils.incrementSafely(numSortedRunStopTrigger());
         }
         checkArgument(maxSortedRunNum > 1, "The sort spill threshold cannot be smaller than 2.");
         return maxSortedRunNum;
@@ -1338,9 +1338,9 @@ public class CoreOptions implements Serializable {
     public int numSortedRunStopTrigger() {
         Integer stopTrigger = options.get(NUM_SORTED_RUNS_STOP_TRIGGER);
         if (stopTrigger == null) {
-            stopTrigger = numSortedRunCompactionTrigger() + 1;
+            stopTrigger = MathUtils.incrementSafely(numSortedRunCompactionTrigger());
         }
-        return Math.max(numSortedRunCompactionTrigger(), stopTrigger);
+        return stopTrigger;
     }
 
     public int numLevels() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1340,7 +1340,7 @@ public class CoreOptions implements Serializable {
         if (stopTrigger == null) {
             stopTrigger = MathUtils.incrementSafely(numSortedRunCompactionTrigger());
         }
-        return stopTrigger;
+        return Math.max(numSortedRunCompactionTrigger(), stopTrigger);
     }
 
     public int numLevels() {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
@@ -93,4 +93,12 @@ public class MathUtils {
 
         return Math.min(v1, v2);
     }
+
+    /** Safely increments the given int value by one, ensuring that no overflow occurs. */
+    public static int incrementSafely(int value) {
+        if (value < Integer.MAX_VALUE) {
+            return value + 1;
+        }
+        return value;
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/MathUtils.java
@@ -95,10 +95,10 @@ public class MathUtils {
     }
 
     /** Safely increments the given int value by one, ensuring that no overflow occurs. */
-    public static int incrementSafely(int value) {
-        if (value < Integer.MAX_VALUE) {
-            return value + 1;
+    public static int incrementSafely(int a) {
+        if (a == Integer.MAX_VALUE) {
+            return a;
         }
-        return value;
+        return a + 1;
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add a no overflow version of `Math.incrementExact` for int increment sately

Math.java (jdk)

```
    public static int incrementExact(int a) {
        if (a == Integer.MAX_VALUE) {
            throw new ArithmeticException("integer overflow");
        }

        return a + 1;
    }
```

MathUtils.java (paimon)

```
    public static int incrementSafely(int a) {
        if (a == Integer.MAX_VALUE) {
            return a;
        }
        return a + 1;
    }
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
