### PR TITLE
[core] Introduce ExpireChangelogImpl to handle the changelog lifecycle

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,12 @@ under the License.
             <td>Whether to generate -U, +U changelog for the same record. This configuration is only valid for the changelog-producer is lookup or full-compaction.</td>
         </tr>
         <tr>
+            <td><h5>changelog.time-retained</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The minimum time of completed changelog to retain.</td>
+        </tr>
+        <tr>
             <td><h5>commit.callback.#.param</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -205,6 +205,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(Duration.ofHours(1))
                     .withDescription("The maximum time of completed snapshots to retain.");
 
+    public static final ConfigOption<Duration> CHANGELOG_TIME_RETAINED =
+            key("changelog.time-retained")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription("The minimum time of completed changelog to retain.");
+
     public static final ConfigOption<ExpireExecutionMode> SNAPSHOT_EXPIRE_EXECUTION_MODE =
             key("snapshot.expire.execution-mode")
                     .enumType(ExpireExecutionMode.class)
@@ -1233,6 +1239,10 @@ public class CoreOptions implements Serializable {
 
     public Duration snapshotTimeRetain() {
         return options.get(SNAPSHOT_TIME_RETAINED);
+    }
+
+    public Duration changelogTimeRetain() {
+        return options.get(CHANGELOG_TIME_RETAINED);
     }
 
     public ExpireExecutionMode snapshotExpireExecutionMode() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -205,11 +205,26 @@ public class CoreOptions implements Serializable {
                     .defaultValue(Duration.ofHours(1))
                     .withDescription("The maximum time of completed snapshots to retain.");
 
+    public static final ConfigOption<Integer> CHANGELOG_NUM_RETAINED_MIN =
+            key("changelog.num-retained.min")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The minimum number of completed changelog to retain. Should be greater than or equal to 1.");
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> CHANGELOG_NUM_RETAINED_MAX =
+            key("changelog.num-retained.max")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            "The maximum number of completed changelog to retain. Should be greater than or equal to the minimum number.");
+
     public static final ConfigOption<Duration> CHANGELOG_TIME_RETAINED =
             key("changelog.time-retained")
                     .durationType()
                     .defaultValue(Duration.ofHours(1))
-                    .withDescription("The minimum time of completed changelog to retain.");
+                    .withDescription("The maximum time of completed changelog to retain.");
 
     public static final ConfigOption<ExpireExecutionMode> SNAPSHOT_EXPIRE_EXECUTION_MODE =
             key("snapshot.expire.execution-mode")
@@ -1241,8 +1256,24 @@ public class CoreOptions implements Serializable {
         return options.get(SNAPSHOT_TIME_RETAINED);
     }
 
+    public int changelogNumRetainMin() {
+        return options.get(CHANGELOG_NUM_RETAINED_MIN);
+    }
+
+    public int changelogNumRetainMax() {
+        return options.get(CHANGELOG_NUM_RETAINED_MAX);
+    }
+
     public Duration changelogTimeRetain() {
         return options.get(CHANGELOG_TIME_RETAINED);
+    }
+
+    public boolean changelogLifecycleDecoupled() {
+        // 其他的选项也要考虑
+        return changelogNumRetainMax() > snapshotNumRetainMax()
+                || options.get(CHANGELOG_TIME_RETAINED)
+                                .compareTo(options.get(SNAPSHOT_TIME_RETAINED))
+                        > 0;
     }
 
     public ExpireExecutionMode snapshotExpireExecutionMode() {

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -1,0 +1,220 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.paimon;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class Changelog {
+
+    private static final int CURRENT_VERSION = 1;
+
+    private static final String FIELD_VERSION = "version";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_SCHEMA_ID = "schemaId";
+    private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
+    private static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
+    private static final String FIELD_COMMIT_KIND = "commitKind";
+    private static final String FIELD_TIME_MILLIS = "timeMillis";
+    private static final String FIELD_RECORD_COUNT = "recordCount";
+    private static final String FIELD_WATERMARK = "watermark";
+
+    @JsonProperty(FIELD_VERSION)
+    private final int version;
+
+    @JsonProperty(FIELD_ID)
+    private final long id;
+
+    @JsonProperty(FIELD_SCHEMA_ID)
+    private final long schemaId;
+
+    @JsonProperty(FIELD_DELTA_MANIFEST_LIST)
+    private final String deltaManifestList;
+
+    @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST)
+    @Nullable
+    private final String changelogManifestList;
+
+    @JsonProperty(FIELD_TIME_MILLIS)
+    private final long timeMillis;
+
+    @JsonProperty(FIELD_RECORD_COUNT)
+    @Nullable
+    private final Long recordCount;
+
+    @JsonProperty(FIELD_WATERMARK)
+    @Nullable
+    private final Long watermark;
+
+    @JsonProperty(FIELD_COMMIT_KIND)
+    private Snapshot.CommitKind commitKind;
+
+    public Changelog(
+            long id,
+            long schemaId,
+            String deltaManifestList,
+            @Nullable String changelogManifestList,
+            Snapshot.CommitKind commitKind,
+            long timeMillis,
+            Long recordCount,
+            @Nullable Long watermark) {
+        this(
+                CURRENT_VERSION,
+                id,
+                schemaId,
+                deltaManifestList,
+                changelogManifestList,
+                commitKind,
+                timeMillis,
+                recordCount,
+                watermark);
+    }
+
+    @JsonCreator
+    public Changelog(
+            @JsonProperty(FIELD_VERSION) @Nullable Integer version,
+            @JsonProperty(FIELD_ID) long id,
+            @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
+            @JsonProperty(FIELD_DELTA_MANIFEST_LIST) @Nullable String deltaManifestList,
+            @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST) @Nullable String changelogManifestList,
+            @JsonProperty(FIELD_COMMIT_KIND) Snapshot.CommitKind commitKind,
+            @JsonProperty(FIELD_TIME_MILLIS) long timeMillis,
+            @JsonProperty(FIELD_RECORD_COUNT) @Nullable Long recordCount,
+            @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark) {
+        this.version = version;
+        this.id = id;
+        this.schemaId = schemaId;
+        this.deltaManifestList = deltaManifestList;
+        this.changelogManifestList = changelogManifestList;
+        this.recordCount = recordCount;
+        this.commitKind = commitKind;
+        this.timeMillis = timeMillis;
+        this.watermark = watermark;
+    }
+
+    @JsonGetter(FIELD_VERSION)
+    public int version() {
+        return version;
+    }
+
+    @JsonGetter(FIELD_ID)
+    public long id() {
+        return id;
+    }
+
+    @JsonGetter(FIELD_CHANGELOG_MANIFEST_LIST)
+    @Nullable
+    public String changelogManifestList() {
+        return changelogManifestList;
+    }
+
+    @JsonGetter(FIELD_DELTA_MANIFEST_LIST)
+    public String deltaManifestList() {
+        return deltaManifestList;
+    }
+
+    @JsonGetter(FIELD_SCHEMA_ID)
+    public long schemaId() {
+        return schemaId;
+    }
+
+    @JsonGetter(FIELD_COMMIT_KIND)
+    public Snapshot.CommitKind commitKind() {
+        return commitKind;
+    }
+
+    @JsonGetter(FIELD_TIME_MILLIS)
+    public long timeMillis() {
+        return timeMillis;
+    }
+
+    @JsonGetter(FIELD_RECORD_COUNT)
+    public Long recordCount() {
+        return recordCount;
+    }
+
+    @JsonGetter(FIELD_WATERMARK)
+    @Nullable
+    public Long watermark() {
+        return watermark;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Changelog)) {
+            return false;
+        }
+        Changelog changelog = (Changelog) o;
+        return version == changelog.version
+                && id == changelog.id
+                && schemaId == changelog.schemaId
+                && timeMillis == changelog.timeMillis
+                && Objects.equals(deltaManifestList, changelog.deltaManifestList)
+                && Objects.equals(changelogManifestList, changelog.changelogManifestList)
+                && Objects.equals(recordCount, changelog.recordCount)
+                && Objects.equals(watermark, changelog.watermark)
+                && commitKind == changelog.commitKind;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                version,
+                id,
+                schemaId,
+                deltaManifestList,
+                changelogManifestList,
+                timeMillis,
+                recordCount,
+                watermark,
+                commitKind);
+    }
+
+    public String toJson() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    public static Changelog fromJson(String json) {
+        return JsonSerdeUtil.fromJson(json, Changelog.class);
+    }
+
+    public static Changelog fromPath(FileIO fileIO, Path path) {
+        try {
+            String json = fileIO.readFileUtf8(path);
+            return Changelog.fromJson(json);
+        } catch (IOException e) {
+            throw new RuntimeException("Fails to read changelog from path " + path, e);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -150,50 +150,14 @@ public abstract class FileDeletionBase {
                 .add(entry.bucket());
     }
 
-    public void cleanUnusedChangelogManifests(Snapshot snapshot) {
-        // clean changelog manifests
-        if (snapshot.changelogManifestList() != null) {
-            deleteFiles(
-                    tryReadManifestList(snapshot.changelogManifestList()),
-                    manifest -> manifestFile.delete(manifest.fileName()));
-            manifestList.delete(snapshot.changelogManifestList());
+    public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
+        // clean statistics
+        if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
+            statsFileHandler.deleteStats(snapshot.statistics());
         }
     }
 
-    public void cleanUnusedManifests(
-            Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
-        // clean base and delta manifests
-        List<String> toDeleteManifests = new ArrayList<>();
-        List<ManifestFileMeta> toExpireManifests = new ArrayList<>();
-        toExpireManifests.addAll(tryReadManifestList(snapshot.baseManifestList()));
-        toExpireManifests.addAll(tryReadManifestList(snapshot.deltaManifestList()));
-        for (ManifestFileMeta manifest : toExpireManifests) {
-            String fileName = manifest.fileName();
-            if (!skippingSet.contains(fileName)) {
-                toDeleteManifests.add(fileName);
-                // to avoid other snapshots trying to delete again
-                skippingSet.add(fileName);
-            }
-        }
-        deleteFiles(toDeleteManifests, manifestFile::delete);
-
-        toDeleteManifests.clear();
-        if (!skippingSet.contains(snapshot.baseManifestList())) {
-            toDeleteManifests.add(snapshot.baseManifestList());
-        }
-        if (!skippingSet.contains(snapshot.deltaManifestList())) {
-            toDeleteManifests.add(snapshot.deltaManifestList());
-        }
-        deleteFiles(toDeleteManifests, manifestList::delete);
-
-        // clean changelog manifests
-        if (deleteChangelog && snapshot.changelogManifestList() != null) {
-            deleteFiles(
-                    tryReadManifestList(snapshot.changelogManifestList()),
-                    manifest -> manifestFile.delete(manifest.fileName()));
-            manifestList.delete(snapshot.changelogManifestList());
-        }
-
+    public void cleanUnusedIndexManifests(Snapshot snapshot, Set<String> skippingSet) {
         // clean index manifests
         String indexManifest = snapshot.indexManifest();
         // check exists, it may have been deleted by other snapshots
@@ -208,11 +172,35 @@ public abstract class FileDeletionBase {
                 indexFileHandler.deleteManifest(indexManifest);
             }
         }
+    }
 
-        // clean statistics
-        if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
-            statsFileHandler.deleteStats(snapshot.statistics());
+    public void cleanUnusedManifestList(String manifestName, Set<String> skippingSet) {
+        List<String> toDeleteManifests = new ArrayList<>();
+        List<ManifestFileMeta> toExpireManifests = tryReadManifestList(manifestName);
+        for (ManifestFileMeta manifest : toExpireManifests) {
+            String fileName = manifest.fileName();
+            if (!skippingSet.contains(fileName)) {
+                toDeleteManifests.add(fileName);
+                // to avoid other snapshots trying to delete again
+                skippingSet.add(fileName);
+            }
         }
+        if (!skippingSet.contains(manifestName)) {
+            toDeleteManifests.add(manifestName);
+        }
+
+        deleteFiles(toDeleteManifests, manifestFile::delete);
+    }
+
+    public void cleanUnusedManifests(
+            Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
+        cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
+        cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
+        if (deleteChangelog) {
+            cleanUnusedManifestList(snapshot.changelogManifestList(), skippingSet);
+        }
+        cleanUnusedIndexManifests(snapshot, skippingSet);
+        cleanUnusedStatisticsManifests(snapshot, skippingSet);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -150,7 +150,17 @@ public abstract class FileDeletionBase {
                 .add(entry.bucket());
     }
 
-    protected void cleanUnusedManifests(
+    public void cleanUnusedChangelogManifests(Snapshot snapshot) {
+        // clean changelog manifests
+        if (snapshot.changelogManifestList() != null) {
+            deleteFiles(
+                    tryReadManifestList(snapshot.changelogManifestList()),
+                    manifest -> manifestFile.delete(manifest.fileName()));
+            manifestList.delete(snapshot.changelogManifestList());
+        }
+    }
+
+    public void cleanUnusedManifests(
             Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
         // clean base and delta manifests
         List<String> toDeleteManifests = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -116,6 +116,7 @@ public class SchemaValidation {
                 SNAPSHOT_NUM_RETAINED_MIN.key()
                         + " should not be larger than "
                         + SNAPSHOT_NUM_RETAINED_MAX.key());
+        // TODO check changelog longer than snapshot
 
         // Get the format type here which will try to convert string value to {@Code
         // FileFormatType}. If the string value is illegal, an exception will be thrown.

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -297,7 +297,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 snapshotManager(),
                 store().newSnapshotDeletion(),
                 coreOptions().snapshotExpireCleanEmptyDirectories(),
-                false);
+                true);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -288,7 +288,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 snapshotManager(),
                 store().newSnapshotDeletion(),
                 store().newTagManager(),
-                coreOptions().snapshotExpireCleanEmptyDirectories());
+                coreOptions().snapshotExpireCleanEmptyDirectories(),
+                coreOptions().changelogLifecycleDecoupled());
     }
 
     @Override
@@ -296,8 +297,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         return new ExpireChangelogImpl(
                 snapshotManager(),
                 store().newSnapshotDeletion(),
-                coreOptions().snapshotExpireCleanEmptyDirectories(),
-                true);
+                coreOptions().snapshotExpireCleanEmptyDirectories());
     }
 
     @Override
@@ -311,7 +311,10 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         Runnable snapshotExpire = null;
         if (!options.writeOnly()) {
             ExpireSnapshots expireChangelog =
-                    newExpireChangelog().maxDeletes(options.snapshotExpireLimit());
+                    newExpireChangelog()
+                            .maxDeletes(options.snapshotExpireLimit())
+                            .retainMin(options.changelogNumRetainMin())
+                            .retainMax(options.changelogNumRetainMax());
             ExpireSnapshots expireSnapshots =
                     newExpireSnapshots()
                             .retainMax(options.snapshotNumRetainMax())

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/** Cleanup the changelog in changelog directory. */
+public class ExpireChangelogImpl implements ExpireSnapshots {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ExpireChangelogImpl.class);
+
+    private final SnapshotManager snapshotManager;
+    private final SnapshotDeletion snapshotDeletion;
+    private final boolean cleanEmptyDirectories;
+    /** Whether to keep the last snapshot. */
+    private final boolean keepLastOne;
+
+    private long olderThanMills = 0;
+    private int maxDeletes = Integer.MAX_VALUE;
+
+    public ExpireChangelogImpl(
+            SnapshotManager snapshotManager,
+            SnapshotDeletion snapshotDeletion,
+            boolean cleanEmptyDirectories,
+            boolean keepLastOne) {
+        this.snapshotManager = snapshotManager;
+        this.snapshotDeletion = snapshotDeletion;
+        this.cleanEmptyDirectories = cleanEmptyDirectories;
+        this.keepLastOne = keepLastOne;
+    }
+
+    @Override
+    public ExpireChangelogImpl retainMax(int retainMax) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpireChangelogImpl retainMin(int retainMin) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpireChangelogImpl olderThanMills(long olderThanMills) {
+        this.olderThanMills = olderThanMills;
+        return this;
+    }
+
+    @Override
+    public ExpireChangelogImpl maxDeletes(int maxDeletes) {
+        this.maxDeletes = maxDeletes;
+        return this;
+    }
+
+    @Override
+    public int expire() {
+        Long latest = snapshotManager.latestLongLivedChangelogId();
+        if (latest == null) {
+            return 0;
+        }
+        Long earliest = snapshotManager.earliestLongLivedChangelogId();
+        if (earliest == null) {
+            return 0;
+        }
+        long maxId = Math.min(maxDeletes + earliest - 1, latest);
+        for (long id = earliest; id <= maxId; id++) {
+            if (snapshotManager.longLivedChangelogExists(id)
+                    && olderThanMills <= snapshotManager.longLivedChangelog(id).timeMillis()) {
+                return expireUntil(earliest, keepLastOne ? id : id + 1);
+            }
+        }
+        return expireUntil(earliest, keepLastOne ? maxId : maxId + 1);
+    }
+
+    public int expireUntil(long earliestId, long endExclusiveId) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Changelog expire range is [" + earliestId + ", " + endExclusiveId + ")");
+        }
+
+        for (long id = earliestId; id < endExclusiveId; id++) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete changelog files from snapshot #" + id);
+            }
+            Snapshot snapshot = snapshotManager.longLivedChangelog(id);
+            // delete changelog files
+            if (snapshot.changelogManifestList() != null) {
+                snapshotDeletion.deleteAddedDataFiles(snapshot.changelogManifestList());
+            }
+            snapshotDeletion.cleanUnusedChangelogManifests(snapshot);
+            snapshotManager.fileIO().deleteQuietly(snapshotManager.longLivedChangelogPath(id));
+        }
+
+        if (cleanEmptyDirectories) {
+            snapshotDeletion.cleanDataDirectories();
+        }
+        writeEarliestHintFile(endExclusiveId);
+        return (int) (endExclusiveId - earliestId);
+    }
+
+    private void writeEarliestHintFile(long earliest) {
+        try {
+            snapshotManager.commitLongLivedChangelogEarliestHint(earliest);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @VisibleForTesting
+    public long getOlderThanMills() {
+        return olderThanMills;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -18,8 +18,9 @@
 
 package org.apache.paimon.table;
 
-import org.apache.paimon.Snapshot;
+import org.apache.paimon.Changelog;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashSet;
 
 /** Cleanup the changelog in changelog directory. */
 public class ExpireChangelogImpl implements ExpireSnapshots {
@@ -35,33 +37,36 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
     public static final Logger LOG = LoggerFactory.getLogger(ExpireChangelogImpl.class);
 
     private final SnapshotManager snapshotManager;
+    private final ConsumerManager consumerManager;
     private final SnapshotDeletion snapshotDeletion;
     private final boolean cleanEmptyDirectories;
-    /** Whether to keep the last snapshot. */
-    private final boolean keepLastOne;
 
     private long olderThanMills = 0;
+    public int retainMin = 1;
+    private int retainMax = Integer.MAX_VALUE;
     private int maxDeletes = Integer.MAX_VALUE;
 
     public ExpireChangelogImpl(
             SnapshotManager snapshotManager,
             SnapshotDeletion snapshotDeletion,
-            boolean cleanEmptyDirectories,
-            boolean keepLastOne) {
+            boolean cleanEmptyDirectories) {
         this.snapshotManager = snapshotManager;
+        this.consumerManager =
+                new ConsumerManager(snapshotManager.fileIO(), snapshotManager.tablePath());
         this.snapshotDeletion = snapshotDeletion;
         this.cleanEmptyDirectories = cleanEmptyDirectories;
-        this.keepLastOne = keepLastOne;
     }
 
     @Override
     public ExpireChangelogImpl retainMax(int retainMax) {
-        throw new UnsupportedOperationException();
+        this.retainMax = retainMax;
+        return this;
     }
 
     @Override
     public ExpireChangelogImpl retainMin(int retainMin) {
-        throw new UnsupportedOperationException();
+        this.retainMin = retainMin;
+        return this;
     }
 
     @Override
@@ -78,22 +83,53 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
 
     @Override
     public int expire() {
-        Long latest = snapshotManager.latestLongLivedChangelogId();
-        if (latest == null) {
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
+        if (latestSnapshotId == null) {
+            // no snapshot, nothing to expire
             return 0;
         }
-        Long earliest = snapshotManager.earliestLongLivedChangelogId();
-        if (earliest == null) {
+
+        Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+        if (earliestSnapshotId == null) {
             return 0;
         }
-        long maxId = Math.min(maxDeletes + earliest - 1, latest);
-        for (long id = earliest; id <= maxId; id++) {
+
+        Long latestChangelogId = snapshotManager.latestLongLivedChangelogId();
+        if (latestChangelogId == null) {
+            return 0;
+        }
+        Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
+        if (earliestChangelogId == null) {
+            return 0;
+        }
+
+        // the min snapshot to retain from 'changelog.num-retained.max'
+        // (the maximum number of snapshots to retain)
+        long min = Math.max(latestSnapshotId - retainMax + 1, earliestChangelogId);
+
+        // the max exclusive snapshot to expire until
+        // protected by 'changelog.num-retained.min'
+        // (the minimum number of completed snapshots to retain)
+        long maxExclusive = latestSnapshotId - retainMin + 1;
+
+        // the snapshot being read by the consumer cannot be deleted
+        maxExclusive =
+                Math.min(maxExclusive, consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE));
+
+        // protected by 'snapshot.expire.limit'
+        // (the maximum number of snapshots allowed to expire at a time)
+        maxExclusive = Math.min(maxExclusive, earliestChangelogId + maxDeletes);
+
+        // Only clean the snapshot in changelog dir
+        maxExclusive = Math.min(maxExclusive, latestChangelogId);
+
+        for (long id = min; id <= maxExclusive; id++) {
             if (snapshotManager.longLivedChangelogExists(id)
                     && olderThanMills <= snapshotManager.longLivedChangelog(id).timeMillis()) {
-                return expireUntil(earliest, keepLastOne ? id : id + 1);
+                return expireUntil(earliestChangelogId, id);
             }
         }
-        return expireUntil(earliest, keepLastOne ? maxId : maxId + 1);
+        return expireUntil(earliestChangelogId, maxExclusive);
     }
 
     public int expireUntil(long earliestId, long endExclusiveId) {
@@ -105,13 +141,23 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ready to delete changelog files from snapshot #" + id);
             }
-            Snapshot snapshot = snapshotManager.longLivedChangelog(id);
-            // delete changelog files
-            if (snapshot.changelogManifestList() != null) {
-                snapshotDeletion.deleteAddedDataFiles(snapshot.changelogManifestList());
+            // The id in changelog dir is not necessary to be continuous
+            if (snapshotManager.longLivedChangelogExists(id)) {
+                Changelog changelog = snapshotManager.longLivedChangelog(id);
+                // delete changelog files
+                if (changelog.changelogManifestList() != null) {
+                    snapshotDeletion.deleteAddedDataFiles(changelog.changelogManifestList());
+                    snapshotDeletion.cleanUnusedManifestList(
+                            changelog.changelogManifestList(), new HashSet<>());
+                }
+                if (changelog.deltaManifestList() != null) {
+                    snapshotDeletion.deleteAddedDataFiles(changelog.deltaManifestList());
+                    snapshotDeletion.cleanUnusedManifestList(
+                            changelog.deltaManifestList(), new HashSet<>());
+                }
+
+                snapshotManager.fileIO().deleteQuietly(snapshotManager.longLivedChangelogPath(id));
             }
-            snapshotDeletion.cleanUnusedChangelogManifests(snapshot);
-            snapshotManager.fileIO().deleteQuietly(snapshotManager.longLivedChangelogPath(id));
         }
 
         if (cleanEmptyDirectories) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.Changelog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
@@ -45,6 +46,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
     private final SnapshotDeletion snapshotDeletion;
     private final TagManager tagManager;
     private final boolean cleanEmptyDirectories;
+    /** Whether to clean the changelog or delta files. */
+    private final boolean changelogDecoupled;
 
     private int retainMax = Integer.MAX_VALUE;
     private int retainMin = 1;
@@ -55,13 +58,15 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             SnapshotManager snapshotManager,
             SnapshotDeletion snapshotDeletion,
             TagManager tagManager,
-            boolean cleanEmptyDirectories) {
+            boolean cleanEmptyDirectories,
+            boolean changelogDecoupled) {
         this.snapshotManager = snapshotManager;
         this.consumerManager =
                 new ConsumerManager(snapshotManager.fileIO(), snapshotManager.tablePath());
         this.snapshotDeletion = snapshotDeletion;
         this.tagManager = tagManager;
         this.cleanEmptyDirectories = cleanEmptyDirectories;
+        this.changelogDecoupled = changelogDecoupled;
     }
 
     @Override
@@ -183,7 +188,17 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                 continue;
             }
 
-            snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
+            if (changelogDecoupled) {
+                if (snapshot.changelogManifestList() != null
+                        || snapshot.commitKind() != Snapshot.CommitKind.APPEND) {
+                    snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
+                }
+            } else {
+                snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
+                if (snapshot.changelogManifestList() != null) {
+                    snapshotDeletion.deleteAddedDataFiles(snapshot.changelogManifestList());
+                }
+            }
         }
 
         // data files and changelog files in bucket directories has been deleted
@@ -204,15 +219,49 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             }
 
             Snapshot snapshot = snapshotManager.snapshot(id);
-            snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, false);
+            if (changelogDecoupled) {
+                Changelog changelog = null;
+                if (snapshot.changelogManifestList() != null) {
+                    changelog =
+                            new Changelog(
+                                    id,
+                                    snapshot.schemaId(),
+                                    null,
+                                    snapshot.changelogManifestList(),
+                                    snapshot.commitKind(),
+                                    snapshot.timeMillis(),
+                                    snapshot.changelogRecordCount(),
+                                    snapshot.watermark());
+                    snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, false);
+                } else if (snapshot.commitKind() == Snapshot.CommitKind.APPEND) {
+                    changelog =
+                            new Changelog(
+                                    id,
+                                    snapshot.schemaId(),
+                                    snapshot.deltaManifestList(),
+                                    null,
+                                    snapshot.commitKind(),
+                                    snapshot.timeMillis(),
+                                    snapshot.deltaRecordCount(),
+                                    snapshot.watermark());
+                    snapshotDeletion.cleanUnusedManifestList(
+                            snapshot.baseManifestList(), skippingSet);
+                    snapshotDeletion.cleanUnusedIndexManifests(snapshot, skippingSet);
+                    snapshotDeletion.cleanUnusedStatisticsManifests(snapshot, skippingSet);
+                }
+                if (changelog != null) {
+                    try {
+                        snapshotManager.commitChangelog(changelog, id);
+                        snapshotManager.commitLongLivedChangelogLatestHint(id);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
 
-            // move snapshot metadata to changelog
-            try {
-                snapshotManager.moveToChangelog(id);
-                snapshotManager.commitLongLivedChangelogLatestHint(id);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            } else {
+                snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, true);
             }
+            snapshotManager.fileIO().deleteQuietly(snapshotManager.snapshotPath(id));
         }
 
         writeEarliestHint(endExclusiveId);

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -156,4 +156,12 @@ public interface ReadonlyTable extends InnerTable {
                         "Readonly Table %s does not support expireSnapshots.",
                         this.getClass().getSimpleName()));
     }
+
+    @Override
+    default ExpireSnapshots newExpireChangelog() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support expireChangelog.",
+                        this.getClass().getSimpleName()));
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
@@ -80,7 +81,8 @@ public class RollbackHelper {
         }
 
         for (Snapshot snapshot : cleanedChangelogs) {
-            snapshotDeletion.cleanUnusedChangelogManifests(snapshot);
+            snapshotDeletion.cleanUnusedManifestList(
+                    snapshot.changelogManifestList(), new HashSet<>());
         }
 
         cleanedTags.removeAll(cleanedSnapshots);

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -100,6 +100,9 @@ public interface Table extends Serializable {
     @Experimental
     ExpireSnapshots newExpireSnapshots();
 
+    @Experimental
+    ExpireSnapshots newExpireChangelog();
+
     // =============== Read & Write Operations ==================
 
     /** Returns a new read builder. */

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.Changelog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
@@ -129,8 +130,8 @@ public class SnapshotManager implements Serializable {
         }
     }
 
-    public Snapshot longLivedChangelog(long snapshotId) {
-        return Snapshot.fromPath(fileIO, longLivedChangelogPath(snapshotId));
+    public Changelog longLivedChangelog(long snapshotId) {
+        return Changelog.fromPath(fileIO, longLivedChangelogPath(snapshotId));
     }
 
     public Snapshot snapshot(String branchName, long snapshotId) {
@@ -428,6 +429,10 @@ public class SnapshotManager implements Serializable {
         Path src = snapshotPath(snapshotId);
         Path dest = longLivedChangelogPath(snapshotId);
         fileIO.rename(src, dest);
+    }
+
+    public void commitChangelog(Changelog changelog, long id) throws IOException {
+        fileIO.writeFileUtf8(longLivedChangelogPath(id), changelog.toJson());
     }
 
     /**

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -155,6 +155,7 @@ public class FileDeletionTest {
 
         // step 5: expire and check file paths
         store.newExpire(1, 1, Long.MAX_VALUE, cleanEmptyDirs).expire();
+        store.newChangelogExpire(0, cleanEmptyDirs, false).expire();
 
         // check dt=0401
         if (cleanEmptyDirs) {
@@ -206,6 +207,8 @@ public class FileDeletionTest {
 
         // check after expiring
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+        store.newChangelogExpire(0, true, false).expire();
+
         assertPathNotExists(fileIO, pathFactory.bucketPath(partition, 0));
         assertPathExists(fileIO, pathFactory.bucketPath(partition, 1));
     }
@@ -290,6 +293,7 @@ public class FileDeletionTest {
 
         // check expiring results
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+        store.newChangelogExpire(0, true, false).expire();
 
         // expiring snapshot 1 will delete file A
         assertPathNotExists(fileIO, pathFactory.bucketPath(partition, 0));
@@ -352,6 +356,7 @@ public class FileDeletionTest {
 
         createTag(snapshotManager.snapshot(1), "tag1");
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+        store.newChangelogExpire(0, true, false).expire();
 
         // check data file and manifests
         FileStorePathFactory pathFactory = store.pathFactory();
@@ -411,6 +416,7 @@ public class FileDeletionTest {
 
         // expire snapshot 1, 2
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+        store.newChangelogExpire(0, true, false).expire();
 
         // check before deleting tag1
         FileStorePathFactory pathFactory = store.pathFactory();
@@ -487,6 +493,7 @@ public class FileDeletionTest {
 
         // expire snapshot 1, 2, 3, 4
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+        store.newChangelogExpire(0, true, false).expire();
 
         // check before deleting tag2
         FileStorePathFactory pathFactory = store.pathFactory();

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -869,9 +869,19 @@ public abstract class FileStoreTableTestBase {
         List<java.nio.file.Path> files =
                 Files.walk(new File(tablePath.toUri().getPath()).toPath())
                         .collect(Collectors.toList());
-        assertThat(files.size()).isEqualTo(16);
-        // rollback snapshot case 0 plus 1:
-        // table-path/tag/tag-test1
+        if (expire) {
+            // rollback snapshot case 0 plus 5:
+            // table-path/tag/tag-test1
+            // table-path/changelog/
+            // table-path/changelog/changelog-1
+            // table-path/changelog/LATEST
+            // table-path/changelog/EARLIEST
+            assertThat(files.size()).isEqualTo(20);
+        } else {
+            // rollback snapshot case 0 plus 1:
+            // table-path/tag/tag-test1
+            assertThat(files.size()).isEqualTo(16);
+        }
     }
 
     private FileStoreTable prepareRollbackTable(int commitTimes) throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2899

In this PR, the `snapshot` will be moved to the `/changelog` directory for decouple the changelog lifecycle. We will always keep one extra metadata file in the `/changelog` directory for the conveniency of streaming scan.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
