### PR TITLE
[core] `AvroReader` should not get file-size by file-io repeatly.

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkFormat.java
@@ -69,18 +69,18 @@ public class AvroBulkFormat implements FormatReaderFactory {
 
         private AvroReader(FileIO fileIO, Path path) throws IOException {
             this.fileIO = fileIO;
-            this.reader = createReaderFromPath(path);
-            this.reader.sync(0);
             this.end = fileIO.getFileSize(path);
+            this.reader = createReaderFromPath(path, end);
+            this.reader.sync(0);
             this.pool = new Pool<>(1);
             this.pool.add(new Object());
         }
 
-        private DataFileReader<InternalRow> createReaderFromPath(Path path) throws IOException {
+        private DataFileReader<InternalRow> createReaderFromPath(Path path, long fileSize)
+                throws IOException {
             DatumReader<InternalRow> datumReader = new AvroRowDatumReader(projectedRowType);
             SeekableInput in =
-                    new SeekableInputStreamWrapper(
-                            fileIO.newInputStream(path), fileIO.getFileSize(path));
+                    new SeekableInputStreamWrapper(fileIO.newInputStream(path), fileSize);
             try {
                 return (DataFileReader<InternalRow>) DataFileReader.openReader(in, datumReader);
             } catch (Throwable e) {


### PR DESCRIPTION
Reduce paimon file-io cost.