### PR TITLE
[build] Fix spotless-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,11 +473,6 @@ under the License.
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-            </plugin>
-
             <!--surefire for unit tests and integration tests-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -837,7 +832,7 @@ under the License.
                         <scala>
                             <scalafmt>
                                 <version>3.4.3</version>
-                                <file>.scalafmt.conf</file>
+                                <file>${project.basedir}/.scalafmt.conf</file>
                             </scalafmt>
 
                             <licenseHeader>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Remove redundant dependency (write twice)
2. Add absolute path for .scalafmt.conf. This is because if we don't add it, it will fail when we build a module in the module path.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
