### PR TITLE
[core] Read optimized table supports value filter pushdown

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -330,7 +330,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                                         Collectors.toList()))
                         .values()
                         .stream()
-                        .filter(this::filterWholeBucketByStats)
+                        .map(this::filterWholeBucketByStats)
                         .flatMap(Collection::stream)
                         .collect(Collectors.toList());
 
@@ -420,7 +420,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     }
 
     /** Note: Keep this thread-safe. */
-    protected abstract boolean filterWholeBucketByStats(List<ManifestEntry> entries);
+    protected abstract List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries);
 
     /** Note: Keep this thread-safe. */
     private List<ManifestEntry> readManifestFileMeta(ManifestFileMeta manifest) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -90,8 +90,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     }
 
     @Override
-    protected boolean filterWholeBucketByStats(List<ManifestEntry> entries) {
+    protected List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries) {
         // We don't need to filter per-bucket entries here
-        return true;
+        return entries;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -155,10 +155,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public InnerTableScan newScan() {
         return new InnerTableScanImpl(
-                coreOptions(),
-                newSnapshotReader(),
-                snapshotManager(),
-                DefaultValueAssigner.create(tableSchema));
+                coreOptions(), newSnapshotReader(), DefaultValueAssigner.create(tableSchema));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScanImpl.java
@@ -24,7 +24,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.StartingScanner;
 import org.apache.paimon.table.source.snapshot.StartingScanner.ScannedResult;
-import org.apache.paimon.utils.SnapshotManager;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +33,6 @@ import java.util.List;
 /** {@link TableScan} implementation for batch planning. */
 public class InnerTableScanImpl extends AbstractInnerTableScan {
 
-    private final SnapshotManager snapshotManager;
     private final DefaultValueAssigner defaultValueAssigner;
 
     private StartingScanner startingScanner;
@@ -45,10 +43,8 @@ public class InnerTableScanImpl extends AbstractInnerTableScan {
     public InnerTableScanImpl(
             CoreOptions options,
             SnapshotReader snapshotReader,
-            SnapshotManager snapshotManager,
             DefaultValueAssigner defaultValueAssigner) {
         super(options, snapshotReader);
-        this.snapshotManager = snapshotManager;
         this.hasNext = true;
         this.defaultValueAssigner = defaultValueAssigner;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -107,7 +107,6 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
         return new InnerTableScanImpl(
                 coreOptions(),
                 newSnapshotReader(),
-                snapshotManager(),
                 DefaultValueAssigner.create(dataTable.schema()));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -48,6 +48,7 @@ import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
@@ -73,6 +74,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -1279,6 +1281,9 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
         List<Split> splits = roTable.newScan().withFilter(builder.equal(2, 210L)).plan().splits();
         assertThat(splits).hasSize(1);
+        Optional<List<RawFile>> rawFiles = splits.get(0).convertToRawFiles();
+        assertThat(rawFiles).isPresent();
+        assertThat(rawFiles.get()).hasSize(1);
 
         write.close();
         commit.close();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The RO table no longer needs to be merged, so we should enable it to have the ability to non-primary key filtering pushdown.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
