### PR TITLE
[Core][Flink] Flink job can throw exception in streaming reading mode when upstream paimon is deleted

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -153,10 +153,11 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                                             + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.",
                                     nextSnapshotId));
                 }
-                if (latestSnapshotId == null || latestSnapshotId < nextSnapshotId - 1) {
+                if (nextSnapshotId > 1
+                        && (latestSnapshotId == null || latestSnapshotId < nextSnapshotId - 1)) {
                     throw new RuntimeException(
                             String.format(
-                                    "The latest snapshot with id %s is smaller than current snapshot id %s. "
+                                    "The latest snapshot with id %s is smaller than current snapshot id %s, "
                                             + "Maybe the paimon table doesn't exist now, please check it",
                                     latestSnapshotId, nextSnapshotId - 1));
                 }
@@ -242,6 +243,11 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
     @Override
     public Long checkpoint() {
         return nextSnapshotId;
+    }
+
+    @Nullable
+    public Long latestSnapshotId() {
+        return snapshotManager.latestSnapshotId();
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -144,6 +144,7 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
 
             if (!snapshotManager.snapshotExists(nextSnapshotId)) {
                 Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+                Long latestSnapshotId = snapshotManager.latestSnapshotId();
                 if (earliestSnapshotId != null && earliestSnapshotId > nextSnapshotId) {
                     throw new OutOfRangeException(
                             String.format(
@@ -151,6 +152,13 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
                                             + "1. increase the snapshot expiration time. "
                                             + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.",
                                     nextSnapshotId));
+                }
+                if (latestSnapshotId == null || latestSnapshotId < nextSnapshotId - 1) {
+                    throw new RuntimeException(
+                            String.format(
+                                    "The latest snapshot with id %s is smaller than current snapshot id %s. "
+                                            + "Maybe the paimon table doesn't exist now, please check it",
+                                    latestSnapshotId, nextSnapshotId - 1));
                 }
                 LOG.debug(
                         "Next snapshot id {} does not exist, wait for the snapshot generation.",


### PR DESCRIPTION
### Purpose
Add a feature to check whether ID of the latest snapshot is valid when scanning the next snapshot in `InnerStreamTableScanImpl` , which can prompt whether the paimon table has been deleted or rebuilt.

Especially in the Flink job when reading paimon, when an upstream table is deleted, an exception can be thrown, causing the flink job failover instead of constantly hanging. Although it appears to be running normally, it is actually unable to consume data and users can't receive an alarm.


### Tests
None
<!-- List UT and IT cases to verify this change -->

### API and Format
None
<!-- Does this change affect API or storage format -->

### Documentation
None
<!-- Does this change introduce a new feature -->
