### PR TITLE
[core] Refactor MergeTreeReaders.readerForMergeTree to unify invoking

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeReaders.java
@@ -24,9 +24,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader.ReaderSupplier;
-import org.apache.paimon.mergetree.compact.MergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
-import org.apache.paimon.mergetree.compact.ReducerMergeFunctionWrapper;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.utils.FieldsComparator;
 
@@ -42,16 +40,15 @@ public class MergeTreeReaders {
 
     private MergeTreeReaders() {}
 
-    public static RecordReader<KeyValue> readerForMergeTree(
+    public static <T> RecordReader<T> readerForMergeTree(
             List<List<SortedRun>> sections,
-            boolean dropDelete,
             KeyValueFileReaderFactory readerFactory,
             Comparator<InternalRow> userKeyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,
-            MergeFunction<KeyValue> mergeFunction,
+            MergeFunctionWrapper<T> mergeFunctionWrapper,
             MergeSorter mergeSorter)
             throws IOException {
-        List<ReaderSupplier<KeyValue>> readers = new ArrayList<>();
+        List<ReaderSupplier<T>> readers = new ArrayList<>();
         for (List<SortedRun> section : sections) {
             readers.add(
                     () ->
@@ -60,14 +57,10 @@ public class MergeTreeReaders {
                                     readerFactory,
                                     userKeyComparator,
                                     userDefinedSeqComparator,
-                                    new ReducerMergeFunctionWrapper(mergeFunction),
+                                    mergeFunctionWrapper,
                                     mergeSorter));
         }
-        RecordReader<KeyValue> reader = ConcatRecordReader.create(readers);
-        if (dropDelete) {
-            reader = new DropDeleteReader(reader);
-        }
-        return reader;
+        return ConcatRecordReader.create(readers);
     }
 
     public static <T> RecordReader<T> readerForSection(
@@ -86,7 +79,7 @@ public class MergeTreeReaders {
                 readers, userKeyComparator, userDefinedSeqComparator, mergeFunctionWrapper);
     }
 
-    public static RecordReader<KeyValue> readerForRun(
+    private static RecordReader<KeyValue> readerForRun(
             SortedRun run, KeyValueFileReaderFactory readerFactory) throws IOException {
         List<ReaderSupplier<KeyValue>> readers = new ArrayList<>();
         for (DataFileMeta file : run.files()) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
(Just code refactor) Compaction should only invoke one `MergeTreeReaders.readerForMergeTree`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
