### PR TITLE
[core] Use overwrite instead of delete-and-write when commit hint file

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -391,7 +391,7 @@ public class SnapshotManager implements Serializable {
         int retryNumber = 0;
         while (retryNumber++ < READ_HINT_RETRY_NUM) {
             try {
-                return Long.parseLong(fileIO.readFileUtf8(path));
+                return fileIO.readOverwrittenFileUtf8(path).map(Long::parseLong).orElse(null);
             } catch (Exception ignored) {
             }
             try {
@@ -422,7 +422,6 @@ public class SnapshotManager implements Serializable {
     private void commitHint(long snapshotId, String fileName) throws IOException {
         Path snapshotDir = snapshotDirectory();
         Path hintFile = new Path(snapshotDir, fileName);
-        fileIO.delete(hintFile, false);
-        fileIO.writeFileUtf8(hintFile, String.valueOf(snapshotId));
+        fileIO.overwriteFileUtf8(hintFile, String.valueOf(snapshotId));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, we use delete-and-write to overwrite the hint file, it's better to run with the atomic overwrite, so there is no intermediate state for the hint file.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
