### PR TITLE
[core] add initial map size to solve load index slowly.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/Int2ShortHashMap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Int2ShortHashMap.java
@@ -29,6 +29,10 @@ public class Int2ShortHashMap {
         this.map = new Int2ShortOpenHashMap();
     }
 
+    public Int2ShortHashMap(int capacity) {
+        this.map = new Int2ShortOpenHashMap(capacity);
+    }
+
     public void put(int key, short value) {
         map.put(key, value);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3038

When using dynamic bucket, i find out that when restart the job, it will cost long time to load index, and after observing the flame graph, i find out the thread was stuck at :
![image](https://github.com/apache/incubator-paimon/assets/60921147/69c39fed-8ca8-4da4-bebe-7dc90744f7f8)
and by watching the code line 249 in Int2ShortOpenHashMap was quoted by 'There's always an unused entry.' 

So i add initial Int2ShortOpenHashMap size to avoid the thread stuck to accelerate the load process.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
