### PR TITLE
[core] Refactor NullFalseLeafFunction

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Equal.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Equal.java
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval equal. */
-public class Equal extends NullFalseLeafBinaryFunction {
+/** A {@link NullFalseLeafOneLiteralFunction} to eval equal. */
+public class Equal extends NullFalseLeafOneLiteralFunction {
 
     public static final Equal INSTANCE = new Equal();
 
     private Equal() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) == 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, min) >= 0 && compareLiteral(type, literal, max) <= 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/GreaterOrEqual.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/GreaterOrEqual.java
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval greater or equal. */
-public class GreaterOrEqual extends NullFalseLeafBinaryFunction {
+/** A {@link NullFalseLeafOneLiteralFunction} to eval greater or equal. */
+public class GreaterOrEqual extends NullFalseLeafOneLiteralFunction {
 
     public static final GreaterOrEqual INSTANCE = new GreaterOrEqual();
 
     private GreaterOrEqual() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) <= 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, max) <= 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/GreaterThan.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/GreaterThan.java
@@ -26,19 +26,19 @@ import java.util.Optional;
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
 /** A {@link LeafFunction} to eval greater. */
-public class GreaterThan extends NullFalseLeafBinaryFunction {
+public class GreaterThan extends NullFalseLeafOneLiteralFunction {
 
     public static final GreaterThan INSTANCE = new GreaterThan();
 
     private GreaterThan() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) < 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, max) < 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/In.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/In.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
 /** A {@link LeafFunction} to eval in. */
-public class In extends LeafFunction {
+public class In extends NullFalseLeafFunction {
 
     private static final long serialVersionUID = 1L;
 
@@ -35,10 +35,7 @@ public class In extends LeafFunction {
     private In() {}
 
     @Override
-    public boolean test(DataType type, Object field, List<Object> literals) {
-        if (field == null) {
-            return false;
-        }
+    public boolean test0(DataType type, Object field, List<Object> literals) {
         for (Object literal : literals) {
             if (literal != null && compareLiteral(type, literal, field) == 0) {
                 return true;
@@ -48,16 +45,13 @@ public class In extends LeafFunction {
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type,
             long rowCount,
             Object min,
             Object max,
             Long nullCount,
             List<Object> literals) {
-        if (nullCount != null && rowCount == nullCount) {
-            return false;
-        }
         for (Object literal : literals) {
             if (literal != null
                     && compareLiteral(type, literal, min) >= 0

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/IsNotNull.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/IsNotNull.java
@@ -23,7 +23,7 @@ import org.apache.paimon.types.DataType;
 import java.util.List;
 import java.util.Optional;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval is not null. */
+/** A {@link LeafUnaryFunction} to eval is not null. */
 public class IsNotNull extends LeafUnaryFunction {
 
     public static final IsNotNull INSTANCE = new IsNotNull();

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/IsNull.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/IsNull.java
@@ -23,7 +23,7 @@ import org.apache.paimon.types.DataType;
 import java.util.List;
 import java.util.Optional;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval is null. */
+/** A {@link LeafUnaryFunction} to eval is null. */
 public class IsNull extends LeafUnaryFunction {
 
     public static final IsNull INSTANCE = new IsNull();

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LessOrEqual.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LessOrEqual.java
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval less or equal. */
-public class LessOrEqual extends NullFalseLeafBinaryFunction {
+/** A {@link NullFalseLeafOneLiteralFunction} to eval less or equal. */
+public class LessOrEqual extends NullFalseLeafOneLiteralFunction {
 
     public static final LessOrEqual INSTANCE = new LessOrEqual();
 
     private LessOrEqual() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) >= 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, min) >= 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LessThan.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LessThan.java
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval less or equal. */
-public class LessThan extends NullFalseLeafBinaryFunction {
+/** A {@link NullFalseLeafOneLiteralFunction} to eval less or equal. */
+public class LessThan extends NullFalseLeafOneLiteralFunction {
 
     public static final LessThan INSTANCE = new LessThan();
 
     private LessThan() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) > 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, min) > 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/NotEqual.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/NotEqual.java
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 import static org.apache.paimon.predicate.CompareUtils.compareLiteral;
 
-/** A {@link NullFalseLeafBinaryFunction} to eval not equal. */
-public class NotEqual extends NullFalseLeafBinaryFunction {
+/** A {@link NullFalseLeafOneLiteralFunction} to eval not equal. */
+public class NotEqual extends NullFalseLeafOneLiteralFunction {
 
     public static final NotEqual INSTANCE = new NotEqual();
 
     private NotEqual() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object literal) {
+    public boolean test0(DataType type, Object field, Object literal) {
         return compareLiteral(type, literal, field) != 0;
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
         return compareLiteral(type, literal, min) != 0 || compareLiteral(type, literal, max) != 0;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -109,7 +109,7 @@ public class PredicateBuilder {
         return leaf(StartsWith.INSTANCE, idx, patternLiteral);
     }
 
-    public Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
+    public Predicate leaf(NullFalseLeafOneLiteralFunction function, int idx, Object literal) {
         DataField field = rowType.getFields().get(idx);
         return new LeafPredicate(function, field.type(), idx, field.name(), singletonList(literal));
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/StartsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/StartsWith.java
@@ -25,23 +25,23 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A {@link NullFalseLeafBinaryFunction} to evaluate {@code filter like 'abc%' or filter like
+ * A {@link NullFalseLeafOneLiteralFunction} to evaluate {@code filter like 'abc%' or filter like
  * 'abc_'}.
  */
-public class StartsWith extends NullFalseLeafBinaryFunction {
+public class StartsWith extends NullFalseLeafOneLiteralFunction {
 
     public static final StartsWith INSTANCE = new StartsWith();
 
     private StartsWith() {}
 
     @Override
-    public boolean test(DataType type, Object field, Object patternLiteral) {
+    public boolean test0(DataType type, Object field, Object patternLiteral) {
         BinaryString fieldString = (BinaryString) field;
         return fieldString.startsWith((BinaryString) patternLiteral);
     }
 
     @Override
-    public boolean test(
+    public boolean test0(
             DataType type,
             long rowCount,
             Object min,

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -66,6 +66,8 @@ public class PredicateTest {
                 .isEqualTo(false);
         assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
+        assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, null)}))
+                .isEqualTo(false);
     }
 
     @Test
@@ -560,8 +562,15 @@ public class PredicateTest {
                 .isEqualTo(false);
 
         // unknown stats, we don't know, likely to hit
-        assertThat(test(predicate, 3, new FieldStats[] {new FieldStats(null, null, 4L)}))
+        assertThat(test(predicate, 3, new FieldStats[] {new FieldStats(null, null, 2L)}))
                 .isEqualTo(true);
+
+        assertThat(test(predicate, 3, new FieldStats[] {new FieldStats(null, null, null)}))
+                .isEqualTo(true);
+
+        // row count = 0 always false
+        assertThat(test(predicate, 0, new FieldStats[] {new FieldStats(null, null, null)}))
+                .isEqualTo(false);
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -102,6 +102,8 @@ public class PredicateTest {
                 .isEqualTo(false);
         assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
+        assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, null)}))
+                .isEqualTo(false);
     }
 
     @Test
@@ -355,6 +357,8 @@ public class PredicateTest {
         assertThat(test(predicate, 3, new FieldStats[] {new FieldStats(6, 7, 0L)}))
                 .isEqualTo(false);
         assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, 1L)}))
+                .isEqualTo(false);
+        assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, null)}))
                 .isEqualTo(false);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- Currently `In` and `NotIn` predicate are null false, this PR extract a common parent class `NullFalseLeafFunction` for them
- fix when all stats is null, equal(0, null) still should be false

### Tests

- All original UT passed
- New case
```
PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
Predicate predicate = builder.equal(0, null);
// new
assertThat(test(predicate, 1, new FieldStats[] {new FieldStats(null, null, null)})).isEqualTo(false);
```

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
