### PR TITLE
[core] Last value and nested_update agg function support retract

### DIFF
--- a/docs/content/concepts/primary-key-table/merge-engine.md
+++ b/docs/content/concepts/primary-key-table/merge-engine.md
@@ -302,7 +302,7 @@ For streaming queries, `aggregation` merge engine must be used together with `lo
 
 ### Retract
 
-Only `sum`, `product`, `count`, `collect`, `merge_map`, `last_value` and `last_non_null_value` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
+Only `sum`, `product`, `count`, `collect`, `merge_map`, `nested_update`, `last_value` and `last_non_null_value` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
 If you allow some functions to ignore retraction messages, you can configure:
 `'fields.${field_name}.ignore-retract'='true'`.
 

--- a/docs/content/concepts/primary-key-table/merge-engine.md
+++ b/docs/content/concepts/primary-key-table/merge-engine.md
@@ -302,11 +302,13 @@ For streaming queries, `aggregation` merge engine must be used together with `lo
 
 ### Retract
 
-Only `sum`, `product`, `count`, `collect` and `merge_map` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
+Only `sum`, `product`, `count`, `collect`, `merge_map`, `last_value` and `last_non_null_value` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
 If you allow some functions to ignore retraction messages, you can configure:
 `'fields.${field_name}.ignore-retract'='true'`.
 
-NOTE: The `collect` and `merge_map` make a best-effort attempt to handle retraction messages, but the results are not 
+The `last_value` and `last_non_null_value` just set field to null when accept retract messages.
+
+The `collect` and `merge_map` make a best-effort attempt to handle retraction messages, but the results are not 
 guaranteed to be accurate. The following behaviors may occur when processing retraction messages:
 
 1. It might fail to handle retraction messages if records are disordered. For example, the table uses `collect`, and the 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
@@ -41,6 +41,6 @@ public class FieldLastNonNullValueAgg extends FieldAggregator {
 
     @Override
     public Object retract(Object accumulator, Object retractField) {
-        return null;
+        return retractField != null ? null : accumulator;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
@@ -38,4 +38,9 @@ public class FieldLastNonNullValueAgg extends FieldAggregator {
     public Object agg(Object accumulator, Object inputField) {
         return (inputField == null) ? accumulator : inputField;
     }
+
+    @Override
+    public Object retract(Object accumulator, Object retractField) {
+        return null;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastValueAgg.java
@@ -38,4 +38,9 @@ public class FieldLastValueAgg extends FieldAggregator {
     public Object agg(Object accumulator, Object inputField) {
         return inputField;
     }
+
+    @Override
+    public Object retract(Object accumulator, Object retractField) {
+        return null;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -20,6 +20,7 @@ package org.apache.paimon.mergetree.compact.aggregate;
 
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.InternalArray;
@@ -34,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
 /**
  * Used to update a field which representing a nested table. The data type of nested table field is
  * {@code ARRAY<ROW>}.
@@ -45,13 +48,22 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
     private final int nestedFields;
 
     @Nullable private final Projection keyProjection;
+    @Nullable private final RecordEqualiser elementEqualiser;
 
     public FieldNestedUpdateAgg(ArrayType dataType, List<String> nestedKey) {
         super(dataType);
         RowType nestedType = (RowType) dataType.getElementType();
         this.nestedFields = nestedType.getFieldCount();
-        this.keyProjection =
-                nestedKey.isEmpty() ? null : CodeGenUtils.newProjection(nestedType, nestedKey);
+        if (nestedKey.isEmpty()) {
+            this.keyProjection = null;
+            this.elementEqualiser =
+                    CodeGenUtils.generateRecordEqualiser(
+                                    nestedType.getFieldTypes(), "elementEqualiser")
+                            .newInstance(FieldNestedUpdateAgg.class.getClassLoader());
+        } else {
+            this.keyProjection = CodeGenUtils.newProjection(nestedType, nestedKey);
+            this.elementEqualiser = null;
+        }
     }
 
     @Override
@@ -87,5 +99,41 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
         }
 
         return new GenericArray(rows.toArray());
+    }
+
+    @Override
+    public Object retract(Object accumulator, Object retractField) {
+        if (accumulator == null || retractField == null) {
+            return accumulator;
+        }
+
+        InternalArray acc = (InternalArray) accumulator;
+        InternalArray retract = (InternalArray) retractField;
+
+        if (keyProjection == null) {
+            checkNotNull(elementEqualiser);
+            List<InternalRow> rows = new ArrayList<>();
+            for (int i = 0; i < acc.size(); i++) {
+                rows.add(acc.getRow(i, nestedFields));
+            }
+            for (int i = 0; i < retract.size(); i++) {
+                InternalRow retractRow = retract.getRow(i, nestedFields);
+                rows.removeIf(next -> elementEqualiser.equals(next, retractRow));
+            }
+            return new GenericArray(rows.toArray());
+        } else {
+            Map<BinaryRow, InternalRow> map = new HashMap<>();
+
+            for (int i = 0; i < acc.size(); i++) {
+                InternalRow row = acc.getRow(i, nestedFields);
+                map.put(keyProjection.apply(row).copy(), row);
+            }
+
+            for (int i = 0; i < retract.size(); i++) {
+                map.remove(keyProjection.apply(retract.getRow(i, nestedFields)));
+            }
+
+            return new GenericArray(new ArrayList<>(map.values()).toArray());
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -317,6 +317,11 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Arrays.asList(row(0, 0, "A"), row(0, 1, "b")));
+
+        current = row(0, 1, "b");
+        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(row(0, 0, "A")));
     }
 
     @Test
@@ -342,6 +347,11 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Arrays.asList(row(0, 1, "B"), row(0, 1, "b")));
+
+        current = row(0, 1, "b");
+        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(row(0, 1, "B")));
     }
 
     private List<Object> unnest(InternalArray array, InternalArray.ElementGetter elementGetter) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -60,25 +60,15 @@ public class FieldAggregatorTest {
     @Test
     public void testFieldBoolAndAgg() {
         FieldBoolAndAgg fieldBoolAndAgg = new FieldBoolAndAgg(new BooleanType());
-        Boolean accumulator = false;
-        Boolean inputField = true;
-        assertThat(fieldBoolAndAgg.agg(accumulator, inputField)).isEqualTo(false);
-
-        accumulator = true;
-        inputField = true;
-        assertThat(fieldBoolAndAgg.agg(accumulator, inputField)).isEqualTo(true);
+        assertThat(fieldBoolAndAgg.agg(false, true)).isEqualTo(false);
+        assertThat(fieldBoolAndAgg.agg(true, true)).isEqualTo(true);
     }
 
     @Test
     public void testFieldBoolOrAgg() {
         FieldBoolOrAgg fieldBoolOrAgg = new FieldBoolOrAgg(new BooleanType());
-        Boolean accumulator = false;
-        Boolean inputField = true;
-        assertThat(fieldBoolOrAgg.agg(accumulator, inputField)).isEqualTo(true);
-
-        accumulator = false;
-        inputField = false;
-        assertThat(fieldBoolOrAgg.agg(accumulator, inputField)).isEqualTo(false);
+        assertThat(fieldBoolOrAgg.agg(false, true)).isEqualTo(true);
+        assertThat(fieldBoolOrAgg.agg(false, false)).isEqualTo(false);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -1082,7 +1082,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
         StreamTableWrite write = table.newWrite("");
         StreamTableCommit commit = table.newCommit("");
         write.write(GenericRow.of(1, 1, 3, 3));
-        write.write(GenericRow.ofKind(RowKind.DELETE, 1, 1, 3, 3));
+        write.write(GenericRow.ofKind(RowKind.DELETE, 1, 1, null, 3));
         commit.commit(0, write.prepareCommit(true, 0));
 
         write.close();
@@ -1105,7 +1105,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 readBuilder.newRead(),
                                 readBuilder.newScan().plan().splits(),
                                 toString))
-                .containsExactly("1|1|null|null");
+                .containsExactly("1|1|3|null");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The `last_value` and `last_non_null_value` just set field to null when accept retract messages.

This is good to most cases.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
