### PR TITLE
[core] Introduce userDefineSeqComparator for MergeSorter

### DIFF
--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -37,20 +37,20 @@ public class CodeGeneratorImpl implements CodeGenerator {
 
     @Override
     public GeneratedClass<NormalizedKeyComputer> generateNormalizedKeyComputer(
-            List<DataType> fieldTypes, String name) {
+            List<DataType> inputTypes, int[] sortFields, String name) {
         return new SortCodeGenerator(
-                        RowType.builder().fields(fieldTypes).build(),
-                        getAscendingSortSpec(fieldTypes.size()))
+                        RowType.builder().fields(inputTypes).build(),
+                        getAscendingSortSpec(sortFields))
                 .generateNormalizedKeyComputer(name);
     }
 
     @Override
     public GeneratedClass<RecordComparator> generateRecordComparator(
-            List<DataType> fieldTypes, String name) {
+            List<DataType> inputTypes, int[] sortFields, String name) {
         return ComparatorCodeGenerator.gen(
                 name,
-                RowType.builder().fields(fieldTypes).build(),
-                getAscendingSortSpec(fieldTypes.size()));
+                RowType.builder().fields(inputTypes).build(),
+                getAscendingSortSpec(sortFields));
     }
 
     /** Generate a {@link RecordEqualiser}. */
@@ -61,10 +61,10 @@ public class CodeGeneratorImpl implements CodeGenerator {
                 .generateRecordEqualiser(name);
     }
 
-    private SortSpec getAscendingSortSpec(int numFields) {
+    private SortSpec getAscendingSortSpec(int[] sortFields) {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
-        for (int i = 0; i < numFields; i++) {
-            builder.addField(i, true, false);
+        for (int sortField : sortFields) {
+            builder.addField(sortField, true, false);
         }
         return builder.build();
     }

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
@@ -32,22 +32,22 @@ public interface CodeGenerator {
     /**
      * Generate a {@link NormalizedKeyComputer}.
      *
-     * @param fieldTypes Both the input row field types and the sort key field types. Records are
-     *     compared by the first field, then the second field, then the third field and so on. All
-     *     fields are compared in ascending order.
+     * @param inputTypes input types.
+     * @param sortFields the sort key fields. Records are compared by the first field, then the
+     *     second field, then the third field and so on. All fields are compared in ascending order.
      */
     GeneratedClass<NormalizedKeyComputer> generateNormalizedKeyComputer(
-            List<DataType> fieldTypes, String name);
+            List<DataType> inputTypes, int[] sortFields, String name);
 
     /**
      * Generate a {@link RecordComparator}.
      *
-     * @param fieldTypes Both the input row field types and the sort key field types. Records are *
-     *     compared by the first field, then the second field, then the third field and so on. All *
-     *     fields are compared in ascending order.
+     * @param inputTypes input types.
+     * @param sortFields the sort key fields. Records are compared by the first field, then the
+     *     second field, then the third field and so on. All fields are compared in ascending order.
      */
     GeneratedClass<RecordComparator> generateRecordComparator(
-            List<DataType> fieldTypes, String name);
+            List<DataType> inputTypes, int[] sortFields, String name);
 
     /**
      * Generate a {@link RecordEqualiser}.

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FieldsComparator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FieldsComparator.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.data.InternalRow;
+
+import java.util.Comparator;
+
+/** A {@link Comparator} to compare fields for {@link InternalRow}. */
+public interface FieldsComparator extends Comparator<InternalRow> {
+
+    int[] compareFields();
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryStringTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryStringTest.java
@@ -26,7 +26,6 @@ import org.apache.paimon.utils.SortUtil;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Random;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.paimon.data.BinaryString.EMPTY_UTF8;
 import static org.apache.paimon.data.BinaryString.blankString;
 import static org.apache.paimon.data.BinaryString.fromBytes;
 import static org.apache.paimon.utils.DecimalUtils.castFrom;
@@ -47,14 +47,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ParameterizedTestExtension.class)
 public class BinaryStringTest {
 
-    private BinaryString empty = fromString("");
-
     private final Mode mode;
 
     public BinaryStringTest(Mode mode) {
         this.mode = mode;
     }
 
+    @SuppressWarnings("unused")
     @Parameters(name = "{0}")
     public static List<Mode> getVarSeg() {
         return Arrays.asList(Mode.ONE_SEG, Mode.MULTI_SEGS, Mode.STRING, Mode.RANDOM);
@@ -78,7 +77,7 @@ public class BinaryStringTest {
                 mode = Mode.ONE_SEG;
             } else if (rnd == 1) {
                 mode = Mode.MULTI_SEGS;
-            } else if (rnd == 2) {
+            } else {
                 mode = Mode.STRING;
             }
         }
@@ -143,10 +142,10 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void emptyStringTest() {
-        assertThat(fromString("")).isEqualTo(empty);
-        assertThat(fromBytes(new byte[0])).isEqualTo(empty);
-        assertThat(empty.numChars()).isEqualTo(0);
-        assertThat(empty.getSizeInBytes()).isEqualTo(0);
+        assertThat(fromString("")).isEqualTo(EMPTY_UTF8);
+        assertThat(fromBytes(new byte[0])).isEqualTo(EMPTY_UTF8);
+        assertThat(EMPTY_UTF8.numChars()).isEqualTo(0);
+        assertThat(EMPTY_UTF8.getSizeInBytes()).isEqualTo(0);
     }
 
     @TestTemplate
@@ -224,7 +223,7 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void contains() {
-        assertThat(empty.contains(empty)).isTrue();
+        assertThat(EMPTY_UTF8.contains(EMPTY_UTF8)).isTrue();
         assertThat(fromString("hello").contains(fromString("ello"))).isTrue();
         assertThat(fromString("hello").contains(fromString("vello"))).isFalse();
         assertThat(fromString("hello").contains(fromString("hellooo"))).isFalse();
@@ -235,7 +234,7 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void startsWith() {
-        assertThat(empty.startsWith(empty)).isTrue();
+        assertThat(EMPTY_UTF8.startsWith(EMPTY_UTF8)).isTrue();
         assertThat(fromString("hello").startsWith(fromString("hell"))).isTrue();
         assertThat(fromString("hello").startsWith(fromString("ell"))).isFalse();
         assertThat(fromString("hello").startsWith(fromString("hellooo"))).isFalse();
@@ -246,7 +245,7 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void endsWith() {
-        assertThat(empty.endsWith(empty)).isTrue();
+        assertThat(EMPTY_UTF8.endsWith(EMPTY_UTF8)).isTrue();
         assertThat(fromString("hello").endsWith(fromString("ello"))).isTrue();
         assertThat(fromString("hello").endsWith(fromString("ellov"))).isFalse();
         assertThat(fromString("hello").endsWith(fromString("hhhello"))).isFalse();
@@ -257,7 +256,7 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void substring() {
-        assertThat(fromString("hello").substring(0, 0)).isEqualTo(empty);
+        assertThat(fromString("hello").substring(0, 0)).isEqualTo(EMPTY_UTF8);
         assertThat(fromString("hello").substring(1, 3)).isEqualTo(fromString("el"));
         assertThat(fromString("数据砖头").substring(0, 1)).isEqualTo(fromString("数"));
         assertThat(fromString("数据砖头").substring(1, 3)).isEqualTo(fromString("据砖"));
@@ -267,9 +266,9 @@ public class BinaryStringTest {
 
     @TestTemplate
     public void indexOf() {
-        assertThat(empty.indexOf(empty, 0)).isEqualTo(0);
-        assertThat(empty.indexOf(fromString("l"), 0)).isEqualTo(-1);
-        assertThat(fromString("hello").indexOf(empty, 0)).isEqualTo(0);
+        assertThat(EMPTY_UTF8.indexOf(EMPTY_UTF8, 0)).isEqualTo(0);
+        assertThat(EMPTY_UTF8.indexOf(fromString("l"), 0)).isEqualTo(-1);
+        assertThat(fromString("hello").indexOf(EMPTY_UTF8, 0)).isEqualTo(0);
         assertThat(fromString("hello").indexOf(fromString("l"), 0)).isEqualTo(2);
         assertThat(fromString("hello").indexOf(fromString("l"), 3)).isEqualTo(3);
         assertThat(fromString("hello").indexOf(fromString("a"), 0)).isEqualTo(-1);
@@ -300,24 +299,21 @@ public class BinaryStringTest {
         writer.writeString(5, BinaryString.fromString("!@#$%^*"));
         writer.complete();
 
-        assertThat(((BinaryString) row.getString(0)).toUpperCase()).isEqualTo(fromString("A"));
-        assertThat(((BinaryString) row.getString(1)).toUpperCase()).isEqualTo(fromString("我是中国人"));
-        assertThat(((BinaryString) row.getString(1)).toLowerCase()).isEqualTo(fromString("我是中国人"));
-        assertThat(((BinaryString) row.getString(3)).toUpperCase())
-                .isEqualTo(fromString("ABCDEFG"));
-        assertThat(((BinaryString) row.getString(3)).toLowerCase())
-                .isEqualTo(fromString("abcdefg"));
-        assertThat(((BinaryString) row.getString(5)).toUpperCase())
-                .isEqualTo(fromString("!@#$%^*"));
-        assertThat(((BinaryString) row.getString(5)).toLowerCase())
-                .isEqualTo(fromString("!@#$%^*"));
+        assertThat(row.getString(0).toUpperCase()).isEqualTo(fromString("A"));
+        assertThat(row.getString(1).toUpperCase()).isEqualTo(fromString("我是中国人"));
+        assertThat(row.getString(1).toLowerCase()).isEqualTo(fromString("我是中国人"));
+        assertThat(row.getString(3).toUpperCase()).isEqualTo(fromString("ABCDEFG"));
+        assertThat(row.getString(3).toLowerCase()).isEqualTo(fromString("abcdefg"));
+        assertThat(row.getString(5).toUpperCase()).isEqualTo(fromString("!@#$%^*"));
+        assertThat(row.getString(5).toLowerCase()).isEqualTo(fromString("!@#$%^*"));
     }
 
     @TestTemplate
-    public void testcastFrom() {
+    public void testCastFrom() {
         class DecimalTestData {
-            private String str;
-            private int precision, scale;
+            private final String str;
+            private final int precision;
+            private final int scale;
 
             private DecimalTestData(String str, int precision, int scale) {
                 this.str = str;
@@ -391,7 +387,7 @@ public class BinaryStringTest {
         writer.complete();
         for (int i = 0; i < data.length; i++) {
             DecimalTestData d = data[i];
-            assertThat(castFrom((BinaryString) row.getString(i), d.precision, d.scale))
+            assertThat(castFrom(row.getString(i), d.precision, d.scale))
                     .isEqualTo(Decimal.fromBigDecimal(new BigDecimal(d.str), d.precision, d.scale));
         }
     }
@@ -407,21 +403,21 @@ public class BinaryStringTest {
             str3 = BinaryString.fromAddress(segments, 15, 0);
         }
 
-        assertThat(BinaryString.EMPTY_UTF8.compareTo(str2)).isLessThan(0);
-        assertThat(str2.compareTo(BinaryString.EMPTY_UTF8)).isGreaterThan(0);
+        assertThat(EMPTY_UTF8.compareTo(str2)).isLessThan(0);
+        assertThat(str2.compareTo(EMPTY_UTF8)).isGreaterThan(0);
 
-        assertThat(BinaryString.EMPTY_UTF8.compareTo(str3)).isEqualTo(0);
-        assertThat(str3.compareTo(BinaryString.EMPTY_UTF8)).isEqualTo(0);
+        assertThat(EMPTY_UTF8.compareTo(str3)).isEqualTo(0);
+        assertThat(str3.compareTo(EMPTY_UTF8)).isEqualTo(0);
 
-        assertThat(str2).isNotEqualTo(BinaryString.EMPTY_UTF8);
-        assertThat(BinaryString.EMPTY_UTF8).isNotEqualTo(str2);
+        assertThat(str2).isNotEqualTo(EMPTY_UTF8);
+        assertThat(EMPTY_UTF8).isNotEqualTo(str2);
 
-        assertThat(str3).isEqualTo(BinaryString.EMPTY_UTF8);
-        assertThat(BinaryString.EMPTY_UTF8).isEqualTo(str3);
+        assertThat(str3).isEqualTo(EMPTY_UTF8);
+        assertThat(EMPTY_UTF8).isEqualTo(str3);
     }
 
     @TestTemplate
-    public void testEncodeWithIllegalCharacter() throws UnsupportedEncodingException {
+    public void testEncodeWithIllegalCharacter() {
 
         // Tis char array has some illegal character, such as 55357
         // the jdk ignores theses character and cast them to '?'
@@ -434,11 +430,11 @@ public class BinaryStringTest {
 
         String str = new String(chars);
 
-        assertThat(BinaryString.encodeUTF8(str)).isEqualTo(str.getBytes("UTF-8"));
+        assertThat(BinaryString.encodeUTF8(str)).isEqualTo(str.getBytes(UTF_8));
     }
 
     @TestTemplate
-    public void testDecodeWithIllegalUtf8Bytes() throws UnsupportedEncodingException {
+    public void testDecodeWithIllegalUtf8Bytes() {
 
         // illegal utf-8 bytes
         byte[] bytes =

--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -23,6 +23,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 /** Utils for code generations. */
 public class CodeGenUtils {
@@ -46,15 +47,16 @@ public class CodeGenUtils {
     }
 
     public static NormalizedKeyComputer newNormalizedKeyComputer(
-            List<DataType> fieldTypes, String name) {
+            List<DataType> inputTypes, int[] sortFields, String name) {
         return CodeGenLoader.getCodeGenerator()
-                .generateNormalizedKeyComputer(fieldTypes, name)
+                .generateNormalizedKeyComputer(inputTypes, sortFields, name)
                 .newInstance(CodeGenUtils.class.getClassLoader());
     }
 
     public static GeneratedClass<RecordComparator> generateRecordComparator(
-            List<DataType> fieldTypes, String name) {
-        return CodeGenLoader.getCodeGenerator().generateRecordComparator(fieldTypes, name);
+            List<DataType> inputTypes, int[] sortFields, String name) {
+        return CodeGenLoader.getCodeGenerator()
+                .generateRecordComparator(inputTypes, sortFields, name);
     }
 
     public static GeneratedClass<RecordEqualiser> generateRecordEqualiser(
@@ -62,8 +64,15 @@ public class CodeGenUtils {
         return CodeGenLoader.getCodeGenerator().generateRecordEqualiser(fieldTypes, name);
     }
 
-    public static RecordComparator newRecordComparator(List<DataType> fieldTypes, String name) {
-        return generateRecordComparator(fieldTypes, name)
+    public static RecordComparator newRecordComparator(
+            List<DataType> inputTypes, int[] sortFields, String name) {
+        return generateRecordComparator(inputTypes, sortFields, name)
+                .newInstance(CodeGenUtils.class.getClassLoader());
+    }
+
+    public static RecordComparator newRecordComparator(List<DataType> inputTypes, String name) {
+        return generateRecordComparator(
+                        inputTypes, IntStream.range(0, inputTypes.size()).toArray(), name)
                 .newInstance(CodeGenUtils.class.getClassLoader());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -67,6 +67,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static org.apache.paimon.lookup.RocksDBOptions.BLOCK_CACHE_SIZE;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -285,8 +286,8 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
         BinaryExternalSortBuffer keyIdBuffer =
                 BinaryExternalSortBuffer.create(
                         ioManager,
-                        keyWithIdType,
                         keyWithRowType,
+                        IntStream.range(0, keyWithIdType.getFieldCount()).toArray(),
                         coreOptions.writeBufferSize() / 2,
                         coreOptions.pageSize(),
                         coreOptions.localSortMaxNumFileHandles(),

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
@@ -107,8 +107,8 @@ public abstract class RocksDBState<K, V, CacheV> {
             IOManager ioManager, CoreOptions options) {
         return BinaryExternalSortBuffer.create(
                 ioManager,
-                RowType.of(DataTypes.BYTES()),
                 RowType.of(DataTypes.BYTES(), DataTypes.BYTES()),
+                new int[] {0},
                 options.writeBufferSize() / 2,
                 options.pageSize(),
                 options.localSortMaxNumFileHandles(),

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
@@ -28,6 +28,9 @@ import org.apache.paimon.mergetree.compact.MergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
 import org.apache.paimon.mergetree.compact.ReducerMergeFunctionWrapper;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.FieldsComparator;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,6 +58,7 @@ public class MergeTreeReaders {
                                     section,
                                     readerFactory,
                                     userKeyComparator,
+                                    null,
                                     new ReducerMergeFunctionWrapper(mergeFunction),
                                     mergeSorter));
         }
@@ -69,6 +73,7 @@ public class MergeTreeReaders {
             List<SortedRun> section,
             KeyValueFileReaderFactory readerFactory,
             Comparator<InternalRow> userKeyComparator,
+            @Nullable FieldsComparator userDefineSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,
             MergeSorter mergeSorter)
             throws IOException {
@@ -76,7 +81,8 @@ public class MergeTreeReaders {
         for (SortedRun run : section) {
             readers.add(() -> readerForRun(run, readerFactory));
         }
-        return mergeSorter.mergeSort(readers, userKeyComparator, mergeFunctionWrapper);
+        return mergeSorter.mergeSort(
+                readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
     }
 
     public static RecordReader<KeyValue> readerForRun(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
@@ -73,7 +73,7 @@ public class MergeTreeReaders {
             List<SortedRun> section,
             KeyValueFileReaderFactory readerFactory,
             Comparator<InternalRow> userKeyComparator,
-            @Nullable FieldsComparator userDefineSeqComparator,
+            @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,
             MergeSorter mergeSorter)
             throws IOException {
@@ -82,7 +82,7 @@ public class MergeTreeReaders {
             readers.add(() -> readerForRun(run, readerFactory));
         }
         return mergeSorter.mergeSort(
-                readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
+                readers, userKeyComparator, userDefinedSeqComparator, mergeFunctionWrapper);
     }
 
     public static RecordReader<KeyValue> readerForRun(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.IntStream;
 
 /** A {@link WriteBuffer} which stores records in {@link BinaryInMemorySortBuffer}. */
 public class SortBufferWriteBuffer implements WriteBuffer {
@@ -74,10 +75,12 @@ public class SortBufferWriteBuffer implements WriteBuffer {
         sortKeyTypes.add(new BigIntType(false));
 
         // for sort binary buffer
+        int[] sortFields = IntStream.range(0, sortKeyTypes.size()).toArray();
         NormalizedKeyComputer normalizedKeyComputer =
-                CodeGenUtils.newNormalizedKeyComputer(sortKeyTypes, "MemTableKeyComputer");
+                CodeGenUtils.newNormalizedKeyComputer(
+                        sortKeyTypes, sortFields, "MemTableKeyComputer");
         RecordComparator keyComparator =
-                CodeGenUtils.newRecordComparator(sortKeyTypes, "MemTableComparator");
+                CodeGenUtils.newRecordComparator(sortKeyTypes, sortFields, "MemTableComparator");
 
         if (memoryPool.freePages() < 3) {
             throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -112,6 +112,7 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                                     section,
                                     readerFactory,
                                     keyComparator,
+                                    null,
                                     createMergeWrapper(outputLevel),
                                     mergeSorter));
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -22,6 +22,9 @@ import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.FieldsComparator;
+
+import javax.annotation.Nullable;
 
 import java.util.Comparator;
 import java.util.List;
@@ -38,15 +41,16 @@ public interface SortMergeReader<T> extends RecordReader<T> {
     static <T> SortMergeReader<T> createSortMergeReader(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
+            @Nullable FieldsComparator userDefineSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,
             SortEngine sortEngine) {
         switch (sortEngine) {
             case MIN_HEAP:
                 return new SortMergeReaderWithMinHeap<>(
-                        readers, userKeyComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
             case LOSER_TREE:
                 return new SortMergeReaderWithLoserTree<>(
-                        readers, userKeyComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
             default:
                 throw new UnsupportedOperationException("Unsupported sort engine: " + sortEngine);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReader.java
@@ -41,16 +41,16 @@ public interface SortMergeReader<T> extends RecordReader<T> {
     static <T> SortMergeReader<T> createSortMergeReader(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
-            @Nullable FieldsComparator userDefineSeqComparator,
+            @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper,
             SortEngine sortEngine) {
         switch (sortEngine) {
             case MIN_HEAP:
                 return new SortMergeReaderWithMinHeap<>(
-                        readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, userDefinedSeqComparator, mergeFunctionWrapper);
             case LOSER_TREE:
                 return new SortMergeReaderWithLoserTree<>(
-                        readers, userKeyComparator, userDefineSeqComparator, mergeFunctionWrapper);
+                        readers, userKeyComparator, userDefinedSeqComparator, mergeFunctionWrapper);
             default:
                 throw new UnsupportedOperationException("Unsupported sort engine: " + sortEngine);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
@@ -21,6 +21,7 @@ package org.apache.paimon.mergetree.compact;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
@@ -38,13 +39,29 @@ public class SortMergeReaderWithLoserTree<T> implements SortMergeReader<T> {
     public SortMergeReaderWithLoserTree(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
+            @Nullable FieldsComparator userDefineSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
         this.mergeFunctionWrapper = mergeFunctionWrapper;
         this.loserTree =
                 new LoserTree<>(
                         readers,
                         (e1, e2) -> userKeyComparator.compare(e2.key(), e1.key()),
-                        (e1, e2) -> Long.compare(e2.sequenceNumber(), e1.sequenceNumber()));
+                        createSequenceComparator(userDefineSeqComparator));
+    }
+
+    private Comparator<KeyValue> createSequenceComparator(
+            @Nullable FieldsComparator userDefineSeqComparator) {
+        if (userDefineSeqComparator == null) {
+            return (e1, e2) -> Long.compare(e2.sequenceNumber(), e1.sequenceNumber());
+        }
+
+        return (o1, o2) -> {
+            int result = userDefineSeqComparator.compare(o2.value(), o1.value());
+            if (result != 0) {
+                return result;
+            }
+            return Long.compare(o2.sequenceNumber(), o1.sequenceNumber());
+        };
     }
 
     /** Compared with heapsort, {@link LoserTree} will only produce one batch. */

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithLoserTree.java
@@ -39,24 +39,24 @@ public class SortMergeReaderWithLoserTree<T> implements SortMergeReader<T> {
     public SortMergeReaderWithLoserTree(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
-            @Nullable FieldsComparator userDefineSeqComparator,
+            @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
         this.mergeFunctionWrapper = mergeFunctionWrapper;
         this.loserTree =
                 new LoserTree<>(
                         readers,
                         (e1, e2) -> userKeyComparator.compare(e2.key(), e1.key()),
-                        createSequenceComparator(userDefineSeqComparator));
+                        createSequenceComparator(userDefinedSeqComparator));
     }
 
     private Comparator<KeyValue> createSequenceComparator(
-            @Nullable FieldsComparator userDefineSeqComparator) {
-        if (userDefineSeqComparator == null) {
+            @Nullable FieldsComparator userDefinedSeqComparator) {
+        if (userDefinedSeqComparator == null) {
             return (e1, e2) -> Long.compare(e2.sequenceNumber(), e1.sequenceNumber());
         }
 
         return (o1, o2) -> {
-            int result = userDefineSeqComparator.compare(o2.value(), o1.value());
+            int result = userDefinedSeqComparator.compare(o2.value(), o1.value());
             if (result != 0) {
                 return result;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
@@ -45,7 +45,7 @@ public class SortMergeReaderWithMinHeap<T> implements SortMergeReader<T> {
     public SortMergeReaderWithMinHeap(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
-            @Nullable FieldsComparator userDefineSeqComparator,
+            @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
         this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
@@ -58,9 +58,9 @@ public class SortMergeReaderWithMinHeap<T> implements SortMergeReader<T> {
                             if (result != 0) {
                                 return result;
                             }
-                            if (userDefineSeqComparator != null) {
+                            if (userDefinedSeqComparator != null) {
                                 result =
-                                        userDefineSeqComparator.compare(
+                                        userDefinedSeqComparator.compare(
                                                 e1.kv.value(), e2.kv.value());
                                 if (result != 0) {
                                     return result;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/SortMergeReaderWithMinHeap.java
@@ -21,6 +21,7 @@ package org.apache.paimon.mergetree.compact;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
@@ -44,6 +45,7 @@ public class SortMergeReaderWithMinHeap<T> implements SortMergeReader<T> {
     public SortMergeReaderWithMinHeap(
             List<RecordReader<KeyValue>> readers,
             Comparator<InternalRow> userKeyComparator,
+            @Nullable FieldsComparator userDefineSeqComparator,
             MergeFunctionWrapper<T> mergeFunctionWrapper) {
         this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
@@ -55,6 +57,14 @@ public class SortMergeReaderWithMinHeap<T> implements SortMergeReader<T> {
                             int result = userKeyComparator.compare(e1.kv.key(), e2.kv.key());
                             if (result != 0) {
                                 return result;
+                            }
+                            if (userDefineSeqComparator != null) {
+                                result =
+                                        userDefineSeqComparator.compare(
+                                                e1.kv.value(), e2.kv.value());
+                                if (result != 0) {
+                                    return result;
+                                }
                             }
                             return Long.compare(e1.kv.sequenceNumber(), e2.kv.sequenceNumber());
                         });

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
@@ -44,7 +44,7 @@ public class DiffReader {
             RecordReader<KeyValue> beforeReader,
             RecordReader<KeyValue> afterReader,
             Comparator<InternalRow> keyComparator,
-            @Nullable FieldsComparator userDefineSeqComparator,
+            @Nullable FieldsComparator userDefinedSeqComparator,
             MergeSorter sorter,
             boolean keepDelete)
             throws IOException {
@@ -53,7 +53,7 @@ public class DiffReader {
                         () -> wrapLevelToReader(beforeReader, BEFORE_LEVEL),
                         () -> wrapLevelToReader(afterReader, AFTER_LEVEL)),
                 keyComparator,
-                userDefineSeqComparator,
+                userDefinedSeqComparator,
                 new DiffMerger(keepDelete));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DiffReader.java
@@ -24,6 +24,7 @@ import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.utils.FieldsComparator;
 
 import javax.annotation.Nullable;
 
@@ -43,6 +44,7 @@ public class DiffReader {
             RecordReader<KeyValue> beforeReader,
             RecordReader<KeyValue> afterReader,
             Comparator<InternalRow> keyComparator,
+            @Nullable FieldsComparator userDefineSeqComparator,
             MergeSorter sorter,
             boolean keepDelete)
             throws IOException {
@@ -51,6 +53,7 @@ public class DiffReader {
                         () -> wrapLevelToReader(beforeReader, BEFORE_LEVEL),
                         () -> wrapLevelToReader(afterReader, AFTER_LEVEL)),
                 keyComparator,
+                userDefineSeqComparator,
                 new DiffMerger(keepDelete));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
@@ -227,6 +227,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
                             batchMergeRead(
                                     split.partition(), split.bucket(), split.dataFiles(), false),
                             keyComparator,
+                            null,
                             mergeSorter,
                             forceKeepDelete);
         }
@@ -255,6 +256,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
                                             ? overlappedSectionFactory
                                             : nonOverlappedSectionFactory,
                                     keyComparator,
+                                    null,
                                     mergeFuncWrapper,
                                     mergeSorter));
         }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -91,16 +91,16 @@ public class BinaryExternalSortBuffer implements SortBuffer {
 
     public static BinaryExternalSortBuffer create(
             IOManager ioManager,
-            RowType keyType,
             RowType rowType,
+            int[] keyFields,
             long bufferSize,
             int pageSize,
             int maxNumFileHandles,
             String compression) {
         return create(
                 ioManager,
-                keyType,
                 rowType,
+                keyFields,
                 new HeapMemorySegmentPool(bufferSize, pageSize),
                 maxNumFileHandles,
                 compression);
@@ -108,17 +108,17 @@ public class BinaryExternalSortBuffer implements SortBuffer {
 
     public static BinaryExternalSortBuffer create(
             IOManager ioManager,
-            RowType keyType,
             RowType rowType,
+            int[] keyFields,
             MemorySegmentPool pool,
             int maxNumFileHandles,
             String compression) {
         RecordComparator comparator =
-                newRecordComparator(keyType.getFieldTypes(), "ExternalSort_comparator");
+                newRecordComparator(rowType.getFieldTypes(), keyFields, "ExternalSort_comparator");
         BinaryInMemorySortBuffer sortBuffer =
                 BinaryInMemorySortBuffer.createBuffer(
                         newNormalizedKeyComputer(
-                                keyType.getFieldTypes(), "ExternalSort_normalized_key"),
+                                rowType.getFieldTypes(), keyFields, "ExternalSort_normalized_key"),
                         new InternalRowSerializer(rowType),
                         comparator,
                         pool);

--- a/paimon-core/src/main/java/org/apache/paimon/utils/KeyComparatorSupplier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/KeyComparatorSupplier.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.RowType;
 
 import java.util.Comparator;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 /** A {@link Supplier} that returns the comparator for the file store key. */
 public class KeyComparatorSupplier implements SerializableSupplier<Comparator<InternalRow>> {
@@ -36,7 +37,10 @@ public class KeyComparatorSupplier implements SerializableSupplier<Comparator<In
 
     public KeyComparatorSupplier(RowType keyType) {
         genRecordComparator =
-                CodeGenUtils.generateRecordComparator(keyType.getFieldTypes(), "KeyComparator");
+                CodeGenUtils.generateRecordComparator(
+                        keyType.getFieldTypes(),
+                        IntStream.range(0, keyType.getFieldCount()).toArray(),
+                        "KeyComparator");
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
@@ -19,28 +19,35 @@
 package org.apache.paimon.mergetree;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader.ReaderSupplier;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
+import org.apache.paimon.testutils.junit.parameterized.Parameters;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.IteratorRecordReader;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +58,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link MergeSorter}. */
+@ExtendWith(ParameterizedTestExtension.class)
 public class MergeSorterTest {
 
     private static final int MEMORY_SIZE = 1024 * 1024 * 32;
@@ -59,17 +67,30 @@ public class MergeSorterTest {
 
     private final RowType valueType = RowType.builder().field("v", DataTypes.INT()).build();
 
+    private final SortEngine sortEngine;
+
     @TempDir Path tempDir;
 
     private IOManager ioManager;
     private MergeSorter sorter;
     private int totalPages;
 
+    public MergeSorterTest(SortEngine sortEngine) {
+        this.sortEngine = sortEngine;
+    }
+
+    @SuppressWarnings("unused")
+    @Parameters(name = "{0}")
+    public static List<SortEngine> getVarSeg() {
+        return Arrays.asList(SortEngine.LOSER_TREE, SortEngine.MIN_HEAP);
+    }
+
     @BeforeEach
     public void beforeTest() {
         ioManager = IOManager.create(tempDir.toString());
         Options options = new Options();
         options.set(CoreOptions.SORT_SPILL_BUFFER_SIZE, new MemorySize(MEMORY_SIZE));
+        options.set(CoreOptions.SORT_ENGINE, sortEngine);
         sorter = new MergeSorter(new CoreOptions(options), keyType, valueType, ioManager);
         totalPages = sorter.memoryPool().freePages();
     }
@@ -86,60 +107,82 @@ public class MergeSorterTest {
         this.ioManager.close();
     }
 
-    @Test
+    @TestTemplate
     public void testSortAndMerge() throws Exception {
+        innerTest(null);
+    }
+
+    @TestTemplate
+    public void testWithUserDefineSequence() throws Exception {
+        innerTest(
+                new FieldsComparator() {
+                    @Override
+                    public int[] compareFields() {
+                        return new int[] {0};
+                    }
+
+                    @Override
+                    public int compare(InternalRow o1, InternalRow o2) {
+                        return Integer.compare(o1.getInt(0), o2.getInt(0));
+                    }
+                });
+    }
+
+    private void innerTest(FieldsComparator userDefineSeqComparator) throws Exception {
+        Comparator<KeyValue> comparator =
+                Comparator.comparingInt((KeyValue o) -> o.key().getInt(0));
+        if (userDefineSeqComparator != null) {
+            comparator =
+                    comparator.thenComparing(
+                            (o1, o2) -> userDefineSeqComparator.compare(o1.value(), o2.value()));
+        }
+        comparator = comparator.thenComparingLong(KeyValue::sequenceNumber);
+
         List<ReaderSupplier<KeyValue>> readers = new ArrayList<>();
         Random rnd = new Random();
         List<KeyValue> expectedKvs = new ArrayList<>();
         Set<Long> distinctSeq = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < rnd.nextInt(10) + 3; i++) {
             List<KeyValue> kvs = new ArrayList<>();
+            Set<Integer> distinctKeys = new HashSet<>();
             for (int j = 0; j < 100; j++) {
-                long seq = rnd.nextLong();
-                while (distinctSeq.contains(seq)) {
-                    rnd.nextLong();
+                while (true) {
+                    int key = rnd.nextInt(1000);
+                    if (distinctKeys.contains(key)) {
+                        continue;
+                    }
+
+                    long seq = rnd.nextLong();
+                    while (distinctSeq.contains(seq)) {
+                        seq = rnd.nextLong();
+                    }
+                    distinctSeq.add(seq);
+                    kvs.add(
+                            new KeyValue()
+                                    .replace(
+                                            GenericRow.of(key),
+                                            seq,
+                                            RowKind.fromByteValue((byte) rnd.nextInt(4)),
+                                            GenericRow.of(rnd.nextInt(1000)))
+                                    .setLevel(rnd.nextInt(100)));
+                    distinctKeys.add(key);
+                    break;
                 }
-                distinctSeq.add(seq);
-                kvs.add(
-                        new KeyValue()
-                                .replace(
-                                        GenericRow.of(rnd.nextInt(100)),
-                                        seq,
-                                        RowKind.fromByteValue((byte) rnd.nextInt(4)),
-                                        GenericRow.of(rnd.nextInt()))
-                                .setLevel(rnd.nextInt(100)));
             }
             expectedKvs.addAll(kvs);
+            kvs.sort(comparator);
             readers.add(() -> new IteratorRecordReader<>(kvs.iterator()));
         }
 
-        expectedKvs.sort(
-                Comparator.comparingInt((KeyValue o) -> o.key().getInt(0))
-                        .thenComparingLong(KeyValue::sequenceNumber));
+        expectedKvs.sort(comparator);
 
-        MergeFunctionWrapper<List<KeyValue>> collectFunc =
-                new MergeFunctionWrapper<List<KeyValue>>() {
-
-                    private List<KeyValue> result;
-
-                    @Override
-                    public void reset() {
-                        result = new ArrayList<>();
-                    }
-
-                    @Override
-                    public void add(KeyValue kv) {
-                        result.add(kv);
-                    }
-
-                    @Nullable
-                    @Override
-                    public List<KeyValue> getResult() {
-                        return result;
-                    }
-                };
+        TestMergeFunctionWrapper collectFunc = new TestMergeFunctionWrapper();
         List<KeyValue> all = new ArrayList<>();
-        sorter.mergeSort(readers, Comparator.comparingInt(o -> o.getInt(0)), collectFunc)
+        sorter.mergeSort(
+                        readers,
+                        Comparator.comparingInt(o -> o.getInt(0)),
+                        userDefineSeqComparator,
+                        collectFunc)
                 .forEachRemaining(all::addAll);
 
         assertThat(toString(all)).containsExactlyElementsOf(toString(expectedKvs));
@@ -147,5 +190,26 @@ public class MergeSorterTest {
 
     private List<String> toString(List<KeyValue> kvs) {
         return kvs.stream().map(kv -> kv.toString(keyType, valueType)).collect(Collectors.toList());
+    }
+
+    private static class TestMergeFunctionWrapper implements MergeFunctionWrapper<List<KeyValue>> {
+
+        private List<KeyValue> result;
+
+        @Override
+        public void reset() {
+            result = new ArrayList<>();
+        }
+
+        @Override
+        public void add(KeyValue kv) {
+            result.add(kv);
+        }
+
+        @Nullable
+        @Override
+        public List<KeyValue> getResult() {
+            return result;
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
@@ -128,13 +128,13 @@ public class MergeSorterTest {
                 });
     }
 
-    private void innerTest(FieldsComparator userDefineSeqComparator) throws Exception {
+    private void innerTest(FieldsComparator userDefinedSeqComparator) throws Exception {
         Comparator<KeyValue> comparator =
                 Comparator.comparingInt((KeyValue o) -> o.key().getInt(0));
-        if (userDefineSeqComparator != null) {
+        if (userDefinedSeqComparator != null) {
             comparator =
                     comparator.thenComparing(
-                            (o1, o2) -> userDefineSeqComparator.compare(o1.value(), o2.value()));
+                            (o1, o2) -> userDefinedSeqComparator.compare(o1.value(), o2.value()));
         }
         comparator = comparator.thenComparingLong(KeyValue::sequenceNumber);
 
@@ -181,7 +181,7 @@ public class MergeSorterTest {
         sorter.mergeSort(
                         readers,
                         Comparator.comparingInt(o -> o.getInt(0)),
-                        userDefineSeqComparator,
+                        userDefinedSeqComparator,
                         collectFunc)
                 .forEachRemaining(all::addAll);
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -48,6 +48,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
         return SortMergeReader.createSortMergeReader(
                 new ArrayList<>(readers),
                 KEY_COMPARATOR,
+                null,
                 new ReducerMergeFunctionWrapper(createMergeFunction()),
                 sortEngine);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 
+import java.util.stream.IntStream;
+
 /** SortOperator to sort the `InternalRow`s by the `KeyType`. */
 public class SortOperator extends TableStreamOperator<InternalRow>
         implements OneInputStreamOperator<InternalRow, InternalRow>, BoundedOneInput {
@@ -87,8 +89,8 @@ public class SortOperator extends TableStreamOperator<InternalRow>
         buffer =
                 BinaryExternalSortBuffer.create(
                         ioManager,
-                        keyType,
                         rowType,
+                        IntStream.range(0, keyType.getFieldCount()).toArray(),
                         maxMemory,
                         pageSize,
                         spillSortMaxNumFiles,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We should separate user define sequence fields and incremental sequence id. This way, there will be no more accuracy issues. When comparing, we can first compare the user-defined sequenceField (We don't need to extract long now, just compare) and then compare our self increasing sequenceId.

There are still many codes that need to be modified as a whole, and this is just the first part.

First step of https://github.com/apache/incubator-paimon/pull/2811

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
