### PR TITLE
[Bug] Throw exception when failed to enumerator the splits

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -228,6 +228,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
                 finished = true;
             } else {
                 LOG.error("Failed to enumerate files", error);
+                throw new RuntimeException(error);
             }
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2881

Also related to https://github.com/apache/incubator-paimon/pull/2762

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
