### PR TITLE
[flink] Remove MigrateDatabaseProcedure's dependency on Hive

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
@@ -22,4 +22,6 @@ package org.apache.paimon.migrate;
 public interface Migrator {
 
     void executeMigrate() throws Exception;
+
+    void renameTable(boolean ignoreIfNotExists) throws Exception;
 }

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -35,7 +35,6 @@ under the License.
 
     <properties>
         <flink.version>1.18.1</flink.version>
-        <hive.version>2.3.9</hive.version>
     </properties>
 
     <dependencies>
@@ -65,59 +64,6 @@ under the License.
             <artifactId>flink-table-runtime</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-metastore</artifactId>
-            <version>${hive.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.pentaho</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-storage-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -18,23 +18,17 @@
 
 package org.apache.paimon.flink.procedure;
 
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.hive.HiveCatalog;
+import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 /** Migrate procedure to migrate all hive tables in database to paimon table. */
 public class MigrateDatabaseProcedure extends ProcedureBase {
-
-    private static final Logger LOG = LoggerFactory.getLogger(MigrateDatabaseProcedure.class);
-    private static final String PAIMON_SUFFIX = "_paimon_";
 
     @Override
     public String identifier() {
@@ -57,28 +51,18 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             throw new IllegalArgumentException("Only support Hive Catalog");
         }
         HiveCatalog hiveCatalog = (HiveCatalog) this.catalog;
-        IMetaStoreClient client = hiveCatalog.getHmsClient();
-        List<String> sourceTables = client.getAllTables(sourceDatabasePath);
-        for (String sourceTable : sourceTables) {
-            String sourceTablePath = sourceDatabasePath + "." + sourceTable;
-            String targetPaimonTablePath = sourceTablePath + PAIMON_SUFFIX;
+        List<Migrator> migrators =
+                TableMigrationUtils.getImporters(
+                        connector,
+                        hiveCatalog,
+                        sourceDatabasePath,
+                        ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-            Identifier sourceTableId = Identifier.fromString(sourceTablePath);
-            Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
-
-            TableMigrationUtils.getImporter(
-                            connector,
-                            (HiveCatalog) this.catalog,
-                            sourceTableId.getDatabaseName(),
-                            sourceTableId.getObjectName(),
-                            targetTableId.getDatabaseName(),
-                            targetTableId.getObjectName(),
-                            ParameterUtils.parseCommaSeparatedKeyValues(properties))
-                    .executeMigrate();
-
-            LOG.info("rename " + targetTableId + " to " + sourceTableId);
-            this.catalog.renameTable(targetTableId, sourceTableId, false);
+        for (Migrator migrator : migrators) {
+            migrator.executeMigrate();
+            migrator.renameTable(false);
         }
+
         return new String[] {"Success"};
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableMigrationUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableMigrationUtils.java
@@ -22,6 +22,7 @@ import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.hive.migrate.HiveMigrator;
 import org.apache.paimon.migrate.Migrator;
 
+import java.util.List;
 import java.util.Map;
 
 /** Migration util to choose importer according to connector. */
@@ -44,6 +45,19 @@ public class TableMigrationUtils {
                         targetDatabase,
                         targetTableName,
                         options);
+            default:
+                throw new UnsupportedOperationException("Don't support connector " + connector);
+        }
+    }
+
+    public static List<Migrator> getImporters(
+            String connector,
+            HiveCatalog paimonCatalog,
+            String sourceDatabase,
+            Map<String, String> options) {
+        switch (connector) {
+            case "hive":
+                return HiveMigrator.databaseMigrators(paimonCatalog, sourceDatabase, options);
             default:
                 throw new UnsupportedOperationException("Don't support connector " + connector);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
paimon-flink module should not depend on Hive directly.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
