### PR TITLE
[core] Exception should be thrown after 'catch' in `AppendOnlyWriter`.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -37,6 +37,7 @@ import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CommitIncrement;
+import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.RecordWriter;
@@ -195,17 +196,6 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         sinkWriter.close();
     }
 
-    public void toBufferedWriter() throws Exception {
-        if (sinkWriter != null && !sinkWriter.bufferSpillableWriter()) {
-            flush(false, false);
-            trySyncLatestCompaction(true);
-
-            sinkWriter.close();
-            sinkWriter = new BufferedSinkWriter(true);
-            sinkWriter.setMemoryPool(memorySegmentPool);
-        }
-    }
-
     private RowDataRollingFileWriter createRollingRowWriter() {
         return new RowDataRollingFileWriter(
                 fileIO,
@@ -217,6 +207,17 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 seqNumCounter,
                 fileCompression,
                 statsCollectors);
+    }
+
+    public void toBufferedWriter() throws Exception {
+        if (sinkWriter != null && !sinkWriter.bufferSpillableWriter()) {
+            flush(false, false);
+            trySyncLatestCompaction(true);
+
+            sinkWriter.close();
+            sinkWriter = new BufferedSinkWriter(true);
+            sinkWriter.setMemoryPool(memorySegmentPool);
+        }
     }
 
     private void trySyncLatestCompaction(boolean blocking)
@@ -379,11 +380,19 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
             if (writeBuffer != null) {
                 writeBuffer.complete();
                 RowDataRollingFileWriter writer = createRollingRowWriter();
+                IOException exception = null;
                 try (RowBuffer.RowBufferIterator iterator = writeBuffer.newIterator()) {
                     while (iterator.advanceNext()) {
                         writer.write(iterator.getRow());
                     }
+                } catch (IOException e) {
+                    exception = e;
                 } finally {
+                    if (exception != null) {
+                        IOUtils.closeQuietly(writer);
+                        // cleanup code that might throw another exception
+                        throw exception;
+                    }
                     writer.close();
                 }
                 flushedFiles.addAll(writer.result());

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -196,6 +196,17 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         sinkWriter.close();
     }
 
+    public void toBufferedWriter() throws Exception {
+        if (sinkWriter != null && !sinkWriter.bufferSpillableWriter()) {
+            flush(false, false);
+            trySyncLatestCompaction(true);
+
+            sinkWriter.close();
+            sinkWriter = new BufferedSinkWriter(true);
+            sinkWriter.setMemoryPool(memorySegmentPool);
+        }
+    }
+
     private RowDataRollingFileWriter createRollingRowWriter() {
         return new RowDataRollingFileWriter(
                 fileIO,
@@ -207,17 +218,6 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 seqNumCounter,
                 fileCompression,
                 statsCollectors);
-    }
-
-    public void toBufferedWriter() throws Exception {
-        if (sinkWriter != null && !sinkWriter.bufferSpillableWriter()) {
-            flush(false, false);
-            trySyncLatestCompaction(true);
-
-            sinkWriter.close();
-            sinkWriter = new BufferedSinkWriter(true);
-            sinkWriter.setMemoryPool(memorySegmentPool);
-        }
     }
 
     private void trySyncLatestCompaction(boolean blocking)


### PR DESCRIPTION
An small bug: Exception have been swallowed if finally throws an exception too.
