### PR TITLE
[core] Remove legacy stats FieldStatsArraySerializer.fromBinary

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/stats/FieldStatsConverters.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/FieldStatsConverters.java
@@ -18,9 +18,7 @@
 
 package org.apache.paimon.stats;
 
-import org.apache.paimon.casting.CastExecutor;
 import org.apache.paimon.schema.IndexCastMapping;
-import org.apache.paimon.schema.SchemaEvolutionUtil;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
@@ -65,15 +63,10 @@ public class FieldStatsConverters {
                     IndexCastMapping indexCastMapping =
                             createIndexCastMapping(schemaTableFields, dataFields);
                     @Nullable int[] indexMapping = indexCastMapping.getIndexMapping();
-                    CastExecutor<Object, Object>[] castExecutors =
-                            (CastExecutor<Object, Object>[])
-                                    SchemaEvolutionUtil.createConvertMapping(
-                                            schemaTableFields, dataFields, indexMapping);
                     // Create field stats array serializer with schema evolution
                     return new FieldStatsArraySerializer(
                             new RowType(dataFields),
                             indexMapping,
-                            castExecutors,
                             indexCastMapping.getCastMapping());
                 });
     }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -27,7 +27,6 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
-import org.apache.paimon.stats.FieldStatsArraySerializer;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.utils.FailingFileIO;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -43,6 +42,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.TestKeyValueGenerator.DEFAULT_PART_TYPE;
+import static org.apache.paimon.stats.StatsTestUtils.convertWithoutSchemaEvolution;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ManifestFile}. */
@@ -130,14 +130,16 @@ public class ManifestFileTest {
                 .isEqualTo(expected.numDeletedFiles());
 
         // check stats
-        FieldStatsArraySerializer statsConverter = new FieldStatsArraySerializer(DEFAULT_PART_TYPE);
-        FieldStats[] fieldStats = statsConverter.fromBinary(expected.partitionStats());
+        FieldStats[] fieldStats =
+                convertWithoutSchemaEvolution(expected.partitionStats(), DEFAULT_PART_TYPE);
         for (int i = 0; i < fieldStats.length; i++) {
             int idx = i;
             StatsTestUtils.checkRollingFileStats(
                     fieldStats[i],
                     actual,
-                    meta -> statsConverter.fromBinary(meta.partitionStats())[idx]);
+                    meta ->
+                            convertWithoutSchemaEvolution(meta.partitionStats(), DEFAULT_PART_TYPE)[
+                                    idx]);
         }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We have introduced `FieldStatsArraySerializer.evolution`, we don't need keep another evolution method `fromBinary`. This PR aims to clean some usage in tests code.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
