### PR TITLE
[Core]add table schema cache for SchemaManager

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -286,6 +286,9 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         Collection<ManifestEntry> mergedEntries = ManifestEntry.mergeEntries(entries);
         long skippedByPartitionAndStats = startDataFiles - cntEntries.get();
         for (ManifestEntry file : mergedEntries) {
+            // cache the data schema
+            schemaManager.schema(file.file().schemaId());
+
             if (checkNumOfBuckets && file.totalBuckets() != numOfBuckets) {
                 String partInfo =
                         partitionType.getFieldCount() > 0

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -47,6 +47,7 @@ import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -90,7 +91,7 @@ public class SchemaManager implements Serializable {
         this.fileIO = fileIO;
         this.tableRoot = tableRoot;
         this.cache = cache;
-        //cache
+        // cache
         listAll();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -379,7 +379,7 @@ public class SchemaManager implements Serializable {
             try {
                 boolean success = commit(newSchema);
                 if (success) {
-                    cache.put(newSchema.id(),newSchema);
+                    cache.put(newSchema.id(), newSchema);
                     return newSchema;
                 }
             } catch (Exception e) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -379,6 +379,7 @@ public class SchemaManager implements Serializable {
             try {
                 boolean success = commit(newSchema);
                 if (success) {
+                    cache.put(newSchema.id(),newSchema);
                     return newSchema;
                 }
             } catch (Exception e) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -47,7 +47,6 @@ import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -58,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -83,13 +83,15 @@ public class SchemaManager implements Serializable {
     private final Map<Long, TableSchema> cache;
 
     public SchemaManager(FileIO fileIO, Path tableRoot) {
-        this(fileIO, tableRoot, null);
+        this(fileIO, tableRoot, new ConcurrentHashMap<>());
     }
 
     public SchemaManager(FileIO fileIO, Path tableRoot, Map<Long, TableSchema> cache) {
         this.fileIO = fileIO;
         this.tableRoot = tableRoot;
         this.cache = cache;
+        //cache
+        listAll();
     }
 
     public SchemaManager withLock(@Nullable Lock lock) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -54,9 +54,11 @@ import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
+
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -55,8 +55,6 @@ import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
-import org.jetbrains.annotations.NotNull;
-
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -85,7 +83,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     protected final TableSchema tableSchema;
     protected final CatalogEnvironment catalogEnvironment;
 
-    protected final Map<Long, TableSchema> schemaCache;
+    protected final SchemaManager tableSchemaManager;
 
     protected AbstractFileStoreTable(
             FileIO fileIO,
@@ -102,17 +100,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         }
         this.tableSchema = tableSchema;
         this.catalogEnvironment = catalogEnvironment;
-        schemaCache = loadSchemaCache(fileIO, path);
-    }
-
-    @NotNull
-    private Map<Long, TableSchema> loadSchemaCache(FileIO fileIO, Path path) {
-        Map<Long, TableSchema> schemaCache = new ConcurrentHashMap<>();
-        SchemaManager schemaManager = new SchemaManager(fileIO, path);
-        for (TableSchema schema : schemaManager.listAll()) {
-            schemaCache.put(schema.id(), schema);
-        }
-        return schemaCache;
+        tableSchemaManager = new SchemaManager(fileIO, path, new ConcurrentHashMap<>());
     }
 
     @Override
@@ -275,7 +263,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     protected SchemaManager schemaManager() {
-        return new SchemaManager(fileIO(), path, schemaCache);
+        return tableSchemaManager;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -65,7 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import static org.apache.paimon.CoreOptions.PATH;
@@ -100,7 +99,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         }
         this.tableSchema = tableSchema;
         this.catalogEnvironment = catalogEnvironment;
-        tableSchemaManager = new SchemaManager(fileIO, path, new ConcurrentHashMap<>());
+        tableSchemaManager = new SchemaManager(fileIO, path);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -63,11 +63,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import static org.apache.paimon.CoreOptions.PATH;
@@ -107,8 +107,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @NotNull
     private Map<Long, TableSchema> loadSchemaCache(FileIO fileIO, Path path) {
-        final Map<Long, TableSchema> schemaCache;
-        schemaCache = new LinkedHashMap<>();
+        Map<Long, TableSchema> schemaCache = new ConcurrentHashMap<>();
         SchemaManager schemaManager = new SchemaManager(fileIO, path);
         for (TableSchema schema : schemaManager.listAll()) {
             schemaCache.put(schema.id(), schema);

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -54,11 +54,9 @@ import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
-
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.FailingFileIO;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,8 +97,7 @@ public class SchemaManagerTest {
     @Test
     public void testCache() throws Exception {
         Path path = new Path(tempDir.toString());
-        SchemaManager manager =
-                new SchemaManager(FileIOFinder.find(path), path);
+        SchemaManager manager = new SchemaManager(FileIOFinder.find(path), path);
         // schema-0
         manager.createTable(schema);
         // schema-1
@@ -106,10 +106,9 @@ public class SchemaManagerTest {
         manager.commitChanges(SchemaChange.setOption("ccc", "ddd"));
 
         SchemaManager newSchemaManager = new SchemaManager(FileIOFinder.find(path), path);
-        Optional<TableSchema> schemaOpt1  = newSchemaManager.latest();
+        Optional<TableSchema> schemaOpt1 = newSchemaManager.latest();
         Optional<TableSchema> schemaOpt2 = newSchemaManager.latest();
         assertThat(schemaOpt1.get()).isSameAs(schemaOpt2.get());
-
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -22,7 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DoubleType;
@@ -31,7 +30,8 @@ import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.FailingFileIO;
-import org.apache.paimon.utils.InstantiationUtil;
+
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -31,8 +31,6 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.FailingFileIO;
 
-import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,13 +106,12 @@ public class SchemaManagerTest {
         // schema-2
         manager.commitChanges(SchemaChange.setOption("ccc", "ddd"));
 
-        Cache<Long, TableSchema> cachedSchema = manager.getCachedSchema();
-        assertThat(cachedSchema.asMap()).hasSize(3);
+        Map<Long, TableSchema> cachedSchema = manager.getCachedSchema();
+        assertThat(cachedSchema).hasSize(3);
 
         manager.deleteSchema(1L);
-        Map<Long, TableSchema> map = cachedSchema.asMap();
-        assertThat(map).hasSize(2);
-        TableSchema tableSchema = map.get(2L);
+        assertThat(cachedSchema).hasSize(2);
+        TableSchema tableSchema = cachedSchema.get(2L);
         assertThat(tableSchema.options()).containsKey("ccc");
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -97,8 +98,8 @@ public class SchemaManagerTest {
     @Test
     public void testCache() throws Exception {
         Path path = new Path(tempDir.toString());
-        SchemaManager manager = new SchemaManager(FileIOFinder.find(path), path);
-
+        SchemaManager manager =
+                new SchemaManager(FileIOFinder.find(path), path, new ConcurrentHashMap<>());
         // schema-0
         manager.createTable(schema);
         // schema-1

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -970,8 +970,6 @@ public abstract class FileStoreTableTestBase {
         assertThat(branchSchema.equals(schema0)).isTrue();
     }
 
-
-
     @Test
     public void testUnsupportedBranchName() throws Exception {
         FileStoreTable table = createFileStoreTable();

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -64,7 +64,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
-import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 import org.apache.paimon.utils.TraceableFileIO;
@@ -1506,20 +1505,5 @@ public abstract class FileStoreTableTestBase {
                                 toSplits(table.newSnapshotReader(BRANCH_NAME).read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
-    }
-
-    @Test
-    public void testSerAndDer() throws Exception {
-        AbstractFileStoreTable originFileStoreTable =
-                (AbstractFileStoreTable) createFileStoreTable();
-        originFileStoreTable.schemaManager().latest();
-        byte[] bytes = InstantiationUtil.serializeObject(originFileStoreTable);
-        AbstractFileStoreTable serializedFileStoreTable =
-                InstantiationUtil.deserializeObject(
-                        bytes, Thread.currentThread().getContextClassLoader());
-        assertThat(serializedFileStoreTable.tableSchemaManager.getCachedSchema().size())
-                .isEqualTo(1);
-        assertThat(serializedFileStoreTable.tableSchemaManager.getCachedSchema())
-                .containsOnlyKeys(0L);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1510,13 +1510,16 @@ public abstract class FileStoreTableTestBase {
 
     @Test
     public void testSerAndDer() throws Exception {
-        FileStoreTable originFileStoreTable = createFileStoreTable();
-
+        AbstractFileStoreTable originFileStoreTable =
+                (AbstractFileStoreTable) createFileStoreTable();
+        originFileStoreTable.schemaManager().latest();
         byte[] bytes = InstantiationUtil.serializeObject(originFileStoreTable);
         AbstractFileStoreTable serializedFileStoreTable =
                 InstantiationUtil.deserializeObject(
                         bytes, Thread.currentThread().getContextClassLoader());
-        assertThat(serializedFileStoreTable.schemaCache.size()).isEqualTo(1);
-        assertThat(serializedFileStoreTable.schemaCache).containsOnlyKeys(0L);
+        assertThat(serializedFileStoreTable.tableSchemaManager.getCachedSchema().size())
+                .isEqualTo(1);
+        assertThat(serializedFileStoreTable.tableSchemaManager.getCachedSchema())
+                .containsOnlyKeys(0L);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -64,6 +64,7 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 import org.apache.paimon.utils.TraceableFileIO;
@@ -969,6 +970,8 @@ public abstract class FileStoreTableTestBase {
         assertThat(branchSchema.equals(schema0)).isTrue();
     }
 
+
+
     @Test
     public void testUnsupportedBranchName() throws Exception {
         FileStoreTable table = createFileStoreTable();
@@ -1505,5 +1508,17 @@ public abstract class FileStoreTableTestBase {
                                 toSplits(table.newSnapshotReader(BRANCH_NAME).read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
+    }
+
+    @Test
+    public void testSerAndDer() throws Exception {
+        FileStoreTable originFileStoreTable = createFileStoreTable();
+
+        byte[] bytes = InstantiationUtil.serializeObject(originFileStoreTable);
+        AbstractFileStoreTable serializedFileStoreTable =
+                InstantiationUtil.deserializeObject(
+                        bytes, Thread.currentThread().getContextClassLoader());
+        assertThat(serializedFileStoreTable.schemaCache.size()).isEqualTo(1);
+        assertThat(serializedFileStoreTable.schemaCache).containsOnlyKeys(0L);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
When reading a split ,recordReader will loads the schema of the split from the FileSystem.
The pr is for adding the cache of TableSchema  for SchemaManager to reduce the access of FileSystem.
<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests
SchemaManagerTest#testCache

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
