### PR TITLE
[Hive] Cache TableSchema into Configuration to avoid loading read scheme file in PaimonSerDe

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
@@ -120,6 +120,14 @@ public class JsonSerdeUtil {
                         fieldName, clazz.getName(), node.getClass().getName()));
     }
 
+    public static <T> T fromJson(String json, TypeReference<T> typeReference) {
+        try {
+            return OBJECT_MAPPER_INSTANCE.readValue(json, typeReference);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     public static <T> T fromJson(String json, Class<T> clazz) {
         try {
             return OBJECT_MAPPER_INSTANCE.reader().readValue(json, clazz);

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -200,7 +200,7 @@ public class HiveSchema {
 
     @VisibleForTesting
     static Optional<TableSchema> getTableSchemaFromCache(Properties properties) {
-        String paimonSchemaStr = properties.getProperty(PaimonStorageHandler.PAIMON_SCHEMA);
+        String paimonSchemaStr = properties.getProperty(PaimonStorageHandler.PAIMON_HIVE_SCHEMA);
         if (paimonSchemaStr != null) {
             return Optional.of(JsonSerdeUtil.fromJson(paimonSchemaStr, TableSchema.class));
         }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonSerDe.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonSerDe.java
@@ -19,9 +19,12 @@
 package org.apache.paimon.hive;
 
 import org.apache.paimon.hive.objectinspector.PaimonInternalRowObjectInspector;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
@@ -33,6 +36,7 @@ import org.apache.hadoop.io.Writable;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -54,9 +58,11 @@ public class PaimonSerDe extends AbstractSerDe {
     @Override
     public void initialize(@Nullable Configuration configuration, Properties properties)
             throws SerDeException {
-        String hiveSchemaStr = properties.getProperty(PaimonStorageHandler.PAIMON_HIVE_SCHEMA);
-        if (hiveSchemaStr != null) {
-            this.tableSchema = JsonSerdeUtil.fromJson(hiveSchemaStr, HiveSchema.class);
+        String dataFieldStr = properties.getProperty(PaimonStorageHandler.PAIMON_TABLE_FIELDS);
+        if (dataFieldStr != null) {
+            List<DataField> dataFields =
+                    JsonSerdeUtil.fromJson(dataFieldStr, new TypeReference<List<DataField>>() {});
+            this.tableSchema = new HiveSchema(new RowType(dataFields));
         } else {
             this.tableSchema = HiveSchema.extract(configuration, properties);
         }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonSerDe.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonSerDe.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.hive;
 
 import org.apache.paimon.hive.objectinspector.PaimonInternalRowObjectInspector;
+import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
@@ -53,11 +54,18 @@ public class PaimonSerDe extends AbstractSerDe {
     @Override
     public void initialize(@Nullable Configuration configuration, Properties properties)
             throws SerDeException {
-        HiveSchema schema = HiveSchema.extract(configuration, properties);
-        this.tableSchema = schema;
+        String hiveSchemaStr = properties.getProperty(PaimonStorageHandler.PAIMON_HIVE_SCHEMA);
+        if (hiveSchemaStr != null) {
+            this.tableSchema = JsonSerdeUtil.fromJson(hiveSchemaStr, HiveSchema.class);
+        } else {
+            this.tableSchema = HiveSchema.extract(configuration, properties);
+        }
+
         inspector =
                 new PaimonInternalRowObjectInspector(
-                        schema.fieldNames(), schema.fieldTypes(), schema.fieldComments());
+                        tableSchema.fieldNames(),
+                        tableSchema.fieldTypes(),
+                        tableSchema.fieldComments());
     }
 
     @Override

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
@@ -47,7 +47,7 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
     private static final String MAPRED_OUTPUT_COMMITTER = "mapred.output.committer.class";
     private static final String PAIMON_WRITE = "paimon.write";
 
-    public static final String PAIMON_HIVE_SCHEMA = "paimon.hive.schema";
+    public static final String PAIMON_TABLE_FIELDS = "paimon.table.fields";
 
     private Configuration conf;
 
@@ -81,8 +81,13 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
         Properties properties = tableDesc.getProperties();
         String paimonLocation = LocationKeyExtractor.getPaimonLocation(conf, properties);
         map.put(LocationKeyExtractor.INTERNAL_LOCATION, paimonLocation);
+        String dataFieldJsonStr = getDataFieldsJsonStr(properties);
+        tableDesc.getProperties().put(PAIMON_TABLE_FIELDS, dataFieldJsonStr);
+    }
+
+    static String getDataFieldsJsonStr(Properties properties) {
         HiveSchema hiveSchema = HiveSchema.extract(null, properties);
-        tableDesc.getProperties().put(PAIMON_HIVE_SCHEMA, JsonSerdeUtil.toJson(hiveSchema));
+        return JsonSerdeUtil.toJson(hiveSchema.fields());
     }
 
     public void configureInputJobCredentials(TableDesc tableDesc, Map<String, String> map) {}

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
@@ -21,6 +21,7 @@ package org.apache.paimon.hive;
 import org.apache.paimon.hive.mapred.PaimonInputFormat;
 import org.apache.paimon.hive.mapred.PaimonOutputCommitter;
 import org.apache.paimon.hive.mapred.PaimonOutputFormat;
+import org.apache.paimon.schema.TableSchema;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
@@ -38,6 +39,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 /** {@link HiveStorageHandler} for paimon. This is the entrance class of Hive API. */
@@ -45,6 +47,8 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
 
     private static final String MAPRED_OUTPUT_COMMITTER = "mapred.output.committer.class";
     private static final String PAIMON_WRITE = "paimon.write";
+
+    public static final String PAIMON_SCHEMA = "paimon.schema";
 
     private Configuration conf;
 
@@ -76,9 +80,16 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
     @Override
     public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> map) {
         Properties properties = tableDesc.getProperties();
-        map.put(
-                LocationKeyExtractor.INTERNAL_LOCATION,
-                LocationKeyExtractor.getPaimonLocation(conf, properties));
+        String paimonLocation = LocationKeyExtractor.getPaimonLocation(conf, properties);
+        map.put(LocationKeyExtractor.INTERNAL_LOCATION, paimonLocation);
+
+        // cache the schema into table properties
+        Optional<TableSchema> existingSchema = HiveSchema.getExistingSchema(null, paimonLocation);
+        if (existingSchema.isPresent()) {
+            String tableSchema = existingSchema.get().toString();
+            tableDesc.getProperties().put(PAIMON_SCHEMA, tableSchema);
+            map.put(PAIMON_SCHEMA, tableSchema);
+        }
     }
 
     public void configureInputJobCredentials(TableDesc tableDesc, Map<String, String> map) {}

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -349,7 +349,7 @@ public class HiveTableSchemaTest {
     }
 
     @Test
-    public void testReadSchemaFromProperties() throws Exception {
+    public void testReadHiveSchemaFromProperties() throws Exception {
         createSchema();
         // cache the TableSchema to properties
         Properties properties = new Properties();
@@ -362,6 +362,7 @@ public class HiveTableSchemaTest {
 
         List<DataField> dataFieldsDeserialized =
                 JsonSerdeUtil.fromJson(dataFieldStr, new TypeReference<List<DataField>>() {});
-        assertThat(dataFields).isEqualTo(dataFieldsDeserialized);
+        HiveSchema newHiveSchema = new HiveSchema(new RowType(dataFieldsDeserialized));
+        assertThat(newHiveSchema).usingRecursiveComparison().isEqualTo(hiveSchema);
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.apache.paimon.hive.PaimonStorageHandler.PAIMON_SCHEMA;
+import static org.apache.paimon.hive.PaimonStorageHandler.PAIMON_HIVE_SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -355,7 +355,7 @@ public class HiveTableSchemaTest {
         assertThat(existingSchema).isPresent();
         Properties properties = new Properties();
         TableSchema tableSchema = existingSchema.get();
-        properties.put(PAIMON_SCHEMA, tableSchema.toString());
+        properties.put(PAIMON_HIVE_SCHEMA, tableSchema.toString());
 
         // get the TableSchema from properties
         Optional<TableSchema> tableSchemaFromCache = HiveSchema.getTableSchemaFromCache(properties);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
The Map Task will fetch  the tableschema  of paimon. we cache the schema json to configuration to reduce the access of FileSystem
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
