### PR TITLE
[doc] Modify the wrong parameters of flink action in the document

### DIFF
--- a/docs/content/maintenance/manage-tags.md
+++ b/docs/content/maintenance/manage-tags.md
@@ -103,7 +103,7 @@ You can create a tag with given name and snapshot ID.
 ```bash
 <FLINK_HOME>/bin/flink run \
     /path/to/paimon-flink-action-{{< version >}}.jar \
-    create-tag \
+    create_tag \
     --warehouse <warehouse-path> \
     --database <database-name> \ 
     --table <table-name> \
@@ -160,7 +160,7 @@ Run the following command:
 ```bash
 <FLINK_HOME>/bin/flink run \
     /path/to/paimon-flink-action-{{< version >}}.jar \
-    delete-tag \
+    delete_tag \
     --warehouse <warehouse-path> \
     --database <database-name> \ 
     --table <table-name> \


### PR DESCRIPTION
### Purpose
Modify the wrong parameters of flink action in the document,create-tag should be changed to create_tag and delete-tag should be changed to delete_tag

### Tests


### API and Format

### Documentation
