### PR TITLE
[core] Integrate deletion vector to reader and writer

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -165,6 +165,12 @@ under the License.
             <td>Whether to ignore delete records in deduplicate mode.</td>
         </tr>
         <tr>
+            <td><h5>deletion-vectors.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable deletion vectors mode. In this mode, index files containing deletion vectors are generated when data is written, which marks the data for deletion. During read operations, by applying these index files, merging can be avoided.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.assigner-parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStrategy.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/LookupStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lookup;
+
+/** Strategy for lookup. */
+public enum LookupStrategy {
+    NO_LOOKUP(false, false),
+
+    CHANGELOG_ONLY(true, false),
+
+    DELETION_VECTOR_ONLY(false, true),
+
+    CHANGELOG_AND_DELETION_VECTOR(true, true);
+
+    public final boolean needLookup;
+
+    public final boolean produceChangelog;
+
+    public final boolean deletionVector;
+
+    LookupStrategy(boolean produceChangelog, boolean deletionVector) {
+        this.produceChangelog = produceChangelog;
+        this.deletionVector = deletionVector;
+        this.needLookup = produceChangelog || deletionVector;
+    }
+
+    public static LookupStrategy from(boolean produceChangelog, boolean deletionVector) {
+        for (LookupStrategy strategy : values()) {
+            if (strategy.produceChangelog == produceChangelog
+                    && strategy.deletionVector == deletionVector) {
+                return strategy;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Invalid combination of produceChangelog : "
+                        + produceChangelog
+                        + " and deletionVector : "
+                        + deletionVector);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.deletionvectors;
+
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.reader.RecordWithPositionIterator;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A {@link RecordReader} which apply {@link DeletionVector} to filter record. */
+public class ApplyDeletionVectorReader<T> implements RecordReader<T> {
+
+    private final RecordReader<T> reader;
+
+    private final DeletionVector deletionVector;
+
+    public ApplyDeletionVectorReader(RecordReader<T> reader, DeletionVector deletionVector) {
+        this.reader = reader;
+        this.deletionVector = deletionVector;
+    }
+
+    @Nullable
+    @Override
+    public RecordIterator<T> readBatch() throws IOException {
+        RecordIterator<T> batch = reader.readBatch();
+
+        if (batch == null) {
+            return null;
+        }
+
+        checkArgument(
+                batch instanceof RecordWithPositionIterator,
+                "There is a bug, RecordIterator in ApplyDeletionVectorReader must be RecordWithPositionIterator");
+
+        RecordWithPositionIterator<T> batchWithPosition = (RecordWithPositionIterator<T>) batch;
+
+        return batchWithPosition.filter(
+                a -> !deletionVector.isDeleted(batchWithPosition.returnedPosition()));
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
@@ -140,9 +140,9 @@ public class DeletionVectorsIndexFile extends IndexFile {
         int version = in.read();
         if (version != VERSION_ID_V1) {
             throw new RuntimeException(
-                    "Version not match, actual size: "
+                    "Version not match, actual version: "
                             + version
-                            + ", expert size: "
+                            + ", expert version: "
                             + VERSION_ID_V1);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.deletionvectors;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
@@ -56,7 +57,7 @@ public class DeletionVectorsMaintainer {
         this.deletionVectors =
                 indexFile == null
                         ? new HashMap<>()
-                        : indexFileHandler.readAllDeletionVectors(indexFile);
+                        : new HashMap<>(indexFileHandler.readAllDeletionVectors(indexFile));
         this.modified = false;
     }
 
@@ -115,12 +116,17 @@ public class DeletionVectorsMaintainer {
         return Optional.ofNullable(deletionVectors.get(fileName));
     }
 
+    @VisibleForTesting
+    public Map<String, DeletionVector> deletionVectors() {
+        return deletionVectors;
+    }
+
     /** Factory to restore {@link DeletionVectorsMaintainer}. */
-    public static class DeletionVectorsMaintainerFactory {
+    public static class Factory {
 
         private final IndexFileHandler handler;
 
-        public DeletionVectorsMaintainerFactory(IndexFileHandler handler) {
+        public Factory(IndexFileHandler handler) {
             this.handler = handler;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
+import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.SortedRun;
 import org.apache.paimon.utils.FieldsComparator;
@@ -64,7 +65,9 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
                 keyComparator,
                 userDefinedSeqComparator,
                 mfFactory,
-                mergeSorter);
+                mergeSorter,
+                LookupStrategy.CHANGELOG_ONLY,
+                null);
         this.valueEqualiser = valueEqualiser;
         this.changelogRowDeduplicate = changelogRowDeduplicate;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -22,9 +22,11 @@ import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
+import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.SortedRun;
@@ -40,6 +42,7 @@ import java.util.List;
 import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.CHANGELOG_NO_REWRITE;
 import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.CHANGELOG_WITH_REWRITE;
 import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.NO_CHANGELOG;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
  * A {@link MergeTreeCompactRewriter} which produces changelog files by lookup for the compaction
@@ -60,7 +63,9 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
             @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
             MergeSorter mergeSorter,
-            MergeFunctionWrapperFactory<T> wrapperFactory) {
+            MergeFunctionWrapperFactory<T> wrapperFactory,
+            LookupStrategy lookupStrategy,
+            @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer) {
         super(
                 maxLevel,
                 mergeEngine,
@@ -69,7 +74,14 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
                 keyComparator,
                 userDefinedSeqComparator,
                 mfFactory,
-                mergeSorter);
+                mergeSorter,
+                lookupStrategy,
+                deletionVectorsMaintainer);
+        if (lookupStrategy.deletionVector) {
+            checkArgument(
+                    deletionVectorsMaintainer != null,
+                    "deletionVectorsMaintainer should not be null, there is a bug.");
+        }
         this.lookupLevels = lookupLevels;
         this.wrapperFactory = wrapperFactory;
     }
@@ -86,12 +98,17 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
             return NO_CHANGELOG;
         }
 
+        // In deletionVector mode, since drop delete is required, rewrite is always required.
+        if (lookupStrategy.deletionVector) {
+            return CHANGELOG_WITH_REWRITE;
+        }
+
         if (outputLevel == maxLevel) {
             return CHANGELOG_NO_REWRITE;
         }
 
         // DEDUPLICATE retains the latest records as the final result, so merging has no impact on
-        // it at all
+        // it at all.
         if (mergeEngine == MergeEngine.DEDUPLICATE) {
             return CHANGELOG_NO_REWRITE;
         }
@@ -104,7 +121,8 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
 
     @Override
     protected MergeFunctionWrapper<ChangelogResult> createMergeWrapper(int outputLevel) {
-        return wrapperFactory.create(mfFactory, outputLevel, lookupLevels);
+        return wrapperFactory.create(
+                mfFactory, outputLevel, lookupLevels, deletionVectorsMaintainer);
     }
 
     @Override
@@ -118,28 +136,34 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
         MergeFunctionWrapper<ChangelogResult> create(
                 MergeFunctionFactory<KeyValue> mfFactory,
                 int outputLevel,
-                LookupLevels<T> lookupLevels);
+                LookupLevels<T> lookupLevels,
+                @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer);
     }
 
     /** A normal {@link MergeFunctionWrapperFactory} to create lookup wrapper. */
-    public static class LookupMergeFunctionWrapperFactory
-            implements MergeFunctionWrapperFactory<KeyValue> {
+    public static class LookupMergeFunctionWrapperFactory<T>
+            implements MergeFunctionWrapperFactory<T> {
 
         private final RecordEqualiser valueEqualiser;
         private final boolean changelogRowDeduplicate;
+        private final LookupStrategy lookupStrategy;
 
         public LookupMergeFunctionWrapperFactory(
-                RecordEqualiser valueEqualiser, boolean changelogRowDeduplicate) {
+                RecordEqualiser valueEqualiser,
+                boolean changelogRowDeduplicate,
+                LookupStrategy lookupStrategy) {
             this.valueEqualiser = valueEqualiser;
             this.changelogRowDeduplicate = changelogRowDeduplicate;
+            this.lookupStrategy = lookupStrategy;
         }
 
         @Override
         public MergeFunctionWrapper<ChangelogResult> create(
                 MergeFunctionFactory<KeyValue> mfFactory,
                 int outputLevel,
-                LookupLevels<KeyValue> lookupLevels) {
-            return new LookupChangelogMergeFunctionWrapper(
+                LookupLevels<T> lookupLevels,
+                @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer) {
+            return new LookupChangelogMergeFunctionWrapper<>(
                     mfFactory,
                     key -> {
                         try {
@@ -149,7 +173,9 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
                         }
                     },
                     valueEqualiser,
-                    changelogRowDeduplicate);
+                    changelogRowDeduplicate,
+                    lookupStrategy,
+                    deletionVectorsMaintainer);
         }
     }
 
@@ -161,7 +187,8 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
         public MergeFunctionWrapper<ChangelogResult> create(
                 MergeFunctionFactory<KeyValue> mfFactory,
                 int outputLevel,
-                LookupLevels<Boolean> lookupLevels) {
+                LookupLevels<Boolean> lookupLevels,
+                @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer) {
             return new FistRowMergeFunctionWrapper(
                     mfFactory,
                     key -> {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -58,6 +58,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
     private final CompactRewriter rewriter;
 
     @Nullable private final CompactionMetrics.Reporter metricsReporter;
+    private final boolean deletionVectorsEnabled;
 
     public MergeTreeCompactManager(
             ExecutorService executor,
@@ -67,7 +68,8 @@ public class MergeTreeCompactManager extends CompactFutureManager {
             long compactionFileSize,
             int numSortedRunStopTrigger,
             CompactRewriter rewriter,
-            @Nullable CompactionMetrics.Reporter metricsReporter) {
+            @Nullable CompactionMetrics.Reporter metricsReporter,
+            boolean deletionVectorsEnabled) {
         this.executor = executor;
         this.levels = levels;
         this.strategy = strategy;
@@ -76,6 +78,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
         this.keyComparator = keyComparator;
         this.rewriter = rewriter;
         this.metricsReporter = metricsReporter;
+        this.deletionVectorsEnabled = deletionVectorsEnabled;
 
         MetricUtils.safeCall(this::reportLevel0FileCount, LOG);
     }
@@ -145,7 +148,8 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                      */
                     boolean dropDelete =
                             unit.outputLevel() != 0
-                                    && unit.outputLevel() >= levels.nonEmptyHighestLevel();
+                                    && (unit.outputLevel() >= levels.nonEmptyHighestLevel()
+                                            || deletionVectorsEnabled);
 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -21,6 +21,7 @@ package org.apache.paimon.mergetree.compact;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
@@ -46,6 +47,7 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
     @Nullable protected final FieldsComparator userDefinedSeqComparator;
     protected final MergeFunctionFactory<KeyValue> mfFactory;
     protected final MergeSorter mergeSorter;
+    @Nullable protected final DeletionVectorsMaintainer deletionVectorsMaintainer;
 
     public MergeTreeCompactRewriter(
             KeyValueFileReaderFactory readerFactory,
@@ -53,13 +55,15 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
             Comparator<InternalRow> keyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,
             MergeFunctionFactory<KeyValue> mfFactory,
-            MergeSorter mergeSorter) {
+            MergeSorter mergeSorter,
+            @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer) {
         this.readerFactory = readerFactory;
         this.writerFactory = writerFactory;
         this.keyComparator = keyComparator;
         this.userDefinedSeqComparator = userDefinedSeqComparator;
         this.mfFactory = mfFactory;
         this.mergeSorter = mergeSorter;
+        this.deletionVectorsMaintainer = deletionVectorsMaintainer;
     }
 
     @Override
@@ -83,6 +87,12 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
                         mergeSorter);
         writer.write(new RecordReaderIterator<>(sectionsReader));
         writer.close();
-        return new CompactResult(extractFilesFromSections(sections), writer.result());
+        List<DataFileMeta> before = extractFilesFromSections(sections);
+        if (deletionVectorsMaintainer != null) {
+            for (DataFileMeta dataFileMeta : before) {
+                deletionVectorsMaintainer.removeDeletionVectorOf(dataFileMeta.fileName());
+            }
+        }
+        return new CompactResult(before, writer.result());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -26,6 +26,7 @@ import org.apache.paimon.compact.CompactManager;
 import org.apache.paimon.compact.NoopCompactManager;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
@@ -85,7 +86,7 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
             FileStoreScan scan,
             CoreOptions options,
             String tableName) {
-        super(commitUser, snapshotManager, scan, options, null, tableName);
+        super(commitUser, snapshotManager, scan, options, null, null, tableName);
         this.fileIO = fileIO;
         this.read = read;
         this.schemaId = schemaId;
@@ -110,7 +111,8 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
             int bucket,
             List<DataFileMeta> restoredFiles,
             @Nullable CommitIncrement restoreIncrement,
-            ExecutorService compactExecutor) {
+            ExecutorService compactExecutor,
+            @Nullable DeletionVectorsMaintainer ignore) {
         // let writer and compact manager hold the same reference
         // and make restore files mutable to update
         long maxSequenceNumber = getMaxSequenceNumber(restoredFiles);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -20,6 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.FileStore;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.IndexMaintainer;
 import org.apache.paimon.io.DataFileMeta;
@@ -146,6 +147,7 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
         protected final long lastModifiedCommitIdentifier;
         protected final List<DataFileMeta> dataFiles;
         @Nullable protected final IndexMaintainer<T> indexMaintainer;
+        @Nullable protected final DeletionVectorsMaintainer deletionVectorsMaintainer;
         protected final CommitIncrement commitIncrement;
 
         protected State(
@@ -155,6 +157,7 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
                 long lastModifiedCommitIdentifier,
                 Collection<DataFileMeta> dataFiles,
                 @Nullable IndexMaintainer<T> indexMaintainer,
+                @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer,
                 CommitIncrement commitIncrement) {
             this.partition = partition;
             this.bucket = bucket;
@@ -162,19 +165,21 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
             this.lastModifiedCommitIdentifier = lastModifiedCommitIdentifier;
             this.dataFiles = new ArrayList<>(dataFiles);
             this.indexMaintainer = indexMaintainer;
+            this.deletionVectorsMaintainer = deletionVectorsMaintainer;
             this.commitIncrement = commitIncrement;
         }
 
         @Override
         public String toString() {
             return String.format(
-                    "{%s, %d, %d, %d, %s, %s, %s}",
+                    "{%s, %d, %d, %d, %s, %s,  %s, %s}",
                     partition,
                     bucket,
                     baseSnapshotId,
                     lastModifiedCommitIdentifier,
                     dataFiles,
                     indexMaintainer,
+                    deletionVectorsMaintainer,
                     commitIncrement);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.index.IndexMaintainer;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
@@ -60,12 +61,14 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
             FileStoreScan scan,
             CoreOptions options,
             @Nullable IndexMaintainer.Factory<T> indexFactory,
+            @Nullable DeletionVectorsMaintainer.Factory deletionVectorsMaintainerFactory,
             String tableName) {
         super(
                 commitUser,
                 snapshotManager,
                 scan,
                 indexFactory,
+                deletionVectorsMaintainerFactory,
                 tableName,
                 options.writeMaxWritersToSpill());
         this.options = options;

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.data.InternalRow;
@@ -89,7 +88,7 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
 
             MergeFunctionFactory<KeyValue> mfFactory =
                     PrimaryKeyTableUtils.createMergeFunctionFactory(tableSchema, extractor);
-            if (options.changelogProducer() == ChangelogProducer.LOOKUP) {
+            if (options.needLookup()) {
                 mfFactory =
                         LookupMergeFunction.wrap(
                                 mfFactory, new RowType(extractor.keyFields(tableSchema)), rowType);

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -86,7 +86,7 @@ public class LocalTableQuery implements TableQuery {
                         options.toConfiguration().get(CoreOptions.LOOKUP_HASH_LOAD_FACTOR),
                         options.toConfiguration().get(CoreOptions.LOOKUP_CACHE_SPILL_COMPRESSION));
 
-        if (options.changelogProducer() == CoreOptions.ChangelogProducer.LOOKUP) {
+        if (options.needLookup()) {
             startLevel = 1;
         } else {
             if (options.sequenceField().isPresent()) {

--- a/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainerTest.java
@@ -42,8 +42,8 @@ public class DeletionVectorsMaintainerTest extends PrimaryKeyTableTestBase {
 
     @Test
     public void test0() {
-        DeletionVectorsMaintainer.DeletionVectorsMaintainerFactory factory =
-                new DeletionVectorsMaintainer.DeletionVectorsMaintainerFactory(fileHandler);
+        DeletionVectorsMaintainer.Factory factory =
+                new DeletionVectorsMaintainer.Factory(fileHandler);
         DeletionVectorsMaintainer dvMaintainer =
                 factory.createOrRestore(null, BinaryRow.EMPTY_ROW, 0);
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -447,7 +447,8 @@ public abstract class MergeTreeTestBase {
                 options.compactionFileSize(),
                 options.numSortedRunStopTrigger(),
                 new TestRewriter(),
-                null);
+                null,
+                false);
     }
 
     static class MockFailResultCompactionManager extends MergeTreeCompactManager {
@@ -467,7 +468,8 @@ public abstract class MergeTreeTestBase {
                     minFileSize,
                     numSortedRunStopTrigger,
                     rewriter,
-                    null);
+                    null,
+                    false);
         }
 
         protected CompactResult obtainCompactResult()

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
+import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.FieldSumAgg;
@@ -69,7 +70,9 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                 RowType.of(DataTypes.INT())),
                         highLevel::get,
                         EQUALISER,
-                        changelogRowDeduplicate);
+                        changelogRowDeduplicate,
+                        LookupStrategy.CHANGELOG_ONLY,
+                        null);
 
         // Without level-0
         function.reset();
@@ -225,7 +228,9 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                 RowType.of(DataTypes.INT())),
                         key -> null,
                         EQUALISER,
-                        changelogRowDeduplicate);
+                        changelogRowDeduplicate,
+                        LookupStrategy.CHANGELOG_ONLY,
+                        null);
 
         // Without level-0
         function.reset();
@@ -384,7 +389,9 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                 RowType.of(DataTypes.INT())),
                         key -> null,
                         EQUALISER,
-                        false);
+                        false,
+                        LookupStrategy.CHANGELOG_ONLY,
+                        null);
 
         function.reset();
         function.add(new KeyValue().replace(row(1), 1, DELETE, row(1)).setLevel(2));

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
@@ -205,7 +205,8 @@ public class MergeTreeCompactManagerTest {
                         2,
                         Integer.MAX_VALUE,
                         new TestRewriter(expectedDropDelete),
-                        null);
+                        null,
+                        false);
         manager.triggerCompaction(false);
         manager.getCompactionResult(true);
         List<LevelMinMax> outputs =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.flink.configuration.ClusterOptions.ENABLE_FINE_GRAINED_RESOURCE_MANAGEMENT;
+import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_LOOKUP_WAIT;
@@ -101,9 +102,11 @@ public abstract class FlinkSink<T> implements Serializable {
         } else {
             Options options = table.coreOptions().toConfiguration();
             ChangelogProducer changelogProducer = table.coreOptions().changelogProducer();
+            // todo: deletion vectors support lookup wait
             waitCompaction =
-                    changelogProducer == ChangelogProducer.LOOKUP
-                            && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
+                    (changelogProducer == ChangelogProducer.LOOKUP
+                                    && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT))
+                            || options.get(DELETION_VECTORS_ENABLED);
 
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_LOOKUP_WAIT;
@@ -240,10 +241,11 @@ public class MultiTablesStoreCompactOperator
             Options options = fileStoreTable.coreOptions().toConfiguration();
             CoreOptions.ChangelogProducer changelogProducer =
                     fileStoreTable.coreOptions().changelogProducer();
+            // todo: deletion vectors support lookup wait
             waitCompaction =
-                    changelogProducer == CoreOptions.ChangelogProducer.LOOKUP
-                            && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
-
+                    (changelogProducer == CoreOptions.ChangelogProducer.LOOKUP
+                                    && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT))
+                            || options.get(DELETION_VECTORS_ENABLED);
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -338,7 +338,22 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
 
     private void testNoChangelogProducerRandom(
             TableEnvironment tEnv, int numProducers, boolean enableFailure) throws Exception {
-        List<TableResult> results = testRandom(tEnv, numProducers, enableFailure, "'bucket' = '4'");
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        boolean enableDeletionVectors = random.nextBoolean();
+        if (enableDeletionVectors) {
+            // Deletion vectors mode not support concurrent write
+            numProducers = 1;
+        }
+        List<TableResult> results =
+                testRandom(
+                        tEnv,
+                        numProducers,
+                        enableFailure,
+                        "'bucket' = '4',"
+                                + String.format(
+                                        "'deletion-vectors.enabled' = '%s'",
+                                        enableDeletionVectors));
+
         for (TableResult result : results) {
             result.await();
         }
@@ -370,7 +385,11 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
     private void testLookupChangelogProducerRandom(
             TableEnvironment tEnv, int numProducers, boolean enableFailure) throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
-
+        boolean enableDeletionVectors = random.nextBoolean();
+        if (enableDeletionVectors) {
+            // Deletion vectors mode not support concurrent write
+            numProducers = 1;
+        }
         testRandom(
                 tEnv,
                 numProducers,
@@ -381,7 +400,9 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                                 random.nextBoolean() ? "512kb" : "1mb")
                         + "'changelog-producer' = 'lookup',"
                         + String.format(
-                                "'changelog-producer.lookup-wait' = '%s'", random.nextBoolean()));
+                                "'changelog-producer.lookup-wait' = '%s',", random.nextBoolean())
+                        + String.format(
+                                "'deletion-vectors.enabled' = '%s'", enableDeletionVectors));
 
         // sleep for a random amount of time to check
         // if we can first read complete records then read incremental records correctly

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -138,7 +138,9 @@ public class TestChangelogDataReadWrite {
                                 ignore -> avro,
                                 pathFactory,
                                 EXTRACTOR,
-                                new CoreOptions(new HashMap<>())));
+                                new CoreOptions(new HashMap<>())),
+                        new CoreOptions(new HashMap<>()),
+                        null);
         return new KeyValueTableRead(read, null) {
 
             @Override
@@ -192,6 +194,7 @@ public class TestChangelogDataReadWrite {
                                 pathFactoryMap,
                                 snapshotManager,
                                 null, // not used, we only create an empty writer
+                                null,
                                 null,
                                 options,
                                 EXTRACTOR,

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeletionVectorTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeletionVectorTest.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.data.BinaryRow
+import org.apache.paimon.deletionvectors.{DeletionVector, DeletionVectorsMaintainer}
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+import org.junit.jupiter.api.Assertions
+
+import scala.util.Random
+
+class DeletionVectorTest extends PaimonSparkTestBase {
+
+  test("Paimon deletionVector: deletion vector write verification") {
+    withTable("T") {
+      spark.sql(s"""
+                   |CREATE TABLE T (id INT, name STRING)
+                   |TBLPROPERTIES (
+                   | 'bucket' = '1',
+                   | 'primary-key' = 'id',
+                   | 'file.format' = 'parquet',
+                   | 'deletion-vectors.enabled' = 'true'
+                   |)
+                   |""".stripMargin)
+      val table = loadTable("T")
+
+      // Insert1
+      // f1 (1, 2, 3), row with positions 0 and 2 in f1 are marked deleted
+      // f2 (1, 3)
+      spark.sql("INSERT INTO T VALUES (1, 'aaaaaaaaaaaaaaaaaaa'), (2, 'b'), (3, 'c')")
+      spark.sql("INSERT INTO T VALUES (1, 'a_new1'), (3, 'c_new1')")
+      checkAnswer(
+        spark.sql(s"SELECT * from T ORDER BY id"),
+        Row(1, "a_new1") :: Row(2, "b") :: Row(3, "c_new1") :: Nil)
+
+      val dvMaintainerFactory =
+        new DeletionVectorsMaintainer.Factory(table.store().newIndexFileHandler())
+
+      def restoreDeletionVectors(): java.util.Map[String, DeletionVector] = {
+        dvMaintainerFactory
+          .createOrRestore(table.snapshotManager().latestSnapshotId(), BinaryRow.EMPTY_ROW, 0)
+          .deletionVectors()
+      }
+
+      val deletionVectors1 = restoreDeletionVectors()
+      // 1, 3 deleted, their row positions are 0, 2
+      Assertions.assertEquals(1, deletionVectors1.size())
+      deletionVectors1
+        .entrySet()
+        .forEach(
+          e => {
+            Assertions.assertTrue(e.getValue.isDeleted(0))
+            Assertions.assertTrue(e.getValue.isDeleted(2))
+          })
+
+      // Compact
+      // f3 (1, 2, 3), no deletion
+      spark.sql("CALL sys.compact('T')")
+      val deletionVectors2 = restoreDeletionVectors()
+      // After compaction, deletionVectors should be empty
+      Assertions.assertTrue(deletionVectors2.isEmpty)
+
+      // Insert2
+      // f3 (1, 2, 3), row with position 1 in f3 is marked deleted
+      // f4 (2)
+      spark.sql("INSERT INTO T VALUES (2, 'b_new2')")
+      checkAnswer(
+        spark.sql(s"SELECT * from T ORDER BY id"),
+        Row(1, "a_new1") :: Row(2, "b_new2") :: Row(3, "c_new1") :: Nil)
+
+      val deletionVectors3 = restoreDeletionVectors()
+      // 2 deleted, row positions is 1
+      Assertions.assertEquals(1, deletionVectors3.size())
+      deletionVectors3
+        .entrySet()
+        .forEach(
+          e => {
+            Assertions.assertTrue(e.getValue.isDeleted(1))
+          })
+    }
+  }
+
+  test("Paimon deletionVector: e2e random write") {
+    val bucket = Random.shuffle(Seq("-1", "1", "3")).head
+    val changelogProducer = Random.shuffle(Seq("none", "lookup")).head
+    val format = Random.shuffle(Seq("orc", "parquet")).head
+    val batchSize = Random.nextInt(1024) + 1
+
+    val dvTbl = "deletion_vector_tbl"
+    val resultTbl = "result_tbl"
+    spark.sql(s"drop table if exists $dvTbl")
+    spark.sql(s"""
+                 |CREATE TABLE $dvTbl (id INT, name STRING, pt STRING)
+                 |TBLPROPERTIES (
+                 | 'primary-key' = 'id, pt',
+                 | 'deletion-vectors.enabled' = 'true',
+                 | 'bucket' = '$bucket',
+                 | 'changelog-producer' = '$changelogProducer',
+                 | 'file.format' = '$format',
+                 | 'read.batch-size' = '$batchSize'
+                 |)
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    spark.sql(s"drop table if exists $resultTbl")
+    spark.sql(s"""
+                 |CREATE TABLE $resultTbl (id INT, name STRING, pt STRING)
+                 |TBLPROPERTIES (
+                 | 'primary-key' = 'id, pt',
+                 | 'deletion-vectors.enabled' = 'false'
+                 |)
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    def insert(t1: String, t2: String, count: Int): Unit = {
+      val ids = (1 to count).map(_ => Random.nextInt(10000))
+      val names = (1 to count).map(_ => (Random.nextInt(26) + 'a'.toInt).toChar.toString)
+      val pts = (1 to count).map(_ => s"p${Random.nextInt(3)}")
+      val values = ids
+        .zip(names)
+        .zip(pts)
+        .map { case ((id, name), pt) => s"($id, '$name', '$pt')" }
+        .mkString(", ")
+      spark.sql(s"INSERT INTO $t1 VALUES $values")
+      spark.sql(s"INSERT INTO $t2 VALUES $values")
+    }
+
+    def delete(t1: String, t2: String, count: Int): Unit = {
+      val ids = (1 to count).map(_ => Random.nextInt(10000)).toList
+      val idsString = ids.mkString(", ")
+      spark.sql(s"DELETE FROM $t1 WHERE id IN ($idsString)")
+      spark.sql(s"DELETE FROM $t2 WHERE id IN ($idsString)")
+    }
+
+    def update(t1: String, t2: String, count: Int): Unit = {
+      val ids = (1 to count).map(_ => Random.nextInt(10000)).toList
+      val idsString = ids.mkString(", ")
+      val randomName = (Random.nextInt(26) + 'a'.toInt).toChar.toString
+      spark.sql(s"UPDATE $t1 SET name = '$randomName' WHERE id IN ($idsString)")
+      spark.sql(s"UPDATE $t2 SET name = '$randomName' WHERE id IN ($idsString)")
+    }
+
+    def checkResult(t1: String, t2: String): Unit = {
+      try {
+        checkAnswer(
+          spark.sql(s"SELECT * FROM $t1 ORDER BY id, pt"),
+          spark.sql(s"SELECT * FROM $t2 ORDER BY id, pt"))
+      } catch {
+        case e: Throwable =>
+          println(s"test error, table params: ${loadTable(dvTbl).options()}")
+          throw new RuntimeException(e)
+      }
+    }
+
+    val operations = Seq(
+      () => insert(dvTbl, resultTbl, 1000),
+      () => update(dvTbl, resultTbl, 100),
+      () => delete(dvTbl, resultTbl, 100)
+    )
+
+    // Insert first
+    operations.head()
+    checkResult(dvTbl, resultTbl)
+
+    for (_ <- 1 to 20) {
+      // Randomly select an operation
+      operations(Random.nextInt(operations.size))()
+      checkResult(dvTbl, resultTbl)
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

subTask of #2898, in this PR:

- add a new conf `deletion-vectors.enabled` to control whether deletion vector mode is enabled. Limit:
  - pk table
  - `file.format` = `orc` or `parquet`
  - `changelog-producer` = `none` or `lookup`
  - `merge-engine` != `first-row` (implement it in the future)
  
- integrate deletion vector to reader and writer, when `deletion-vectors.enabled` is true:
  - for writer: update dv index when lookup, since drop delete is necessary, rewrite is always required in lookup compaction
  - for reader: introduce `ApplyDeletionVectorReader` for applying DeletionVector to filter record

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
