### PR TITLE
[core] Avoid read the snapshot file twice

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -168,13 +168,13 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                     && supportStreamingReadOverwrite) {
                 LOG.debug("Find overwrite snapshot id {}.", nextSnapshotId);
                 SnapshotReader.Plan overwritePlan =
-                        followUpScanner.getOverwriteChangesPlan(nextSnapshotId, snapshotReader);
+                        followUpScanner.getOverwriteChangesPlan(snapshot, snapshotReader);
                 currentWatermark = overwritePlan.watermark();
                 nextSnapshotId++;
                 return overwritePlan;
             } else if (followUpScanner.shouldScanSnapshot(snapshot)) {
                 LOG.debug("Find snapshot id {}.", nextSnapshotId);
-                SnapshotReader.Plan plan = followUpScanner.scan(nextSnapshotId, snapshotReader);
+                SnapshotReader.Plan plan = followUpScanner.scan(snapshot, snapshotReader);
                 currentWatermark = plan.watermark();
                 nextSnapshotId++;
                 return plan;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/AllDeltaFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/AllDeltaFollowUpScanner.java
@@ -30,7 +30,7 @@ public class AllDeltaFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).readChanges();
+    public SnapshotReader.Plan scan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshot).readChanges();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScanner.java
@@ -48,7 +48,7 @@ public class CompactionChangelogFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshotId).read();
+    public SnapshotReader.Plan scan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshot).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScanner.java
@@ -48,7 +48,7 @@ public class ContinuousAppendAndCompactFollowUpScanner implements FollowUpScanne
     }
 
     @Override
-    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).read();
+    public SnapshotReader.Plan scan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshot).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScanner.java
@@ -44,7 +44,7 @@ public class DeltaFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshotId).read();
+    public SnapshotReader.Plan scan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withMode(ScanMode.DELTA).withSnapshot(snapshot).read();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/FollowUpScanner.java
@@ -27,9 +27,9 @@ public interface FollowUpScanner {
 
     boolean shouldScanSnapshot(Snapshot snapshot);
 
-    Plan scan(long snapshotId, SnapshotReader snapshotReader);
+    Plan scan(Snapshot snapshot, SnapshotReader snapshotReader);
 
-    default Plan getOverwriteChangesPlan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withSnapshot(snapshotId).readChanges();
+    default Plan getOverwriteChangesPlan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withSnapshot(snapshot).readChanges();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScanner.java
@@ -44,7 +44,7 @@ public class InputChangelogFollowUpScanner implements FollowUpScanner {
     }
 
     @Override
-    public SnapshotReader.Plan scan(long snapshotId, SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshotId).read();
+    public SnapshotReader.Plan scan(Snapshot snapshot, SnapshotReader snapshotReader) {
+        return snapshotReader.withMode(ScanMode.CHANGELOG).withSnapshot(snapshot).read();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
@@ -79,7 +79,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
         snapshot = snapshotManager.snapshot(3);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(3, snapshotReader);
+        TableScan.Plan plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|102", "+I 1|20|200", "+I 1|30|300"));
 
@@ -90,7 +90,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
         snapshot = snapshotManager.snapshot(5);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(5, snapshotReader);
+        plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(
                         Arrays.asList("-U 1|10|102", "+U 1|10|103", "-D 1|30|300", "+I 1|40|401"));

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -97,21 +97,21 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotReader);
+        TableScan.Plan plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|1|0|1", "+I 1|2|0|1"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotReader);
+        plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 2|1|0|2", "+I 2|2|0|1"));
 
         snapshot = snapshotManager.snapshot(3);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(3, snapshotReader);
+        plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits())).hasSameElementsAs(Arrays.asList("+I 3|1|0|1"));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/DeltaFollowUpScannerTest.java
@@ -61,14 +61,14 @@ public class DeltaFollowUpScannerTest extends ScannerTestBase {
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotReader);
+        TableScan.Plan plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|100", "+I 1|20|200", "+I 1|40|400"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotReader);
+        plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|102", "+I 1|30|300", "-D 1|40|400"));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/InputChangelogFollowUpScannerTest.java
@@ -64,14 +64,14 @@ public class InputChangelogFollowUpScannerTest extends ScannerTestBase {
         Snapshot snapshot = snapshotManager.snapshot(1);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        TableScan.Plan plan = scanner.scan(1, snapshotReader);
+        TableScan.Plan plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|100", "+I 1|20|200", "+I 1|40|400"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
         assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.scan(2, snapshotReader);
+        plan = scanner.scan(snapshot, snapshotReader);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(
                         Arrays.asList("+I 1|10|101", "+I 1|30|300", "+I 1|10|102", "-D 1|40|400"));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Directly pass the Snapshot to reader to avoid read the snapshot file twice

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
