### PR TITLE
[core] Optimize full compaction for manifest entries

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -81,14 +81,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
      * <p>NOTE: This method is atomic.
      */
     public List<ManifestFileMeta> write(List<ManifestEntry> entries) {
-        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
-                new RollingFileWriter<>(
-                        () ->
-                                new ManifestEntryWriter(
-                                        writerFactory,
-                                        pathFactory.newPath(),
-                                        CoreOptions.FILE_COMPRESSION.defaultValue()),
-                        suggestedFileSize);
+        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer = createRollingWriter();
         try {
             writer.write(entries);
             writer.close();
@@ -96,6 +89,16 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
             throw new RuntimeException(e);
         }
         return writer.result();
+    }
+
+    public RollingFileWriter<ManifestEntry, ManifestFileMeta> createRollingWriter() {
+        return new RollingFileWriter<>(
+                () ->
+                        new ManifestEntryWriter(
+                                writerFactory,
+                                pathFactory.newPath(),
+                                CoreOptions.FILE_COMPRESSION.defaultValue()),
+                suggestedFileSize);
     }
 
     private class ManifestEntryWriter extends SingleFileWriter<ManifestEntry, ManifestFileMeta> {

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.manifest;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.manifest.FileEntry.Identifier;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -28,6 +29,7 @@ import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
 
 import org.slf4j.Logger;
@@ -41,7 +43,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Metadata of a manifest file. */
 public class ManifestFileMeta {
@@ -170,7 +175,7 @@ public class ManifestFileMeta {
             for (ManifestFileMeta manifest : newMetas) {
                 manifestFile.delete(manifest.fileName);
             }
-            throw e;
+            throw new RuntimeException(e);
         }
     }
 
@@ -229,7 +234,8 @@ public class ManifestFileMeta {
             ManifestFile manifestFile,
             long suggestedMetaSize,
             long sizeTrigger,
-            RowType partitionType) {
+            RowType partitionType)
+            throws Exception {
         // 1. should trigger full compaction
 
         List<ManifestFileMeta> base = new ArrayList<>();
@@ -311,15 +317,16 @@ public class ManifestFileMeta {
                     }
                 });
 
-        Map<Identifier, ManifestEntry> fullMerged = new LinkedHashMap<>();
+        List<ManifestEntry> mergedEntries = new ArrayList<>();
         for (; j < base.size(); j++) {
             ManifestFileMeta file = base.get(j);
-            FileEntry.mergeEntries(manifestFile.read(file.fileName), fullMerged);
             boolean contains = false;
-            for (Identifier identifier : deleteEntries) {
-                if (fullMerged.containsKey(identifier)) {
+            for (ManifestEntry entry : manifestFile.read(file.fileName)) {
+                checkArgument(entry.kind() == FileKind.ADD);
+                if (deleteEntries.contains(entry.identifier())) {
                     contains = true;
-                    break;
+                } else {
+                    mergedEntries.add(entry);
                 }
             }
             if (contains) {
@@ -327,25 +334,53 @@ public class ManifestFileMeta {
                 j++;
                 break;
             } else {
-                fullMerged.clear();
+                mergedEntries.clear();
                 result.add(file);
             }
         }
 
-        // 2.3. merge base files
+        // 2.3. merge
 
-        FileEntry.mergeEntries(manifestFile, base.subList(j, base.size()), fullMerged);
-        FileEntry.mergeEntries(deltaMerged.values(), fullMerged);
+        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
+                manifestFile.createRollingWriter();
+        Exception exception = null;
+        try {
 
-        // 2.4. write new manifest files
+            // 2.3.1 merge mergedEntries
+            for (ManifestEntry entry : mergedEntries) {
+                writer.write(entry);
+            }
 
-        if (!fullMerged.isEmpty()) {
-            List<ManifestFileMeta> merged =
-                    manifestFile.write(new ArrayList<>(fullMerged.values()));
-            result.addAll(merged);
-            newMetas.addAll(merged);
+            // 2.3.2 merge base files
+            for (Supplier<List<ManifestEntry>> reader :
+                    FileEntry.readManifestEntries(manifestFile, base.subList(j, base.size()))) {
+                for (ManifestEntry entry : reader.get()) {
+                    checkArgument(entry.kind() == FileKind.ADD);
+                    if (!deleteEntries.contains(entry.identifier())) {
+                        writer.write(entry);
+                    }
+                }
+            }
+
+            // 2.3.3 merge deltaMerged
+            for (ManifestEntry entry : deltaMerged.values()) {
+                if (entry.kind() == FileKind.ADD) {
+                    writer.write(entry);
+                }
+            }
+        } catch (Exception e) {
+            exception = e;
+        } finally {
+            if (exception != null) {
+                IOUtils.closeQuietly(writer);
+                throw exception;
+            }
+            writer.close();
         }
 
+        List<ManifestFileMeta> merged = writer.result();
+        result.addAll(merged);
+        newMetas.addAll(merged);
         return Optional.of(result);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -210,7 +210,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
     }
 
     @Test
-    public void testTriggerFullCompaction() {
+    public void testTriggerFullCompaction() throws Exception {
         List<ManifestEntry> entries = new ArrayList<>();
         for (int i = 0; i < 16; i++) {
             entries.add(makeEntry(true, String.valueOf(i)));
@@ -260,7 +260,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
     }
 
     @Test
-    public void testMultiPartitionsFullCompaction() {
+    public void testMultiPartitionsFullCompaction() throws Exception {
 
         List<ManifestFileMeta> input = createBaseManifestFileMetas(true);
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -107,6 +107,7 @@ public abstract class ManifestFileMetaTestBase {
                         .collect(Collectors.toList());
         List<String> entryBeforeMerge =
                 FileEntry.mergeEntries(inputEntry).stream()
+                        .filter(entry -> entry.kind() == FileKind.ADD)
                         .map(entry -> entry.kind() + "-" + entry.file().fileName())
                         .collect(Collectors.toList());
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Before optimization: Read all entries into memory, which is prone to OOM.
Optimized: Stream read entries into files, no longer reading all entries into memory.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
