### PR TITLE
[common] Cache the ServiceLoader.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -25,13 +25,13 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ServiceLoaderUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.ServiceLoader;
 
 /**
  * Factory class which creates reader and writer factories for specific file format.
@@ -92,9 +92,8 @@ public abstract class FileFormat {
 
     private static Optional<FileFormat> fromIdentifier(
             String formatIdentifier, FormatContext context, ClassLoader classLoader) {
-        ServiceLoader<FileFormatFactory> serviceLoader =
-                ServiceLoader.load(FileFormatFactory.class, classLoader);
-        for (FileFormatFactory factory : serviceLoader) {
+        for (FileFormatFactory factory :
+                ServiceLoaderUtils.getImplements(FileFormatFactory.class, classLoader)) {
             if (factory.identifier().equals(formatIdentifier.toLowerCase())) {
                 return Optional.of(factory.create(context));
             }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ServiceLoaderUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ServiceLoaderUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public final class ServiceLoaderUtils {
+
+    private static final ConcurrentMap<Pair<Class<?>, ClassLoader>, List<?>> SERVICELOADERS =
+            new ConcurrentHashMap<>();
+
+    private ServiceLoaderUtils() {}
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> getImplements(Class<T> clazz, ClassLoader clazzLoader) {
+        if (clazz != null && clazzLoader != null) {
+            return (List<T>)
+                    SERVICELOADERS.computeIfAbsent(
+                            Pair.of(clazz, clazzLoader),
+                            p -> {
+                                List<T> impl = new ArrayList<>();
+                                ServiceLoader.load(p.getLeft(), clazzLoader)
+                                        .forEach(i -> impl.add((T) i));
+                                return Collections.unmodifiableList(impl);
+                            });
+        } else if (clazz == null) {
+            throw new IllegalArgumentException("Service interface can not be null.");
+        } else {
+            throw new IllegalArgumentException("ClassLoader can not be null.");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> remove(Class<T> clazz, ClassLoader clazzLoader) {
+        if (clazz != null && clazzLoader != null) {
+            List<?> removed = SERVICELOADERS.remove(Pair.of(clazz, clazzLoader));
+            return removed != null ? (List<T>) removed : null;
+        } else if (clazz == null) {
+            throw new IllegalArgumentException("Service interface can not be null.");
+        } else {
+            throw new IllegalArgumentException("ClassLoader can not be null.");
+        }
+    }
+
+    public static void reload() {
+        SERVICELOADERS.clear();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ServiceLoaderUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ServiceLoaderUtils.java
@@ -25,6 +25,7 @@ import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+/** Utils for ServiceLoader. Mainly for caching ServiceLoader. */
 public final class ServiceLoaderUtils {
 
     private static final ConcurrentMap<Pair<Class<?>, ClassLoader>, List<?>> SERVICELOADERS =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
To avoid the performance overhead caused by multiple invocations of `ServiceLoader#load()`, use `ServiceLoaderUtils` for caching in places where `ServiceLoader#load()` is frequently called, while also considering its thread safety.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
