### PR TITLE
[hive] Drop a Hive external table only deletes metadata but not data files.

### DIFF
--- a/docs/layouts/shortcodes/generated/jdbc_catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/jdbc_catalog_configuration.html
@@ -28,7 +28,7 @@ under the License.
     <tbody>
         <tr>
             <td><h5>catalog-key</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">"jdbc"</td>
             <td>String</td>
             <td>Custom jdbc catalog store key.</td>
         </tr>

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -31,7 +31,6 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.utils.Preconditions;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
@@ -78,7 +77,7 @@ public class JdbcCatalog extends AbstractCatalog {
     protected JdbcCatalog(
             FileIO fileIO, String catalogKey, Map<String, String> config, String warehouse) {
         super(fileIO);
-        this.catalogKey = StringUtils.isBlank(catalogKey) ? "jdbc" : catalogKey;
+        this.catalogKey = catalogKey;
         this.options = config;
         this.warehouse = warehouse;
         Preconditions.checkNotNull(options, "Invalid catalog properties: null");

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
@@ -27,7 +27,7 @@ public final class JdbcCatalogOptions {
     public static final ConfigOption<String> CATALOG_KEY =
             ConfigOptions.key("catalog-key")
                     .stringType()
-                    .defaultValue(null)
+                    .defaultValue("jdbc")
                     .withDescription("Custom jdbc catalog store key.");
 
     private JdbcCatalogOptions() {}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
@@ -140,15 +140,15 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
 
                                 Pair<int[], RowType> partitionPair = null;
                                 if (!dataSchema.partitionKeys().isEmpty()) {
-                                    Pair<int[], int[][]> partitionMappping =
+                                    Pair<int[], int[][]> partitionMapping =
                                             PartitionUtils.constructPartitionMapping(
                                                     dataSchema, dataProjection);
                                     // if partition fields are not selected, we just do nothing
-                                    if (partitionMappping != null) {
-                                        dataProjection = partitionMappping.getRight();
+                                    if (partitionMapping != null) {
+                                        dataProjection = partitionMapping.getRight();
                                         partitionPair =
                                                 Pair.of(
-                                                        partitionMappping.getLeft(),
+                                                        partitionMapping.getLeft(),
                                                         dataSchema.projectedLogicalRowType(
                                                                 dataSchema.partitionKeys()));
                                     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -64,6 +64,7 @@ public class BulkFormatMapping {
         return castMapping;
     }
 
+    @Nullable
     public Pair<int[], RowType> getPartitionPair() {
         return partitionPair;
     }
@@ -166,15 +167,15 @@ public class BulkFormatMapping {
 
             Pair<int[], RowType> partitionPair = null;
             if (!dataSchema.partitionKeys().isEmpty()) {
-                Pair<int[], int[][]> partitionMappping =
+                Pair<int[], int[][]> partitionMapping =
                         PartitionUtils.constructPartitionMapping(
                                 dataRecordType, dataSchema.partitionKeys(), dataProjection);
                 // is partition fields are not selected, we just do nothing.
-                if (partitionMappping != null) {
-                    dataProjection = partitionMappping.getRight();
+                if (partitionMapping != null) {
+                    dataProjection = partitionMapping.getRight();
                     partitionPair =
                             Pair.of(
-                                    partitionMappping.getLeft(),
+                                    partitionMapping.getLeft(),
                                     dataSchema.projectedLogicalRowType(dataSchema.partitionKeys()));
                 }
             }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -508,14 +508,6 @@ public class HiveCatalog extends AbstractCatalog {
         return table;
     }
 
-    private TableType hiveTableType() {
-        TableType tableType =
-                OptionsUtils.convertToEnum(
-                        hiveConf.get(TABLE_TYPE.key(), TableType.MANAGED.toString()),
-                        TableType.class);
-        return tableType;
-    }
-
     private void updateHmsTable(Table table, Identifier identifier, TableSchema schema) {
         StorageDescriptor sd = new StorageDescriptor();
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -277,7 +277,7 @@ public abstract class HiveCatalogITCaseBase {
                 .isTrue();
         tEnv.executeSql("DROP TABLE t").await();
         Path tablePath = new Path(path, "test_db.db/t");
-        assertThat(tablePath.getFileSystem().exists(tablePath)).isFalse();
+        assertThat(tablePath.getFileSystem().exists(tablePath)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

1.Drop a Hive external table only deletes metadata but not data files.
2.Remove uncalled methods: checkIdentifierUpperCase、schemaFileExists
3.Modify wrong words


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
