### PR TITLE
[core] Fix merge index out of range for sequence field

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1492,8 +1492,10 @@ public class CoreOptions implements Serializable {
         return options.get(DYNAMIC_BUCKET_ASSIGNER_PARALLELISM);
     }
 
-    public Optional<List<String>> sequenceField() {
-        return options.getOptional(SEQUENCE_FIELD).map(s -> Arrays.asList(s.split(",")));
+    public List<String> sequenceField() {
+        return options.getOptional(SEQUENCE_FIELD)
+                .map(s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.emptyList());
     }
 
     public Optional<String> rowkindField() {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -38,13 +38,10 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.KeyComparatorSupplier;
 import org.apache.paimon.utils.UserDefinedSeqComparator;
 import org.apache.paimon.utils.ValueEqualiserSupplier;
-
-import javax.annotation.Nullable;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -123,12 +120,12 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     @Override
     public KeyValueFileStoreRead newRead() {
         return new KeyValueFileStoreRead(
+                options,
                 schemaManager,
                 schemaId,
                 keyType,
                 valueType,
                 newKeyComparator(),
-                userDefinedSeqComparator(),
                 mfFactory,
                 newReaderFactoryBuilder());
     }
@@ -144,11 +141,6 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 pathFactory(),
                 keyValueFieldsExtractor,
                 options);
-    }
-
-    @Nullable
-    private FieldsComparator userDefinedSeqComparator() {
-        return UserDefinedSeqComparator.create(valueType, options);
     }
 
     @Override
@@ -175,7 +167,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 keyType,
                 valueType,
                 keyComparatorSupplier,
-                this::userDefinedSeqComparator,
+                () -> UserDefinedSeqComparator.create(valueType, options),
                 valueEqualiserSupplier,
                 mfFactory,
                 pathFactory(),

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -167,13 +167,13 @@ public class SchemaValidation {
             }
         }
 
-        Optional<List<String>> sequenceField = options.sequenceField();
-        sequenceField.ifPresent(
-                fields ->
-                        checkArgument(
-                                schema.fieldNames().containsAll(fields),
-                                "Nonexistent sequence fields: '%s'",
-                                fields));
+        List<String> sequenceField = options.sequenceField();
+        if (sequenceField.size() > 0) {
+            checkArgument(
+                    schema.fieldNames().containsAll(sequenceField),
+                    "Nonexistent sequence fields: '%s'",
+                    sequenceField);
+        }
 
         Optional<String> rowkindField = options.rowkindField();
         rowkindField.ifPresent(
@@ -183,18 +183,18 @@ public class SchemaValidation {
                                 "Nonexistent rowkind field: '%s'",
                                 field));
 
-        sequenceField.ifPresent(
-                fields ->
-                        fields.forEach(
-                                field ->
-                                        checkArgument(
-                                                options.fieldAggFunc(field) == null,
-                                                "Should not define aggregation on sequence field: '%s'",
-                                                field)));
+        if (sequenceField.size() > 0) {
+            sequenceField.forEach(
+                    field ->
+                            checkArgument(
+                                    options.fieldAggFunc(field) == null,
+                                    "Should not define aggregation on sequence field: '%s'",
+                                    field));
+        }
 
         CoreOptions.MergeEngine mergeEngine = options.mergeEngine();
         if (mergeEngine == CoreOptions.MergeEngine.FIRST_ROW) {
-            if (sequenceField.isPresent()) {
+            if (sequenceField.size() > 0) {
                 throw new IllegalArgumentException(
                         "Do not support use sequence field on FIRST_MERGE merge engine");
             }
@@ -214,7 +214,7 @@ public class SchemaValidation {
                                 schema.primaryKeys(), schema.partitionKeys()));
             }
 
-            if (sequenceField.isPresent()) {
+            if (sequenceField.size() > 0) {
                 throw new IllegalArgumentException(
                         String.format(
                                 "You can not use sequence.field in cross partition update case "

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -90,10 +90,10 @@ public class LocalTableQuery implements TableQuery {
         if (options.needLookup()) {
             startLevel = 1;
         } else {
-            if (options.sequenceField().isPresent()) {
+            if (options.sequenceField().size() > 0) {
                 throw new UnsupportedOperationException(
                         "Not support sequence field definition, but is: "
-                                + options.sequenceField().get());
+                                + options.sequenceField());
             }
 
             if (options.mergeEngine() != DEDUPLICATE) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/UserDefinedSeqComparator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/UserDefinedSeqComparator.java
@@ -27,7 +27,6 @@ import org.apache.paimon.types.RowType;
 import javax.annotation.Nullable;
 
 import java.util.List;
-import java.util.Optional;
 
 /** A {@link FieldsComparator} for user defined sequence fields. */
 public class UserDefinedSeqComparator implements FieldsComparator {
@@ -52,17 +51,7 @@ public class UserDefinedSeqComparator implements FieldsComparator {
 
     @Nullable
     public static UserDefinedSeqComparator create(RowType rowType, CoreOptions options) {
-        Optional<List<String>> sequenceField = options.sequenceField();
-        if (!sequenceField.isPresent()) {
-            return null;
-        }
-
-        List<String> fieldNames = rowType.getFieldNames();
-        int[] fields = sequenceField.get().stream().mapToInt(fieldNames::indexOf).toArray();
-        RecordComparator comparator =
-                CodeGenUtils.newRecordComparator(
-                        rowType.getFieldTypes(), fields, "UserDefinedSeqComparator");
-        return new UserDefinedSeqComparator(fields, comparator);
+        return create(rowType, options.sequenceField());
     }
 
     @Nullable

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -72,7 +72,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
         FileStoreTable table = context.table;
         List<String> sequenceFields = new ArrayList<>();
         if (table.primaryKeys().size() > 0) {
-            new CoreOptions(table.options()).sequenceField().ifPresent(sequenceFields::addAll);
+            sequenceFields = new CoreOptions(table.options()).sequenceField();
         }
         RowType projectedType = TypeUtils.project(table.rowType(), context.projection);
         if (sequenceFields.size() > 0) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -120,14 +120,15 @@ public class TestChangelogDataReadWrite {
                     rowDataIteratorCreator) {
         SchemaManager schemaManager = new SchemaManager(LocalFileIO.create(), tablePath);
         long schemaId = 0;
+        CoreOptions options = new CoreOptions(new HashMap<>());
         KeyValueFileStoreRead read =
                 new KeyValueFileStoreRead(
+                        options,
                         schemaManager,
                         schemaId,
                         KEY_TYPE,
                         VALUE_TYPE,
                         COMPARATOR,
-                        null,
                         DeduplicateMergeFunction.factory(),
                         KeyValueFileReaderFactory.builder(
                                 LocalFileIO.create(),
@@ -138,7 +139,7 @@ public class TestChangelogDataReadWrite {
                                 ignore -> avro,
                                 pathFactory,
                                 EXTRACTOR,
-                                new CoreOptions(new HashMap<>())));
+                                options));
         return new KeyValueTableRead(read, null) {
 
             @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In the reading merging process, if there is a projection inside, we did not consider the existence of the sequence field and its index position.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
