### PR TITLE
[flink] Introduce max_pt for Flink lookup join

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -57,6 +57,18 @@ under the License.
             <td>The cache mode of lookup join.<br /><br />Possible values:<ul><li>"AUTO"</li><li>"FULL"</li></ul></td>
         </tr>
         <tr>
+            <td><h5>lookup.dynamic-partition</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specific dynamic partition for lookup, only support 'max_pt()' currently.</td>
+        </tr>
+        <tr>
+            <td><h5>lookup.dynamic-partition.refresh-interval</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>Specific dynamic partition refresh interval for lookup, scan all partitions and obtain corresponding partition.</td>
+        </tr>
+        <tr>
             <td><h5>scan.infer-parallelism</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
@@ -75,6 +75,10 @@ public class JoinedRow implements InternalRow {
         this.row2 = row2;
     }
 
+    public static JoinedRow join(InternalRow row1, InternalRow row2) {
+        return new JoinedRow(row1, row2);
+    }
+
     /**
      * Replaces the {@link InternalRow} backing this {@link JoinedRow}.
      *

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -46,8 +46,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 
@@ -159,6 +161,21 @@ public class PredicateBuilder {
         return predicates.stream()
                 .reduce((a, b) -> new CompoundPredicate(And.INSTANCE, Arrays.asList(a, b)))
                 .get();
+    }
+
+    @Nullable
+    public static Predicate andNullable(Predicate... predicates) {
+        return andNullable(Arrays.asList(predicates));
+    }
+
+    @Nullable
+    public static Predicate andNullable(List<Predicate> predicates) {
+        predicates = predicates.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        if (predicates.isEmpty()) {
+            return null;
+        }
+
+        return and(predicates);
     }
 
     public static Predicate or(Predicate... predicates) {

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -27,6 +27,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonGenerator
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -182,6 +183,21 @@ public final class RowType extends DataType {
         int newId = currentHighestFieldId(fields) + 1;
         newFields.add(new DataField(newId, name, type));
         return new RowType(newFields);
+    }
+
+    public RowType project(int[] mapping) {
+        List<DataField> fields = getFields();
+        return new RowType(
+                Arrays.stream(mapping).mapToObj(fields::get).collect(Collectors.toList()));
+    }
+
+    public RowType project(List<String> names) {
+        List<DataField> fields = getFields();
+        List<String> fieldNames = fields.stream().map(DataField::name).collect(Collectors.toList());
+        return new RowType(
+                names.stream()
+                        .map(k -> fields.get(fieldNames.indexOf(k)))
+                        .collect(Collectors.toList()));
     }
 
     public static RowType of(DataType... types) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/KeyProjectedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/KeyProjectedRow.java
@@ -44,6 +44,10 @@ public class KeyProjectedRow implements InternalRow {
         return this;
     }
 
+    public int[] indexMapping() {
+        return indexMapping;
+    }
+
     @Override
     public int getFieldCount() {
         return indexMapping.length;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -293,6 +293,21 @@ public class FlinkConnectorOptions {
                     .defaultValue(LookupCacheMode.AUTO)
                     .withDescription("The cache mode of lookup join.");
 
+    public static final ConfigOption<String> LOOKUP_DYNAMIC_PARTITION =
+            ConfigOptions.key("lookup.dynamic-partition")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specific dynamic partition for lookup, only support 'max_pt()' currently.");
+
+    public static final ConfigOption<Duration> LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL =
+            ConfigOptions.key("lookup.dynamic-partition.refresh-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            "Specific dynamic partition refresh interval for lookup, "
+                                    + "scan all partitions and obtain corresponding partition.");
+
     public static final ConfigOption<Boolean> SINK_AUTO_TAG_FOR_SAVEPOINT =
             ConfigOptions.key("sink.savepoint.auto-tag")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.codegen.CodeGenUtils;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Dynamic partition for lookup. */
+public class DynamicPartitionLoader implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String MAX_PT = "max_pt()";
+
+    private final Table table;
+    private final Duration refreshInterval;
+
+    private TableScan scan;
+    private Comparator<InternalRow> comparator;
+
+    private LocalDateTime lastRefresh;
+    private BinaryRow partition;
+
+    private DynamicPartitionLoader(Table table, Duration refreshInterval) {
+        this.table = table;
+        this.refreshInterval = refreshInterval;
+    }
+
+    public void open() {
+        this.scan = table.newReadBuilder().newScan();
+        RowType partitionType = table.rowType().project(table.partitionKeys());
+        this.comparator =
+                CodeGenUtils.newRecordComparator(partitionType.getFieldTypes(), "Partition");
+    }
+
+    public void addJoinKeys(List<String> joinKeys) {
+        List<String> partitionKeys = table.partitionKeys();
+        checkArgument(joinKeys.stream().noneMatch(partitionKeys::contains));
+        joinKeys.addAll(partitionKeys);
+    }
+
+    @Nullable
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    /** @return true if partition changed. */
+    public boolean checkRefresh() {
+        if (lastRefresh != null
+                && !lastRefresh.plus(refreshInterval).isBefore(LocalDateTime.now())) {
+            return false;
+        }
+
+        BinaryRow previous = this.partition;
+        partition = scan.listPartitions().stream().max(comparator).orElse(null);
+        lastRefresh = LocalDateTime.now();
+
+        return !Objects.equals(previous, partition);
+    }
+
+    @Nullable
+    public static DynamicPartitionLoader of(Table table) {
+        Options options = Options.fromMap(table.options());
+        String dynamicPartition = options.get(LOOKUP_DYNAMIC_PARTITION);
+        if (dynamicPartition == null) {
+            return null;
+        }
+
+        if (!dynamicPartition.equalsIgnoreCase(MAX_PT)) {
+            throw new UnsupportedOperationException(
+                    "Unsupported dynamic partition pattern: " + dynamicPartition);
+        }
+
+        Duration refresh =
+                options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
+        return new DynamicPartitionLoader(table, refresh);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.flink.FlinkConnectorOptions.LookupCacheMode;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowWrapper;
@@ -51,6 +53,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
@@ -73,6 +76,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreLookupFunction.class);
 
     private final Table table;
+    @Nullable private final DynamicPartitionLoader partitionLoader;
     private final List<String> projectFields;
     private final List<String> joinKeys;
     @Nullable private final Predicate predicate;
@@ -89,12 +93,17 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         TableScanUtils.streamingReadingValidate(table);
 
         this.table = table;
+        this.partitionLoader = DynamicPartitionLoader.of(table);
 
         // join keys are based on projection fields
         this.joinKeys =
                 Arrays.stream(joinKeyIndex)
                         .mapToObj(i -> table.rowType().getFieldNames().get(projection[i]))
                         .collect(Collectors.toList());
+
+        if (partitionLoader != null) {
+            partitionLoader.addJoinKeys(joinKeys);
+        }
 
         this.projectFields =
                 Arrays.stream(projection)
@@ -126,6 +135,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     }
 
     private void open() throws Exception {
+        if (partitionLoader != null) {
+            partitionLoader.open();
+        }
+
         this.nextLoadTime = -1;
 
         Options options = Options.fromMap(table.options());
@@ -165,6 +178,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
             this.lookupTable = FullCacheLookupTable.create(context, options.get(LOOKUP_CACHE_ROWS));
         }
 
+        refreshDynamicPartition(false);
         lookupTable.open();
     }
 
@@ -187,7 +201,17 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     public Collection<RowData> lookup(RowData keyRow) {
         try {
             checkRefresh();
-            List<InternalRow> results = lookupTable.get(new FlinkRowWrapper(keyRow));
+
+            InternalRow key = new FlinkRowWrapper(keyRow);
+            if (partitionLoader != null) {
+                InternalRow partition = refreshDynamicPartition(true);
+                if (partition == null) {
+                    return Collections.emptyList();
+                }
+                key = JoinedRow.join(key, partition);
+            }
+
+            List<InternalRow> results = lookupTable.get(key);
             List<RowData> rows = new ArrayList<>(results.size());
             for (InternalRow matchedRow : results) {
                 rows.add(new FlinkRowData(matchedRow));
@@ -199,6 +223,23 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Nullable
+    private BinaryRow refreshDynamicPartition(boolean reopen) throws Exception {
+        if (partitionLoader == null) {
+            return null;
+        }
+
+        boolean partitionChanged = partitionLoader.checkRefresh();
+        lookupTable.specificPartition(partitionLoader.partition());
+
+        if (partitionChanged && reopen) {
+            lookupTable.close();
+            lookupTable.open();
+        }
+
+        return partitionLoader.partition();
     }
 
     private void reopen() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -86,7 +86,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
 
     @Override
     public void open() throws Exception {
-        Predicate scanPredicate = context.projectedPredicate;
+        Predicate scanPredicate = context.tablePredicate;
         if (specificPartition != null) {
             scanPredicate = createSpecificPartFilter(scanPredicate);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.lookup;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 
 import java.io.Closeable;
@@ -26,6 +27,8 @@ import java.util.List;
 
 /** A lookup table which provides get and refresh. */
 public interface LookupTable extends Closeable {
+
+    default void specificPartition(BinaryRow partition) {}
 
     void open() throws Exception;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
@@ -18,8 +18,8 @@
 
 package org.apache.paimon.flink.lookup;
 
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.predicate.Predicate;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import java.util.List;
 /** A lookup table which provides get and refresh. */
 public interface LookupTable extends Closeable {
 
-    default void specificPartition(BinaryRow partition) {}
+    void specificPartitionFilter(Predicate filter);
 
     void open() throws Exception;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -41,8 +41,6 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     protected final long lruCacheSize;
 
-    protected final int[] primaryKeyMapping;
-
     protected final KeyProjectedRow primaryKeyRow;
 
     @Nullable private final ProjectedRow keyRearrange;
@@ -55,7 +53,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
         this.lruCacheSize = lruCacheSize;
         List<String> fieldNames = projectedType.getFieldNames();
         FileStoreTable table = context.table;
-        this.primaryKeyMapping =
+        int[] primaryKeyMapping =
                 table.primaryKeys().stream().mapToInt(fieldNames::indexOf).toArray();
         this.primaryKeyRow = new KeyProjectedRow(primaryKeyMapping);
 
@@ -77,7 +75,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
                 stateFactory.valueState(
                         "table",
                         InternalSerializers.create(
-                                TypeUtils.project(projectedType, primaryKeyMapping)),
+                                TypeUtils.project(projectedType, primaryKeyRow.indexMapping())),
                         InternalSerializers.create(projectedType),
                         lruCacheSize);
         super.open();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -53,8 +53,8 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
                         InternalSerializers.create(
                                 TypeUtils.project(projectedType, secKeyRow.indexMapping())),
                         InternalSerializers.create(
-                                TypeUtils.project(projectedType, primaryKeyMapping)),
-                        lruCacheSize / 2);
+                                TypeUtils.project(projectedType, primaryKeyRow.indexMapping())),
+                        lruCacheSize);
         super.open();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -34,22 +34,28 @@ import java.util.List;
 /** A {@link LookupTable} for primary key table which provides lookup by secondary key. */
 public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
 
-    private final RocksDBSetState<InternalRow, InternalRow> indexState;
-
     private final KeyProjectedRow secKeyRow;
+
+    private RocksDBSetState<InternalRow, InternalRow> indexState;
 
     public SecondaryIndexLookupTable(Context context, long lruCacheSize) throws IOException {
         super(context, lruCacheSize / 2, context.table.primaryKeys());
         List<String> fieldNames = projectedType.getFieldNames();
         int[] secKeyMapping = context.joinKey.stream().mapToInt(fieldNames::indexOf).toArray();
         this.secKeyRow = new KeyProjectedRow(secKeyMapping);
+    }
+
+    @Override
+    public void open() throws Exception {
         this.indexState =
                 stateFactory.setState(
                         "sec-index",
-                        InternalSerializers.create(TypeUtils.project(projectedType, secKeyMapping)),
+                        InternalSerializers.create(
+                                TypeUtils.project(projectedType, secKeyRow.indexMapping())),
                         InternalSerializers.create(
                                 TypeUtils.project(projectedType, primaryKeyMapping)),
                         lruCacheSize / 2);
+        super.open();
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -24,7 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.LocalQueryExecutor;
 import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.QueryExecutor;
-import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.RemoveQueryExecutor;
+import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.RemoteQueryExecutor;
 import org.apache.paimon.lookup.RocksDBOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
@@ -142,7 +142,7 @@ public class FileStoreLookupFunctionTest {
         assertThat(lookupFunction.lookupTable()).isInstanceOf(PrimaryKeyPartialLookupTable.class);
         QueryExecutor queryExecutor =
                 ((PrimaryKeyPartialLookupTable) lookupFunction.lookupTable()).queryExecutor();
-        assertThat(queryExecutor).isInstanceOf(RemoveQueryExecutor.class);
+        assertThat(queryExecutor).isInstanceOf(RemoteQueryExecutor.class);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -116,6 +116,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f0"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         // test bulk load error
         {
@@ -174,6 +175,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f0"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
         for (int i = 1; i <= 10; i++) {
@@ -218,6 +220,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f0"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         table.refresh(singletonList(sequence(row(1, 11, 111), -1L)).iterator(), false);
         List<InternalRow> result = table.get(row(1));
@@ -249,6 +252,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f0"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         table.refresh(singletonList(sequence(row(1, 11, 111), -1L)).iterator(), false);
         List<InternalRow> result = table.get(row(1));
@@ -272,6 +276,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         // test bulk load 100_000 records
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
@@ -316,6 +321,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
         Random rnd = new Random();
@@ -370,6 +376,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         table.refresh(singletonList(sequence(row(1, 11, 111), -1L)).iterator(), false);
         List<InternalRow> result = table.get(row(11));
@@ -410,6 +417,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         // test bulk load 100_000 records
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
@@ -452,6 +460,7 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
 
         table.refresh(singletonList(row(1, 11, 333)).iterator(), false);
         List<InternalRow> result = table.get(row(11));
@@ -478,6 +487,8 @@ public class LookupTableTest extends TableTestBase {
                         new int[] {0, 1, 2},
                         tempDir.toFile(),
                         ImmutableList.of("pk1", "pk2"));
+        table.open();
+
         List<InternalRow> result = table.get(row(1, -1));
         assertThat(result).hasSize(0);
 
@@ -508,6 +519,7 @@ public class LookupTableTest extends TableTestBase {
                         new int[] {2, 1},
                         tempDir.toFile(),
                         ImmutableList.of("pk1", "pk2"));
+        table.open();
         List<InternalRow> result = table.get(row(1, -1));
         assertThat(result).hasSize(0);
 
@@ -533,6 +545,8 @@ public class LookupTableTest extends TableTestBase {
                         new int[] {2, 1},
                         tempDir.toFile(),
                         ImmutableList.of("pk2", "pk1"));
+        table.open();
+
         List<InternalRow> result = table.get(row(-1, 1));
         assertThat(result).hasSize(0);
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In many cases, data is stored in the payload by partition, and each partition contains the full amount of data, while the latest data is often stored in the latest partition.

We introduce a max_pt mechanism here to only look up the latest partition.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
