### PR TITLE
[codegen] EqualiserCodeGenerator supports ARRAY<ROW>

### DIFF
--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
@@ -19,10 +19,10 @@
 package org.apache.paimon.codegen
 
 import org.apache.paimon.codegen.GenerateUtils._
-import org.apache.paimon.codegen.ScalarOperatorGens.generateEquals
-import org.apache.paimon.types.{BooleanType, DataType, RowType}
-import org.apache.paimon.types.DataTypeChecks.{getFieldTypes, isCompositeType}
+import org.apache.paimon.codegen.ScalarOperatorGens.{generateEquals, generateRowEqualiser}
+import org.apache.paimon.types.DataTypeChecks.isCompositeType
 import org.apache.paimon.types.DataTypeRoot._
+import org.apache.paimon.types.{BooleanType, DataType, RowType}
 import org.apache.paimon.utils.TypeUtils.isPrimitive
 
 import scala.collection.JavaConverters._
@@ -136,19 +136,7 @@ class EqualiserCodeGenerator(fieldTypes: Array[DataType]) {
     if (isInternalPrimitive(fieldType)) {
       ("", s"$leftFieldTerm == $rightFieldTerm")
     } else if (isCompositeType(fieldType)) {
-      val equaliserGenerator =
-        new EqualiserCodeGenerator(getFieldTypes(fieldType).asScala.toArray)
-      val generatedEqualiser = equaliserGenerator.generateRecordEqualiser("fieldGeneratedEqualiser")
-      val generatedEqualiserTerm =
-        ctx.addReusableObject(generatedEqualiser, "fieldGeneratedEqualiser")
-      val equaliserTypeTerm = classOf[RecordEqualiser].getCanonicalName
-      val equaliserTerm = newName("equaliser")
-      ctx.addReusableMember(s"private $equaliserTypeTerm $equaliserTerm = null;")
-      ctx.addReusableInitStatement(
-        s"""
-           |$equaliserTerm = ($equaliserTypeTerm)
-           |  $generatedEqualiserTerm.newInstance(this.getClass().getClassLoader());
-           |""".stripMargin)
+      val equaliserTerm = generateRowEqualiser(ctx, fieldType)
       ("", s"$equaliserTerm.equals($leftFieldTerm, $rightFieldTerm)")
     } else {
       val left = GeneratedExpression(leftFieldTerm, leftNullTerm, "", fieldType)

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
@@ -20,9 +20,9 @@ package org.apache.paimon.codegen
 
 import org.apache.paimon.codegen.GenerateUtils._
 import org.apache.paimon.codegen.ScalarOperatorGens.{generateEquals, generateRowEqualiser}
+import org.apache.paimon.types.{BooleanType, DataType, RowType}
 import org.apache.paimon.types.DataTypeChecks.isCompositeType
 import org.apache.paimon.types.DataTypeRoot._
-import org.apache.paimon.types.{BooleanType, DataType, RowType}
 import org.apache.paimon.utils.TypeUtils.isPrimitive
 
 import scala.collection.JavaConverters._

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
@@ -20,8 +20,8 @@ package org.apache.paimon.codegen
 
 import org.apache.paimon.codegen.GenerateUtils._
 import org.apache.paimon.data.serializer.InternalMapSerializer
-import org.apache.paimon.types.DataTypeChecks.{getFieldTypes, isCompositeType}
 import org.apache.paimon.types._
+import org.apache.paimon.types.DataTypeChecks.{getFieldTypes, isCompositeType}
 import org.apache.paimon.utils.InternalRowUtils
 import org.apache.paimon.utils.TypeCheckUtils._
 import org.apache.paimon.utils.TypeUtils.isInteroperable

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
@@ -20,10 +20,13 @@ package org.apache.paimon.codegen
 
 import org.apache.paimon.codegen.GenerateUtils._
 import org.apache.paimon.data.serializer.InternalMapSerializer
+import org.apache.paimon.types.DataTypeChecks.{getFieldTypes, isCompositeType}
 import org.apache.paimon.types._
 import org.apache.paimon.utils.InternalRowUtils
 import org.apache.paimon.utils.TypeCheckUtils._
 import org.apache.paimon.utils.TypeUtils.isInteroperable
+
+import scala.collection.JavaConverters._
 
 /**
  * Utilities to generate SQL scalar operators, e.g. arithmetic operator, compare operator, equal
@@ -78,6 +81,10 @@ object ScalarOperatorGens {
     // comparable types of same type
     else if (isComparable(left.resultType) && canEqual) {
       generateComparison(ctx, "==", left, right, resultType)
+    } else if (isCompositeType(left.resultType) && canEqual) {
+      val equaliserTerm = generateRowEqualiser(ctx, left.resultType)
+      generateOperatorIfNotNull(ctx, resultType, left, right)(
+        (leftTerm, rightTerm) => s"$equaliserTerm.equals($leftTerm, $rightTerm)")
     }
     // non comparable types
     else {
@@ -93,6 +100,25 @@ object ScalarOperatorGens {
         }
       }
     }
+  }
+
+  /** Generates [[RecordEqualiser]] code for row and return equaliser name. */
+  def generateRowEqualiser(ctx: CodeGeneratorContext, fieldType: DataType): String = {
+    val equaliserGenerator =
+      new EqualiserCodeGenerator(getFieldTypes(fieldType).asScala.toArray)
+    val generatedEqualiser =
+      equaliserGenerator.generateRecordEqualiser("fieldGeneratedEqualiser")
+    val generatedEqualiserTerm =
+      ctx.addReusableObject(generatedEqualiser, "fieldGeneratedEqualiser")
+    val equaliserTypeTerm = classOf[RecordEqualiser].getCanonicalName
+    val equaliserTerm = newName("equaliser")
+    ctx.addReusableMember(s"private $equaliserTypeTerm $equaliserTerm = null;")
+    ctx.addReusableInitStatement(
+      s"""
+         |$equaliserTerm = ($equaliserTypeTerm)
+         |  $generatedEqualiserTerm.newInstance(this.getClass().getClassLoader());
+         |""".stripMargin)
+    equaliserTerm
   }
 
   /** Generates comparison code for numeric types and comparable types of same type. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See the test case:
If we didn't handle ARRAY<ROW>, the `valueEqualiser` in `FullChangelogMergeFunctionWrapper` and `LookupChangelogMergeFunctionWrapper` might throw exception when call `equals`. 
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
