### PR TITLE
[core] Fix bug that changelog may not be produced when setting changelog-producer.lookup-wait to false

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -172,6 +172,11 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         return increment;
     }
 
+    @Override
+    public boolean isCompacting() {
+        return compactManager.isCompacting();
+    }
+
     private void flush(boolean waitForLatestCompaction, boolean forcedFullCompaction)
             throws Exception {
         long start = System.currentTimeMillis();

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
@@ -44,6 +44,11 @@ public abstract class CompactFutureManager implements CompactManager {
         }
     }
 
+    @Override
+    public boolean isCompacting() {
+        return taskFuture != null;
+    }
+
     protected final Optional<CompactResult> innerGetCompactionResult(boolean blocking)
             throws ExecutionException, InterruptedException {
         if (taskFuture != null) {

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
@@ -51,4 +51,7 @@ public interface CompactManager extends Closeable {
 
     /** Cancel currently running compaction task. */
     void cancelCompaction();
+
+    /** Check if a compaction is in progress, or if a compaction result remains to be fetched. */
+    boolean isCompacting();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/compact/NoopCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/NoopCompactManager.java
@@ -71,5 +71,10 @@ public class NoopCompactManager implements CompactManager {
     public void cancelCompaction() {}
 
     @Override
+    public boolean isCompacting() {
+        return false;
+    }
+
+    @Override
     public void close() throws IOException {}
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -259,6 +259,11 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
+    public boolean isCompacting() {
+        return compactManager.isCompacting();
+    }
+
+    @Override
     public void sync() throws Exception {
         trySyncLatestCompaction(true);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -211,7 +211,11 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 result.add(committable);
 
                 if (committable.isEmpty()) {
-                    if (writerContainer.lastModifiedCommitIdentifier <= latestCommittedIdentifier) {
+                    // Condition 1: There is no more record waiting to be committed.
+                    // Condition 2: No compaction is in progress. That is, no more changelog will be
+                    // produced.
+                    if (writerContainer.lastModifiedCommitIdentifier <= latestCommittedIdentifier
+                            && !writerContainer.writer.isCompacting()) {
                         // Clear writer if no update, and if its latest modification has committed.
                         //
                         // We need a mechanism to clear writers, otherwise there will be more and

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -61,6 +61,9 @@ public interface RecordWriter<T> {
      */
     CommitIncrement prepareCommit(boolean waitCompaction) throws Exception;
 
+    /** Check if a compaction is in progress, or if a compaction result remains to be fetched. */
+    boolean isCompacting();
+
     /**
      * Sync the writer. The structure related to file reading and writing is thread unsafe, there
      * are asynchronous threads inside the writer, which should be synced before reading data.

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -379,7 +379,9 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                         + String.format(
                                 "'write-buffer-size' = '%s',",
                                 random.nextBoolean() ? "512kb" : "1mb")
-                        + "'changelog-producer' = 'lookup'");
+                        + "'changelog-producer' = 'lookup',"
+                        + String.format(
+                                "'changelog-producer.lookup-wait' = '%s'", random.nextBoolean()));
 
         // sleep for a random amount of time to check
         // if we can first read complete records then read incremental records correctly
@@ -436,6 +438,8 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                                 "'write-buffer-size' = '%s',",
                                 random.nextBoolean() ? "512kb" : "1mb")
                         + "'changelog-producer' = 'lookup',"
+                        + String.format(
+                                "'changelog-producer.lookup-wait' = '%s'", random.nextBoolean())
                         + "'write-only' = 'true'");
 
         // sleep for a random amount of time to check


### PR DESCRIPTION
### Purpose

In `AbstractFileStoreWrite#prepareCommit`, if a writer does not produce any new `CommitIncrement` and all previous `CommitIncrement`s have been committed, we'll close this writer.

However, this writer may have an ongoing compaction (possibly triggered by lookup changelog producer). If we ignore this compaction and close the writer, we'll interrupt the compaction and thus interrupt changelog producing.

This PR fixes the bug by checking if a writer has an ongoing compaction.

### Tests

* `TableWriteTest#testChangelogWhenNotWaitForCompaction`

### API and Format

No.

### Documentation

No.
