### PR TITLE
[core] KeyValueTableRead should always project keys

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ConcatRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ConcatRecordReader.java
@@ -24,6 +24,7 @@ import org.apache.paimon.utils.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -48,6 +49,11 @@ public class ConcatRecordReader<T> implements RecordReader<T> {
 
     public static <R> RecordReader<R> create(List<ReaderSupplier<R>> readers) throws IOException {
         return readers.size() == 1 ? readers.get(0).get() : new ConcatRecordReader<>(readers);
+    }
+
+    public static <R> RecordReader<R> create(ReaderSupplier<R> reader1, ReaderSupplier<R> reader2)
+            throws IOException {
+        return create(Arrays.asList(reader1, reader2));
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
@@ -200,12 +200,13 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
             // streaming concat read
             return ConcatRecordReader.create(
                     () ->
-                            noMergeRead(
-                                    split.partition(),
-                                    split.bucket(),
-                                    split.beforeFiles(),
-                                    split.beforeDeletionFiles().orElse(null),
-                                    true),
+                            new ReverseReader(
+                                    noMergeRead(
+                                            split.partition(),
+                                            split.bucket(),
+                                            split.beforeFiles(),
+                                            split.beforeDeletionFiles().orElse(null),
+                                            true)),
                     () ->
                             noMergeRead(
                                     split.partition(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreRead.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -180,77 +179,79 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
 
     private RecordReader<KeyValue> createReaderWithoutOuterProjection(DataSplit split)
             throws IOException {
-        ReaderSupplier<KeyValue> beforeSupplier = null;
-        if (split.beforeFiles().size() > 0) {
-            if (split.isStreaming() || split.beforeDeletionFiles().isPresent()) {
-                beforeSupplier =
-                        () ->
-                                new ReverseReader(
-                                        noMergeRead(
-                                                split.partition(),
-                                                split.bucket(),
-                                                split.beforeFiles(),
-                                                split.beforeDeletionFiles().orElse(null),
-                                                split.isStreaming()));
+        if (split.beforeFiles().isEmpty()) {
+            if (split.isStreaming() || split.deletionFiles().isPresent()) {
+                return noMergeRead(
+                        split.partition(),
+                        split.bucket(),
+                        split.dataFiles(),
+                        split.deletionFiles().orElse(null),
+                        split.isStreaming());
             } else {
-                beforeSupplier =
-                        () ->
-                                mergeRead(
-                                        split.partition(),
-                                        split.bucket(),
-                                        split.beforeFiles(),
-                                        false);
+                return mergeRead(
+                        split.partition(),
+                        split.bucket(),
+                        split.dataFiles(),
+                        split.deletionFiles().orElse(null),
+                        forceKeepDelete,
+                        true);
             }
-        }
-
-        ReaderSupplier<KeyValue> dataSupplier;
-        if (split.isStreaming() || split.deletionFiles().isPresent()) {
-            dataSupplier =
+        } else if (split.isStreaming()) {
+            // streaming concat read
+            return ConcatRecordReader.create(
+                    () ->
+                            noMergeRead(
+                                    split.partition(),
+                                    split.bucket(),
+                                    split.beforeFiles(),
+                                    split.beforeDeletionFiles().orElse(null),
+                                    true),
                     () ->
                             noMergeRead(
                                     split.partition(),
                                     split.bucket(),
                                     split.dataFiles(),
                                     split.deletionFiles().orElse(null),
-                                    split.isStreaming());
+                                    true));
         } else {
-            dataSupplier =
-                    () ->
-                            mergeRead(
-                                    split.partition(),
-                                    split.bucket(),
-                                    split.dataFiles(),
-                                    split.beforeFiles().isEmpty() && forceKeepDelete);
-        }
-
-        if (split.isStreaming()) {
-            return beforeSupplier == null
-                    ? dataSupplier.get()
-                    : ConcatRecordReader.create(Arrays.asList(beforeSupplier, dataSupplier));
-        } else {
-            return beforeSupplier == null
-                    ? dataSupplier.get()
-                    : DiffReader.readDiff(
-                            beforeSupplier.get(),
-                            dataSupplier.get(),
-                            keyComparator,
-                            userDefinedSeqComparator,
-                            mergeSorter,
-                            forceKeepDelete);
+            // batch diff read
+            return DiffReader.readDiff(
+                    mergeRead(
+                            split.partition(),
+                            split.bucket(),
+                            split.beforeFiles(),
+                            split.beforeDeletionFiles().orElse(null),
+                            false,
+                            false),
+                    mergeRead(
+                            split.partition(),
+                            split.bucket(),
+                            split.dataFiles(),
+                            split.deletionFiles().orElse(null),
+                            false,
+                            false),
+                    keyComparator,
+                    userDefinedSeqComparator,
+                    mergeSorter,
+                    forceKeepDelete);
         }
     }
 
     private RecordReader<KeyValue> mergeRead(
-            BinaryRow partition, int bucket, List<DataFileMeta> files, boolean keepDelete)
+            BinaryRow partition,
+            int bucket,
+            List<DataFileMeta> files,
+            @Nullable List<DeletionFile> deletionFiles,
+            boolean keepDelete,
+            boolean projectKeys)
             throws IOException {
         // Sections are read by SortMergeReader, which sorts and merges records by keys.
         // So we cannot project keys or else the sorting will be incorrect.
+        DeletionVector.Factory dvFactory = DeletionVector.factory(fileIO, files, deletionFiles);
         KeyValueFileReaderFactory overlappedSectionFactory =
-                readerFactoryBuilder.build(
-                        partition, bucket, DeletionVector.emptyFactory(), false, filtersForKeys);
+                readerFactoryBuilder.build(partition, bucket, dvFactory, false, filtersForKeys);
         KeyValueFileReaderFactory nonOverlappedSectionFactory =
-                readerFactoryBuilder.build(
-                        partition, bucket, DeletionVector.emptyFactory(), false, filtersForAll);
+                readerFactoryBuilder.build(partition, bucket, dvFactory, false, filtersForAll);
 
         List<ReaderSupplier<KeyValue>> sectionReaders = new ArrayList<>();
         MergeFunctionWrapper<KeyValue> mergeFuncWrapper =
@@ -274,8 +275,12 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
             reader = new DropDeleteReader(reader);
         }
 
-        // Project results from SortMergeReader using ProjectKeyRecordReader.
-        return keyProjectedFields == null ? reader : projectKey(reader, keyProjectedFields);
+        if (projectKeys) {
+            // Project results from SortMergeReader using ProjectKeyRecordReader.
+            reader = keyProjectedFields == null ? reader : projectKey(reader, keyProjectedFields);
+        }
+
+        return reader;
     }
 
     private RecordReader<KeyValue> noMergeRead(
@@ -285,12 +290,11 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
             @Nullable List<DeletionFile> deletionFiles,
             boolean onlyFilterKey)
             throws IOException {
-        DeletionVector.Factory dvFactory = DeletionVector.factory(fileIO, files, deletionFiles);
         KeyValueFileReaderFactory readerFactory =
                 readerFactoryBuilder.build(
                         partition,
                         bucket,
-                        dvFactory,
+                        DeletionVector.factory(fileIO, files, deletionFiles),
                         true,
                         onlyFilterKey ? filtersForKeys : filtersForAll);
         List<ReaderSupplier<KeyValue>> suppliers = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -39,7 +39,9 @@ public abstract class KeyValueTableRead extends AbstractDataTableRead<KeyValue> 
 
     protected KeyValueTableRead(KeyValueFileStoreRead read, TableSchema schema) {
         super(read, schema);
-        this.read = read;
+        // We don't need any key fields, the columns that need to be read are already included in
+        // the value
+        this.read = read.withKeyProjection(new int[0][]);
     }
 
     @Override
@@ -51,10 +53,6 @@ public abstract class KeyValueTableRead extends AbstractDataTableRead<KeyValue> 
     @Override
     public final RecordReader<InternalRow> reader(Split split) throws IOException {
         return new RowDataRecordReader(read.createReader((DataSplit) split));
-    }
-
-    public final RecordReader<KeyValue> kvReader(Split split) throws IOException {
-        return read.createReader((DataSplit) split);
     }
 
     protected abstract RecordReader.RecordIterator<InternalRow> rowDataRecordIteratorFromKv(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In fact, `KeyValueTableRead` only reads the content of the value and does not read the columns of the key. We should default to opening the projection of the key.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
