### PR TITLE
[flink] Postpone sink materializer check from compile time to runtime

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SerializableRunnable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SerializableRunnable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.Serializable;
+
+/** A serializable {@link Runnable}. */
+@FunctionalInterface
+public interface SerializableRunnable extends Runnable, Serializable {}


### PR DESCRIPTION
### Purpose

Currently we check for sink materializer and throws exception in SQL compile time. However, some cloud computing flatform (for example, aliyun VVP) allows user to change some Flink configurations after compiling SQL but before starting the job.

This PR postpone sink materializer check from compile time to runtime to work around such case.

### Tests

Existing tests should cover this change.

### API and Format

No.

### Documentation

No,
