### PR TITLE
[checkstyle] forbid use of org.jetbrains.annotations.Nullable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PlanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PlanImpl.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
 
 import java.util.List;
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeSorterTest.java
@@ -36,12 +36,13 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.IteratorRecordReader;
 
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.nio.file.Files;

--- a/paimon-core/src/test/java/org/apache/paimon/utils/AsyncRecordReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/AsyncRecordReaderTest.java
@@ -20,8 +20,9 @@ package org.apache.paimon.utils;
 
 import org.apache.paimon.reader.RecordReader;
 
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ParallelExecutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ParallelExecutionTest.java
@@ -22,8 +22,9 @@ import org.apache.paimon.data.serializer.IntSerializer;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.utils.ParallelExecution.ParallelBatch;
 
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
@@ -55,12 +55,13 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
 import org.apache.flink.table.factories.DynamicTableFactory;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -34,8 +34,9 @@ import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumerator
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.source.coordinator.ExecutorNotifier;
 import org.assertj.core.api.Assertions;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -118,6 +118,13 @@ This file is based on the checkstyle file of Apache Beam.
 
 		-->
 
+		<!-- forbid use of org.jetbrains.annotations.Nullable validate -->
+		<module name="Regexp">
+			<property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable."/>
+		</module>
 		<!-- forbid use of commons lang validate -->
 		<module name="Regexp">
 			<property name="format" value="org\.apache\.commons\.lang3\.Validate"/>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
