### PR TITLE
[hotfix] Add project root path to files to facilitate compiling modules in child dirs

### DIFF
--- a/.mvn/readme.txt
+++ b/.mvn/readme.txt
@@ -1,0 +1,4 @@
+The .mvn directory is needed to be able to use the ${maven.multiModuleProjectDirectory} property, since git cannot
+commit an empty directory, add this file.
+
+Once we do not use ${maven.multiModuleProjectDirectory}, we can remove this file and .mvn directory.

--- a/pom.xml
+++ b/pom.xml
@@ -830,18 +830,19 @@ under the License.
                             </importOrder>
 
                             <licenseHeader>
-                                <file>copyright.txt</file>
+                                <!-- replace it with ${project.rootDirectory} after maven 4.0.0, see MNG-7038 -->
+                                <file>${maven.multiModuleProjectDirectory}/copyright.txt</file>
                                 <delimiter>${spotless.delimiter}</delimiter>
                             </licenseHeader>
                         </java>
                         <scala>
                             <scalafmt>
                                 <version>3.4.3</version>
-                                <file>.scalafmt.conf</file>
+                                <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
                             </scalafmt>
 
                             <licenseHeader>
-                                <file>copyright.txt</file>
+                                <file>${maven.multiModuleProjectDirectory}/copyright.txt</file>
                                 <delimiter>${spotless.delimiter}</delimiter>
                             </licenseHeader>
                         </scala>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Someone may want to compile a child module in the child directory instead of using `-pl`, but after #2883 using this way to compile will raise an error.
Even though I don't agree with compiling like this (doge.jpg), still find a way to fix it 

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
