### PR TITLE
[core] Optimize partition expire by filtering partitions while scanning

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -131,6 +131,12 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     }
 
     @Override
+    public FileStoreScan withPartitionFilter(PartitionPredicate predicate) {
+        this.partitionFilter = predicate;
+        return this;
+    }
+
+    @Override
     public FileStoreScan withBucket(int bucket) {
         this.bucketFilter = i -> i == bucket;
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -26,6 +26,7 @@ import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.operation.metrics.ScanMetrics;
+import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.Filter;
@@ -44,6 +45,8 @@ public interface FileStoreScan {
     FileStoreScan withPartitionFilter(Predicate predicate);
 
     FileStoreScan withPartitionFilter(List<BinaryRow> partitions);
+
+    FileStoreScan withPartitionFilter(PartitionPredicate predicate);
 
     FileStoreScan withBucket(int bucket);
 


### PR DESCRIPTION
### Purpose

Currently, `PartitionExpire` will scan all manifest entries and merge them in memory before extracting the partitions. This is very inefficient any may cause OOM.

This PR optimizes `PartitionExpire` by filtering partitions while scanning, thus decreasing the number of manifest entries to be merged.

### Tests

Existing tests should cover the change.

### API and Format

No.

### Documentation

No.
