### PR TITLE
[core] Skip rewrite when delete row count is 0 with dv

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -37,7 +37,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.CHANGELOG_NO_REWRITE;
-import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.NO_CHANGELOG;
+import static org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.UpgradeStrategy.NO_CHANGELOG_NO_REWRITE;
 
 /** A {@link MergeTreeCompactRewriter} which produces changelog files for each full compaction. */
 public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRewriter {
@@ -84,8 +84,8 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
     }
 
     @Override
-    protected UpgradeStrategy upgradeChangelog(int outputLevel, DataFileMeta file) {
-        return outputLevel == maxLevel ? CHANGELOG_NO_REWRITE : NO_CHANGELOG;
+    protected UpgradeStrategy upgradeStrategy(int outputLevel, DataFileMeta file) {
+        return outputLevel == maxLevel ? CHANGELOG_NO_REWRITE : NO_CHANGELOG_NO_REWRITE;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -82,7 +82,7 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
         writer.write(new RecordReaderIterator<>(reader));
         writer.close();
         List<DataFileMeta> before = extractFilesFromSections(sections);
-        notifyCompactBefore(before);
+        notifyRewriteCompactBefore(before);
         return new CompactResult(before, writer.result());
     }
 
@@ -98,10 +98,5 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
                 mergeSorter);
     }
 
-    /**
-     * Hook to handle the files before compact in rewriting stage. Note: In addition to normal
-     * rewrite, in some cases, upgrade can also transition into rewrite, see {@link
-     * ChangelogMergeTreeRewriter#upgrade}
-     */
-    protected void notifyCompactBefore(List<DataFileMeta> files) {}
+    protected void notifyRewriteCompactBefore(List<DataFileMeta> files) {}
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -98,5 +98,10 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
                 mergeSorter);
     }
 
+    /**
+     * Hook to handle the files before compact in rewriting stage. Note: In addition to normal
+     * rewrite, in some cases, upgrade can also transition into rewrite, see {@link
+     * ChangelogMergeTreeRewriter#upgrade}
+     */
     protected void notifyCompactBefore(List<DataFileMeta> files) {}
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When upgrade is possible and delete row count is 0, we can avoid rewrite

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
