### PR TITLE
[hive] hivesql query paimon external table can work after schema evolution. 

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
@@ -49,7 +49,7 @@ public class SearchArgumentToPredicateConverter {
 
     private final ExpressionTree root;
     private final List<PredicateLeaf> leaves;
-    private final List<String> columnNames;
+    private final List<String> hiveColumnNames;
     private final List<DataType> columnTypes;
     @Nullable private final Set<String> readColumnNames;
     private final PredicateBuilder builder;
@@ -61,7 +61,7 @@ public class SearchArgumentToPredicateConverter {
             @Nullable Set<String> readColumnNames) {
         this.root = searchArgument.getExpression();
         this.leaves = searchArgument.getLeaves();
-        this.columnNames =
+        this.hiveColumnNames =
                 columnNames.stream().map(String::toLowerCase).collect(Collectors.toList());
         this.columnTypes = columnTypes;
         if (readColumnNames != null) {
@@ -74,7 +74,7 @@ public class SearchArgumentToPredicateConverter {
                 new PredicateBuilder(
                         RowType.of(
                                 this.columnTypes.toArray(new DataType[0]),
-                                this.columnNames.toArray(new String[0])));
+                                columnNames.toArray(new String[0])));
     }
 
     public Optional<Predicate> convert() {
@@ -140,7 +140,7 @@ public class SearchArgumentToPredicateConverter {
                             + " is a partition column.");
         }
 
-        int idx = columnNames.indexOf(columnName);
+        int idx = hiveColumnNames.indexOf(columnName);
         Preconditions.checkArgument(idx >= 0, "Column " + columnName + " not found.");
         DataType columnType = columnTypes.get(idx);
         switch (leaf.getOperator()) {


### PR DESCRIPTION
…whatever use uppercase or lowercase field name in sql.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2844

hivesql query paimon external table can work after schema evolution. whatever use uppercase or lowercase field name in sql.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
