### PR TITLE
[Hive]Pass Table into Split to Avoid Loading from FileSystem when createRecordReader

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputFormat.java
@@ -48,8 +48,7 @@ public class PaimonInputFormat implements InputFormat<Void, RowDataContainer> {
     @Override
     public RecordReader<Void, RowDataContainer> getRecordReader(
             InputSplit inputSplit, JobConf jobConf, Reporter reporter) throws IOException {
-        FileStoreTable table = createFileStoreTable(jobConf);
         PaimonInputSplit split = (PaimonInputSplit) inputSplit;
-        return createRecordReader(table, split, jobConf);
+        return createRecordReader(split, jobConf);
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputSplit.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonInputSplit.java
@@ -21,7 +21,9 @@ package org.apache.paimon.hive.mapred;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataOutputSerializer;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.utils.InstantiationUtil;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
@@ -41,12 +43,15 @@ public class PaimonInputSplit extends FileSplit {
     private String path;
     private DataSplit split;
 
+    private FileStoreTable table;
+
     // public no-argument constructor for deserialization
     public PaimonInputSplit() {}
 
-    public PaimonInputSplit(String path, DataSplit split) {
+    public PaimonInputSplit(String path, DataSplit split, FileStoreTable table) {
         this.path = path;
         this.split = split;
+        this.table = table;
     }
 
     public DataSplit split() {
@@ -73,6 +78,10 @@ public class PaimonInputSplit extends FileSplit {
         return ANYWHERE;
     }
 
+    public FileStoreTable getTable() {
+        return table;
+    }
+
     @Override
     public void write(DataOutput dataOutput) throws IOException {
         dataOutput.writeUTF(path);
@@ -80,6 +89,17 @@ public class PaimonInputSplit extends FileSplit {
         split.serialize(out);
         dataOutput.writeInt(out.length());
         dataOutput.write(out.getCopyOfBuffer());
+        writeFileStoreTable(dataOutput);
+    }
+
+    private void writeFileStoreTable(DataOutput dataOutput) throws IOException {
+        if (table == null) {
+            dataOutput.writeInt(0);
+        } else {
+            byte[] bytes = InstantiationUtil.serializeObject(table);
+            dataOutput.writeInt(bytes.length);
+            dataOutput.write(bytes);
+        }
     }
 
     @Override
@@ -89,6 +109,22 @@ public class PaimonInputSplit extends FileSplit {
         byte[] bytes = new byte[length];
         dataInput.readFully(bytes);
         split = DataSplit.deserialize(new DataInputDeserializer(bytes));
+        readFileStoreTable(dataInput);
+    }
+
+    private void readFileStoreTable(DataInput dataInput) throws IOException {
+        int length = dataInput.readInt();
+        if (length > 0) {
+            byte[] bytes = new byte[length];
+            dataInput.readFully(bytes);
+            try {
+                table =
+                        InstantiationUtil.deserializeObject(
+                                bytes, Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @Override
@@ -105,11 +141,13 @@ public class PaimonInputSplit extends FileSplit {
             return false;
         }
         PaimonInputSplit that = (PaimonInputSplit) o;
-        return Objects.equals(path, that.path) && Objects.equals(split, that.split);
+        return Objects.equals(path, that.path)
+                && Objects.equals(split, that.split)
+                && Objects.equals(table, that.table);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, split);
+        return Objects.hash(path, split, table);
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonRecordReader.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonRecordReader.java
@@ -174,7 +174,8 @@ public class PaimonRecordReader implements RecordReader<Void, RowDataContainer> 
     }
 
     public static RecordReader<Void, RowDataContainer> createRecordReader(
-            FileStoreTable table, PaimonInputSplit split, JobConf jobConf) throws IOException {
+            PaimonInputSplit split, JobConf jobConf) throws IOException {
+        FileStoreTable table = split.getTable();
         ReadBuilder readBuilder = table.newReadBuilder();
         createPredicate(table.schema(), jobConf, true).ifPresent(readBuilder::withFilter);
         List<String> paimonColumns = table.schema().fieldNames();

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
@@ -96,7 +96,10 @@ public class HiveSplitGenerator {
             scan.plan()
                     .splits()
                     .forEach(
-                            split -> splits.add(new PaimonInputSplit(location, (DataSplit) split)));
+                            split ->
+                                    splits.add(
+                                            new PaimonInputSplit(
+                                                    location, (DataSplit) split, table)));
         }
         return splits.toArray(new InputSplit[0]);
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/mapred/PaimonRecordReaderTest.java
@@ -155,7 +155,7 @@ public class PaimonRecordReaderTest {
                 List<String> originalColumns = ((FileStoreTable) table).schema().fieldNames();
                 return new PaimonRecordReader(
                         table.newReadBuilder(),
-                        new PaimonInputSplit(tempDir.toString(), dataSplit),
+                        new PaimonInputSplit(tempDir.toString(), dataSplit, (FileStoreTable) table),
                         originalColumns,
                         originalColumns,
                         selectedColumns,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->


### Purpose

Pass Table to Split to Avoid Loading from File System when createRecordReader ,this can reduce the access of FileSystem.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
