### PR TITLE
[core][bug] Write Spillable with memory preemption has bug : preempt memory will cause writer flush memory to disk which should not happen

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -176,8 +176,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         return compactManager.isCompacting();
     }
 
-    private void flush(boolean waitForLatestCompaction, boolean forcedFullCompaction)
-            throws Exception {
+    @VisibleForTesting
+    void flush(boolean waitForLatestCompaction, boolean forcedFullCompaction) throws Exception {
         long start = System.currentTimeMillis();
         List<DataFileMeta> flushedFiles = sinkWriter.flush();
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -279,9 +279,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
 
     @Override
     public void flushMemory() throws Exception {
-        if (sinkWriter.bufferSpillableWriter()) {
-            sinkWriter.spill();
-        } else {
+        boolean success = sinkWriter.flushMemory();
+        if (!success) {
             flush(false, false);
         }
     }
@@ -307,6 +306,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
 
         List<DataFileMeta> flush() throws IOException;
 
+        boolean flushMemory() throws IOException;
+
         long memoryOccupancy();
 
         void close();
@@ -314,8 +315,6 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         void setMemoryPool(MemorySegmentPool memoryPool);
 
         boolean bufferSpillableWriter();
-
-        void spill() throws IOException;
     }
 
     /**
@@ -347,6 +346,11 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         }
 
         @Override
+        public boolean flushMemory() throws IOException {
+            return false;
+        }
+
+        @Override
         public long memoryOccupancy() {
             return 0;
         }
@@ -368,9 +372,6 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         public boolean bufferSpillableWriter() {
             return false;
         }
-
-        @Override
-        public void spill() throws IOException {}
     }
 
     /**
@@ -441,8 +442,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         }
 
         @Override
-        public void spill() throws IOException {
-            writeBuffer.spill();
+        public boolean flushMemory() throws IOException {
+            return writeBuffer.flushMemory();
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
@@ -126,7 +126,7 @@ public class ExternalBuffer implements RowBuffer {
                         + memorySize());
     }
 
-    private void spill() throws IOException {
+    public void spill() throws IOException {
         FileIOChannel.ID channel = ioManager.createChannel();
 
         BufferFileWriter writer = ioManager.createBufferFileWriter(channel);

--- a/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
@@ -88,6 +88,12 @@ public class ExternalBuffer implements RowBuffer {
     }
 
     @Override
+    public boolean flushMemory() throws IOException {
+        spill();
+        return true;
+    }
+
+    @Override
     public boolean put(InternalRow row) throws IOException {
         checkState(!addCompleted, "This buffer has add completed.");
         if (!inMemoryBuffer.put(row)) {
@@ -126,7 +132,7 @@ public class ExternalBuffer implements RowBuffer {
                         + memorySize());
     }
 
-    public void spill() throws IOException {
+    private void spill() throws IOException {
         FileIOChannel.ID channel = ioManager.createChannel();
 
         BufferFileWriter writer = ioManager.createBufferFileWriter(channel);

--- a/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
@@ -81,8 +81,8 @@ public class InMemoryBuffer implements RowBuffer {
     }
 
     @Override
-    public void spill() {
-        throw new UnsupportedOperationException();
+    public boolean flushMemory() throws IOException {
+        return false;
     }
 
     private void returnToSegmentPool() {

--- a/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/InMemoryBuffer.java
@@ -80,6 +80,11 @@ public class InMemoryBuffer implements RowBuffer {
         }
     }
 
+    @Override
+    public void spill() {
+        throw new UnsupportedOperationException();
+    }
+
     private void returnToSegmentPool() {
         pool.returnAll(this.recordBufferSegments);
         this.recordBufferSegments.clear();

--- a/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
@@ -39,7 +39,7 @@ public interface RowBuffer {
 
     void reset();
 
-    void spill() throws IOException;
+    boolean flushMemory() throws IOException;
 
     RowBufferIterator newIterator();
 

--- a/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
@@ -39,6 +39,8 @@ public interface RowBuffer {
 
     void reset();
 
+    void spill() throws IOException;
+
     RowBufferIterator newIterator();
 
     /** Iterator to fetch record from buffer. */

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -419,7 +419,7 @@ public class AppendOnlyWriterTest {
             writer.write(row(j, String.valueOf(s), PART));
         }
 
-        writer.flushMemory();
+        writer.flush(false, false);
         Assertions.assertThat(writer.memoryOccupancy()).isEqualTo(0L);
         Assertions.assertThat(writer.getWriteBuffer().size()).isEqualTo(0);
         Assertions.assertThat(writer.getNewFiles().size()).isGreaterThan(0);
@@ -430,7 +430,7 @@ public class AppendOnlyWriterTest {
         for (int j = 0; j < 100; j++) {
             writer.write(row(j, String.valueOf(s), PART));
         }
-        writer.flushMemory();
+        writer.flush(false, false);
 
         Assertions.assertThat(writer.memoryOccupancy()).isEqualTo(0L);
         Assertions.assertThat(writer.getWriteBuffer().size()).isEqualTo(0);


### PR DESCRIPTION

Fix bug when open spillable, still many small files generated.
