### PR TITLE
[hotfix] Fix unstable testRandomCdcEventsUnawareBucket

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -78,9 +78,8 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
         innerTestRandomCdcEvents(() -> -1, false);
     }
 
-    @Disabled
     @Test
-    @Timeout(180)
+    @Timeout(120)
     public void testRandomCdcEventsUnawareBucket() throws Exception {
         innerTestRandomCdcEvents(() -> -1, true);
     }
@@ -177,12 +176,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
 
         // enable failure when running jobs if needed
         FailingFileIO.reset(failingName, 2, 10000);
-        if (unawareBucketMode) {
-            // there's a compact operator which won't terminate
-            env.executeAsync();
-        } else {
-            env.execute();
-        }
+        env.execute();
 
         // no failure when checking results
         FailingFileIO.reset(failingName, 0, 1);
@@ -204,6 +198,8 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
         conf.set(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, 100L);
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
+        // disable compaction for unaware bucket mode to avoid unstable test
+        conf.set(CoreOptions.WRITE_ONLY, true);
 
         TableSchema tableSchema =
                 SchemaUtils.forceCommit(

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -45,7 +45,6 @@ import org.apache.paimon.utils.TraceableFileIO;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -68,16 +67,14 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
 
     @TempDir java.nio.file.Path tempDir;
 
-    @Disabled
     @Test
     @Timeout(120)
     public void testRandomCdcEvents() throws Exception {
         innerTestRandomCdcEvents(() -> ThreadLocalRandom.current().nextInt(5) + 1, false);
     }
 
-    @Disabled
     @Test
-    @Timeout(180)
+    @Timeout(120)
     public void testRandomCdcEventsDynamicBucket() throws Exception {
         innerTestRandomCdcEvents(() -> -1, false);
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkCatalogFactory;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.FileIO;
@@ -29,12 +30,15 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FailingFileIO;
 import org.apache.paimon.utils.TraceableFileIO;
@@ -173,7 +177,16 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         // no failure when checking results
         FailingFileIO.reset(failingName, 0, 1);
 
-        testTable.assertResult(table);
+        table = table.copyWithLatestSchema();
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        TableSchema schema = schemaManager.latest().get();
+
+        ReadBuilder readBuilder = table.newReadBuilder();
+        TableScan.Plan plan = readBuilder.newScan().plan();
+        try (RecordReaderIterator<InternalRow> it =
+                new RecordReaderIterator<>(readBuilder.newRead().createReader(plan))) {
+            testTable.assertResult(schema, it);
+        }
     }
 
     private FileStoreTable createFileStoreTable(
@@ -189,8 +202,10 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         conf.set(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, 100L);
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
-        // disable compaction for unaware bucket mode to avoid unstable test
-        conf.set(CoreOptions.WRITE_ONLY, true);
+        // disable compaction for unaware bucket mode to avoid instability
+        if (primaryKeys.isEmpty() && numBucket == -1) {
+            conf.set(CoreOptions.WRITE_ONLY, true);
+        }
 
         TableSchema tableSchema =
                 SchemaUtils.forceCommit(

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -168,13 +168,7 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
 
         // enable failure when running jobs if needed
         FailingFileIO.reset(failingName, 10, 10000);
-
-        if (unawareBucketMode) {
-            // there's a compact operator which won't terminate
-            env.executeAsync();
-        } else {
-            env.execute();
-        }
+        env.execute();
 
         // no failure when checking results
         FailingFileIO.reset(failingName, 0, 1);
@@ -195,6 +189,8 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         conf.set(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, 100L);
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(4096 * 3));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(4096));
+        // disable compaction for unaware bucket mode to avoid unstable test
+        conf.set(CoreOptions.WRITE_ONLY, true);
 
         TableSchema tableSchema =
                 SchemaUtils.forceCommit(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The TestCdcSourceFunction is bounded source, which will cause the downstream to produce committable with ID Long.MAX_VALUE. But the compaction of unaware bucket is unbounded, so it won't call the `endInput()`, thus the final committable may not be handled.

Additionally, revert some test codes, so others tests may be more stable.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
