### PR TITLE
[core] Remove useless exception message when commit conflicts

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -154,7 +154,7 @@ public class ManifestEntry {
                 case ADD:
                     Preconditions.checkState(
                             !map.containsKey(identifier),
-                            "Trying to add file %s which is already added. Manifest might be corrupted.",
+                            "Trying to add file %s which is already added.",
                             identifier);
                     map.put(identifier, entry);
                     break;
@@ -181,7 +181,7 @@ public class ManifestEntry {
         for (ManifestEntry entry : entries) {
             Preconditions.checkState(
                     entry.kind() != FileKind.DELETE,
-                    "Trying to delete file %s which is not previously added. Manifest might be corrupted.",
+                    "Trying to delete file %s which is not previously added.",
                     entry.file().fileName());
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
"Manifest might be corrupted" makes users panic...

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
