### PR TITLE
[core] Add more validation for sequence field during create table.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -28,7 +28,6 @@ import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.options.OptionsUtils;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
@@ -2100,41 +2099,6 @@ public class CoreOptions implements Serializable {
         @Override
         public InlineElement getDescription() {
             return text(description);
-        }
-    }
-
-    /** Specifies the way of making up time precision for sequence field. */
-    public enum SequenceAutoPadding implements DescribedEnum {
-        ROW_KIND_FLAG(
-                "row-kind-flag",
-                "Pads a bit flag to indicate whether it is retract (0) or add (1) message."),
-        SECOND_TO_MICRO(
-                "second-to-micro",
-                "Pads the sequence field that indicates time with precision of seconds to micro-second."),
-        MILLIS_TO_MICRO(
-                "millis-to-micro",
-                "Pads the sequence field that indicates time with precision of milli-second to micro-second.");
-
-        private final String value;
-        private final String description;
-
-        SequenceAutoPadding(String value, String description) {
-            this.value = value;
-            this.description = description;
-        }
-
-        @Override
-        public String toString() {
-            return value;
-        }
-
-        @Override
-        public InlineElement getDescription() {
-            return text(description);
-        }
-
-        public static SequenceAutoPadding fromString(String s) {
-            return OptionsUtils.convertToEnum(s, SequenceAutoPadding.class);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -190,7 +190,7 @@ public class SchemaValidation {
                         field ->
                                 checkArgument(
                                         schema.fieldNames().contains(field),
-                                        "Nonexistent rowkind field: '%s'",
+                                        "Rowkind field: '%s' can not be found in table schema.",
                                         field));
 
         if (options.deletionVectorsEnabled()) {

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -131,7 +131,7 @@ public class SchemaManagerTest {
                                                                         "f4"),
                                                                 ""))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Nonexistent sequence fields: '[f4]'");
+                .hasMessageContaining("Sequence field: 'f4' can not be found in table schema.");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.schema;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
@@ -68,12 +67,6 @@ public class SchemaUtils {
                 highestFieldId = RowType.currentHighestFieldId(fields);
                 id = 0;
             }
-
-            String sequenceField = options.get(CoreOptions.SEQUENCE_FIELD.key());
-            Preconditions.checkArgument(
-                    sequenceField == null || rowType.getFieldNames().contains(sequenceField),
-                    "Nonexistent sequence field: '%s'",
-                    sequenceField);
 
             TableSchema newSchema =
                     new TableSchema(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.schema;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -30,7 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.CoreOptions.AGG_FUNCTION;
 import static org.apache.paimon.CoreOptions.BUCKET;
+import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
+import static org.apache.paimon.CoreOptions.MERGE_ENGINE;
 import static org.apache.paimon.CoreOptions.SEQUENCE_FIELD;
 import static org.apache.paimon.schema.SchemaValidation.validateTableSchema;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,6 +120,45 @@ public class TableSchemaTest {
         assertThatThrownBy(() -> RowType.currentHighestFieldId(fields2))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Broken schema, field id 0 is duplicated.");
+    }
+
+    @Test
+    public void testSequenceField() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.INT()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "f2", DataTypes.INT()),
+                        new DataField(3, "f3", DataTypes.INT()));
+        List<String> partitionKeys = Collections.singletonList("f0");
+        List<String> primaryKeys = Collections.singletonList("f1");
+        Map<String, String> options = new HashMap<>();
+
+        TableSchema schema =
+                new TableSchema(1, fields, 10, partitionKeys, primaryKeys, options, "");
+
+        options.put(SEQUENCE_FIELD.key(), "f3");
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessageContaining(
+                        "You can not use sequence.field in cross partition update case (Primary key constraint '[f1]' not include all partition fields '[f0]').");
+
+        options.put(SEQUENCE_FIELD.key(), "f4");
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessageContaining("Sequence field: 'f4' can not be found in table schema.");
+
+        options.put(SEQUENCE_FIELD.key(), "f2,f3,f3");
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessageContaining("Sequence field 'f3' is defined repeatedly.");
+
+        options.put(SEQUENCE_FIELD.key(), "f3");
+        options.put(MERGE_ENGINE.key(), CoreOptions.MergeEngine.FIRST_ROW.toString());
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessageContaining(
+                        "Do not support use sequence field on FIRST_MERGE merge engine.");
+
+        options.put(FIELDS_PREFIX + ".f3." + AGG_FUNCTION, "max");
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessageContaining("Should not define aggregation on sequence field: 'f3'.");
     }
 
     static RowType newRowType(boolean isNullable, int fieldId) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1, add more validation for sequence field.
2, remove sequence padding from CoreOptions.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
